### PR TITLE
Fixed logic to determine the number of batches per epoch

### DIFF
--- a/keras/models.py
+++ b/keras/models.py
@@ -80,7 +80,7 @@ class Sequential(object):
             if shuffle:
                 np.random.shuffle(index_array)
 
-            nb_batch = len(X)/batch_size+1
+            nb_batch = np.ceil(len(X)/float(batch_size))
             progbar = Progbar(target=len(X))
             for batch_index in range(0, nb_batch):
                 batch_start = batch_index*batch_size


### PR DESCRIPTION
Fixed a bug wherein the number of batches that was calculated would be too large when `Num_Examples % batch_size == 0`