### PR TITLE
Advanced Reshape Layer

### DIFF
--- a/keras/layers/advanced_activations.py
+++ b/keras/layers/advanced_activations.py
@@ -6,8 +6,8 @@ class LeakyReLU(Layer):
         self.alpha = alpha
         self.params = []
 
-    def output(self, train, batch_size):
-        X = self.get_input(train, batch_size)
+    def output(self, train, current_batch_size):
+        X = self.get_input(train, current_batch_size)
         return ((X + abs(X)) / 2.0) + self.alpha * ((X - abs(X)) / 2.0)
 
 
@@ -21,8 +21,8 @@ class PReLU(Layer):
         self.alphas = shared_zeros(input_shape)
         self.params = [self.alphas]
 
-    def output(self, train, batch_size):
-        X = self.get_input(train, batch_size)
+    def output(self, train, current_batch_size):
+        X = self.get_input(train, current_batch_size)
         pos = ((X + abs(X)) / 2.0)
         neg = self.alphas * ((X - abs(X)) / 2.0)
         return pos + neg

--- a/keras/layers/advanced_activations.py
+++ b/keras/layers/advanced_activations.py
@@ -6,8 +6,8 @@ class LeakyReLU(Layer):
         self.alpha = alpha
         self.params = []
 
-    def output(self, train):
-        X = self.get_input(train)
+    def output(self, train, batch_size):
+        X = self.get_input(train, batch_size)
         return ((X + abs(X)) / 2.0) + self.alpha * ((X - abs(X)) / 2.0)
 
 
@@ -21,8 +21,8 @@ class PReLU(Layer):
         self.alphas = shared_zeros(input_shape)
         self.params = [self.alphas]
 
-    def output(self, train):
-        X = self.get_input(train)
+    def output(self, train, batch_size):
+        X = self.get_input(train, batch_size)
         pos = ((X + abs(X)) / 2.0)
         neg = self.alphas * ((X - abs(X)) / 2.0)
         return pos + neg

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -34,8 +34,8 @@ class Convolution2D(Layer):
         if weights is not None:
             self.set_weights(weights)
 
-    def output(self, train, batch_size):
-        X = self.get_input(train, batch_size)
+    def output(self, train, current_batch_size):
+        X = self.get_input(train, current_batch_size)
 
         conv_out = theano.tensor.nnet.conv.conv2d(X, self.W, 
             border_mode=self.border_mode, subsample=self.subsample, image_shape=self.image_shape)
@@ -50,8 +50,8 @@ class MaxPooling2D(Layer):
         self.ignore_border = ignore_border
         self.params = []
 
-    def output(self, train, batch_size):
-        X = self.get_input(train, batch_size)
+    def output(self, train, current_batch_size):
+        X = self.get_input(train, current_batch_size)
         output = downsample.max_pool_2d(X, self.poolsize, ignore_border=self.ignore_border)
         return output
 

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -34,8 +34,8 @@ class Convolution2D(Layer):
         if weights is not None:
             self.set_weights(weights)
 
-    def output(self, train):
-        X = self.get_input(train)
+    def output(self, train, batch_size):
+        X = self.get_input(train, batch_size)
 
         conv_out = theano.tensor.nnet.conv.conv2d(X, self.W, 
             border_mode=self.border_mode, subsample=self.subsample, image_shape=self.image_shape)
@@ -50,8 +50,8 @@ class MaxPooling2D(Layer):
         self.ignore_border = ignore_border
         self.params = []
 
-    def output(self, train):
-        X = self.get_input(train)
+    def output(self, train, batch_size):
+        X = self.get_input(train, batch_size)
         output = downsample.max_pool_2d(X, self.poolsize, ignore_border=self.ignore_border)
         return output
 

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -44,8 +44,8 @@ class Dropout(Layer):
         self.p = p
         self.params = []
 
-    def output(self, train):
-        X = self.get_input(train)
+    def output(self, train, batch_size):
+        X = self.get_input(train, batch_size)
         if self.p > 0.:
             retain_prob = 1. - self.p
             if train:
@@ -78,8 +78,8 @@ class Reshape(Layer):
         self.dims = dims
         self.params = []
 
-    def output(self, train):
-        X = self.get_input(train)
+    def output(self, train, batch_size):
+        X = self.get_input(train, batch_size)
         nshape = make_tuple(X.shape[0], *self.dims)
         return theano.tensor.reshape(X, nshape)
 
@@ -111,8 +111,8 @@ class Flatten(Layer):
         self.size = size
         self.params = []
 
