### PR TITLE
scikit-learn classifier wrapper

### DIFF
--- a/keras/wrappers/scikit_learn.py
+++ b/keras/wrappers/scikit_learn.py
@@ -1,0 +1,151 @@
+from __future__ import absolute_import
+import numpy as np
+
+class KerasClassifier(object):
+    """
+    Implementation of the scikit-learn classifier API for Keras.
+
+    Parameters
+    ----------
+    model : object, optional
+        A pre-compiled Keras model is required to use the scikit-learn wrapper.
+    """
+    def __init__(self, model=None):
+        self.model = model
+        self.classes_ = []
+        self.config_ = []
+        self.weights_ = []
+
+    def get_params(self, deep=True):
+        """
+        Get parameters for this estimator.
+
+        Parameters
+        ----------
+        deep: boolean, optional
+            If True, will return the parameters for this estimator and
+            contained subobjects that are estimators.
+
+        Returns
+        -------
+        params : dict
+            Dictionary of parameter names mapped to their values.
+        """
+        return {'model': self.model}
+
+    def set_params(self, **params):
+        """
+        Set the parameters of this estimator.
+
+        Parameters
+        ----------
+        params: dict
+            Dictionary of parameter names mapped to their values.
+
+        Returns
+        -------
+        self
+        """
+        for parameter, value in params.items():
+            self.setattr(parameter, value)
+        return self
+
+    def fit(self, X, y, batch_size=128, nb_epoch=100, verbose=0, shuffle=True):
+        """
+        Fit the model according to the given training data.
+
+        Parameters
+        ----------
+        X : array-like, shape = (n_samples, n_features)
+            Training samples where n_samples in the number of samples
+            and n_features is the number of features.
+        y : array-like, shape = (n_samples) or (n_samples, n_outputs)
+            True labels for X.
+        batch_size : int, optional
+            Number of training samples evaluated at a time.
+        nb_epochs : int, optional
+            Number of training epochs.
+        verbose : int, optional
+            Verbosity level.
+        shuffle : boolean, optional
+            Indicator to shuffle the training data.
+
+        Returns
+        -------
+        self : object
+            Returns self.
+        """
+        if len(y.shape) == 1:
+            self.classes_ = list(np.unique(y))
+        else:
+            self.classes_ = np.arange(0, y.shape[1])
+        self.model.fit(X, y, batch_size=batch_size, nb_epoch=nb_epoch, verbose=verbose, shuffle=shuffle)
+        self.config_ = self.model.get_config()
+        self.weights_ = self.model.get_weights()
+        return self
+
+    def score(self, X, y, batch_size=128, verbose=0):
+        """
+        Returns the mean accuracy on the given test data and labels.
+
+        Parameters
+        ----------
+        X : array-like, shape = (n_samples, n_features)
+            Test samples where n_samples in the number of samples
+            and n_features is the number of features.
+        y : array-like, shape = (n_samples) or (n_samples, n_outputs)
+            True labels for X.
+        batch_size : int, optional
+            Number of test samples evaluated at a time.
+        verbose : int, optional
+            Verbosity level.
+
+        Returns
+        -------
+        score : float
+            Mean accuracy of self.predict(X) wrt. y.
+        """
+        loss, accuracy = self.model.evaluate(X, y, batch_size=batch_size, show_accuracy=True, verbose=verbose)
+        return accuracy
+
+    def predict(self, X, batch_size=128, verbose=0):
+        """
+        Returns the class predictions for the given test data.
+
+        Parameters
+        ----------
+        X : array-like, shape = (n_samples, n_features)
+            Test samples where n_samples in the number of samples
+            and n_features is the number of features.
+        batch_size : int, optional
+            Number of test samples evaluated at a time.
+        verbose : int, optional
+            Verbosity level.
+
+        Returns
+        -------
+        preds : array-like, shape = (n_samples)
+            Class predictions.
+        """
+        return self.model.predict_classes(X, batch_size=batch_size, verbose=verbose)
+
+    def predict_proba(self, X, batch_size=128, verbose=0):
+        """
+        Returns class probability estimates for the given test data.
+
+        Parameters
+        ----------
+        X : array-like, shape = (n_samples, n_features)
+            Test samples where n_samples in the number of samples
+            and n_features is the number of features.
+        batch_size : int, optional
+            Number of test samples evaluated at a time.
+        verbose : int, optional
+            Verbosity level.
+
+        Returns
+        -------
+        proba : array-like, shape = (n_samples, n_outputs)
+            Class probability estimates.
+        """
+        return self.model.predict_proba(X, batch_size=batch_size, verbose=verbose)

