### PR TITLE
Fixed path concatenation for datasets

### DIFF
--- a/keras/datasets/cifar10.py
+++ b/keras/datasets/cifar10.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import
 from .data_utils import get_file
 import random
-import sys
+import sys, os
 import numpy as np
 import six.moves.cPickle
 from six.moves import range
@@ -16,7 +16,7 @@ def load_data(test_split=0.1, seed=113):
     X = np.zeros((nb_samples, 3, 32, 32), dtype="uint8")
     y = np.zeros((nb_samples,), dtype="uint8")
     for i in range(1, 6):
-        fpath = path + '/data_batch_' + str(i)
+        fpath = os.path.join(path, 'data_batch_' + str(i))
         f = open(fpath, 'rb')
         if sys.version_info < (3,):
             d = six.moves.cPickle.load(f)

--- a/keras/datasets/data_utils.py
+++ b/keras/datasets/data_utils.py
@@ -5,7 +5,7 @@ from six.moves.urllib.request import urlretrieve
 from ..utils.generic_utils import Progbar
 
 def get_file(fname, origin, untar=False):
-    datadir = os.path.expanduser("~/.keras/datasets")
+    datadir = os.path.expanduser(os.path.join('~', '.keras', 'datasets'))
     if not os.path.exists(datadir):
         os.makedirs(datadir)
 

--- a/keras/datasets/reuters.py
+++ b/keras/datasets/reuters.py
@@ -4,11 +4,11 @@ from __future__ import print_function
 from .data_utils import get_file
 import string
 import random
+import os
 import six.moves.cPickle
 from six.moves import zip
 
-def make_reuters_dataset(path='datasets/temp/reuters21578/', min_samples_per_topic=15):
-    import os
+def make_reuters_dataset(path=os.path.join('datasets', 'temp', 'reuters21578'), min_samples_per_topic=15):
     import re
     from ..preprocessing.text import Tokenizer
 
@@ -74,8 +74,8 @@ def make_reuters_dataset(path='datasets/temp/reuters21578/', min_samples_per_top
     dataset = (X, labels) 
     print('-')
     print('Saving...')
-    six.moves.cPickle.dump(dataset, open('datasets/data/reuters.pkl', 'w'))
-    six.moves.cPickle.dump(tokenizer.word_index, open('datasets/data/reuters_word_index.pkl', 'w'))
+    six.moves.cPickle.dump(dataset, open(os.path.join('datasets', 'data', 'reuters.pkl'), 'w'))
+    six.moves.cPickle.dump(tokenizer.word_index, open(os.path.join('datasets','data', 'reuters_word_index.pkl'), 'w'))
 
 
 


### PR DESCRIPTION
Using `os.path.join` to generate paths according to the user's OS (i.e., using `\` as the file path separator on Windows and `/` on POSIX). This was tested on OS X and Windows 8, both with Python 2.7 and Python 3.4.