### PR TITLE
add support for larger dimensional tensors and SharedDense Layer

### DIFF
--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -139,6 +139,40 @@ class Dense(Layer):
         return output
 
 
+class SharedDense(Layer):
+    '''
+       Apply a same DenseLayer for each dimension[1] (shared_dimension) input 
+       Especially useful after a recurrent network with 'return_sequence=True'
+       Tensor input dimensions:   (nb_sample, shared_dimension, input_dim)
+       Tensor output dimensions:  (nb_sample, shared_dimension, output_dim)
+    '''
+    def __init__(self, input_dim, output_dim, init='uniform', activation='linear', weights=None):
+        self.init = initializations.get(init)
+        self.activation = activations.get(activation)
+        self.input_dim = input_dim
+        self.output_dim = output_dim
+
+        self.input = T.matrix()
+        self.W = self.init((self.input_dim, self.output_dim))
+        self.b = shared_zeros((self.output_dim))
+
+        self.params = [self.W, self.b]
+
+        if weights is not None:
+            self.set_weights(weights)
+
+    def output(self, train):
+        X = self.get_input(train)
+
+        def act_func(X):
+            return self.activation(T.dot(X, self.W) + self.b)
+
+        output, _ = theano.scan(fn = act_func,
+                                sequences = X.dimshuffle(1,0,2),
+                                outputs_info=None)
+        return output.dimshuffle(1,0,2)
+
+
 class Embedding(Layer):
     '''
         Turn a list of integers >=0 into a dense vector of fixed size. 

--- a/keras/models.py
+++ b/keras/models.py
@@ -106,16 +106,19 @@ class Sequential(object):
             batch_preds = self._predict(X[batch])
 
             if batch_index == 0:
-                preds = np.zeros((len(X), batch_preds.shape[1]))
+                shape = (len(X),) + batch_preds.shape[1:]
+                preds = np.zeros(shape)
             preds[batch] = batch_preds
         return preds
 
     def predict_classes(self, X, batch_size=128):
         proba = self.predict_proba(X, batch_size=batch_size)
-        if proba.shape[1] > 1:
-            return proba.argmax(axis=1)
+        # The last dimension is the one containing the class probas
+        classes_dim = proba.ndim - 1
+        if proba.shape[classes_dim] > 1:
+            return proba.argmax(axis=classes_dim)
         else:
-            return np.array([1 if p > 0.5 else 0 for p in proba])
+            return (proba>0.5).astype('int32')
 
     def evaluate(self, X, y, batch_size=128):
         y = standardize_y(y)


### PR DESCRIPTION
Outputs from RNNs have a 3 dimensional shape: 
(nb_sample, time, output_dim)

- Added support in predict_proba and predict_classes for a 3 dimensional output.
- Added a SharedDense Layer ( a dense layer applied to each output of the time dimension ).

I wanted to do a more general Layer that applies the next Layer to each element of the time dimension, but couldn't figure out how to without destroying the architecture.