### PR TITLE
Added support for Activation layers over tensor3 inputs

### DIFF
--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -62,6 +62,10 @@ class Activation(Layer):
 
     def output(self, train):
         X = self.get_input(train)
+        if X.ndim == 3:
+            xshape = X.shape
+            X = X.reshape((xshape[0]*xshape[1], xshape[2]))
+            return self.activation(X).reshape(xshape)
         return self.activation(X)
 
 


### PR DESCRIPTION
Added a check in the Activation layer for a tensor3 input. If so, the tensor is reshaped into a matrix.

Assumed shape transformation: ```(nb_samples, time, nb_outputs)``` --> ```(nb_samples * time, nb_outputs)```

The activation (including softmax) can then be done correctly.