### PR TITLE
Loading weights with incompatible shape

### DIFF
--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -30,6 +30,8 @@ class Layer(object):
 
     def set_weights(self, weights):
         for p, w in zip(self.params, weights):
+            if p.eval().shape != w.shape:
+                raise Exception("Layer shape %s not compatible with weight shape %s." % (p.eval().shape, w.shape))
             p.set_value(floatX(w))
 
     def get_weights(self):


### PR DESCRIPTION
Hey François,

I added a check for the shape of the current layer and the weights to be loaded in `keras.layers.Layer.set_weights`. Without that check it can happen that the weights alter the structure of the model. It raises an exception which is probably what should happen. Printing out a warning instead would work too, I guess.

Negative test case:

```
from __future__ import absolute_import
from __future__ import print_function
from keras.models import Sequential
from keras.layers.core import Dense, Activation, Merge

def createModelA():
    model = Sequential()
    model.add(Dense(784, 50))
    model.add(Activation('relu'))
    model.add(Dense(50, 10))
    model.add(Activation('softmax'))
    model.compile(loss='categorical_crossentropy', optimizer='rmsprop')
    return model

def createModelB():
    model = Sequential()
    model.add(Dense(784, 50))
    model.add(Activation('relu'))
    model.add(Dense(25, 10))
    model.add(Activation('softmax'))
    model.compile(loss='categorical_crossentropy', optimizer='rmsprop')
    return model

def cleanup():
    import os
    os.remove('a.hdf5')
    os.remove('b.hdf5')

modelA = createModelA()
modelB = createModelB()
modelA.save_weights('a.hdf5', overwrite=True)
modelB.save_weights('b.hdf5', overwrite=True)
# should not cause an error
modelA.load_weights('a.hdf5')
modelB.load_weights('b.hdf5')

#################
# negative test #
#################

try:
    modelA.load_weights('b.hdf5')
except:
    import sys
    #print("Expected error:", sys.exc_info()[0])
    print('Test passed, cleaning up')
    cleanup()
    sys.exit(0)

cleanup()
raise Exception('Test did not pass')
```

I can include the test case in the PR if needed.
