### PR TITLE
fixed missing parenthesis in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ model.add(Dense(20, 64, init='uniform', activation='tanh'))
 model.add(Dropout(0.5))
 model.add(Dense(64, 64, init='uniform', activation='tanh'))
 model.add(Dropout(0.5))
-model.add(Dense(64, 1, init='uniform', activation='softmax')
+model.add(Dense(64, 1, init='uniform', activation='softmax'))
 
 sgd = SGD(lr=0.1, decay=1e-6, momentum=0.9, nesterov=True)
 model.compile(loss='mean_squared_error', optimizer=sgd)


### PR DESCRIPTION
As the title indicates the README had a missing parenthesis in a python code example.