### PR TITLE
Added helper class to use data in HDF5 datasets

### DIFF
--- a/keras/utils/io_utils.py
+++ b/keras/utils/io_utils.py
@@ -1,0 +1,52 @@
+import h5py, numpy
+from collections import defaultdict
+
+class HDF5Matrix:
+    
+    refs = defaultdict(int)
+
+    def __init__(self, datapath, dataset, start, end, normalizer=None):
+        if datapath not in self.refs.keys():
+            f = h5py.File(datapath)
+            self.refs[datapath] = f
+        else:
+            f = self.refs[datapath]
+        self.start = start
+        self.end = end
+        self.data = f[dataset]
+        self.normalizer = normalizer
+    
+    def __len__(self):
+        return self.end - self.start
+
+    def __getitem__(self, key):
+        if isinstance(key, slice):
+            if key.stop + self.start <= self.end:
+                idx = slice(key.start+self.start, key.stop + self.start)
+            else:
+                raise IndexError
+        elif isinstance(key, int):
+            if key + self.start < self.end:
+                idx = key+self.start
+            else:
+                raise IndexError
+        elif isinstance(key, numpy.ndarray):
+            if numpy.max(key) + self.start < self.end:
+                idx = (self.start + key).tolist()
+            else:
+                raise IndexError
+        elif isinstance(key, list):
+            if max(key) + self.start < self.end:
+                idx = map(lambda x: x + self.start, key)
+            else:
+                raise IndexError
+        if self.normalizer is not None:
+            return self.normalizer(self.data[idx])
+        else:
+            return self.data[idx]
+
+    @property
+    def shape(self):
+        return tuple([self.end - self.start, self.data.shape[1]])
+
+


### PR DESCRIPTION
This class enables one to use slices of datasets in an HDF5 file as matrices for training/testing algorithms in keras.

Usage example:

```
X_train = HDF5Matrix(datapath, 'features', train_start, train_start+n_training_examples, normalizer=normalize_data)
y_train = HDF5Matrix(datapath, 'targets', train_start, train_start+n_training_examples)
```

The arguments are:
`datapath`: path to HDF5 file
`dataset`: name of the dataset in the HDF5 from which to take the data
`start` and `end`: indices to slice the given dataset
`normalizer`: function to be applied to the data coming from the dataset on-the-fly. Can be used for centering/standardizing/scaling data, but cannot change the dimensions of the data in any way.