### PR TITLE
Fix save_weights in models.py when None

### DIFF
--- a/keras/models.py
+++ b/keras/models.py
@@ -237,7 +237,8 @@ class Sequential(object):
                 param_dset = g.create_dataset(param_name, param.shape, dtype='float64')
                 param_dset[:] = param
             for k, v in l.get_config().items():
-                g.attrs[k] = v
+                if v is not None:
+                    g.attrs[k] = v
         f.flush()
         f.close()
 


### PR DESCRIPTION
Hi,
h5py cannot handle None, so when I call save_weights  on model with default parameters (for example image_shape in Conv) I got error. So I just ignored None values.
