### PR TITLE
Improved setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,11 +13,15 @@ setup(name='Keras',
       url='https://github.com/fchollet/keras',
       license='MIT',
       packages=[
-        'keras', 
-        'keras.layers', 
-        'keras.preprocessing', 
-        'keras.datasets', 
-        'keras.utils',
+          'keras',
+          'keras.layers',
+          'keras.preprocessing',
+          'keras.datasets',
+          'keras.utils',
       ],
-      install_requires=['numpy', 'scipy', 'theano']
+      install_requires=['numpy', 'scipy', 'theano'],
+      extras_require={
+          'images': ['pil'], # working with images
+          'CNNs': ['cudnn-python-wrappers'], # working with CNNs
+      }
 )

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 
 setup(name='Keras',
       version='0.0.1',
@@ -16,5 +16,5 @@ setup(name='Keras',
         'keras.datasets', 
         'keras.utils',
       ],
-      # TODO: dependencies
+      install_requires=['numpy', 'scipy', 'theano']
 )

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 
-from setuptools import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 
 setup(name='Keras',
       version='0.0.1',


### PR DESCRIPTION
 - using setuptools if available
 - specified required and optional dependencies, as listed in read me. `scipy` could probably be made optional because all of its usages in `np_utils.py` can be replaced with `numpy`, and the remaining usages are all image-related.