### PR TITLE
Fix sampling table lookup in skipgrams

### DIFF
--- a/keras/preprocessing/sequence.py
+++ b/keras/preprocessing/sequence.py
@@ -69,7 +69,7 @@ def skipgrams(sequence, vocabulary_size,
         if not wi:
             continue
         if sampling_table is not None:
-            if sampling_table[i] < random.random():
+            if sampling_table[wi] < random.random():
                 continue
 
         window_start = max(0, i-window_size)


### PR DESCRIPTION
```sampling_table``` should be looked up with the index from the vocabulary, and not with the positional index from the sequence. 