### PR TITLE
Fixed python 2.x bug with input() in save_weights()

### DIFF
--- a/keras/models.py
+++ b/keras/models.py
@@ -320,9 +320,13 @@ class Sequential(Model, containers.Sequential):
         import os.path
         # if file exists and should not be overwritten
         if not overwrite and os.path.isfile(filepath):
-            overwrite = input('[WARNING] %s already exists - overwrite? [y/n]' % (filepath))
+            import sys
+            get_input = input
+            if sys.version_info[:2] <= (2, 7):
+                get_input = raw_input
+            overwrite = get_input('[WARNING] %s already exists - overwrite? [y/n]' % (filepath))
             while overwrite not in ['y', 'n']:
-                overwrite = input('Enter "y" (overwrite) or "n" (cancel).')
+                overwrite = get_input('Enter "y" (overwrite) or "n" (cancel).')
             if overwrite == 'n':
                 return
             print('[TIP] Next time specify overwrite=True in save_weights!')


### PR DESCRIPTION
Hey François,

the `save_weights` method makes more trouble. :)

For Python 2.x using `input()` does not work. Instead to reliably get the input in python 2/3 one needs to use different functions.