### PR TITLE
NumPy Array <-> PIL Image conversion when image is grayscale

### DIFF
--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -87,12 +87,18 @@ def array_to_img(x, scale=True):
         return Image.fromarray(x.astype("uint8"), "RGB")
     else:
         # grayscale
-        return Image.fromarray(x.astype("uint8"), "L")
+        return Image.fromarray(x[:,:,0].astype("uint8"), "L")
 
 
 def img_to_array(img):
     x = np.asarray(img, dtype='float32')
-    return x.transpose(2, 0, 1)
+    if len(x.shape)==3:
+        # RGB: height, width, channel -> channel, height, width
+        x = x.transpose(2, 0, 1)
+    else:
+        # grayscale: height, width -> channel, height, width
+        x = x.reshape((1, x.shape[0], x.shape[1]))
+    return x
 
 
 def load_img(path, grayscale=False):

--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -106,6 +106,8 @@ def load_img(path, grayscale=False):
     img = Image.open(open(path))
     if grayscale:
         img = img.convert('L')
+    else: # Assure 3 channel even when loaded image is grayscale
+        img = img.convert('RGB')
     return img
 
 


### PR DESCRIPTION
Fixed conversion between NumPy Array and PIL Image object when input image is grayscale.

Originally,
* (Line 90: `array_to_img`) When NumPy Array `x` with one channel is passed to `array_to_img`, `Image.fromarray(x.astype("uint8"), "L")` raised `ValueError: Too many dimensions: 3 > 2.`.
* (Line 95: `img_to_array`) When grayscale image is passed to `img_to_array`, `x` becomes 2D array and `x = x.transpose(2, 0, 1)` raised `ValueError: axes don't match array` 
* (Line 100: `load_img`) When grayscale image is loaded, but grayscale is set False, this function still returns the grayscale image. This behavior cause a problem when loading multiple images including both color and grayscale images. 