### PR TITLE
Time-Masked RNN

### DIFF
--- a/docs/sources/layers/recurrent.md
+++ b/docs/sources/layers/recurrent.md
@@ -4,7 +4,7 @@
 ```python
 keras.layers.recurrent.SimpleRNN(input_dim, output_dim, 
         init='glorot_uniform', inner_init='orthogonal', activation='sigmoid', weights=None,
-        truncate_gradient=-1, return_sequences=False)
+        truncate_gradient=-1, time_mask=False, return_time_mask=None, return_sequences=False)
 ```
 Fully connected RNN where output is to fed back to input. Not a particularly useful model, included for demonstration purposes.
 
@@ -21,6 +21,8 @@ Fully connected RNN where output is to fed back to input. Not a particularly use
     - __activation__: activation function. Can be the name of an existing function (str), or a Theano function (see: [activations](../activations.md)).
     - __weights__: list of numpy arrays to set as initial weights. The list should have 3 elements, of shapes: `[(input_dim, output_dim), (output_dim, output_dim), (output_dim,)]`.
     - __truncate_gradient__: Number of steps to use in truncated BPTT. See: [Theano "scan"](http://deeplearning.net/software/theano/library/scan.html).
+	- __time_mask__: Whether a mask is passed concatenated along with the input representing which timesteps should be ignored
+	- __return_time_mask__: Whether or not the time mask should be returned (unchanged) concatenated to the output
     - __return_sequences__: Boolean. Whether to return the last output in the output sequence, or the full sequence.
 
 ---

--- a/keras/layers/embeddings.py
+++ b/keras/layers/embeddings.py
@@ -44,7 +44,7 @@ class Embedding(Layer):
         out = self.W[X]
 
         if self.pass_mask:
-            return T.concatenate((out, mask), axis=2)
+            return T.concatenate((out, mask), axis=2).astype(theano.config.floatX)
         else:
             return out
 

--- a/keras/layers/embeddings.py
+++ b/keras/layers/embeddings.py
@@ -15,25 +15,39 @@ class Embedding(Layer):
         @input_dim: size of vocabulary (highest input integer + 1)
         @out_dim: size of dense representation
     '''
-    def __init__(self, input_dim, output_dim, init='uniform', weights=None, W_regularizer=None, W_constraint=None):
+    def __init__(self, input_dim, output_dim, init='uniform', weights=None, W_regularizer=None, W_constraint=None, pass_mask=False):
         super(Embedding,self).__init__()
         self.init = initializations.get(init)
         self.input_dim = input_dim
         self.output_dim = output_dim
 
-        self.input = T.imatrix()
         self.W = self.init((self.input_dim, self.output_dim))
         self.params = [self.W]
         self.constraints = [W_constraint]
         self.regularizers = [W_regularizer]
+
+        self.pass_mask = pass_mask
+
+        if pass_mask:
+            self.input = T.itensor3()
+        else:
+            self.input = T.imatrix()
 
         if weights is not None:
             self.set_weights(weights)
 
     def get_output(self, train=False):
         X = self.get_input(train)
+        if self.pass_mask:
+            mask = X[:,:,-1:]
+            X = X[:,:,0]
         out = self.W[X]
-        return out
+
+        if self.pass_mask:
+            return T.concatenate((out, mask), axis=2)
+        else:
+            return out
+
 
     def get_config(self):
         return {"name":self.__class__.__name__,

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -19,7 +19,7 @@ class SimpleRNN(Layer):
     '''
     def __init__(self, input_dim, output_dim, 
         init='glorot_uniform', inner_init='orthogonal', activation='sigmoid', weights=None,
-        truncate_gradient=-1, return_sequences=False):
+        truncate_gradient=-1, return_sequences=False, time_mask=False, return_time_mask=None):
         super(SimpleRNN,self).__init__()
         self.init = initializations.get(init)
         self.inner_init = initializations.get(inner_init)
@@ -28,6 +28,13 @@ class SimpleRNN(Layer):
         self.truncate_gradient = truncate_gradient
         self.activation = activations.get(activation)
         self.return_sequences = return_sequences
+        self.time_mask = time_mask
+        if return_time_mask is None:
+            self.return_time_mask = self.time_mask and self.return_sequences
+        else:
+            if not self.return_sequences:
+                raise Exception("Can't return the time mask if not returning sequences")
+            self.return_time_mask = return_time_mask
         self.input = T.tensor3()
 
         self.W = self.init((self.input_dim, self.output_dim))
@@ -38,18 +45,27 @@ class SimpleRNN(Layer):
         if weights is not None:
             self.set_weights(weights)
 
