### PR TITLE
Fixed incorrect datatype in range function from the last commit

### DIFF
--- a/keras/models.py
+++ b/keras/models.py
@@ -80,7 +80,7 @@ class Sequential(object):
             if shuffle:
                 np.random.shuffle(index_array)
 
-            nb_batch = np.ceil(len(X)/float(batch_size))
+            nb_batch = int(np.ceil(len(X)/float(batch_size)))
             progbar = Progbar(target=len(X))
             for batch_index in range(0, nb_batch):
                 batch_start = batch_index*batch_size


### PR DESCRIPTION
Apologies, the `nb_batch` size fix from last time resulted in an unsuitable datatype for the `range` function - I missed that in the tests as I was working in another branch and just happen to notice the `nb_batch` bug.