### PR TITLE
add autoencoder and denoising autoencoder

### DIFF
--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -293,31 +293,35 @@ class TimeDistributedDense(Layer):
 class AutoEncoder(Layer):
     '''
         A customizable autoencoder model.
-        If output_reconstruction then dim(input) = dim(output)
-        else dim(output) = dim(hidden)
+          - Supports deep architectures by passing appropriate encoders/decoders list
+          - If output_reconstruction then dim(input) = dim(output) else dim(output) = dim(hidden)
     '''
-    def __init__(self, encoder=None, decoder=None, output_reconstruction=True, tie_weights=False, weights=None):
+    def __init__(self, encoders=[], decoders=[], output_reconstruction=True, tie_weights=False, weights=None):
 
         super(AutoEncoder,self).__init__()
-        if encoder is None or decoder is None:
+        if not encoders or not decoders:
             raise Exception("Please specify the encoder/decoder layers")
 
-        if not isinstance(encoder, Layer) or not isinstance(decoder, Layer):
-            raise Exception("Only Layer types are supported as inputs for autoencoders")
+        if not len(encoders) == len(decoders):
+            raise Exception("There need to be an equal number of encoders and decoders")
 
-        self.input_dim = encoder.input_dim
-        self.hidden_dim = decoder.input_dim
+        # connect all encoders & decoders to their previous (respectively)
+        for i in xrange(len(encoders)-1, 0, -1):
+            encoders[i].connect(encoders[i-1])
+            decoders[i].connect(decoders[i-1])
+        decoders[0].connect(encoders[-1])  # connect the first to the last
+
+        self.input_dim = encoders[0].input_dim
+        self.hidden_dim = reversed([d.input_dim for d in decoders])
         self.output_reconstruction = output_reconstruction
         self.tie_weights = tie_weights
-        self.encoder = encoder
-        self.decoder = decoder
-
-        self.decoder.connect(self.encoder)
+        self.encoders = encoders
+        self.decoders = decoders
 
         self.params = []
         self.regularizers = []
         self.constraints = []
-        for m in [encoder, decoder]:
+        for m in encoders + decoders:
             self.params += m.params
             if hasattr(m, 'regularizers'):
                 self.regularizers += m.regularizers
@@ -328,53 +332,54 @@ class AutoEncoder(Layer):
             self.set_weights(weights)
 
     def connect(self, node):
-        self.encoder.previous = node
+        self.encoders[0].previous = node
 
     def get_weights(self):
         weights = []
-        for m in [encoder, decoder]:
+        for m in encoders + decoders:
             weights += m.get_weights()
         return weights
 
     def set_weights(self, weights):
-        models = [encoder, decoder]
+        models = encoders + decoders
         for i in range(len(models)):
             nb_param = len(models[i].params)
             models[i].set_weights(weights[:nb_param])
             weights = weights[nb_param:]
 
     def get_input(self, train=False):
-        if hasattr(self.encoder, 'previous'):
-            return  self.encoder.previous.get_output(train=train)
+        if hasattr(self.encoders[0], 'previous'):
+            return  self.encoders[0].previous.get_output(train=train)
         else:
-            return self.encoder.input
+            return self.encoders[0].input
 
     @property
     def input(self):
         return self.get_input()
 
     def _get_hidden(self, train):
-        return self.encoder.get_output(train)
+        return self.encoders[-1].get_output(train)
+
+    def _tranpose_weights(self, src, dest):
+        if len(dest.shape) > 1:
+            dest = src.T
 
     def get_output(self, train):
         if not train and not self.output_reconstruction:
             return self._get_hidden(train)
 
-        decode = self.decoder.get_output(train)
+        decode = self.decoders[-1].get_output(train)
 
         if self.tie_weights:
-            encoder_params = self.encoder.get_weights()
-            decoder_params = self.decoder.get_weights()
-            for dec_param, enc_param in zip(decoder_params, encoder_params):
-                if len(dec_param.shape) > 1:
-                    enc_param = dec_param.T
+            for e,d in zip(self.encoders, self.decoders):
+                map(self._tranpose_weights, e.get_weights(), d.get_weights())
 
         return decode
 
     def get_config(self):
         return {"name":self.__class__.__name__,
-                "encoder_config":self.encoder.get_config(),
-                "decoder_config":self.decoder.get_config(),
+                "encoder_config":[e.get_config() for e in self.encoders],
+                "decoder_config":[d.get_config() for d in self.decoders],
                 "output_reconstruction":self.output_reconstruction,
                 "tie_weights":self.tie_weights}
 
@@ -383,8 +388,8 @@ class DenoisingAutoEncoder(AutoEncoder):
     '''
         A denoising autoencoder model that inherits the base features from autoencoder
     '''
-    def __init__(self, encoder=None, decoder=None, output_reconstruction=True, tie_weights=False, weights=None, corruption_level=0.3):
-        super(DenoisingAutoEncoder, self).__init__(encoder, decoder, output_reconstruction, tie_weights, weights)
+    def __init__(self, encoders=None, decoders=None, output_reconstruction=True, tie_weights=False, weights=None, corruption_level=0.3):
+        super(DenoisingAutoEncoder, self).__init__(encoders, decoders, output_reconstruction, tie_weights, weights)
         self.corruption_level = corruption_level
 
     def _get_corrupted_input(self, input):