-    def output(self, train):
-        X = self.get_input(train)
+    def output(self, train, batch_size):
+        X = self.get_input(train, batch_size)
         nshape = (X.shape[0], self.size)
         return theano.tensor.reshape(X, nshape)
 
@@ -128,8 +128,8 @@ class RepeatVector(Layer):
         self.n = n
         self.params = []
 
-    def output(self, train):
-        X = self.get_input(train)
+    def output(self, train, batch_size):
+        X = self.get_input(train, batch_size)
         tensors = [X]*self.n
         stacked = theano.tensor.stack(*tensors)
         return stacked.dimshuffle((1,0,2))
@@ -180,7 +180,7 @@ class Embedding(Layer):
         if weights is not None:
             self.set_weights(weights)
 
-    def output(self, train):
-        X = self.get_input(train)
+    def output(self, train, batch_size):
+        X = self.get_input(train, batch_size)
         return self.W[X]
 

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -33,7 +33,6 @@ class Layer(object):
         return weights
 
 
-
 class Dropout(Layer):
     '''
         Hinton's dropout. 

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -32,8 +32,6 @@ class Layer(object):
             weights.append(p.get_value())
         return weights
 
-    def get_nb_samples(self):
-        return 2
 
 
 class Dropout(Layer):

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -16,9 +16,9 @@ class Layer(object):
     def output(self, train):
         raise NotImplementedError
 
-    def get_input(self, train):
+    def get_input(self, train, batch_size):
         if hasattr(self, 'previous_layer'):
-            return self.previous_layer.output(train=train)
+            return self.previous_layer.output(train=train, batch_size=batch_size)
         else:
             return self.input
 
@@ -63,8 +63,8 @@ class Activation(Layer):
         self.activation = activations.get(activation)
         self.params = []
 
-    def output(self, train):
-        X = self.get_input(train)
+    def output(self, train, batch_size):
+        X = self.get_input(train, batch_size)
         return self.activation(X)
 
 
@@ -96,9 +96,9 @@ class AdvancedReshape(Layer):
         self.new_shape_fn = new_shape_fn
         self.params = []
 
-    def output(self, train):
-        X = self.get_input(train)
-        nshape = self.new_shape_fn(self.get_nb_samples(), X.shape)
+    def output(self, train, batch_size):
+        X = self.get_input(train, batch_size)
+        nshape = self.new_shape_fn(batch_size, X.shape)
         return theano.tensor.reshape(X, nshape)
 
 
@@ -154,8 +154,8 @@ class Dense(Layer):
         if weights is not None:
             self.set_weights(weights)
 
-    def output(self, train):
-        X = self.get_input(train)
+    def output(self, train, batch_size):
+        X = self.get_input(train, batch_size)
         output = self.activation(T.dot(X, self.W) + self.b)
         return output
 

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -32,6 +32,9 @@ class Layer(object):
             weights.append(p.get_value())
         return weights
 
+    def get_nb_samples(self):
+        return 2
+
 
 class Dropout(Layer):
     '''
@@ -78,6 +81,24 @@ class Reshape(Layer):
     def output(self, train):
         X = self.get_input(train)
         nshape = make_tuple(X.shape[0], *self.dims)
+        return theano.tensor.reshape(X, nshape)
+
+class AdvancedReshape(Layer):
+    '''
+        Reshape an output to a certain shape.
+        Allows advanced reshaping, such that the total size of the array is maintained before and after reshaping,
+            with no other restrictions.
+        Can't be used as first layer in a model (no fixed input!)
+        Example of usage: Reshaping a 2D batch of inputs into a tensor3 (and/or back again)
+    '''
+    def __init__(self, new_shape_fn):
+        assert(callable(new_shape_fn))
+        self.new_shape_fn = new_shape_fn
+        self.params = []
+
+    def output(self, train):
+        X = self.get_input(train)
+        nshape = self.new_shape_fn(self.get_nb_samples(), X.shape)
         return theano.tensor.reshape(X, nshape)
 
 

--- a/keras/layers/normalization.py
+++ b/keras/layers/normalization.py
@@ -20,8 +20,8 @@ class BatchNormalization(Layer):
         if weights is not None:
             self.set_weights(weights)
 
-    def output(self, train):
-        X = self.get_input(train)
+    def output(self, train, batch_size):
+        X = self.get_input(train, batch_size)
         X_normed = (X - X.mean(keepdims=True)) / (X.std(keepdims=True) + self.epsilon)
         out = self.gamma * X_normed + self.beta
         return out

