### PR TITLE
Autoencoder model

### DIFF
--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -47,8 +47,6 @@ class Merge(object):
         ''' Merge the output of a list of models into a single tensor.
             mode: {'sum', 'concat'}
         '''
-        if len(models) < 2:
-            raise Exception("Please specify two or more input models to merge")
         self.mode = mode
         self.models = models
         self.params = []
@@ -101,6 +99,9 @@ class Merge(object):
         return {"name":self.__class__.__name__,
             "models":[m.get_config() for m in self.models],
             "mode":self.mode}
+
+    def connect(self, node, which=0):
+        self.models[which].layers[0].previous = node
 
 
 class Dropout(Layer):

--- a/keras/models.py
+++ b/keras/models.py
@@ -9,6 +9,8 @@ from . import optimizers
 from . import objectives
 from . import regularizers
 from . import constraints
+from .layers.core import Merge
+
 import time, copy
 from .utils.generic_utils import Progbar, printv
 from six.moves import range
@@ -391,4 +393,28 @@ class Sequential(Model):
             weights = [g['param_{}'.format(p)] for p in range(g.attrs['nb_params'])]
             self.layers[k].set_weights(weights)
         f.close()
-        
+
+
+class Autoencoder(Sequential):
+
+    def __init__(self, encoder, decoder):
+        super(Autoencoder,self).__init__()
+        self.encoder = encoder
+        self.decoder = decoder
+
+        self.add(Merge([self.encoder]))
+        self.add(Merge([self.decoder]))
+
+    def train(self, X, **kwargs):
+        super(Autoencoder,self).train(X,X,**kwargs)
+
+    def test(self, X, **kwargs):
+        super(Autoencoder,self).test(X,X,**kwargs)
+
+    def fit(self, X, **kwargs):
+        super(Autoencoder,self).fit(X,X,**kwargs)
+
+    def freeze_encoder(self):
+        def zero_grad(g, p):
+            return 0.
+        self.encoder.regularizers = [zero_grad for r in self.encoder.regularizers]

--- a/test/test_autoencoder.py
+++ b/test/test_autoencoder.py
@@ -1,0 +1,62 @@
+from __future__ import absolute_import
+from __future__ import print_function
+from keras.datasets import mnist
+from keras.models import Sequential, Autoencoder
+from keras.layers.core import Dense, Dropout, Activation, Layer, Merge
+from keras.optimizers import RMSprop
+import theano.tensor as T
+import numpy as np
+
+from theano.sandbox.rng_mrg import MRG_RandomStreams as RandomStreams
+srng = RandomStreams()
+
+
+(X_train, y_train), (_, _) = mnist.load_data()
+
+X_train = X_train.reshape((X_train.shape[0],-1)).astype(float)/255.
+
+encoder = Sequential()
+decoder = Sequential()
+
+n_hidden = 64
+
+layer_enc = Dense(X_train.shape[1],n_hidden,W_regularizer=None)
+layer_dec = Dense(n_hidden,X_train.shape[1])
+
+# Tie the weights of encoder and decoder
+layer_dec.params.remove(layer_dec.W)
+layer_dec.W = T.transpose(layer_enc.W)
+
+encoder.add(layer_enc)
+encoder.add(Dropout(p=0.3))
+encoder.add(Activation('relu'))
+encoder.add(Activation('softmax'))
+
+decoder.add(layer_dec)
+decoder.add(Activation('relu'))
+
+autoencoder = Autoencoder(encoder,decoder)
+
+rms = RMSprop()
+autoencoder.compile(loss='mean_squared_error', optimizer=rms)
+
+autoencoder.fit(X_train, verbose=1, nb_epoch=10)
+
+autoencoder.freeze_encoder()
+
+testnet = Sequential()
+testnet.add(Merge([autoencoder.encoder]))
+testnet.add(Dense(n_hidden,10))
+testnet.add(Activation('sigmoid'))
+
+W_pretrain = layer_enc.W.get_value()
+
+y_train_full = np.zeros((y_train.shape[0],10))
+for n in range(len(y_train)):
+    y_train_full[n,y_train[n]] = 1.
+testnet.compile(loss='mean_squared_error', optimizer=rms)
+testnet.fit(X_train,y_train_full,nb_epoch=10)
+
+W_posttrain = layer_enc.W.get_value()
+
+assert(np.abs(W_posttrain-W_pretrain).max() < 1e-9)


### PR DESCRIPTION
I added a relatively generic autoencoder model. It allows the encoding stage to be reused as a layer in subsequent networks, and it can be frozen using a trick I got from @kenterao in #56 . In order to make this concise, I had to modify the Merge layer to allow 'merging' a single model, so basically turning it into a container layer. Also happy to do this in a separate Container layer, but I think that would include some duplication.

One thing that is typically done in autoencoders, which for now has to be done by hand, is tying of weights. I couldn't come up with a neat way of doing this, while allowing general encoders and decoders. So I left it up to the enduser to do this for now (see the test to see how it is done.)

Let me know what you think, and I am happy to write documentation for this.