### PR TITLE
Add regularization and constraints to layers

### DIFF
--- a/keras/models.py
+++ b/keras/models.py
@@ -25,12 +25,16 @@ class Sequential(object):
     def __init__(self):
         self.layers = []
         self.params = []
+        self.regularizer = []
+        self.constraint = []
 
     def add(self, layer):
         self.layers.append(layer)
         if len(self.layers) > 1:
             self.layers[-1].connect(self.layers[-2])
         self.params += [p for p in layer.params]
+        self.regularizer += [r for r in layer.regularizer]
+        self.constraint += [c for c in layer.constraint]
 
     def compile(self, optimizer, loss, class_mode="categorical"):
         self.optimizer = optimizers.get(optimizer)
@@ -58,7 +62,7 @@ class Sequential(object):
             raise Exception("Invalid class mode:" + str(class_mode))
         self.class_mode = class_mode
 
-        updates = self.optimizer.get_updates(self.params, train_loss)
+        updates = self.optimizer.get_updates(self.params, self.regularizer, self.constraint, train_loss)
 
         self._train = theano.function([self.X, self.y], train_loss, 
             updates=updates, allow_input_downcast=True)


### PR DESCRIPTION
I went ahead and implemented layerwise regularization and constraints. They can be used as:

from keras.layers.core import l1, l2, ident, maxnorm
model.add(Dense(784, 1000,  regularizer=[l2(.05), ident], constraint=[maxnorm(2), ident]))

The first term applies to the weights and the second to the bias. ident is just the identity function and is the default.