--- a/keras/layers/normalization.py
+++ b/keras/layers/normalization.py
@@ -20,8 +20,8 @@ class BatchNormalization(Layer):
         if weights is not None:
             self.set_weights(weights)
 
-    def output(self, train, batch_size):
-        X = self.get_input(train, batch_size)
+    def output(self, train, current_batch_size):
+        X = self.get_input(train, current_batch_size)
         X_normed = (X - X.mean(keepdims=True)) / (X.std(keepdims=True) + self.epsilon)
         out = self.gamma * X_normed + self.beta
         return out

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -43,8 +43,8 @@ class SimpleRNN(Layer):
         '''
         return self.activation(x_t + T.dot(h_tm1, u))
 
-    def output(self, train, batch_size):
-        X = self.get_input(train, batch_size) # shape: (nb_samples, time (padded with zeros at the end), input_dim)
+    def output(self, train, current_batch_size):
+        X = self.get_input(train, current_batch_size) # shape: (nb_samples, time (padded with zeros at the end), input_dim)
         # new shape: (time, nb_samples, input_dim) -> because theano.scan iterates over main dimension
         X = X.dimshuffle((1,0,2)) 
 
@@ -105,8 +105,8 @@ class SimpleDeepRNN(Layer):
             o += self.inner_activation(T.dot(args[i], args[i+self.depth]))
         return o        
 
-    def output(self, train, batch_size):
-        X = self.get_input(train, batch_size)
+    def output(self, train, current_batch_size):
+        X = self.get_input(train, current_batch_size)
         X = X.dimshuffle((1,0,2)) 
 
         x = T.dot(X, self.W) + self.b
@@ -196,8 +196,8 @@ class GRU(Layer):
         h_t = z * h_tm1 + (1 - z) * hh_t
         return h_t
 
-    def output(self, train, batch_size):
-        X = self.get_input(train, batch_size)
+    def output(self, train, current_batch_size):
+        X = self.get_input(train, current_batch_size)
         X = X.dimshuffle((1,0,2)) 
 
         x_z = T.dot(X, self.W_z) + self.b_z
@@ -294,8 +294,8 @@ class LSTM(Layer):
         h_t = o_t * self.activation(c_t)
         return h_t, c_t
 
-    def output(self, train, batch_size):
-        X = self.get_input(train, batch_size)
+    def output(self, train, current_batch_size):
+        X = self.get_input(train, current_batch_size)
         X = X.dimshuffle((1,0,2))
 
         xi = T.dot(X, self.W_i) + self.b_i

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -43,8 +43,8 @@ class SimpleRNN(Layer):
         '''
         return self.activation(x_t + T.dot(h_tm1, u))
 
-    def output(self, train):
-        X = self.get_input(train) # shape: (nb_samples, time (padded with zeros at the end), input_dim)
+    def output(self, train, batch_size):
+        X = self.get_input(train, batch_size) # shape: (nb_samples, time (padded with zeros at the end), input_dim)
         # new shape: (time, nb_samples, input_dim) -> because theano.scan iterates over main dimension
         X = X.dimshuffle((1,0,2)) 
 
@@ -105,8 +105,8 @@ class SimpleDeepRNN(Layer):
             o += self.inner_activation(T.dot(args[i], args[i+self.depth]))
         return o        
 
-    def output(self, train):
-        X = self.get_input(train)
+    def output(self, train, batch_size):
+        X = self.get_input(train, batch_size)
         X = X.dimshuffle((1,0,2)) 
 
         x = T.dot(X, self.W) + self.b
@@ -196,8 +196,8 @@ class GRU(Layer):
         h_t = z * h_tm1 + (1 - z) * hh_t
         return h_t
 
-    def output(self, train):
-        X = self.get_input(train) 
+    def output(self, train, batch_size):
+        X = self.get_input(train, batch_size)
         X = X.dimshuffle((1,0,2)) 
 
         x_z = T.dot(X, self.W_z) + self.b_z
@@ -294,8 +294,8 @@ class LSTM(Layer):
         h_t = o_t * self.activation(c_t)
         return h_t, c_t
 
-    def output(self, train):
-        X = self.get_input(train) 
+    def output(self, train, batch_size):
+        X = self.get_input(train, batch_size)
         X = X.dimshuffle((1,0,2))
 
         xi = T.dot(X, self.W_i) + self.b_i

