### PR TITLE
PReLU layer does not need to dump input_shape as a config parameter

### DIFF
--- a/keras/layers/advanced_activations.py
+++ b/keras/layers/advanced_activations.py
@@ -24,6 +24,7 @@ class PReLU(Layer):
     def __init__(self, input_shape):
         self.alphas = shared_zeros(input_shape)
         self.params = [self.alphas]
+        self.input_shape = input_shape
 
     def output(self, train):
         X = self.get_input(train)
@@ -32,4 +33,5 @@ class PReLU(Layer):
         return pos + neg
 
     def get_config(self):
-        return {"name":self.__class__.__name__}
+        return {"name":self.__class__.__name__,
+        "input_shape":self.input_shape}

--- a/keras/layers/advanced_activations.py
+++ b/keras/layers/advanced_activations.py
@@ -32,5 +32,4 @@ class PReLU(Layer):
         return pos + neg
 
     def get_config(self):
-        return {"name":self.__class__.__name__,
-            "input_shape":self.input_shape}
+        return {"name":self.__class__.__name__}


### PR DESCRIPTION
This was causing `model.save_weights` to break on models with a PReLU layer, as it does not store `input_shape` as an attribute. We do not need to save it, though, since this is just an activation layer.