### PR TITLE
Fix a typo in the kaggle otto exmaple.

### DIFF
--- a/examples/kaggle_otto_nn.py
+++ b/examples/kaggle_otto_nn.py
@@ -53,7 +53,7 @@ def preprocess_data(X, scaler=None):
     X = scaler.transform(X)
     return X, scaler
 
-def preprocess_labels(y, encoder=None, categorical=True):
+def preprocess_labels(labels, encoder=None, categorical=True):
     if not encoder:
         encoder = LabelEncoder()
         encoder.fit(labels)


### PR DESCRIPTION
The original file somehow works because `labels` is a global variable :)