### PR TITLE
Layerwise constraints and regularization

### DIFF
--- a/docs/sources/activations.md
+++ b/docs/sources/activations.md
@@ -28,7 +28,7 @@ You can also specifiy a desired `target` for the average activation of hidden un
 This is accomplished by a generalized KL divergence penalty on the activations. The weighting of this penalty is determined by `beta`:
 
 ```python
-model.add(Activation('tanh', target=.05, beta=.1))
+model.add(Activation('relu', target=.05, beta=.1))
 ```
 
 ## Available activations

--- a/docs/sources/activations.md
+++ b/docs/sources/activations.md
@@ -24,6 +24,13 @@ model.add(Dense(20, 64, init='uniform', activation=tanh))
 model.add(Activation(tanh))
 ```
 
+You can also specifiy a desired `target` for the average activation of hidden units in a layer.
+This is accomplished by a generalized KL divergence penalty on the activations. The weighting of this penalty is determined by `beta`:
+
+```python
+model.add(Activation('tanh', target=.05, beta=.1))
+```
+
 ## Available activations
 
 - __softmax__: Should only be applied to 2D layers (expected shape: `(nb_samples, nb_dims)`).

--- a/docs/sources/constraints.md
+++ b/docs/sources/constraints.md
@@ -4,16 +4,17 @@
 
 Regularizers allow the use of penalties on particular sets of parameters during optimization.
 
-A constraint is initilized with the value of the constraint: `maxnorm(1)`
+A constraint is initilized with the value of the constraint. 
+For example `maxnorm(3)` will constrain the weight vector to each hidden unit to have a maximum norm of 3.
 The keyword arguments used for passing constraints to parameters in a layer will depend on the layer. 
-For weights in the `Dense` layer it is simply `W_constraint`
-For biases in the `Dense` layer it is simply `b_constraint`
+For weights in the `Dense` layer it is simply `W_constraint`.
+For biases in the `Dense` layer it is simply `b_constraint`.
 
 ```python
 model.add(Dense(64, 64, W_constraint = maxnorm(2)))
 ```
 
-## Available penalties
+## Available constraints
 
 - __maxnorm__: maximum-norm constraint
 - __nonneg__: non-negative constraint

--- a/docs/sources/constraints.md
+++ b/docs/sources/constraints.md
@@ -1,0 +1,19 @@
+#Constraints
+
+## Usage of constraints
+
+Regularizers allow the use of penalties on particular sets of parameters during optimization.
+
+A constraint is initilized with the value of the constraint: `maxnorm(1)`
+The keyword arguments used for passing constraints to parameters in a layer will depend on the layer. 
+For weights in the `Dense` layer it is simply `W_constraint`
+For biases in the `Dense` layer it is simply `b_constraint`
+
+```python
+model.add(Dense(64, 64, W_constraint = maxnorm(2)))
+```
+
+## Available penalties
+
+- __maxnorm__: maximum-norm constraint
+- __nonneg__: non-negative constraint

--- a/docs/sources/optimizers.md
+++ b/docs/sources/optimizers.md
@@ -28,12 +28,9 @@ model.compile(loss='mean_squared_error', optimizer='sgd')
 keras.optimizers.Optimizer(**kwargs)
 ```
 
-All optimizers descended from this class support the following keyword arguments:
+All optimizers descended from this class support the following keyword argument:
 
-- __l1__: float >= 0. L1 regularization penalty.
-- __l2__: float >= 0. L2 regularization penalty.
 - __clipnorm__: float >= 0.
-- __maxnorm__: float >= 0.
 
 Note: this is base class for building optimizers, not an actual optimizer that can be used for training models.
 

--- a/docs/sources/regularizers.md
+++ b/docs/sources/regularizers.md
@@ -4,10 +4,10 @@
 
 Regularizers allow the use of penalties on particular sets of parameters during optimization.
 
-A penalty is initilized with its weight during optimization: `l1(.05)`
+A penalty is initilized with its weight during optimization: `l1(.05)`.
 The keyword arguments used for passing penalties to parameters in a layer will depend on the layer. 
