### PR TITLE
Add new initializations

### DIFF
--- a/keras/initializations.py
+++ b/keras/initializations.py
@@ -20,6 +20,18 @@ def lecun_uniform(shape):
     scale = 1./np.sqrt(m)
     return uniform(shape, scale)
 
+def glorot_normal(shape):
+    ''' Reference: Glorot & Bengio, AISTATS 2010
+    '''
+    s = np.sqrt(2 / (shape[0] + shape[1]))
+    return normal(shape, s)
+
+def he_normal(shape):
+    ''' Reference:  He et al., http://arxiv.org/abs/1502.01852
+    '''
+    s = np.sqrt(2 / (shape[1]))
+    return normal(shape, s)
+
 def orthogonal(shape, scale=1.1):
     ''' From Lasagne
     '''


### PR DESCRIPTION
This PR adds two new initialization methods:

*  The method from "Understanding the difficulty of training deep feedforward neural networks", Glorot & Bengio, AISTATS 2010. This works very well for sigmoid/tanh activation functions. This is known as the "xavier" initialization in [Caffe](http://caffe.berkeleyvision.org/), where it is the default initialization method for dense layers.

* The improvements on the above method made by [He et. al](http://arxiv.org/abs/1502.01852), which they showed works much better when using ReLU activation functions. 
