### PR TITLE
Fix progress bar issue in screen where output clobbered previous output

### DIFF
--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -70,7 +70,7 @@ class Progbar(object):
         now = time.time()
         if self.verbose == 1:
             prev_total_width = self.total_width
-            sys.stdout.write("\b" * (self.total_width+1))
+            sys.stdout.write("\b" * prev_total_width)
             sys.stdout.write("\r")
 
             numdigits = int(np.floor(np.log10(self.target))) + 1


### PR DESCRIPTION
When running model.fit with verbose=1 inside screen, the progress bar currently prints out lines that scroll upward on the terminal. For instance, on the following test script:

```
from keras.utils.generic_utils import Progbar

pb = Progbar(target=10, verbose=1)
for i in range(1, 11):
  pb.update(i, [('test', i)])
```

The output is:

```
10/10 [==============================] - 0s - test: 5.0000     
me@test:~/tmp/kerastest$ ========>...] - ETA: 0s - test: 5.0000
 8/10 [=======================>......] - ETA: 0s - test: 4.0000
 7/10 [====================>.........] - ETA: 0s - test: 4.0000
 6/10 [=================>............] - ETA: 0s - test: 3.0000
 5/10 [==============>...............] - ETA: 0s - test: 3.0000
 4/10 [===========>..................] - ETA: 0s - test: 2.0000
 3/10 [========>.....................] - ETA: 0s - test: 2.0000
 2/10 [=====>........................] - ETA: 0s - test: 1.0000
 1/10 [==>...........................] - ETA: 0s - test: 1.0000
```

This clobbering of previous screen output also prevents previous epochs' results from being visible after the end of the call to fit.