### PR TITLE
Added layer config info to exported HDF5 file

### DIFF
--- a/keras/models.py
+++ b/keras/models.py
@@ -236,6 +236,8 @@ class Sequential(object):
                 param_name = 'param_{}'.format(n)
                 param_dset = g.create_dataset(param_name, param.shape, dtype='float64')
                 param_dset[:] = param
+            for k, v in l.get_config().items():
+                g.attrs[k] = v
         f.flush()
         f.close()
 


### PR DESCRIPTION
Adding layer configuration info as attributes to the corresponding layer group in the HDF5 file exported by `model.save_weights`. For now this information is ignored when loading weights from a file, but it may be useful for reconstructing a model in case a user loses the corresponding source code.