### PR TITLE
Noise module

### DIFF
--- a/docs/sources/examples.md
+++ b/docs/sources/examples.md
@@ -5,7 +5,8 @@ Here are a few examples to get you started!
 
 ```python
 from keras.models import Sequential
-from keras.layers.core import Dense, Dropout, Activation
+from keras.layers.core import Dense, Activation
+from keras.layers.noise import Dropout
 from keras.optimizers import SGD
 
 model = Sequential()
@@ -47,7 +48,8 @@ model.compile(loss='mean_squared_error', optimizer=sgd)
 
 ```python
 from keras.models import Sequential
-from keras.layers.core import Dense, Dropout, Activation, Flatten
+from keras.layers.core import Dense, Activation, Flatten
+from keras.layers.noise import Dropout
 from keras.layers.convolutional import Convolution2D, MaxPooling2D
 from keras.optimizers import SGD
 
@@ -87,7 +89,8 @@ model.fit(X_train, Y_train, batch_size=32, nb_epoch=1)
 
 ```python
 from keras.models import Sequential
-from keras.layers.core import Dense, Dropout, Activation, Embedding
+from keras.layers.core import Dense, Activation, Embedding
+from keras.layers.noise import Dropout
 from keras.layers.recurrent import LSTM
 
 model = Sequential()

--- a/docs/sources/layers/core.md
+++ b/docs/sources/layers/core.md
@@ -132,23 +132,6 @@ Apply an activation function to the input.
 
 ---
 
-## Dropout
-```python
-keras.layers.core.Dropout(p)
-```
-Apply dropout to the input. Dropout consists in randomly setting a fraction `p` of input units to 0 at each update during training time, which helps prevent overfitting. Reference: [Dropout: A Simple Way to Prevent Neural Networks from Overfitting](http://www.cs.toronto.edu/~rsalakhu/papers/srivastava14a.pdf)
-
-- __Input shape__: This layer does not assume a specific input shape. As a result, it cannot be used as the first layer in a model.
-
-- __Output shape__: Same as input.
-
-- __Arguments__:
-
-    - __p__: float (0 <= p < 1). Fraction of the input that gets dropped out at training time. 
-
-
----
-
 ## Reshape
 ```python
 keras.layers.core.Reshape(*dims)

--- a/docs/sources/layers/noise.md
+++ b/docs/sources/layers/noise.md
@@ -19,7 +19,7 @@ Apply dropout to the input. Dropout consists in randomly setting a fraction `p` 
 ```python
 keras.layers.core.GaussianNoise(p)
 ```
