### PR TITLE
Loss visualization

### DIFF
--- a/docs/sources/models.md
+++ b/docs/sources/models.md
@@ -38,7 +38,7 @@ model = keras.models.Sequential()
         - __Return__: loss over the data, or tuple `(loss, accuracy)` if `accuracy=True`.
     - __test__(X, y, accuracy=False): Single performance evaluation on one batch. if accuracy==False, return tuple (loss_on_batch, accuracy_on_batch). Else, return loss_on_batch.
         - __Return__: loss over the data, or tuple `(loss, accuracy)` if `accuracy=True`.
-    - __save_weights__(fname, overwrite=False): Store the weights of all layers to a HDF5 file. If overwrite==False and the file already exists, an exception will be thrown.
+    - __save_weights__(fname): Store the weights of all layers to a HDF5 file.
     - __load_weights__(fname): Sets the weights of a model, based to weights stored by __save__weights__. You can only __load__weights__ on a savefile from a model with an identical architecture. __load_weights__ can be called either before or after the __compile__ step.
 
 __Examples__:

--- a/docs/sources/models.md
+++ b/docs/sources/models.md
@@ -38,7 +38,7 @@ model = keras.models.Sequential()
         - __Return__: loss over the data, or tuple `(loss, accuracy)` if `accuracy=True`.
     - __test__(X, y, accuracy=False): Single performance evaluation on one batch. if accuracy==False, return tuple (loss_on_batch, accuracy_on_batch). Else, return loss_on_batch.
         - __Return__: loss over the data, or tuple `(loss, accuracy)` if `accuracy=True`.
-    - __save_weights__(fname): Store the weights of all layers to a HDF5 file. 
+    - __save_weights__(fname, overwrite=False): Store the weights of all layers to a HDF5 file. If overwrite==False and the file already exists, an exception will be thrown.
     - __load_weights__(fname): Sets the weights of a model, based to weights stored by __save__weights__. You can only __load__weights__ on a savefile from a model with an identical architecture. __load_weights__ can be called either before or after the __compile__ step.
 
 __Examples__:

--- a/keras/models.py
+++ b/keras/models.py
@@ -362,7 +362,7 @@ class Sequential(Model):
             self.layers[i].set_weights(weights[:nb_param])
             weights = weights[nb_param:]
 
-    def save_weights(self, filepath, overwrite=False):
+    def save_weights(self, filepath):
         # Save weights from all layers to HDF5
         import h5py
         # FIXME: fail if file exists, or add option to overwrite!

--- a/keras/models.py
+++ b/keras/models.py
@@ -362,11 +362,15 @@ class Sequential(Model):
             self.layers[i].set_weights(weights[:nb_param])
             weights = weights[nb_param:]
 
-    def save_weights(self, filepath):
+    def save_weights(self, filepath, overwrite=False):
         # Save weights from all layers to HDF5
         import h5py
-        # FIXME: fail if file exists, or add option to overwrite!
+        import os.path
+        # if file exists and should not be overwritten
+        if not overwrite and os.path.isfile(filepath):
+            raise IOError('%s already exists' % (filepath))
         f = h5py.File(filepath, 'w')
+
         f.attrs['nb_layers'] = len(self.layers)
         for k, l in enumerate(self.layers):
             g = f.create_group('layer_{}'.format(k))
@@ -388,4 +392,4 @@ class Sequential(Model):
             weights = [g['param_{}'.format(p)] for p in range(g.attrs['nb_params'])]
             self.layers[k].set_weights(weights)
         f.close()
-        
+

--- a/keras/models.py
+++ b/keras/models.py
@@ -365,12 +365,8 @@ class Sequential(Model):
     def save_weights(self, filepath, overwrite=False):
         # Save weights from all layers to HDF5
         import h5py
-        import os.path
-        # if file exists and should not be overwritten
-        if not overwrite and os.path.isfile(filepath):
-            raise IOError('%s already exists' % (filepath))
+        # FIXME: fail if file exists, or add option to overwrite!
         f = h5py.File(filepath, 'w')
