### PR TITLE
Overwrite parameter for keras.models.save_weights

### DIFF
--- a/docs/sources/models.md
+++ b/docs/sources/models.md
@@ -38,7 +38,7 @@ model = keras.models.Sequential()
         - __Return__: loss over the data, or tuple `(loss, accuracy)` if `accuracy=True`.
     - __test__(X, y, accuracy=False): Single performance evaluation on one batch. if accuracy==False, return tuple (loss_on_batch, accuracy_on_batch). Else, return loss_on_batch.
         - __Return__: loss over the data, or tuple `(loss, accuracy)` if `accuracy=True`.
-    - __save_weights__(fname): Store the weights of all layers to a HDF5 file. 
+    - __save_weights__(fname, overwrite=False): Store the weights of all layers to a HDF5 file. If overwrite==False and the file already exists, an exception will be thrown.
     - __load_weights__(fname): Sets the weights of a model, based to weights stored by __save__weights__. You can only __load__weights__ on a savefile from a model with an identical architecture. __load_weights__ can be called either before or after the __compile__ step.
 
 __Examples__:

--- a/keras/models.py
+++ b/keras/models.py
@@ -362,10 +362,13 @@ class Sequential(Model):
             self.layers[i].set_weights(weights[:nb_param])
             weights = weights[nb_param:]
 
-    def save_weights(self, filepath):
+    def save_weights(self, filepath, overwrite=False):
         # Save weights from all layers to HDF5
         import h5py
-        # FIXME: fail if file exists, or add option to overwrite!
+        import os.path
+        # if file exists and should not be overwritten
+        if not overwrite and os.path.isfile(filepath):
+            raise IOError('%s already exists' % (filepath))
         f = h5py.File(filepath, 'w')
         f.attrs['nb_layers'] = len(self.layers)
         for k, l in enumerate(self.layers):


### PR DESCRIPTION
A patch for the FIXME (https://github.com/fchollet/keras/blob/df4e3a2d8d2195505ff2c744a37d1ecf467c2e9a/keras/models.py#L368) in the save_weights method.

If overwrite is not changed to True the method will throw an IOError when the file already exists.