### PR TITLE
Enable pad_sequences to operate on sequences of numpy arrays

### DIFF
--- a/keras/preprocessing/sequence.py
+++ b/keras/preprocessing/sequence.py
@@ -4,7 +4,6 @@ import numpy as np
 import random
 from six.moves import range
 
-
 def pad_sequences(sequences, maxlen=None, dtype='int32', padding='pre'):
     """
         Pad each sequence to the same length: 
@@ -22,23 +21,21 @@ def pad_sequences(sequences, maxlen=None, dtype='int32', padding='pre'):
     nb_samples = len(sequences)
     if maxlen is None:
         maxlen = np.max(lengths)
-    
-    array_like = False
-    for idx, l in enumerate(lengths):
-        if l > 0:
-            if isinstance(sequences[idx][0], np.ndarray):
-                array_like = True
-                dim = len(sequences[idx][0])
-            break
+
+    array_like = isinstance(sequences[0][0], np.ndarray)
+
+    if array_like:
+        try:
+            dim = len(sequences[0][0])
+        except:
+            raise Exception('"sequences" input to preprocessing.sequence.pad_sequences should be a non-empty list of non-empty sequences (scalars or arrays)')
 
     if not array_like:
         x = np.zeros((nb_samples, maxlen)).astype(dtype)
     else:
         x = np.zeros((nb_samples, maxlen, dim)).astype(dtype)
-     
+
     for idx, s in enumerate(sequences):
-        if len(s) == 0:
-            continue
         if padding == 'post':
             x[idx, :lengths[idx]] = s[:maxlen]
         else:

--- a/keras/preprocessing/sequence.py
+++ b/keras/preprocessing/sequence.py
@@ -13,8 +13,8 @@ def pad_sequences(sequences, maxlen=None, dtype='int32', padding='pre', vector_s
         If maxlen is provided, any sequence longer
         then maxlen is truncated to maxlen.
         
-        If vector_sequence is true, then each sequences of numpy
-        arrays is padded using arrays of zeros.
+        If vector_sequence is true, then each sequence of numpy
+        array is padded using zero arrays.
 
         Support post-padding and pre-padding (default).
     """

--- a/keras/preprocessing/sequence.py
+++ b/keras/preprocessing/sequence.py
@@ -29,8 +29,7 @@ def pad_sequences(sequences, maxlen=None, dtype='int32', padding='pre'):
             if isinstance(sequences[idx][0], np.ndarray):
                 array_like = True
                 dim = len(sequences[idx][0])
-            else:
-                break
+            break
 
     if not array_like:
         x = np.zeros((nb_samples, maxlen)).astype(dtype)

--- a/keras/preprocessing/sequence.py
+++ b/keras/preprocessing/sequence.py
@@ -4,31 +4,39 @@ import numpy as np
 import random
 from six.moves import range
 
-def pad_sequences(sequences, maxlen=None, dtype='int32', padding='pre'):
+
+def pad_sequences(sequences, maxlen=None, dtype='int32', padding='pre', vector_sequence=False):
     """
         Pad each sequence to the same length: 
         the length of the longuest sequence.
 
         If maxlen is provided, any sequence longer
-        than maxlen is truncated to maxlen.
+        then maxlen is truncated to maxlen.
+        
+        If vector_sequence is true, then each sequences of numpy
+        arrays is padded using arrays of zeros.
 
         Support post-padding and pre-padding (default).
     """
     lengths = [len(s) for s in sequences]
-
     nb_samples = len(sequences)
     if maxlen is None:
         maxlen = np.max(lengths)
-
-    x = np.zeros((nb_samples, maxlen)).astype(dtype)
+    
+    if not vector_sequence:
+        x = np.zeros((nb_samples, maxlen)).astype(dtype)
+    else:
+        dim = len(sequences[0][0])
+        x = np.zeros((nb_samples, maxlen, dim)).astype(dtype)
+     
     for idx, s in enumerate(sequences):
         if padding == 'post':
             x[idx, :lengths[idx]] = s[:maxlen]
         else:
             x[idx, -min(maxlen, lengths[idx]):] = s[:maxlen]
     return x
-
-
+        
+        
 def make_sampling_table(size, sampling_factor=1e-5):
     '''
         This generates an array where the ith element

--- a/keras/preprocessing/sequence.py
+++ b/keras/preprocessing/sequence.py
@@ -21,14 +21,14 @@ def pad_sequences(sequences, maxlen=None, dtype='int32', padding='pre'):
     nb_samples = len(sequences)
     if maxlen is None:
         maxlen = np.max(lengths)
-
-    array_like = isinstance(sequences[0][0], np.ndarray)
-
-    if array_like:
-        try:
-            dim = len(sequences[0][0])
-        except:
-            raise Exception('"sequences" input to preprocessing.sequence.pad_sequences should be a non-empty list of non-empty sequences (scalars or arrays)')
+    
+    array_like = True
+    try:
+        dim = len(sequences[0][0])
+    except TypeError:
+        array_like = False
+    except IndexError:
+        raise Exception('"sequences" input to preprocessing.sequence.pad_sequences should be a non-empty list of non-empty sequences (scalars or arrays)')
 
     if not array_like:
         x = np.zeros((nb_samples, maxlen)).astype(dtype)

--- a/keras/preprocessing/sequence.py
+++ b/keras/preprocessing/sequence.py
@@ -5,7 +5,7 @@ import random
 from six.moves import range
 
 
-def pad_sequences(sequences, maxlen=None, dtype='int32', padding='pre', vector_sequence=False):
+def pad_sequences(sequences, maxlen=None, dtype='int32', padding='pre'):
     """
         Pad each sequence to the same length: 
         the length of the longuest sequence.
@@ -13,8 +13,8 @@ def pad_sequences(sequences, maxlen=None, dtype='int32', padding='pre', vector_s
         If maxlen is provided, any sequence longer
         then maxlen is truncated to maxlen.
         
-        If vector_sequence is true, then each sequence of numpy
-        array is padded using zero arrays.
+        Each sequence is padded using zeros or zero arrays 
+        accordingly to the input shape.
 
         Support post-padding and pre-padding (default).
     """
@@ -23,20 +23,30 @@ def pad_sequences(sequences, maxlen=None, dtype='int32', padding='pre', vector_s
     if maxlen is None:
         maxlen = np.max(lengths)
     
-    if not vector_sequence:
+    array_like = False
+    for idx, l in enumerate(lengths):
+        if l > 0:
+            if isinstance(sequences[idx][0], np.ndarray):
+                array_like = True
+                dim = len(sequences[idx][0])
+            else:
+                break
+
+    if not array_like:
         x = np.zeros((nb_samples, maxlen)).astype(dtype)
     else:
-        dim = len(sequences[0][0])
         x = np.zeros((nb_samples, maxlen, dim)).astype(dtype)
      
     for idx, s in enumerate(sequences):
+        if len(s) == 0:
+            continue
         if padding == 'post':
             x[idx, :lengths[idx]] = s[:maxlen]
         else:
             x[idx, -min(maxlen, lengths[idx]):] = s[:maxlen]
     return x
-        
-        
+
+
 def make_sampling_table(size, sampling_factor=1e-5):
     '''
         This generates an array where the ith element


### PR DESCRIPTION
Hello,

As I am working  with LSTM using w2v embeddings, enabling pad_sequences to operate on sequence of numpy arrays would be very useful for such applications!

Robert