### PR TITLE
Added Clip layer for clipping of outputs

### DIFF
--- a/keras/activations.py
+++ b/keras/activations.py
@@ -28,12 +28,6 @@ def hard_sigmoid(x):
 def linear(x):
     return x
 
-def clip_high(x, high):
-    return T.minimum(x, high)
-
-def clip_low(x, low):
-    return T.maximum(x, low)
-
 from utils.generic_utils import get_from_module
 def get(identifier):
     return get_from_module(identifier, globals(), 'activation function')

--- a/keras/activations.py
+++ b/keras/activations.py
@@ -28,6 +28,12 @@ def hard_sigmoid(x):
 def linear(x):
     return x
 
+def clip_high(x, high):
+    return T.minimum(x, high)
+
+def clip_low(x, low):
+    return T.maximum(x, low)
+
 from utils.generic_utils import get_from_module
 def get(identifier):
     return get_from_module(identifier, globals(), 'activation function')

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -65,6 +65,24 @@ class Activation(Layer):
         return self.activation(X)
 
 
+class Clip(Layer):
+    '''
+        Apply a clipping (low, high or both) to an activation
+    '''
+    def __init__(self, low=None, high=None):
+        self.low = low
+        self.high = high
+        self.params = []
+
+    def output(self, train):#, current_batch_size):
+        X = self.get_input(train)#, current_batch_size)
+        if self.low is not None:
+            X = activations.clip_low(X, self.low)
+        if self.high is not None:
+            X = activations.clip_high(X, self.high)
+        return X
+
+
 class Reshape(Layer):
     '''
         Reshape an output to a certain shape.

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import theano
 import theano.tensor as T
+import numpy as np
 
 from .. import activations, initializations
 from ..utils.theano_utils import shared_zeros, floatX
@@ -69,18 +70,14 @@ class Clip(Layer):
     '''
         Apply a clipping (low, high or both) to an activation
     '''
-    def __init__(self, low=None, high=None):
+    def __init__(self, low=-np.inf, high=np.inf):
         self.low = low
         self.high = high
         self.params = []
 
     def output(self, train):#, current_batch_size):
         X = self.get_input(train)#, current_batch_size)
-        if self.low is not None:
-            X = activations.clip_low(X, self.low)
-        if self.high is not None:
-            X = activations.clip_high(X, self.high)
-        return X
+        return T.maximum(T.minimum(X, self.high), self.low)
 
 
 class Reshape(Layer):


### PR DESCRIPTION
**DON'T MERGE - LET ME KNOW IF MERGE #36 IS USED - Either way, there is an additional commit that will need to be applied.**

This provides the ability to apply a clipping to a Layer. Clipping is sometimes used to defend against output saturation and vanishing gradient.

EX:
```python
model = Sequential()
model.add(Dense(2,1, activation='sigmoid', init='example_normal')) # this example_normal is an additional PR
model.add(Clip(high=.32, low=.20))


sgd = SGD(lr=0.1, decay=1e-6, momentum=0.9, nesterov=True)
model.compile(loss='mse', optimizer='sgd')

A = model._predict(np.asarray([[1,1],[2,2]]))
print A
```
Yields
```
[[ 0.31999999]
 [ 0.2       ]]
```