--- a/test/test_wrappers.py
+++ b/test/test_wrappers.py
@@ -1,0 +1,77 @@
+from __future__ import absolute_import
+from __future__ import print_function
+from keras.datasets import mnist
+from keras.models import Sequential
+from keras.layers.core import Dense, Activation
+from keras.utils import np_utils
+from keras.wrappers.scikit_learn import KerasClassifier
+import numpy as np
+
+nb_classes = 10
+batch_size = 128
+nb_epoch = 1
+
+max_train_samples = 5000
+max_test_samples = 1000
+
+np.random.seed(1337) # for reproducibility
+
+# the data, shuffled and split between tran and test sets
+(X_train, y_train), (X_test, y_test) = mnist.load_data()
+
+X_train = X_train.reshape(60000,784)[:max_train_samples]
+X_test = X_test.reshape(10000,784)[:max_test_samples]
+X_train = X_train.astype('float32')
+X_test = X_test.astype('float32')
+X_train /= 255
+X_test /= 255
+
+Y_train = np_utils.to_categorical(y_train, nb_classes)[:max_train_samples]
+Y_test = np_utils.to_categorical(y_test, nb_classes)[:max_test_samples]
+
+#############################
+# scikit-learn wrapper test #
+#############################
+print('Beginning scikit-learn wrapper test')
+
+print('Defining model')
+model = Sequential()
+model.add(Dense(784, 50))
+model.add(Activation('relu'))
+model.add(Dense(50, 10))
+model.add(Activation('softmax'))
+
+print('Creating wrapper')
+classifier = KerasClassifier(model)
+
+print('Fitting model')
+classifier.fit(X_train, Y_train, batch_size=batch_size, nb_epoch=nb_epoch)
+
+print('Testing score function')
+score = classifier.score(X_train, Y_train)
+print('Score: ', score)
+
+print('Testing predict function')
+preds = classifier.predict(X_test)
+print('Preds.shape: ', preds.shape)
+
+print('Testing predict proba function')
+proba = classifier.predict_proba(X_test)
+print('Proba.shape: ', proba.shape)
+
+print('Testing get params')
+print(classifier.get_params())
+
+print('Testing set params')
+classifier.set_params(optimizer='sgd', loss='mse')
+print(classifier.get_params())
+
+print('Testing attributes')
+print('Classes')
+print(classifier.classes_)
+print('Config')
+print(classifier.config_)
+print('Weights')
+print(classifier.weights_)
+
+print('Test script complete.')


### PR DESCRIPTION
Resolves issue #149

Some quick notes/observations:

- After a few design iterations, I opted to use a constructor that accepts a pre-defined (but not yet compiled) Keras model.  I'm reasonably sure this is the most sensible approach, but not 100% sure.  The advantage is that one can still build model definitions using the existing APIs, which are very fluid and expressive.  The disadvantage is that it's not possible to build a model using all default parameters, as one can do with the other scikit-learn estimators (I'm not sure this even makes sense for a neural net though).
- In order to allow meta-estimators such as ensembles to make copies of the base estimator, I'm making a copy of the model definition in the fit method before compilation.  I don't think this will cause any problems, but I'm not positive.  I tested it on my "Otto Group" Kaggle script and was able to build an ensemble using the wrapper class and scikit-learn's bagging classifier.
- I only created a classification wrapper.  It would probably make sense to pull most of this out into an abstract base class and create derived classes for classification and regression instead.  I'll leave that to a future enhancement though.