### PR TITLE
New initializations

### DIFF
--- a/docs/sources/initializations.md
+++ b/docs/sources/initializations.md
@@ -17,3 +17,5 @@ model.add(Dense(64, 64, init='uniform'))
 - __normal__
 - __orthogonal__: Use with square 2D layers (`shape[0] == shape[1]`).
 - __zero__
+- __glorot_normal__: Gaussian initialization scaled by fan_in + fan_out (Glorot 2010)
+- __he_normal__: Gaussian initialization scaled by fan_in (He et al., 2014)

--- a/keras/initializations.py
+++ b/keras/initializations.py
@@ -20,6 +20,21 @@ def lecun_uniform(shape):
     scale = 1./np.sqrt(m)
     return uniform(shape, scale)
 
+def glorot_normal(shape):
+    ''' Reference: Glorot & Bengio, AISTATS 2010
+    '''
+    fan_in = shape[0] if len(shape) == 2 else np.prod(shape[1:])
+    fan_out = shape[1] if len(shape) == 2 else shape[0]
+    s = np.sqrt(2. / (fan_in + fan_out)
+    return normal(shape, s)
+
+def he_normal(shape):
+    ''' Reference:  He et al., http://arxiv.org/abs/1502.01852
+    '''
+    fan_in = shape[1] if len(shape) == 2 else np.prod(shape[1:])
+    s = np.sqrt(2. / fan_in)
+    return normal(shape, s)
+
 def orthogonal(shape, scale=1.1):
     ''' From Lasagne
     '''

--- a/keras/initializations.py
+++ b/keras/initializations.py
@@ -25,7 +25,7 @@ def glorot_normal(shape):
     '''
     fan_in = shape[0] if len(shape) == 2 else np.prod(shape[1:])
     fan_out = shape[1] if len(shape) == 2 else shape[0]
-    s = np.sqrt(2. / (fan_in + fan_out)
+    s = np.sqrt(2. / (fan_in + fan_out))
     return normal(shape, s)
 
 def he_normal(shape):


### PR DESCRIPTION
This PR adds two new initialization methods:

*    The method from "Understanding the difficulty of training deep feedforward neural networks", Glorot & Bengio, AISTATS 2010. This works very well for sigmoid/tanh activation functions. This is known as the "xavier" initialization in Caffe, where it is the default initialization method for dense layers.

*    The improvements on the above method made by He et. al, which they showed works much better when using ReLU activation functions.


This time, care was taken that everything runs under Py2, and also works with convolutional layers.