### PR TITLE
Add theano_mode argument to models.compile. 

### DIFF
--- a/docs/sources/models.md
+++ b/docs/sources/models.md
@@ -12,6 +12,7 @@ model = keras.models.Sequential()
             - __optimizer__: str (name of optimizer) or optimizer object. See [optimizers](optimizers.md).
             - __loss__: str (name of objective function) or objective function. See [objectives](objectives.md).
             - __class_mode__: one of "categorical", "binary". This is only used for computing classification accuracy or using the predict_classes method. 
+            - __theano_mode__: A `theano.compile.mode.Mode` instance controlling specifying compilation options.
     - __fit__(X, y, batch_size=128, nb_epoch=100, verbose=1, validation_split=0., validation_data=None, shuffle=True, show_accuracy=False): Train a model for a fixed number of epochs.
         - __Arguments__: 
             - __X__: data.

--- a/keras/models.py
+++ b/keras/models.py
@@ -71,7 +71,7 @@ class Sequential(object):
     def get_output(self, train):
         return self.layers[-1].get_output(train)
 
-    def compile(self, optimizer, loss, class_mode="categorical", y_dim_components=1):
+    def compile(self, optimizer, loss, class_mode="categorical", y_dim_components=1, theano_mode=None):
         self.optimizer = optimizers.get(optimizer)
         self.loss = objectives.get(loss)
 
@@ -107,15 +107,15 @@ class Sequential(object):
         updates = self.optimizer.get_updates(self.params, self.regularizers, self.constraints, train_loss)
 
         self._train = theano.function([self.X, self.y], train_loss, 
-            updates=updates, allow_input_downcast=True)
+            updates=updates, allow_input_downcast=True, mode=theano_mode)
         self._train_with_acc = theano.function([self.X, self.y], [train_loss, train_accuracy], 
-            updates=updates, allow_input_downcast=True)
+            updates=updates, allow_input_downcast=True, mode=theano_mode)
         self._predict = theano.function([self.X], self.y_test, 
-            allow_input_downcast=True)
+            allow_input_downcast=True, mode=theano_mode)
         self._test = theano.function([self.X, self.y], test_score, 
-            allow_input_downcast=True)
+            allow_input_downcast=True, mode=theano_mode)
         self._test_with_acc = theano.function([self.X, self.y], [test_score, test_accuracy], 
-            allow_input_downcast=True)
+            allow_input_downcast=True, mode=theano_mode)
 
 
     def train(self, X, y, accuracy=False):


### PR DESCRIPTION
This allows to specify a theano.compile.mode.Mode instance to use, for example to use a MonitorMode
with a post_func to debug nans.