-    def _step(self, x_t, h_tm1, u):
+    def _step(self, x_t, mask, h_tm1, u):
         '''
             Variable names follow the conventions from: 
             http://deeplearning.net/software/theano/library/scan.html
 
         '''
-        return self.activation(x_t + T.dot(h_tm1, u))
+        h_t = self.activation(x_t + T.dot(h_tm1, u)) 
+        return mask*h_t + (1-mask)*h_tm1
 
     def get_output(self, train):
         X = self.get_input(train) # shape: (nb_samples, time (padded with zeros at the end), input_dim)
         # new shape: (time, nb_samples, input_dim) -> because theano.scan iterates over main dimension
         X = X.dimshuffle((1,0,2)) 
+
+        if self.time_mask:
+            # [X, mask]
+            mask = X[X.shape[0]//2:, : ,0:1] # we will always broadcast our masks across input dimensions
+            X = X[:X.shape[0]//2, :, :]
+        else:
+            mask = T.ones((X.shape[0], X.shape[1], 1))
+        mask = T.addbroadcast(mask, 2)
 
         x = T.dot(X, self.W) + self.b
         
@@ -58,14 +74,22 @@ class SimpleRNN(Layer):
         # Iterate over the first dimension of the x array (=time).
         outputs, updates = theano.scan(
             self._step, # this will be called with arguments (sequences[i], outputs[i-1], non_sequences[i])
-            sequences=x, # tensors to iterate over, inputs to _step
+            sequences=[x, mask], # tensors to iterate over, inputs to _step
             # initialization of the output. Input to _step with default tap=-1.
             outputs_info=T.unbroadcast(alloc_zeros_matrix(X.shape[1], self.output_dim), 1),
             non_sequences=self.U, # static inputs to _step
             truncate_gradient=self.truncate_gradient
         )
+
+
         if self.return_sequences:
-            return outputs.dimshuffle((1,0,2))
+            result = outputs.dimshuffle((1,0,2))
+            if self.return_time_mask:
+                maskout = T.zeros_like(result)
+                maskout = T.set_subtensor(maskout[:,:,0:1], mask.dimshuffle((1,0,2)))
+                return T.concatenate((result, maskout), 1) # concatenate the masks along the time axis
+            else:
+                return result
         return outputs[-1]
 
     def get_config(self):

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -64,7 +64,8 @@ class SimpleRNN(Layer):
             mask = X[:, :, -1:]
             X = X[:, :, :-1]
         else:
-            mask = T.ones((X.shape[0], X.shape[1], 1))
+            mask = T.alloc(np.cast[theano.config.floatX](1.), X.shape[0], X.shape[1], 1) # ones
+
         mask = T.addbroadcast(mask, 2)
 
         x = T.dot(X, self.W) + self.b

--- a/test/test_masked_recurrent.py
+++ b/test/test_masked_recurrent.py
@@ -5,13 +5,14 @@ import numpy as np
 from keras.utils.theano_utils import sharedX
 from keras.models import Sequential
 from keras.layers.core import Dense, Activation, Merge
+from keras.layers.embeddings import Embedding
 from keras.layers.recurrent import SimpleRNN
 import theano
 
 theano.config.exception_verbosity='high' 
 
 # (nb_samples, timesteps, dimensions)
-X = np.random.random_integers(20, size=(100000,3,2))
+X = np.random.random_integers(0, 3, size=(40000,3))
 
 def my_eye(scale=1.0):
     def inner(shape):
@@ -19,57 +20,77 @@ def my_eye(scale=1.0):
     return inner
 
 unmasked_model = Sequential()
+unmasked_model.add(Embedding(4, 2))
 unmasked_model.add(SimpleRNN(2,3, activation='relu', return_sequences=True))
 unmasked_model.add(SimpleRNN(3,3, activation='relu'))
-unmasked_model.add(Dense(3,2))
-unmasked_model.compile(loss='mse', optimizer='rmsprop', theano_mode=theano.compile.mode.FAST_COMPILE)
+unmasked_model.add(Dense(3,4, activation='softmax'))
+unmasked_model.compile(loss='categorical_crossentropy',
+        optimizer='rmsprop', theano_mode=theano.compile.mode.FAST_COMPILE)
 print("Compiled unmasked_model")
 
 unmasked_model_b = Sequential()
+unmasked_model_b.add(Embedding(4, 2))
 unmasked_model_b.add(SimpleRNN(2,3, activation='relu', return_sequences=True))
 unmasked_model_b.add(SimpleRNN(3,3, activation='relu'))
-unmasked_model_b.add(Dense(3,2))
-unmasked_model_b.compile(loss='mse', optimizer='rmsprop', theano_mode=theano.compile.mode.FAST_COMPILE)
+unmasked_model_b.add(Dense(3,4, activation='softmax'))
+unmasked_model_b.compile(loss='categorical_crossentropy', optimizer='rmsprop', theano_mode=theano.compile.mode.FAST_COMPILE)
 print("Compiled unmasked_model")
 
 masked_model = Sequential()
+masked_model.add(Embedding(4, 2, pass_mask=True))
 masked_model.add(SimpleRNN(2,3, activation='relu', time_mask=True, return_sequences=True))
 masked_model.add(SimpleRNN(3,3, activation='relu', time_mask=True))
-masked_model.add(Dense(3,2))
-masked_model.compile(loss='mse', optimizer='rmsprop', theano_mode=theano.compile.mode.FAST_COMPILE)
+masked_model.add(Dense(3,4, activation='softmax'))
+masked_model.compile(loss='categorical_crossentropy', optimizer='rmsprop', theano_mode=theano.compile.mode.FAST_COMPILE)
 print("Compiled masked_model")
 
 # This masked model is expected to learn
 masked_model_b = Sequential()
+masked_model_b.add(Embedding(4, 2, pass_mask=True))
 masked_model_b.add(SimpleRNN(2,3, activation='relu', time_mask=True, return_sequences=True))
 masked_model_b.add(SimpleRNN(3,3, activation='relu', time_mask=True))
-masked_model_b.add(Dense(3,2))
-masked_model_b.compile(loss='mse', optimizer='rmsprop', theano_mode=theano.compile.mode.FAST_COMPILE)
+masked_model_b.add(Dense(3,4, activation='softmax'))
+masked_model_b.compile(loss='categorical_crossentropy', optimizer='rmsprop', theano_mode=theano.compile.mode.FAST_COMPILE)
 print("Compiled masked_model")
 
 
-mask = np.ones(X.shape)
-mask[:,0,:] = 0 # mask out the first timestep
-withmask = np.concatenate((X, mask), axis=1)
+# Uniform score: 4 options = ln(4) nats (2 bits)
+# we should not do better than this when we mask out the part of the input
+# that gives us the correct answer
+uniform_score = np.log(4)
 
-unmasked_model.fit(X, X[:,0,:], nb_epoch=1)
-score = unmasked_model.evaluate(X, X[:,0,:])
-if np.sqrt(score) > 5.744:
+mask = np.ones((X.shape[0], X.shape[1], 1))
+mask[:,0,:] = 0 # mask out the first timestep
+withmask = np.concatenate((X[:,:,np.newaxis], mask), axis=2)
+
+X0_onehot = np.zeros((X.shape[0], 4))
+X1_onehot = np.zeros((X.shape[0], 4))
+for i, row in enumerate(X):
+    X0_onehot[i, row[0]] = 1
+    X1_onehot[i, row[1]] = 1
+
+#print(X0_onehot[:10])
+#print("+++++")
+#print(withmask[:10])
+
+unmasked_model.fit(X, X0_onehot, nb_epoch=1)
+score = unmasked_model.evaluate(X, X0_onehot)
+if score > uniform_score*0.9:
     raise Exception('Failed to learn to copy timestep 0, score %f' % score)
 
-unmasked_model_b.fit(X[:,1:,:], X[:,1,:], nb_epoch=1)
-score = unmasked_model_b.evaluate(X[:,1:,:], X[:,1,:])
-if np.sqrt(score) > 5.744:
+unmasked_model_b.fit(X[:,1:], X1_onehot, nb_epoch=1)
+score = unmasked_model_b.evaluate(X[:,1:], X1_onehot)
+if score > uniform_score*0.9:
     raise Exception('Failed to learn to copy timestep 1, score %f' % score)
 
-masked_model.fit(withmask, X[:,0,:], nb_epoch=1)
-score = masked_model.evaluate(withmask, X[:,0,:])
-if np.sqrt(score) < 5.744:
-    raise Exception('Somehow learned to copy timestep 0 despite mask, score %f' % score)
+masked_model.fit(withmask, X0_onehot, nb_epoch=1)
+score = masked_model.evaluate(withmask, X0_onehot)
+if score < uniform_score*0.9:
+   raise Exception('Somehow learned to copy timestep 0 despite mask, score %f' % score)
 
 
-masked_model_b.fit(withmask, X[:,1,:], nb_epoch=1)
-score = masked_model_b.evaluate(withmask, X[:,1,:])
-if np.sqrt(score) > 5.744:
+masked_model_b.fit(withmask, X1_onehot, nb_epoch=1)
+score = masked_model_b.evaluate(withmask, X1_onehot)
+if score > uniform_score*0.9:
     raise Exception('Failed to learn to copy timestep 1 in masked model, score %f' % score)
 

--- a/test/test_masked_recurrent.py
+++ b/test/test_masked_recurrent.py
@@ -1,0 +1,75 @@
+# Dummy test data as input to RNN. This input is 3 timesteps long where the third timestep always matches the
+# first. Without masking it should be able to learn it, with masking it should fail.
+
+import numpy as np
+from keras.utils.theano_utils import sharedX
+from keras.models import Sequential
+from keras.layers.core import Dense, Activation, Merge
+from keras.layers.recurrent import SimpleRNN
+import theano
+
+theano.config.exception_verbosity='high' 
+
+# (nb_samples, timesteps, dimensions)
+X = np.random.random_integers(20, size=(100000,3,2))
+
+def my_eye(scale=1.0):
+    def inner(shape):
+        return sharedX(scale*np.eye(shape[0], shape[1]))
+    return inner
+
+unmasked_model = Sequential()
+unmasked_model.add(SimpleRNN(2,3, activation='relu', return_sequences=True))
+unmasked_model.add(SimpleRNN(3,3, activation='relu'))
+unmasked_model.add(Dense(3,2))
+unmasked_model.compile(loss='mse', optimizer='rmsprop', theano_mode=theano.compile.mode.FAST_COMPILE)
+print("Compiled unmasked_model")
+
+unmasked_model_b = Sequential()
+unmasked_model_b.add(SimpleRNN(2,3, activation='relu', return_sequences=True))
+unmasked_model_b.add(SimpleRNN(3,3, activation='relu'))
+unmasked_model_b.add(Dense(3,2))
+unmasked_model_b.compile(loss='mse', optimizer='rmsprop', theano_mode=theano.compile.mode.FAST_COMPILE)
+print("Compiled unmasked_model")
+
+masked_model = Sequential()
+masked_model.add(SimpleRNN(2,3, activation='relu', time_mask=True, return_sequences=True))
+masked_model.add(SimpleRNN(3,3, activation='relu', time_mask=True))
+masked_model.add(Dense(3,2))
+masked_model.compile(loss='mse', optimizer='rmsprop', theano_mode=theano.compile.mode.FAST_COMPILE)
+print("Compiled masked_model")
+
+# This masked model is expected to learn
+masked_model_b = Sequential()
+masked_model_b.add(SimpleRNN(2,3, activation='relu', time_mask=True, return_sequences=True))
+masked_model_b.add(SimpleRNN(3,3, activation='relu', time_mask=True))
+masked_model_b.add(Dense(3,2))
+masked_model_b.compile(loss='mse', optimizer='rmsprop', theano_mode=theano.compile.mode.FAST_COMPILE)
+print("Compiled masked_model")
+
+
+mask = np.ones(X.shape)
+mask[:,0,:] = 0 # mask out the first timestep
+withmask = np.concatenate((X, mask), axis=1)
+
+unmasked_model.fit(X, X[:,0,:], nb_epoch=1)
+score = unmasked_model.evaluate(X, X[:,0,:])
+if np.sqrt(score) > 5.744:
+    raise Exception('Failed to learn to copy timestep 0, score %f' % score)
+
+unmasked_model_b.fit(X[:,1:,:], X[:,1,:], nb_epoch=1)
+score = unmasked_model_b.evaluate(X[:,1:,:], X[:,1,:])
+if np.sqrt(score) > 5.744:
+    raise Exception('Failed to learn to copy timestep 1, score %f' % score)
+
+masked_model.fit(withmask, X[:,0,:], nb_epoch=1)
+score = masked_model.evaluate(withmask, X[:,0,:])
+if np.sqrt(score) < 5.744:
+    raise Exception('Somehow learned to copy timestep 0 despite mask, score %f' % score)
+
+
+masked_model_b.fit(withmask, X[:,1,:], nb_epoch=1)
+score = masked_model_b.evaluate(withmask, X[:,1,:])
+if np.sqrt(score) > 5.744:
+    raise Exception('Failed to learn to copy timestep 1 in masked model, score %f' % score)
+


### PR DESCRIPTION
This introduces a new mode to the SimpleRNN where it can be
"time-masked" in which case the input shape to the layer becomes doubled along the time
dimension, with X[:,X.shape[1]//2:,0] becoming a mask vector which, when
set to 0, compels the _scan function to simply copy its h_tm1 to the
output.

I've only added this to SimpleRNN. I know there's been some discussion in the issues here about masking so I think this could be helpful to some other people as well. I'm happy to discuss further if there are questions about this!

My test fails sometimes, because depending on the initialization of the RNN it sometimes fails to learn the simple rule (copy input x_0 to get output). I am happy to discuss better testing approaches here, one approach could be to just train the unmasked model several times and ensure at least one converges.

Incidentally I also added an empty `__init__.py` to the tests directory so that I could use it as a module
