### PR TITLE
Added function to compute activation statistics for BatchNormalization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ temp/*
 build/*
 keras/datasets/data/*
 keras/datasets/temp/*
+Keras.egg-info/*
+

--- a/keras/layers/normalization.py
+++ b/keras/layers/normalization.py
@@ -2,6 +2,8 @@ from ..layers.core import Layer
 from ..utils.theano_utils import shared_zeros
 from .. import initializations
 
+import theano, numpy
+
 class BatchNormalization(Layer):
     '''
         Reference: 
@@ -16,13 +18,19 @@ class BatchNormalization(Layer):
         self.gamma = self.init((self.input_shape))
         self.beta = shared_zeros(self.input_shape)
 
+        self.data_mean = shared_zeros(self.input_shape)
+        self.data_std = shared_zeros(self.input_shape)
+
         self.params = [self.gamma, self.beta]
         if weights is not None:
             self.set_weights(weights)
 
     def output(self, train):
         X = self.get_input(train)
-        X_normed = (X - X.mean(keepdims=True)) / (X.std(keepdims=True) + self.epsilon)
+        if train:
+            X_normed = (X - X.mean(keepdims=True)) / (X.std(keepdims=True) + self.epsilon)
+        else:
+            X_normed = (X - self.data_mean) / (self.data_std + self.epsilon)
         out = self.gamma * X_normed + self.beta
         return out
 
@@ -30,3 +38,35 @@ class BatchNormalization(Layer):
         return {"name":self.__class__.__name__,
             "input_shape":self.input_shape,
             "epsilon":self.epsilon}
+
+def set_activation_stats(model, X, batch_size, shuffle=False, verbose=False):
+    from keras.models import make_batches
+    # Find all BatchNormalization layers in the model
+    bn_layers = [layer for layer in model.layers if (layer.__class__.__name__ == BatchNormalization.__name__)]
+    for layer in bn_layers:
+        if verbose:
+            print('Setting activation statistics for layer {}'.format(layer))
+        activations = layer.get_input(train=False)
+        activation_stats = theano.function([model.layers[0].input], outputs=[activations.mean(axis=0), activations.std(axis=0)])
+        
+        # Prepare training data and compute activation statistics
+        index_array = numpy.arange(len(X))
+        if shuffle:
+            numpy.random.shuffle(index_array)
+        batches = make_batches(len(X), batch_size)
+        X_shape = list(layer.input_shape)
+        X_shape.insert(0, len(batches))
+        batch_means = numpy.empty(X_shape)
+        batch_stds = numpy.empty(X_shape)
+
+        for batch_index, (batch_start, batch_end) in enumerate(batches):
+            if shuffle:
+                batch_ids = index_array[batch_start:batch_end]
+            else:
+                batch_ids = slice(batch_start, batch_end)
+            X_batch = X[batch_ids]
+            batch_means[batch_index,...], batch_stds[batch_index,...] = activation_stats(X_batch)
+        layer.data_mean.set_value(batch_means.mean(axis=0))
+        layer.data_std.set_value((batch_size/(batch_size-1))*batch_stds.mean(axis=0))
+    return
+


### PR DESCRIPTION
This adds a function, `set_activation_stats(model, X_train, batch_size, verbose)` that computes the activation mean and standard deviation for each BatchNormalization layer in a model and stores them as layer attributes. It also changes the BatchNormalization layer to use this information during test/inference. The only issue I see with this, which comes from using batch normalization and not from the implementation, is that in theory one needs to compute the activation statistics after each epoch if they want to check the validation or test performance. Otherwise, since they will not have these values, we don't have a way to normalize the data during testing.