-For weights in the `Dense` layer it is simply `W_regularizer`
-For biases in the `Dense` layer it is simply `b_regularizer`
+For weights in the `Dense` layer it is simply `W_regularizer`.
+For biases in the `Dense` layer it is simply `b_regularizer`.
 
 ```python
 model.add(Dense(64, 64, W_regularizer = l2(.01)))
@@ -16,4 +16,4 @@ model.add(Dense(64, 64, W_regularizer = l2(.01)))
 ## Available penalties
 
 - __l1__: L1 regularization penalty, also known as LASSO
-- __l2__: L2 regularization penalty, also known as weight decay
+- __l2__: L2 regularization penalty, also known as weight decay, or Ridge

--- a/docs/sources/regularizers.md
+++ b/docs/sources/regularizers.md
@@ -1,0 +1,19 @@
+# Regularizers
+
+## Usage of regularizers
+
+Regularizers allow the use of penalties on particular sets of parameters during optimization.
+
+A penalty is initilized with its weight during optimization: `l1(.05)`
+The keyword arguments used for passing penalties to parameters in a layer will depend on the layer. 
+For weights in the `Dense` layer it is simply `W_regularizer`
+For biases in the `Dense` layer it is simply `b_regularizer`
+
+```python
+model.add(Dense(64, 64, W_regularizer = l2(.01)))
+```
+
+## Available penalties
+
+- __l1__: L1 regularization penalty, also known as LASSO
+- __l2__: L2 regularization penalty, also known as weight decay

--- a/examples/mnist_nn.py
+++ b/examples/mnist_nn.py
@@ -1,0 +1,51 @@
+from __future__ import absolute_import
+from __future__ import print_function
+import keras
+from keras.datasets import mnist
+import keras.models
+from keras.models import Sequential
+from keras.layers.core import Dense, Dropout, Activation
+from keras.regularizers import l2, l1
+from keras.constraints import maxnorm
+from keras.optimizers import SGD, Adam, RMSprop
+
+'''
+    Train a (fairly simple) deep NN on the MNIST dataset.
+
+'''
+
+batch_size = 100
+nb_classes = 10
+nb_epoch = 200
+
+# the data, shuffled and split between tran and test sets
+(X_train, y_train), (X_test, y_test) = mnist.load_data(test_split=0.1)
+print(X_train.shape[0], 'train samples')
+print(X_test.shape[0], 'test samples')
+
+# convert class vectors to binary class matrices
+Y_train = np_utils.to_categorical(y_train, nb_classes)
+Y_test = np_utils.to_categorical(y_test, nb_classes)
+
+model = Sequential()
+model.add(Dense(784, 100, W_constraint=maxnorm(3)))
+model.add(Activation('relu'))
+model.add(Dropout(0.25))
+model.add(Dense(100, 100))
+model.add(Activation('relu'))
+model.add(Dropout(0.25))
+model.add(Dense(100, 10, W_constraint=maxnorm(3)))
+model.add(Activation('softmax'))
+
+
+# let's train the model using SGD + momentum (how original).
+sgd = SGD(lr=0.01, decay=1e-6, momentum=0.9, nesterov=True)
+model.compile(loss='categorical_crossentropy', optimizer=sgd)
+
+X_train = X_train.astype("float32")
+X_test = X_test.astype("float32")
+X_train /= 255
+X_test /= 255
+model.fit(X_train, Y_train, batch_size=batch_size, nb_epoch=10)
+score = model.evaluate(X_test, Y_test, batch_size=batch_size)
+print('Test score:', score)

--- a/examples/mnist_nn.py
+++ b/examples/mnist_nn.py
@@ -8,6 +8,7 @@ from keras.layers.core import Dense, Dropout, Activation
 from keras.regularizers import l2, l1
 from keras.constraints import maxnorm
 from keras.optimizers import SGD, Adam, RMSprop
+from keras.utils import np_utils, generic_utils
 
 '''
     Train a (fairly simple) deep NN on the MNIST dataset.
@@ -16,10 +17,16 @@ from keras.optimizers import SGD, Adam, RMSprop
 
 batch_size = 100
 nb_classes = 10
-nb_epoch = 200
+nb_epoch = 20
 
 # the data, shuffled and split between tran and test sets
-(X_train, y_train), (X_test, y_test) = mnist.load_data(test_split=0.1)
+(X_train, y_train), (X_test, y_test) = mnist.load_data()
+X_train=X_train.reshape(60000,784)
+X_test=X_test.reshape(10000,784)
+X_train = X_train.astype("float32")
+X_test = X_test.astype("float32")
+X_train /= 255
+X_test /= 255
 print(X_train.shape[0], 'train samples')
 print(X_test.shape[0], 'test samples')
 
@@ -30,22 +37,19 @@ Y_test = np_utils.to_categorical(y_test, nb_classes)
 model = Sequential()
 model.add(Dense(784, 100, W_constraint=maxnorm(3)))
 model.add(Activation('relu'))
-model.add(Dropout(0.25))
+model.add(Dropout(0.1))
 model.add(Dense(100, 100))
 model.add(Activation('relu'))
-model.add(Dropout(0.25))
+model.add(Dropout(0.1))
 model.add(Dense(100, 10, W_constraint=maxnorm(3)))
 model.add(Activation('softmax'))
 
 
 # let's train the model using SGD + momentum (how original).
-sgd = SGD(lr=0.01, decay=1e-6, momentum=0.9, nesterov=True)
-model.compile(loss='categorical_crossentropy', optimizer=sgd)
+rms = RMSprop()
+model.compile(loss='categorical_crossentropy', optimizer=rms)
 
-X_train = X_train.astype("float32")
-X_test = X_test.astype("float32")
-X_train /= 255
-X_test /= 255
-model.fit(X_train, Y_train, batch_size=batch_size, nb_epoch=10)
-score = model.evaluate(X_test, Y_test, batch_size=batch_size)
+
+model.fit(X_train, Y_train, batch_size=batch_size, nb_epoch=nb_epoch, show_accuracy=True, verbose=2)
+score = model.evaluate(X_test, Y_test, show_accuracy=True, verbose=2)
 print('Test score:', score)

--- a/keras/constraints.py
+++ b/keras/constraints.py
@@ -1,0 +1,16 @@
+from __future__ import absolute_import
+import theano
+import theano.tensor as T
+import numpy as np
+
+def maxnorm(m=2):
+    def maxnorm_wrap(p):
+        norms = T.sqrt(T.sum(T.sqr(p), axis=0))
+        desired = T.clip(norms, 0, m)
+        p = p * (desired / (1e-7 + norms))
+        return p
+    return maxnorm_wrap
+
+def nonneg(p):
+    p *= T.ge(p,0)
+    return p

--- a/keras/datasets/mnist.py
+++ b/keras/datasets/mnist.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+# modified from https://github.com/niboshi/mnist_loader.git
+import os
+import urllib
+import urllib2
+import StringIO
+import gzip
+import struct
+import numpy as np
+
+def load_data():
+    (X_train, y_train) = load(set_name='train')
+    (X_test, y_test) = load(set_name='test')
+
+    return (X_train, y_train), (X_test, y_test)
+    
+    
+def open_data_url(url, cache_dir=None):
+    """
+    Opens an URL as a file-like object.
+    """
+
+    if cache_dir is None:
+        cache_dir = os.path.expanduser(os.path.join('~', '.keras', 'datasets','mnist'))
+
+    cache_path = os.path.join(cache_dir, urllib.quote(url, safe=''))
+
+    if os.path.isfile(cache_path):
+        return open(cache_path, 'rb')
+    else:
+        request = urllib2.Request(url)
+        response = urllib2.urlopen(request)
+        buf = StringIO.StringIO()
+        block = 1024
+        while True:
+            data = response.read(block)
+            if data is None:
+                break
+            if len(data) == 0:
+                break
+
+            buf.write(data)
+
+        if not os.path.isdir(os.path.dirname(cache_path)):
+            os.makedirs(os.path.dirname(cache_path))
+        with open(cache_path, 'wb') as fo:
+            fo.write(buf.getvalue())
+
+        buf.seek(0)
+        return buf
+
+def read_data(file_in):
+    """
+    Parses the IDX file format.
+    """
+
+    # Magic code
+    magic = file_in.read(4)
+    magic = [ord(_) for _ in magic]
+    if len(magic) != 4 or magic[0] != 0 or magic[1] != 0:
+        raise RuntimeError("Invalid magic number: [{}]".format('-'.join(['{:02x}'.format(_) for _ in magic])))
+
+    # Type code
+    type_code = magic[2]
+    dtype_map = {
+        0x08: np.uint8,
+        0x09: np.int8,
+        0x0B: np.int16,
+        0x0C: np.int32,
+        0x0D: np.float32,
+        0x0E: np.float64,
+    }
+    dtype = dtype_map[type_code]
+
+    # Dimensions
+    ndim = magic[3]
+
+    dims = []
+    for idim in range(ndim):
+        dim, = struct.unpack('>I', file_in.read(4))
+        dims.append(dim)
+
+    # Data
+    data = file_in.read()
+    data = np.fromstring(data, dtype=dtype).reshape(tuple(dims))
+
+    return data
+
+def read_data_from_url(url, cache_dir=None):
+    """
+    Extracts multidimensional data from an URL.
+    """
+    return read_data(gzip.GzipFile(fileobj=open_data_url(url, cache_dir=cache_dir)))
+
+def load(set_name='train', cache_dir=None):
+    """
+    Loads the MNIST data set.
+    """
+
+    if set_name == 'train':
+        urls = (
+            'http://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz',
+            'http://yann.lecun.com/exdb/mnist/train-labels-idx1-ubyte.gz',
+        )
+    elif set_name == 'test':
+        urls = (
+            'http://yann.lecun.com/exdb/mnist/t10k-images-idx3-ubyte.gz',
+            'http://yann.lecun.com/exdb/mnist/t10k-labels-idx1-ubyte.gz',
+        )
+    else:
+        assert False, "Invalid set name: {}".format(set_name)
+
+    data_url, labels_url = urls
+    data   = read_data_from_url(data_url, cache_dir=cache_dir)
+    labels = read_data_from_url(labels_url, cache_dir=cache_dir)
+
+    return data, labels
+

--- a/keras/layers/advanced_activations.py
+++ b/keras/layers/advanced_activations.py
@@ -3,8 +3,8 @@ from ..utils.theano_utils import shared_zeros
 
 class LeakyReLU(Layer):
     def __init__(self, alpha=0.3):
+        super(LeakyReLU,self).__init__()
         self.alpha = alpha
-        self.params = []
 
     def output(self, train):
         X = self.get_input(train)
@@ -22,6 +22,7 @@ class PReLU(Layer):
                 http://arxiv.org/pdf/1502.01852v1.pdf
     '''
     def __init__(self, input_shape):
+        super(PReLU,self).__init__()
         self.alphas = shared_zeros(input_shape)
         self.params = [self.alphas]
 

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -19,6 +19,7 @@ class Convolution2D(Layer):
     def __init__(self, nb_filter, stack_size, nb_row, nb_col, 
         init='uniform', activation='linear', weights=None, 
         image_shape=None, border_mode='valid', subsample=(1,1)):
+        super(Convolution2D,self).__init__()
 
         self.init = initializations.get(init)
         self.activation = activations.get(activation)
@@ -63,10 +64,10 @@ class Convolution2D(Layer):
 
 class MaxPooling2D(Layer):
     def __init__(self, poolsize=(2, 2), ignore_border=True):
+        super(MaxPooling2D,self).__init__()
         self.input = T.tensor4()
         self.poolsize = poolsize
         self.ignore_border = ignore_border
-        self.params = []
 
     def output(self, train):
         X = self.get_input(train)

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -14,6 +14,11 @@ from six.moves import zip
 srng = RandomStreams()
 
 class Layer(object):
+    def __init__(self):
+        self.params = []
+        self.regularizer = []
+        self.constraint = []
+
     def connect(self, previous_layer):
         self.previous_layer = previous_layer
 
@@ -45,10 +50,8 @@ class Dropout(Layer):
         Hinton's dropout.
     '''
     def __init__(self, p):
+        super(Dropout,self).__init__()
         self.p = p
-        self.params = []
-        self.regularizer = []
-        self.constraint = []
 
     def output(self, train):
         X = self.get_input(train)
@@ -70,10 +73,8 @@ class Activation(Layer):
         Apply an activation function to an output.
     '''
     def __init__(self, activation):
+        super(Activation,self).__init__()
         self.activation = activations.get(activation)
-        self.params = []
-        self.regularizer = []
-        self.constraint = []
 
     def output(self, train):
         X = self.get_input(train)
@@ -91,10 +92,8 @@ class Reshape(Layer):
         First dimension is assumed to be nb_samples.
     '''
     def __init__(self, *dims):
+        super(Reshape,self).__init__()
         self.dims = dims
-        self.params = []
-        self.regularizer = []
-        self.constraint = []
 
     def output(self, train):
         X = self.get_input(train)
@@ -112,9 +111,7 @@ class Flatten(Layer):
         First dimension is assumed to be nb_samples.
     '''
     def __init__(self):
-        self.params = []
-        self.regularizer = []
-        self.constraint = []
+        super(Flatten,self).__init__()
 
     def output(self, train):
         X = self.get_input(train)
@@ -131,10 +128,8 @@ class RepeatVector(Layer):
         Return tensor of shape (nb_samples, n, dim).
     '''
     def __init__(self, n):
+        super(RepeatVector,self).__init__()
         self.n = n
-        self.params = []
-        self.regularizer = []
-        self.constraint = []
 
     def output(self, train):
         X = self.get_input(train)
@@ -152,6 +147,7 @@ class Dense(Layer):
         Just your regular fully connected NN layer.
     '''
     def __init__(self, input_dim, output_dim, init='uniform', activation='linear', weights=None, W_regularizer=ident, b_regularizer=ident, W_constraint=ident, b_constraint=ident):
+        super(Dense,self).__init__()
         self.init = initializations.get(init)
         self.activation = activations.get(activation)
         self.input_dim = input_dim
@@ -191,6 +187,7 @@ class TimeDistributedDense(Layer):
 
     '''
     def __init__(self, input_dim, output_dim, init='uniform', activation='linear', weights=None, W_regularizer=ident, b_regularizer=ident, W_constraint=ident, b_constraint=ident):
+        super(TimeDistributedDense,self).__init__()
         self.init = initializations.get(init)
         self.activation = activations.get(activation)
         self.input_dim = input_dim

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -5,7 +5,7 @@ import theano
 import theano.tensor as T
 
 from .. import activations, initializations
-from ..regularizers import ident
+from ..regularizers import identity
 from ..utils.theano_utils import shared_zeros, floatX
 from ..utils.generic_utils import make_tuple
 
@@ -72,9 +72,11 @@ class Activation(Layer):
     '''
         Apply an activation function to an output.
     '''
-    def __init__(self, activation):
+    def __init__(self, activation, target=0, beta=0.1):
         super(Activation,self).__init__()
         self.activation = activations.get(activation)
+        self.target = target
+        self.beta = beta
 
     def output(self, train):
         X = self.get_input(train)
@@ -146,7 +148,7 @@ class Dense(Layer):
     '''
         Just your regular fully connected NN layer.
     '''
-    def __init__(self, input_dim, output_dim, init='glorot_uniform', activation='linear', weights=None, W_regularizer=ident, b_regularizer=ident, W_constraint=ident, b_constraint=ident):
+    def __init__(self, input_dim, output_dim, init='glorot_uniform', activation='linear', weights=None, W_regularizer=identity, b_regularizer=identity, W_constraint=identity, b_constraint=identity):
         super(Dense,self).__init__()
         self.init = initializations.get(init)
         self.activation = activations.get(activation)
@@ -186,7 +188,7 @@ class TimeDistributedDense(Layer):
        Tensor output dimensions:  (nb_sample, shared_dimension, output_dim)
 
     '''
-    def __init__(self, input_dim, output_dim, init='glorot_uniform', activation='linear', weights=None, W_regularizer=ident, b_regularizer=ident, W_constraint=ident, b_constraint=ident):
+    def __init__(self, input_dim, output_dim, init='glorot_uniform', activation='linear', weights=None, W_regularizer=identity, b_regularizer=identity, W_constraint=identity, b_constraint=identity):
         super(TimeDistributedDense,self).__init__()
         self.init = initializations.get(init)
         self.activation = activations.get(activation)

--- a/keras/layers/embeddings.py
+++ b/keras/layers/embeddings.py
@@ -15,6 +15,7 @@ class Embedding(Layer):
         @out_dim: size of dense representation
     '''
     def __init__(self, input_dim, output_dim, init='uniform', weights=None):
+        super(Embedding,self).__init__()
         self.init = initializations.get(init)
         self.input_dim = input_dim
         self.output_dim = output_dim
@@ -64,6 +65,7 @@ class WordContextProduct(Layer):
     '''
     def __init__(self, input_dim, proj_dim=128, 
         init='uniform', activation='sigmoid', weights=None):
+        super(WordContextProduct,self).__init__()
         self.input_dim = input_dim
         self.proj_dim = proj_dim
         self.init = initializations.get(init)

--- a/keras/layers/normalization.py
+++ b/keras/layers/normalization.py
@@ -9,6 +9,7 @@ class BatchNormalization(Layer):
                 http://arxiv.org/pdf/1502.03167v3.pdf
     '''
     def __init__(self, input_shape, epsilon=1e-6, weights=None):
+        super(BatchNormalization,self).__init__()
         self.init = initializations.get("uniform")
         self.input_shape = input_shape
         self.epsilon = epsilon

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -20,6 +20,7 @@ class SimpleRNN(Layer):
     def __init__(self, input_dim, output_dim, 
         init='uniform', inner_init='orthogonal', activation='sigmoid', weights=None,
         truncate_gradient=-1, return_sequences=False):
+        super(SimpleRNN,self).__init__()
         self.init = initializations.get(init)
         self.inner_init = initializations.get(inner_init)
         self.input_dim = input_dim
@@ -92,6 +93,7 @@ class SimpleDeepRNN(Layer):
         init='uniform', inner_init='orthogonal', 
         activation='sigmoid', inner_activation='hard_sigmoid',
         weights=None, truncate_gradient=-1, return_sequences=False):
+        super(SimpleDeepRNN,self).__init__()
         self.init = initializations.get(init)
         self.inner_init = initializations.get(inner_init)
         self.input_dim = input_dim
@@ -177,6 +179,7 @@ class GRU(Layer):
         activation='sigmoid', inner_activation='hard_sigmoid',
         weights=None, truncate_gradient=-1, return_sequences=False):
 
+        super(GRU,self).__init__()
         self.input_dim = input_dim
         self.output_dim = output_dim
         self.truncate_gradient = truncate_gradient
@@ -278,7 +281,8 @@ class LSTM(Layer):
         init='uniform', inner_init='orthogonal', 
         activation='tanh', inner_activation='hard_sigmoid',
         weights=None, truncate_gradient=-1, return_sequences=False):
-
+    
+        super(LSTM,self).__init__()
         self.input_dim = input_dim
         self.output_dim = output_dim
         self.truncate_gradient = truncate_gradient

--- a/keras/models.py
+++ b/keras/models.py
@@ -62,7 +62,7 @@ class Sequential(object):
             raise Exception("Invalid class mode:" + str(class_mode))
         self.class_mode = class_mode
 
-        updates = self.optimizer.get_updates(self.params, self.regularizer, self.constraint, train_loss)
+        updates = self.optimizer.get_updates(self.params, self.regularizer, self.constraint, self.layers, train_loss)
 
         self._train = theano.function([self.X, self.y], train_loss, 
             updates=updates, allow_input_downcast=True)

--- a/keras/models.py
+++ b/keras/models.py
@@ -25,12 +25,16 @@ class Sequential(object):
     def __init__(self):
         self.layers = []
         self.params = []
+        self.regularizer = []
+        self.constraint = []
 
     def add(self, layer):
         self.layers.append(layer)
         if len(self.layers) > 1:
             self.layers[-1].connect(self.layers[-2])
         self.params += [p for p in layer.params]
+        self.regularizer += [r for r in layer.regularizer]
+        self.constraint += [c for c in layer.constraint]
 
     def compile(self, optimizer, loss, class_mode="categorical"):
         self.optimizer = optimizers.get(optimizer)
@@ -58,7 +62,7 @@ class Sequential(object):
             raise Exception("Invalid class mode:" + str(class_mode))
         self.class_mode = class_mode
 
-        updates = self.optimizer.get_updates(self.params, train_loss)
+        updates = self.optimizer.get_updates(self.params, self.regularizer, self.constraint, train_loss)
 
         self._train = theano.function([self.X, self.y], train_loss, 
             updates=updates, allow_input_downcast=True)

--- a/keras/regularizers.py
+++ b/keras/regularizers.py
@@ -1,0 +1,19 @@
+from __future__ import absolute_import
+import theano
+import theano.tensor as T
+import numpy as np
+
+def l1(lam=.01):
+    def l1wrap(g,p):
+        g += T.sgn(p) * lam
+        return g
+    return l1wrap
+
+def l2(lam=.01):
+    def l2wrap(g,p):
+        g += p * lam
+        return g
+    return l2wrap
+
+def ident(g,*l):
+    return g

--- a/keras/regularizers.py
+++ b/keras/regularizers.py
@@ -15,5 +15,5 @@ def l2(lam=.01):
         return g
     return l2wrap
 
-def ident(g,*l):
+def identity(g,*l):
     return g

--- a/test/test_constraints.py
+++ b/test/test_constraints.py
@@ -1,0 +1,129 @@
+from __future__ import absolute_import
+from __future__ import print_function
+import keras
+from keras.datasets import mnist
+import keras.models
+from keras.models import Sequential
+from keras.layers.core import Dense, Dropout, Activation
+from keras.regularizers import l2, l1
+from keras.constraints import maxnorm, nonneg
+from keras.optimizers import SGD, Adam, RMSprop
+from keras.utils import np_utils, generic_utils
+import theano
+import theano.tensor as T
+import numpy as np
+import scipy
+
+batch_size = 100
+nb_classes = 10
+nb_epoch = 10
+
+# the data, shuffled and split between tran and test sets
+(X_train, y_train), (X_test, y_test) = mnist.load_data()
+X_train=X_train.reshape(60000,784)
+X_test=X_test.reshape(10000,784)
+X_train = X_train.astype("float32")
+X_test = X_test.astype("float32")
+X_train /= 255
+X_test /= 255
+
+# convert class vectors to binary class matrices
+Y_train = np_utils.to_categorical(y_train, nb_classes)
+Y_test = np_utils.to_categorical(y_test, nb_classes)
+
+model = Sequential()
+model.add(Dense(784, 20, W_constraint=maxnorm(1)))
+model.add(Activation('relu'))
+model.add(Dropout(0.1))
+model.add(Dense(20, 20, W_constraint=nonneg))
+model.add(Activation('relu'))
+model.add(Dropout(0.1))
+model.add(Dense(20, 10, W_constraint=maxnorm(1)))
+model.add(Activation('softmax'))
+
+
+rms = RMSprop()
+model.compile(loss='categorical_crossentropy', optimizer=rms)
+
+model.fit(X_train, Y_train, batch_size=batch_size, nb_epoch=nb_epoch, show_accuracy=True, verbose=0)
+
+a=model.params[0].eval()
+if np.isclose(np.max(np.sqrt(np.sum(a**2, axis=0))),1):
+	print('Maxnorm test passed')
+else:
+	raise ValueError('Maxnorm test failed!')
+		
+b=model.params[2].eval()
+if np.min(b)==0 and np.min(a)!=0:
+	print('Nonneg test passed')
+else:
+	raise ValueError('Nonneg test failed!')
+	
+model = Sequential()
+model.add(Dense(784, 20))
+model.add(Activation('relu', target=.4))
+model.add(Dropout(0.1))
+model.add(Dense(20, 20))
+model.add(Activation('relu', target=.3))
+model.add(Dropout(0.1))
+model.add(Dense(20, 10))
+model.add(Activation('softmax'))
+
+
+rms = RMSprop()
+model.compile(loss='categorical_crossentropy', optimizer=rms)
+
+model.fit(X_train, Y_train, batch_size=batch_size, nb_epoch=20, show_accuracy=True, verbose=0)
+
+
+
+get_activations1 = theano.function([model.layers[0].input], model.layers[1].output(train=False), allow_input_downcast=True)
+activations1 = get_activations1(X_train)
+get_activations2 = theano.function([model.layers[0].input], model.layers[4].output(train=False), allow_input_downcast=True)
+activations2 = get_activations2(X_train)
+
+if np.isclose(np.mean(activations1), .4, atol=.02) and np.isclose(np.mean(activations2), .3, atol=.02):
+	print('KL penalty test passed')
+else:
+	raise ValueError('KL penalty test failed!')
+	
+
+
+model = Sequential()
+model.add(Dense(784, 20))
+model.add(Activation('relu'))
+model.add(Dense(20, 20, W_regularizer=l1(.01)))
+model.add(Activation('relu'))
+model.add(Dense(20, 10))
+model.add(Activation('softmax'))
+
+
+rms = RMSprop()
+model.compile(loss='categorical_crossentropy', optimizer=rms)
+
+model.fit(X_train, Y_train, batch_size=batch_size, nb_epoch=20, show_accuracy=True, verbose=0)
+
+a=model.params[2].eval().reshape(400)
+(D, p1) = scipy.stats.kurtosistest(a)
+
+model = Sequential()
+model.add(Dense(784, 20))
+model.add(Activation('relu'))
+model.add(Dense(20, 20, W_regularizer=l2(.01)))
+model.add(Activation('relu'))
+model.add(Dense(20, 10))
+model.add(Activation('softmax'))
+
+
+rms = RMSprop()
+model.compile(loss='categorical_crossentropy', optimizer=rms)
+
+model.fit(X_train, Y_train, batch_size=batch_size, nb_epoch=20, show_accuracy=True, verbose=0)
+
+a=model.params[2].eval().reshape(400)
+(D, p2) = scipy.stats.kurtosistest(a)
+
+if p1<.01 and p2>.01:
+	print('L1 and L2 regularization tests passed')
+else:
+	raise ValueError('L1 and L2 regularization tests failed!')


### PR DESCRIPTION
I've moved the functions to relevant modules which can be used as below. And I've separated the weight and bias regularizers for better clarity, with the defaults being no regularization or constraints.
I don't think it makes sense to have the regularizers and constraints specified by strings, i.e. W_constraint='maxnorm' , since the user will usually want to specify the parameter and it's not clear how to do that with the string convention. It works fine when the defaults are probably fine, as with the initializations. But even in that case, how would one specify the scale for the initialization ```init='normal' ``` if you wanted to change it? The way I have it below seems clearer and easier to work with and is similar to the way the dropout rate is specified. Let me know what you think and if you think I should change something.

```python
from keras.constraints import maxnorm
from keras.regularizers import l2

model = Sequential()
model.add(Dense(784, 1000, W_regularizer=l2(.05), W_constraint=maxnorm(2)))