-
         f.attrs['nb_layers'] = len(self.layers)
         for k, l in enumerate(self.layers):
             g = f.create_group('layer_{}'.format(k))

--- a/keras/utils/drawing_utils.py
+++ b/keras/utils/drawing_utils.py
@@ -1,0 +1,28 @@
+import matplotlib.pyplot as plt
+
+class EpochDrawer(object):
+    '''
+    takes the history of keras.models.Sequential().fit() and
+    plots training and validation loss over the epochs
+    '''
+    def __init__(self, history, save_filename = None):
+
+        self.x = history['epoch']
+        self.legend = ['loss']
+
+        plt.plot(self.x, history['loss'], marker='.')
+
+        if 'val_loss' in history:
+            self.legend.append('val loss')
+            plt.plot(self.x, history['val_loss'], marker='.')
+
+        plt.title('Loss over epochs')
+        plt.xlabel('Epochs')
+        plt.xticks(history['epoch'], history['epoch'])
+        plt.legend(self.legend, loc = 'upper right')
+
+        if save_filename is not None:
+            plt.savefig(save_filename)
+
+        plt.show()
+

--- a/test/test_epochdrawer.py
+++ b/test/test_epochdrawer.py
@@ -1,0 +1,59 @@
+from __future__ import absolute_import
+from __future__ import print_function
+from keras.datasets import mnist
+from keras.models import Sequential
+from keras.layers.core import Dense, Dropout, Activation
+from keras.regularizers import l2, l1
+from keras.constraints import maxnorm
+from keras.optimizers import SGD, Adam, RMSprop
+from keras.utils import np_utils
+from keras.utils.drawing_utils import EpochDrawer
+import numpy as np
+
+'''
+    Train a simple deep NN on the MNIST dataset and plot the train/val loss
+    over the epochs.
+'''
+
+batch_size = 64
+nb_classes = 10
+nb_epoch = 20
+
+np.random.seed(1337) # for reproducibility
+
+# the data, shuffled and split between tran and test sets
+(X_train, y_train), (X_test, y_test) = mnist.load_data()
+
+X_train=X_train.reshape(60000,784)
+X_test=X_test.reshape(10000,784)
+X_train = X_train.astype("float32")
+X_test = X_test.astype("float32")
+X_train /= 255
+X_test /= 255
+print(X_train.shape[0], 'train samples')
+print(X_test.shape[0], 'test samples')
+
+# convert class vectors to binary class matrices
+Y_train = np_utils.to_categorical(y_train, nb_classes)
+Y_test = np_utils.to_categorical(y_test, nb_classes)
+
+model = Sequential()
+model.add(Dense(784, 128))
+model.add(Activation('relu'))
+model.add(Dropout(0.2))
+model.add(Dense(128, 128))
+model.add(Activation('relu'))
+model.add(Dropout(0.2))
+model.add(Dense(128, 10))
+model.add(Activation('softmax'))
+
+rms = RMSprop()
+model.compile(loss='categorical_crossentropy', optimizer=rms)
+
+history = model.fit(X_train, Y_train, batch_size=batch_size, nb_epoch=nb_epoch, show_accuracy=True, verbose=2, validation_data=(X_test, Y_test))
+score = model.evaluate(X_test, Y_test, show_accuracy=True, verbose=0)
+print('Test score:', score[0])
+print('Test accuracy:', score[1])
+
+EpochDrawer(history, save_filename='epochs.png')
+


### PR DESCRIPTION
A simple utility module to add a visualization of the loss history over the epochs, as returned by the fit method of the Sequential model.

If #171 is merged then a callback based animation of the loss curves would be possible.

Example figure from the provided MNIST test case:

![epochs](https://cloud.githubusercontent.com/assets/8267636/7880709/72addd64-05fc-11e5-8d36-301fb9db6427.png)

