### PR TITLE
Pad the progress bar strings

### DIFF
--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -73,7 +73,9 @@ class Progbar(object):
             sys.stdout.write("\b" * (self.total_width+1))
             sys.stdout.write("\r")
 
-            bar = '%d/%d [' % (current, self.target)
+            numdigits = int(np.floor(np.log10(self.target))) + 1
+            barstr = '%%%dd/%%%dd [' % (numdigits, numdigits)
+            bar = barstr % (current, self.target)
             prog = float(current)/self.target
             prog_width = int(self.width*prog)
             if prog_width > 0:


### PR DESCRIPTION
Pad the progress bars so formatting stays when going from 99 to 100, etc.

Behavior before:

    900/7228 [==>...........................] - ETA: 226s - loss: 0.4990
    1050/7228 [===>..........................] - ETA: 194s - loss: 0.4868

Behavior after:

     900/7228 [==>...........................] - ETA: 226s - loss: 0.4990
    1050/7228 [===>..........................] - ETA: 194s - loss: 0.4868