### PR TITLE
Added an Example initialization such that example code can provide consistent outputs

### DIFF
--- a/keras/initializations.py
+++ b/keras/initializations.py
@@ -4,6 +4,14 @@ import numpy as np
 
 from utils.theano_utils import sharedX
 
+def example_normal(shape):
+    rng = np.random.RandomState(1234)
+    return sharedX(rng.normal(size=shape))
+
+def example_uniform(shape):
+    rng = np.random.RandomState(1234)
+    return sharedX(rng.uniform(size=shape))
+
 def uniform(shape, scale=0.05):
     return sharedX(np.random.uniform(low=-scale, high=scale, size=shape))
 


### PR DESCRIPTION
I've added two initialization schemas that allow for the consistent generation of weights.

In theory, coupled with setting `shuffle=False` in `model.fit()`, this should allow for example code to be run and achieve the same output.

This may also be useful for automated testing in the future.