--- a/keras/models.py
+++ b/keras/models.py
@@ -92,7 +92,6 @@ class Sequential(object):
                 loss = self._train(X_batch, y_batch)
                 
                 if verbose:
-                    print "BI:,", batch_index, "m1:,", nb_batch - 1, "\n"
                     is_last_batch = (batch_index == nb_batch - 1)
                     if not is_last_batch or not do_validation:
                         progbar.update(batch_end, [('loss', loss)])

--- a/keras/models.py
+++ b/keras/models.py
@@ -30,8 +30,8 @@ class Sequential(object):
 
         self.X = self.layers[0].input # input of model 
         # (first layer must have an "input" attribute!)
-        self.y_train = self.layers[-1].output(train=True)
-        self.y_test = self.layers[-1].output(train=False)
+        self.y_train = self.layers[-1].output(train=True, batch_size=self.X.shape[0])
+        self.y_test = self.layers[-1].output(train=False, batch_size=self.X.shape[0])
 
         # output of model
         self.Y = T.matrix() # TODO: support for custom output shapes
@@ -80,7 +80,7 @@ class Sequential(object):
             if shuffle:
                 np.random.shuffle(index_array)
 
-            nb_batch = len(X)/batch_size+1
+            nb_batch = int(np.ceil(len(X)/float(batch_size)))
             progbar = Progbar(target=len(X))
             for batch_index in range(0, nb_batch):
                 batch_start = batch_index*batch_size
@@ -92,6 +92,7 @@ class Sequential(object):
                 loss = self._train(X_batch, y_batch)
                 
                 if verbose:
+                    print "BI:,", batch_index, "m1:,", nb_batch - 1, "\n"
                     is_last_batch = (batch_index == nb_batch - 1)
                     if not is_last_batch or not do_validation:
                         progbar.update(batch_end, [('loss', loss)])

--- a/keras/models.py
+++ b/keras/models.py
@@ -30,8 +30,8 @@ class Sequential(object):
 
         self.X = self.layers[0].input # input of model 
         # (first layer must have an "input" attribute!)
-        self.y_train = self.layers[-1].output(train=True, batch_size=self.X.shape[0])
-        self.y_test = self.layers[-1].output(train=False, batch_size=self.X.shape[0])
+        self.y_train = self.layers[-1].output(train=True, current_batch_size=self.X.shape[0])
+        self.y_test = self.layers[-1].output(train=False, current_batch_size=self.X.shape[0])
 
         # output of model
         self.Y = T.matrix() # TODO: support for custom output shapes


### PR DESCRIPTION
I've added a bit of an architecture change, as well as a new layer to allow Advanced Reshaping.

Basically, to allow reshapes involving the first dimension, the number of samples in the current batch (`current_batch_size`) must be available to the AdvancedReshape layer. The easiest way that I could see to allow that is to throw a new parameter (`current_batch_size`) to the `Layer.output` function. This recursively passes the current number of samples in the batch to each layer, so that it has it available if it is necessary. This required touching every layer.

The AdvancedReshape layer takes a lambda expression for the initialization parameter. This lambda should take 2 arguments: current_batch_size and current_shape (can be seen below). From these parameters, it is possible to reshape between 1D, 2D, 3D (and possibly to ND, although I am unsure on that). *This lambda should return a tuple.*

Below is an example in which the current_batch_size changes on the pass over the last batch. It is simplistic and not overly useful, but it shows that AdvancedReshape can correctly reshape from 2D -> 3D and then from 3D -> 2D without breaking over the toughest example:
```python
model = Sequential()
model.add(Dense(2,1, activation='sigmoid'))

# Reshape to 3D: (number of sample in current batch, elements in each sample, values)
model.add(AdvancedReshape(new_shape_fn=lambda current_batch_size, current_shape: (current_batch_size, current_shape[0]/current_batch_size, current_shape[1])))
# Reshape back to 2D ((number of sample in current batch * elements in each sample, values))
model.add(AdvancedReshape(new_shape_fn=lambda current_batch_size, current_shape: (current_batch_size * current_shape[1], current_shape[2])))

sgd = SGD(lr=0.1, decay=1e-6, momentum=0.9, nesterov=True)
model.compile(loss='mse', optimizer='sgd')

X = np.zeros((3,2))
Y = np.zeros((3,1))
model.fit(X, Y, batch_size=2, nb_epoch=1)
```
```
Epoch 0
2/3 [===================>..........] - ETA: 0s - loss: 0.2500
3/3 [==============================] - 0s - loss: 0.2497
```