### PR TITLE
Make Progressbar work in IPython notebooks

### DIFF
--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -48,7 +48,7 @@ class Progbar(object):
         now = time.time()
         if self.verbose == 1:
             prev_total_width = self.total_width
-            sys.stdout.write("\b" * (self.total_width+1))
+            sys.stdout.write("\r")
 
             bar = '%d/%d [' % (current, self.target)
             prog = float(current)/self.target
@@ -63,7 +63,7 @@ class Progbar(object):
             bar += ']'
             sys.stdout.write(bar)
             self.total_width = len(bar)
-            
+
             if current:
                 time_per_unit = (now - self.start) / current
             else:


### PR DESCRIPTION
Currently, the Progressbar doesn't play nice within IPython-notebooks ( http://imgur.com/UOyIloR ). Using "\r" instead of  several "\b" works well (both on the shell and within notebooks). I tested it under Linux only, but PyMC's progressbar also uses "\r", so I assume this works on every plattform.