-Apply Gaussian dropout (multiplicative Gaussain noise) to the input. Gaussian dropout consists in multiplying the input units by samples from Gaussian with mean 0 and variance `p/(1-p)` each update during training time, which helps prevent overfitting. Reference: [Dropout: A Simple Way to Prevent Neural Networks from Overfitting](http://www.cs.toronto.edu/~rsalakhu/papers/srivastava14a.pdf)
+Apply Gaussian dropout (multiplicative Gaussain noise) to the input. Gaussian dropout consists in multiplying the input units by samples from Gaussian with mean 1 and variance `p/(1-p)` each update during training time, which helps prevent overfitting. Reference: [Dropout: A Simple Way to Prevent Neural Networks from Overfitting](http://www.cs.toronto.edu/~rsalakhu/papers/srivastava14a.pdf)
 
 - __Input shape__: This layer does not assume a specific input shape. As a result, it cannot be used as the first layer in a model.
 

--- a/docs/sources/layers/noise.md
+++ b/docs/sources/layers/noise.md
@@ -1,0 +1,30 @@
+## Dropout
+```python
+keras.layers.core.Dropout(p)
+```
+Apply dropout to the input. Dropout consists in randomly setting a fraction `p` of input units to 0 at each update during training time, which helps prevent overfitting. Reference: [Dropout: A Simple Way to Prevent Neural Networks from Overfitting](http://www.cs.toronto.edu/~rsalakhu/papers/srivastava14a.pdf)
+
+- __Input shape__: This layer does not assume a specific input shape. As a result, it cannot be used as the first layer in a model.
+
+- __Output shape__: Same as input.
+
+- __Arguments__:
+
+    - __p__: float (0 <= p < 1). Fraction of the input that gets dropped out at training time. 
+
+
+---
+
+## GaussianNoise
+```python
+keras.layers.core.GaussianNoise(p)
+```
+Apply Gaussian dropout (multiplicative Gaussain noise) to the input. Gaussian dropout consists in multiplying the input units by samples from Gaussian with mean 0 and variance `p/(1-p)` each update during training time, which helps prevent overfitting. Reference: [Dropout: A Simple Way to Prevent Neural Networks from Overfitting](http://www.cs.toronto.edu/~rsalakhu/papers/srivastava14a.pdf)
+
+- __Input shape__: This layer does not assume a specific input shape. As a result, it cannot be used as the first layer in a model.
+
+- __Output shape__: Same as input.
+
+- __Arguments__:
+
+    - __p__: float (0 <= p < 1). Controls variance of multiplicative noise. 

--- a/docs/sources/models.md
+++ b/docs/sources/models.md
@@ -38,7 +38,8 @@ __Examples__:
 
 ```python
 from keras.models import Sequential
-from keras.layers.core import Dense, Dropout, Activation
+from keras.layers.core import Dense, Activation
+from keras.layers.noise import Dropout
 from keras.optimizers import SGD
 
 model = Sequential()

--- a/examples/cifar10_cnn.py
+++ b/examples/cifar10_cnn.py
@@ -3,7 +3,8 @@ from __future__ import print_function
 from keras.datasets import cifar10
 from keras.preprocessing.image import ImageDataGenerator
 from keras.models import Sequential
-from keras.layers.core import Dense, Dropout, Activation, Flatten
+from keras.layers.core import Dense, Activation, Flatten
+from keras.layers.noise import Dropout
 from keras.layers.convolutional import Convolution2D, MaxPooling2D
 from keras.optimizers import SGD, Adadelta, Adagrad
 from keras.utils import np_utils, generic_utils

--- a/examples/imdb_lstm.py
+++ b/examples/imdb_lstm.py
@@ -6,7 +6,8 @@ from keras.preprocessing import sequence
 from keras.optimizers import SGD, RMSprop, Adagrad
 from keras.utils import np_utils
 from keras.models import Sequential
-from keras.layers.core import Dense, Dropout, Activation
+from keras.layers.core import Dense, Activation
+from keras.layers.noise import Dropout
 from keras.layers.embeddings import Embedding
 from keras.layers.recurrent import LSTM, GRU
 from keras.datasets import imdb

--- a/examples/kaggle_otto_nn.py
+++ b/examples/kaggle_otto_nn.py
@@ -5,7 +5,8 @@ import numpy as np
 import pandas as pd
 
 from keras.models import Sequential
-from keras.layers.core import Dense, Dropout, Activation
+from keras.layers.core import Dense, Activation
+from keras.layers.noise import Dropout
 from keras.layers.normalization import BatchNormalization
 from keras.layers.advanced_activations import PReLU
 from keras.utils import np_utils, generic_utils

--- a/examples/mnist_nn.py
+++ b/examples/mnist_nn.py
@@ -2,7 +2,8 @@ from __future__ import absolute_import
 from __future__ import print_function
 from keras.datasets import mnist
 from keras.models import Sequential
-from keras.layers.core import Dense, Dropout, Activation
+from keras.layers.core import Dense, Activation
+from keras.layers.noise import Dropout
 from keras.regularizers import l2, l1
 from keras.constraints import maxnorm
 from keras.optimizers import SGD, Adam, RMSprop

--- a/examples/mnist_nn.py
+++ b/examples/mnist_nn.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 from keras.datasets import mnist
 from keras.models import Sequential
 from keras.layers.core import Dense, Activation
-from keras.layers.noise import Dropout
+from keras.layers.noise import Dropout, GaussianNoise
 from keras.regularizers import l2, l1
 from keras.constraints import maxnorm
 from keras.optimizers import SGD, Adam, RMSprop
@@ -39,10 +39,10 @@ Y_test = np_utils.to_categorical(y_test, nb_classes)
 model = Sequential()
 model.add(Dense(784, 128))
 model.add(Activation('relu'))
-model.add(Dropout(0.2))
+model.add(GaussianNoise(0.2))
 model.add(Dense(128, 128))
 model.add(Activation('relu'))
-model.add(Dropout(0.2))
+model.add(GaussianNoise(0.2))
 model.add(Dense(128, 10))
 model.add(Activation('softmax'))
 

--- a/examples/reuters_mlp.py
+++ b/examples/reuters_mlp.py
@@ -4,7 +4,8 @@ import numpy as np
 
 from keras.datasets import reuters
 from keras.models import Sequential
-from keras.layers.core import Dense, Dropout, Activation
+from keras.layers.core import Dense, Activation
+from keras.layers.noise import Dropout
 from keras.layers.normalization import BatchNormalization
 from keras.utils import np_utils
 from keras.preprocessing.text import Tokenizer

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -45,29 +45,6 @@ class Layer(object):
         return {"name":self.__class__.__name__}
 
 
-class Dropout(Layer):
-    '''
-        Hinton's dropout.
-    '''
-    def __init__(self, p):
-        super(Dropout,self).__init__()
-        self.p = p
-
-    def output(self, train):
-        X = self.get_input(train)
-        if self.p > 0.:
-            retain_prob = 1. - self.p
-            if train:
-                X *= srng.binomial(X.shape, p=retain_prob, dtype=theano.config.floatX)
-            else:
-                X *= retain_prob
-        return X
-
-    def get_config(self):
-        return {"name":self.__class__.__name__,
-            "p":self.p}
-
-
 class Activation(Layer):
     '''
         Apply an activation function to an output.

--- a/keras/layers/noise.py
+++ b/keras/layers/noise.py
@@ -8,6 +8,7 @@ from .. import activations, initializations
 from ..regularizers import identity
 from ..utils.theano_utils import shared_zeros, floatX
 from ..utils.generic_utils import make_tuple
+from ..layers.core import Layer
 
 from theano.sandbox.rng_mrg import MRG_RandomStreams as RandomStreams
 from six.moves import zip

--- a/keras/layers/noise.py
+++ b/keras/layers/noise.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division
+
+import theano
+import theano.tensor as T
+
+from .. import activations, initializations
+from ..regularizers import identity
+from ..utils.theano_utils import shared_zeros, floatX
+from ..utils.generic_utils import make_tuple
+
+from theano.sandbox.rng_mrg import MRG_RandomStreams as RandomStreams
+from six.moves import zip
+srng = RandomStreams()
+
+
+class Dropout(Layer):
+    '''
+        Hinton's dropout.
+    '''
+    def __init__(self, p):
+        super(Dropout,self).__init__()
+        self.p = p
+
+    def output(self, train):
+        X = self.get_input(train)
+        if self.p > 0.:
+            retain_prob = 1. - self.p
+            if train:
+                X *= srng.binomial(X.shape, p=retain_prob, dtype=theano.config.floatX)
+            else:
+                X *= retain_prob
+        return X
+
+    def get_config(self):
+        return {"name":self.__class__.__name__,
+            "p":self.p}
+            
+            
+class GaussianNoise(Layer):
+    '''
+        Multiplicative Gaussian Noise
+        Reference: 
+            Dropout: A Simple Way to Prevent Neural Networks from Overfitting
+            Srivastava, Hinton, et al. 2014
+    '''
+    def __init__(self, p):
+        self.p = p
+        self.params = []
+        self.regularizer = []
+        self.constraint = []
+
+    def output(self, train):
+        X = self.get_input(train)
+        if train:
+            # self.p refers to drop probability rather than retain probability (as in paper) to match Dropout layer syntax
+            X *= srng.normal(X.shape, avg = 1., std=T.sqrt(self.p/(1-self.p)), dtype=theano.config.floatX)
+        return X
+                    

--- a/keras/layers/noise.py
+++ b/keras/layers/noise.py
@@ -46,10 +46,8 @@ class GaussianNoise(Layer):
             Srivastava, Hinton, et al. 2014
     '''
     def __init__(self, p):
+        super(GaussianNoise,self).__init__()
         self.p = p
-        self.params = []
-        self.regularizer = []
-        self.constraint = []
 
     def output(self, train):
         X = self.get_input(train)

--- a/test/test_constraints.py
+++ b/test/test_constraints.py
@@ -4,7 +4,8 @@ import keras
 from keras.datasets import mnist
 import keras.models
 from keras.models import Sequential
-from keras.layers.core import Dense, Dropout, Activation
+from keras.layers.core import Dense, Activation
+from keras.layers.noise import Dropout
 from keras.regularizers import l2, l1
 from keras.constraints import maxnorm, nonneg
 from keras.optimizers import SGD, Adam, RMSprop


### PR DESCRIPTION
I moved dropout to a new noise.py module and added multiplicative Gaussian noise (from the Dropout paper) as well. According to the paper this "Gaussian dropout" actually works slightly better, and it seems to in the MNIST example. I updated all the docs and examples to comply with the changes.