### PR TITLE
Python3 compatibility

### DIFF
--- a/keras/datasets/cifar10.py
+++ b/keras/datasets/cifar10.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import
 from .data_utils import get_file
 import random
+import sys
 import numpy as np
 import six.moves.cPickle
 from six.moves import range
@@ -17,11 +18,18 @@ def load_data(test_split=0.1, seed=113):
     for i in range(1, 6):
         fpath = path + '/data_batch_' + str(i)
         f = open(fpath, 'rb')
-        d = six.moves.cPickle.load(f)
+        if sys.version_info < (3,):
+            d = six.moves.cPickle.load(f)
+        else:
+            d = six.moves.cPickle.load(f, encoding="bytes")
+            # decode utf8
+            for k, v in d.items():
+                del(d[k])
+                d[k.decode("utf8")] = v
         f.close()
         data = d["data"]
         labels = d["labels"]
-        
+
         data = data.reshape(data.shape[0], 3, 32, 32)
         X[(i-1)*10000:i*10000, :, :, :] = data
         y[(i-1)*10000:i*10000] = labels
@@ -40,4 +48,3 @@ def load_data(test_split=0.1, seed=113):
     y_test = y[int(len(X)*(1-test_split)):]
 
     return (X_train, y_train), (X_test, y_test)
-

--- a/keras/datasets/data_utils.py
+++ b/keras/datasets/data_utils.py
@@ -41,6 +41,3 @@ def get_file(fname, origin, untar=False):
         return untar_fpath
 
     return fpath
-
-
-

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import theano
 import theano.tensor as T
@@ -38,7 +38,7 @@ class Layer(object):
 
 class Dropout(Layer):
     '''
-        Hinton's dropout. 
+        Hinton's dropout.
     '''
     def __init__(self, p):
         self.p = p
@@ -94,7 +94,7 @@ class Flatten(Layer):
 
     def output(self, train):
         X = self.get_input(train)
-        size = theano.tensor.prod(X.shape) / X.shape[0]
+        size = theano.tensor.prod(X.shape) // X.shape[0]
         nshape = (X.shape[0], size)
         return theano.tensor.reshape(X, nshape)
 
@@ -143,7 +143,7 @@ class Dense(Layer):
 
 class TimeDistributedDense(Layer):
     '''
-       Apply a same DenseLayer for each dimension[1] (shared_dimension) input 
+       Apply a same DenseLayer for each dimension[1] (shared_dimension) input
        Especially useful after a recurrent network with 'return_sequence=True'
        Tensor input dimensions:   (nb_sample, shared_dimension, input_dim)
        Tensor output dimensions:  (nb_sample, shared_dimension, output_dim)
@@ -174,5 +174,3 @@ class TimeDistributedDense(Layer):
                                 sequences = X.dimshuffle(1,0,2),
                                 outputs_info=None)
         return output.dimshuffle(1,0,2)
-
-


### PR DESCRIPTION
This PR fixes two py3 compatibility issues

1. It fixes a float<>integer division problem in the `Flatten` layer (This layer is broken in py3 without this fix)
2. It makes sure that CIFAR10 can be loaded without re-pickling on Python 3: a fix was introduced today to make downloading possible, but the pickle file is still a bit tricky to load in py3. This PR fixes that.