@@ -401,8 +406,8 @@ class DenoisingAutoEncoder(AutoEncoder):
 
     def get_config(self):
         return {"name":self.__class__.__name__,
-                "encoder_config":self.encoder.get_config(),
-                "decoder_config":self.decoder.get_config(),
+                "encoder_config":[e.get_config() for e in self.encoders],
+                "decoder_config":[d.get_config() for d in self.decoders],
                 "corruption_level":self.corruption_level,
                 "output_reconstruction":self.output_reconstruction,
                 "tie_weights":self.tie_weights}

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -296,8 +296,7 @@ class AutoEncoder(Layer):
         If output_reconstruction then dim(input) = dim(output)
         else dim(output) = dim(hidden)
     '''
-    def __init__(self, encoder=None, decoder=None, output_reconstruction=True, tie_weights=False,
-                 weights=None, W_regularizer=None, b_regularizer=None, W_constraint=None, b_constraint=None):
+    def __init__(self, encoder=None, decoder=None, output_reconstruction=True, tie_weights=False, weights=None):
 
         super(AutoEncoder,self).__init__()
         if encoder is None or decoder is None:
@@ -383,13 +382,9 @@ class AutoEncoder(Layer):
 class DenoisingAutoEncoder(AutoEncoder):
     '''
         A denoising autoencoder model that inherits the base features from autoencoder
