### PR TITLE
Remove the dot in the path

### DIFF
--- a/keras/datasets/data_utils.py
+++ b/keras/datasets/data_utils.py
@@ -5,7 +5,7 @@ from six.moves.urllib.request import urlretrieve
 from ..utils.generic_utils import Progbar
 
 def get_file(fname, origin, untar=False):
-    datadir = os.path.expanduser("~/.keras/datasets")
+    datadir = os.path.expanduser("~/keras/datasets")
     if not os.path.exists(datadir):
         os.makedirs(datadir)
 


### PR DESCRIPTION
`datadir = os.path.expanduser("~/.keras/datasets")`, the dot causes error when testing `cifar10.py` in Windows 7. After remove the dot in the path, it's ok.