### PR TITLE
Added Time Distributed Softmax to allow softmax activation over 3D inputs

### DIFF
--- a/keras/activations.py
+++ b/keras/activations.py
@@ -5,6 +5,11 @@ import types
 def softmax(x):
     return T.nnet.softmax(x)
 
+def time_distributed_softmax(x):
+    xshape = x.shape
+    X = x.reshape((xshape[0] * xshape[1], xshape[2]))
+    return T.nnet.softmax(X).reshape(xshape)
+
 def softplus(x):
     return T.nnet.softplus(x)
 


### PR DESCRIPTION
Allows softmax activation over tensor3 values. Given output A from this activation, `sum(A[i][j][:])==1.0`

Impetus: Output from RNNs is generally considered of size `(nb_samples, time_steps, values)`. This activation allows for softmax over this tensor3, where the softmax is applied over a vector of size `(values, )` which corresponds to the softmax of one sample at one time step.

Example:
```python
model = Sequential()
model.add(SimpleRNN(2, 3, return_sequences=True))
model.add(Activation('time_distributed_softmax'))

sgd = SGD(lr=0.1, decay=1e-6, momentum=0.9, nesterov=True)
model.compile(loss='mse', optimizer='sgd')
A = model._predict(np.asarray([[[1,1],[2,2]], [[3,3], [4,4]]]))

print A
print np.sum(A[0][0][:])
```

Yields
```python
[[[ 0.32846826  0.33231813  0.33921361]
  [ 0.32311559  0.33156598  0.34531844]]

 [[ 0.31882143  0.33012739  0.35105121]
  [ 0.31376582  0.32922304  0.35701114]]]
1.0
```