### PR TITLE
Use the inner_init for internal weights in SimpleRNN

### DIFF
--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -31,7 +31,7 @@ class SimpleRNN(Layer):
         self.input = T.tensor3()
 
         self.W = self.init((self.input_dim, self.output_dim))
-        self.U = self.init((self.output_dim, self.output_dim))
+        self.U = self.inner_init((self.output_dim, self.output_dim))
         self.b = shared_zeros((self.output_dim))
         self.params = [self.W, self.U, self.b]
 


### PR DESCRIPTION
It appears this was a bug in the implementation of SimpleRNN. The `init` initializer was being used for both sets of weights.