-        Cannot be the first layer in a model: same reasoning as Dropout, etc
     '''
-    def __init__(self, encoder=None, decoder=None, output_reconstruction=True, tie_weights=False,
-                 weights=None, W_regularizer=None, b_regularizer=None, W_constraint=None, b_constraint=None,
-                 corruption_level=0.3):
-        super(DenoisingAutoEncoder, self).__init__(encoder, decoder, output_reconstruction, tie_weights,
-                                                   weights, W_regularizer, b_regularizer, W_constraint, b_constraint)
+    def __init__(self, encoder=None, decoder=None, output_reconstruction=True, tie_weights=False, weights=None, corruption_level=0.3):
+        super(DenoisingAutoEncoder, self).__init__(encoder, decoder, output_reconstruction, tie_weights, weights)
         self.corruption_level = corruption_level
 
     def _get_corrupted_input(self, input):

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -361,20 +361,18 @@ class AutoEncoder(Layer):
         return self.encoders[-1].get_output(train)
 
     def _tranpose_weights(self, src, dest):
-        if len(dest.shape) > 1:
+        if len(dest.shape) > 1 and len(src.shape) > 1:
             dest = src.T
 
     def get_output(self, train):
         if not train and not self.output_reconstruction:
             return self._get_hidden(train)
 
-        decode = self.decoders[-1].get_output(train)
-
         if self.tie_weights:
             for e,d in zip(self.encoders, self.decoders):
                 map(self._tranpose_weights, e.get_weights(), d.get_weights())
 
-        return decode
+        return self.decoders[-1].get_output(train)
 
     def get_config(self):
         return {"name":self.__class__.__name__,

--- a/test/test_autoencoder.py
+++ b/test/test_autoencoder.py
@@ -1,0 +1,139 @@
+from __future__ import absolute_import
+from __future__ import print_function
+from keras.datasets import mnist
+from keras.models import Sequential
+from keras.layers.core import DenoisingAutoEncoder, AutoEncoder, Dense, Activation, TimeDistributedDense, Flatten
+from keras.layers.recurrent import LSTM
+from keras.layers.embeddings import Embedding
+from keras.layers.core import Layer
+from keras.utils import np_utils
+
+import numpy as np
+
+# Try different things here: 'lstm' or 'classical' or 'denoising'
+autoencoder_type = 'lstm'
+
+nb_classes = 10
+batch_size = 128
+nb_epoch = 10
+activation = 'linear'
+
+input_dim = 784
+hidden_dim = 392
+
+max_train_samples = 5000
+max_test_samples = 1000
+
+# the data, shuffled and split between tran and test sets
+(X_train, y_train), (X_test, y_test) = mnist.load_data()
+
+X_train = X_train.reshape(60000,input_dim)[:max_train_samples]
+X_test = X_test.reshape(10000,input_dim)[:max_test_samples]
+X_train = X_train.astype("float32")
+X_test = X_test.astype("float32")
+X_train /= 255
+X_test /= 255
+
+# convert class vectors to binary class matrices
+Y_train = np_utils.to_categorical(y_train, nb_classes)[:max_train_samples]
+Y_test = np_utils.to_categorical(y_test, nb_classes)[:max_test_samples]
+
+print("X_train: ", X_train.shape)
+print("X_test: ", X_test.shape)
+
+##########################
+# dense model test       #
+##########################
+
+print("Training classical fully connected layer for classification")
+model_classical = Sequential()
+model_classical.add(Dense(input_dim, 10, activation=activation))
+model_classical.add(Activation('softmax'))
+model_classical.get_config(verbose=1)
+model_classical.compile(loss='categorical_crossentropy', optimizer='adam')
+model_classical.fit(X_train, Y_train, batch_size=batch_size, nb_epoch=nb_epoch, show_accuracy=False, verbose=0, validation_data=(X_test, Y_test))
+classical_score = model_classical.evaluate(X_test, Y_test, verbose=0)
+print('\nclassical_score:', classical_score)
+print('\n')
+
+##########################
+# autoencoder model test #
+##########################
+
+def build_lstm_autoencoder(autoencoder, X_train, X_test):
+	X_train = X_train[:, np.newaxis, :] 
+	X_test = X_test[:, np.newaxis, :]
+	print("Modified X_train: ", X_train.shape)
+	print("Modified X_test: ", X_test.shape)
+
+	# The TimeDistributedDense isn't really necessary, however you need a lot of GPU memory to do 784x394-394x784
+	autoencoder.add(TimeDistributedDense(input_dim, 16))
+	autoencoder.add(AutoEncoder(encoder=LSTM(16, 8, activation=activation, return_sequences=True)
+								, decoder=LSTM(8, input_dim, activation=activation, return_sequences=True)
+								, output_reconstruction=False))
+	return autoencoder, X_train, X_test
+
+def build_classical_autoencoder(autoencoder):
+	autoencoder.add(AutoEncoder(encoder=Dense(input_dim, hidden_dim, activation=activation)
+								, decoder=Dense(hidden_dim, input_dim, activation=activation)
+								, output_reconstruction=False, tie_weights=True))
+	return autoencoder
+
+def build_denoising_autoencoder(autoencoder):
+	# You need another layer before a denoising autoencoder
+	# This is similar to the dropout layers, etc..
+	autoencoder.add(Dense(input_dim, input_dim))
+	autoencoder.add(DenoisingAutoEncoder(encoder=Dense(input_dim, hidden_dim, activation=activation)
+										, decoder=Dense(hidden_dim, input_dim, activation=activation)
+										, output_reconstruction=False, tie_weights=True, corruption_level=0.3))
+	return autoencoder
+
+# Build our autoencoder model
+autoencoder = Sequential()
+if autoencoder_type == 'lstm':
+	print("Training LSTM AutoEncoder")
+	autoencoder, X_train, X_test = build_lstm_autoencoder(autoencoder, X_train, X_test)
+elif autoencoder_type == 'denoising':
+	print("Training Denoising AutoEncoder")
+	autoencoder = build_denoising_autoencoder(autoencoder)
+elif autoencoder_type == 'classical':
+	print("Training Classical AutoEncoder")
+	autoencoder = build_classical_autoencoder(autoencoder)
+else:
+	print("Error: unknown autoencoder type!")
+	exit(-1)
+
+autoencoder.get_config(verbose=1)
+autoencoder.compile(loss='mean_squared_error', optimizer='adam')
+# Do NOT use validation data with return output_reconstruction=True
+autoencoder.fit(X_train, X_train, batch_size=batch_size, nb_epoch=nb_epoch, show_accuracy=False, verbose=0)
+
+# Do an inference pass
+prefilter_train = autoencoder.predict(X_train, verbose=0)
+prefilter_test = autoencoder.predict(X_test, verbose=0)
+print("prefilter_train: ", prefilter_train.shape)
+print("prefilter_test: ", prefilter_test.shape)
+
+# Classify results from Autoencoder
+print("Building classical fully connected layer for classification")
+model = Sequential()
+if autoencoder_type == 'lstm':
+	model.add(TimeDistributedDense(8, 10, activation=activation))
+	model.add(Flatten())
+else:
+	model.add(Dense(392, 10, activation=activation))
+
+model.add(Activation('softmax'))
+
+model.get_config(verbose=1)
+model.compile(loss='categorical_crossentropy', optimizer='adam')
+model.fit(prefilter_train, Y_train, batch_size=batch_size, nb_epoch=nb_epoch, show_accuracy=False, verbose=0, validation_data=(prefilter_test, Y_test))
+
+score = model.evaluate(prefilter_test, Y_test, verbose=0, show_accuracy=False)
+print('\nscore:', score)
+print('\n')
+
+if score < classical_score:
+	print("error: classical score > autoencoder score!")
+else:
+	print("autoencoder improvement: ", 100.0*(float(score)-float(classical_score))/float(classical_score), "%")


### PR DESCRIPTION
This implementation creates a base autoencoder class that should be inherited for all other implementations of autoencoders. Since we have added a get_hidden() method this can be used later on when we start stacking autoencoders. I.e. we can do something along the lines of:

```python
    if isinstance(my_new_stacked_autoencoder_layer, AutoEncoder):
        return previous_layer.get_hidden() # instead of .get_output()
```

A denoising autoencoder has also been added to demo how to inherit from AutoEncoder.
I have tried to be consistent with your coding style. Let me know if there are any issues.