### PR TITLE
Plotter callback

### DIFF
--- a/docs/sources/callbacks.md
+++ b/docs/sources/callbacks.md
@@ -42,6 +42,14 @@ keras.callbacks.EarlyStopping(patience=0, verbose=0)
 
 Stop training after no improvement of the validation loss is seen for `patience` epochs.
 
+```python
+keras.callbacks.Plotter(save_to_filepath=None, show_plot_window=True, linestyles=['r-', 'b-', 'r:', 'b:'], linestyles_first_epoch=['rs-', 'b^-', 'r:', 'b:'], show_regressions=True, poly_forward_perc=0.1, poly_backward_perc=0.2, poly_n_forward_min=10, poly_n_backward_min=20, poly_degree=1)
+```
+
+Creates a plot which shows the changes in loss and accuracy (for both training and validation datasets) over time.
+The plot is updated at the end of each epoch. Setting the parameter `save_to_filepath` allows to save the generated plot. An older file with the same name will be overwritten. Some image viewers may support automatic reloading of that file upon any change (i.e. at the end of each epoch).
+Setting `show_plot_window` to `False` will hide the plot window and only save to the file.
+
 ---
 
 

--- a/docs/sources/callbacks.md
+++ b/docs/sources/callbacks.md
@@ -43,7 +43,7 @@ keras.callbacks.EarlyStopping(patience=0, verbose=0)
 Stop training after no improvement of the validation loss is seen for `patience` epochs.
 
 ```python
-keras.callbacks.Plotter(save_to_filepath=None, show_plot_window=True, linestyles=['r-', 'b-', 'r:', 'b:'], linestyles_first_epoch=['rs-', 'b^-', 'r:', 'b:'], show_regressions=True, poly_forward_perc=0.1, poly_backward_perc=0.2, poly_n_forward_min=10, poly_n_backward_min=20, poly_degree=1)
+keras.callbacks.Plotter(save_to_filepath=None, show_plot_window=True, linestyles=None, linestyles_first_epoch=None, show_regressions=True, poly_forward_perc=0.1, poly_backward_perc=0.2, poly_n_forward_min=10, poly_n_backward_min=20, poly_degree=1)
 ```
 
 Creates a plot which shows the changes in loss and accuracy (for both training and validation datasets) over time.

--- a/docs/sources/callbacks.md
+++ b/docs/sources/callbacks.md
@@ -43,7 +43,7 @@ keras.callbacks.EarlyStopping(patience=0, verbose=0)
 Stop training after no improvement of the validation loss is seen for `patience` epochs.
 
 ```python
-keras.callbacks.Plotter(save_to_filepath=None, show_plot_window=True, linestyles=None, linestyles_first_epoch=None, show_regressions=True, poly_forward_perc=0.1, poly_backward_perc=0.2, poly_n_forward_min=10, poly_n_backward_min=20, poly_degree=1)
+keras.callbacks.Plotter(save_to_filepath=None, show_plot_window=True, linestyles=None, linestyles_first_epoch=None, show_regressions=True, poly_forward_perc=0.1, poly_backward_perc=0.2, poly_n_forward_min=5, poly_n_backward_min=10, poly_degree=1)
 ```
 
 Creates a plot which shows the changes in loss and accuracy (for both training and validation datasets) over time.

--- a/examples/mnist_cnn.py
+++ b/examples/mnist_cnn.py
@@ -59,7 +59,7 @@ model.compile(loss='categorical_crossentropy', optimizer='adadelta')
 
 model.fit(X_train, Y_train, batch_size=batch_size, nb_epoch=nb_epoch,
           show_accuracy=True, verbose=1, validation_data=(X_test, Y_test),
-          callbacks=[Plotter()])
+          callbacks=[Plotter(show_regressions=False)])
 score = model.evaluate(X_test, Y_test, show_accuracy=True, verbose=0)
 print('Test score:', score[0])
 print('Test accuracy:', score[1])

--- a/examples/mnist_cnn.py
+++ b/examples/mnist_cnn.py
@@ -5,6 +5,7 @@ from keras.models import Sequential
 from keras.layers.core import Dense, Dropout, Activation, Flatten
 from keras.layers.convolutional import Convolution2D, MaxPooling2D
 from keras.utils import np_utils
+from keras.callbacks import Plotter
 import numpy as np
 
 '''
@@ -56,7 +57,9 @@ model.add(Activation('softmax'))
 
 model.compile(loss='categorical_crossentropy', optimizer='adadelta')
 
-model.fit(X_train, Y_train, batch_size=batch_size, nb_epoch=nb_epoch, show_accuracy=True, verbose=1, validation_data=(X_test, Y_test))
+model.fit(X_train, Y_train, batch_size=batch_size, nb_epoch=nb_epoch,
+          show_accuracy=True, verbose=1, validation_data=(X_test, Y_test),
+          callbacks=[Plotter()])
 score = model.evaluate(X_test, Y_test, show_accuracy=True, verbose=0)
 print('Test score:', score[0])
 print('Test accuracy:', score[1])

--- a/examples/mnist_mlp.py
+++ b/examples/mnist_mlp.py
@@ -52,7 +52,7 @@ model.compile(loss='categorical_crossentropy', optimizer=rms)
 
 model.fit(X_train, Y_train, batch_size=batch_size, nb_epoch=nb_epoch,
           show_accuracy=True, verbose=2, validation_data=(X_test, Y_test),
-          callbacks=[Plotter()])
+          callbacks=[Plotter(save_to_filepath="/tmp/last_plot.png")])
 score = model.evaluate(X_test, Y_test, show_accuracy=True, verbose=0)
 print('Test score:', score[0])
 print('Test accuracy:', score[1])

--- a/examples/mnist_mlp.py
+++ b/examples/mnist_mlp.py
@@ -52,7 +52,7 @@ model.compile(loss='categorical_crossentropy', optimizer=rms)
 
 model.fit(X_train, Y_train, batch_size=batch_size, nb_epoch=nb_epoch,
           show_accuracy=True, verbose=2, validation_data=(X_test, Y_test),
-          callbacks=[Plotter()])
+          callbacks=[Plotter(show_regressions=False)])
 score = model.evaluate(X_test, Y_test, show_accuracy=True, verbose=0)
 print('Test score:', score[0])
 print('Test accuracy:', score[1])

--- a/examples/mnist_mlp.py
+++ b/examples/mnist_mlp.py
@@ -5,6 +5,7 @@ from keras.models import Sequential
 from keras.layers.core import Dense, Dropout, Activation
 from keras.optimizers import SGD, Adam, RMSprop
 from keras.utils import np_utils
+from keras.callbacks import Plotter
 import numpy as np
 
 '''
@@ -49,7 +50,9 @@ model.add(Activation('softmax'))
 rms = RMSprop()
 model.compile(loss='categorical_crossentropy', optimizer=rms)
 
-model.fit(X_train, Y_train, batch_size=batch_size, nb_epoch=nb_epoch, show_accuracy=True, verbose=2, validation_data=(X_test, Y_test))
+model.fit(X_train, Y_train, batch_size=batch_size, nb_epoch=nb_epoch,
+          show_accuracy=True, verbose=2, validation_data=(X_test, Y_test),
+          callbacks=[Plotter()])
 score = model.evaluate(X_test, Y_test, show_accuracy=True, verbose=0)
 print('Test score:', score[0])
 print('Test accuracy:', score[1])

--- a/examples/mnist_mlp.py
+++ b/examples/mnist_mlp.py
@@ -52,7 +52,7 @@ model.compile(loss='categorical_crossentropy', optimizer=rms)
 
 model.fit(X_train, Y_train, batch_size=batch_size, nb_epoch=nb_epoch,
           show_accuracy=True, verbose=2, validation_data=(X_test, Y_test),
-          callbacks=[Plotter(save_to_filepath="/tmp/last_plot.png")])
+          callbacks=[Plotter()])
 score = model.evaluate(X_test, Y_test, show_accuracy=True, verbose=0)
 print('Test score:', score[0])
 print('Test accuracy:', score[1])

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -183,13 +183,15 @@ class History(Callback):
                 self.validation_accuracy.append(val_acc)
 
 class Plotter(History):
-    def __init__(self, linestyles=['r-', 'b-', 'r:', 'b:'],
+    # see PlotGenerator.__init__() for a description of the parameters
+    def __init__(self,
+                 save_to_filepath=None, show_plot_window=True,
+                 linestyles=['r-', 'b-', 'r:', 'b:'],
                  linestyles_first_epoch=['rs-', 'b^-', 'r:', 'b:'],
                  show_regressions=True,
                  poly_forward_perc=0.1, poly_backward_perc=0.2,
                  poly_n_forward_min=10, poly_n_backward_min=20,
-                 poly_degree=1,
-                 show_plot_window=True, save_to_filepath=None):
+                 poly_degree=1):
         super(Plotter, self).__init__()
         self.plot_generator = PlotGenerator(
                                 linestyles=linestyles,

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -186,38 +186,36 @@ class Plotter(History):
     # see PlotGenerator.__init__() for a description of the parameters
     def __init__(self,
                  save_to_filepath=None, show_plot_window=True,
-                 linestyles=['r-', 'b-', 'r:', 'b:'],
-                 linestyles_first_epoch=['rs-', 'b^-', 'r:', 'b:'],
+                 linestyles=None, linestyles_first_epoch=None,
                  show_regressions=True,
                  poly_forward_perc=0.1, poly_backward_perc=0.2,
                  poly_n_forward_min=10, poly_n_backward_min=20,
                  poly_degree=1):
         super(Plotter, self).__init__()
-        self.plot_generator = PlotGenerator(
-                                linestyles=linestyles,
-                                linestyles_first_epoch=linestyles_first_epoch,
-                                show_regressions=show_regressions,
-                                poly_forward_perc=poly_forward_perc,
-                                poly_backward_perc=poly_backward_perc,
-                                poly_n_forward_min=poly_n_forward_min,
-                                poly_n_backward_min=poly_n_backward_min,
-                                poly_degree=poly_degree,
-                                show_plot_window=show_plot_window,
-                                save_to_filepath=save_to_filepath
-                              )
+        pgen = PlotGenerator(linestyles=linestyles,
+                             linestyles_first_epoch=linestyles_first_epoch,
+                             show_regressions=show_regressions,
+                             poly_forward_perc=poly_forward_perc,
+                             poly_backward_perc=poly_backward_perc,
+                             poly_n_forward_min=poly_n_forward_min,
+                             poly_n_backward_min=poly_n_backward_min,
+                             poly_degree=poly_degree,
+                             show_plot_window=show_plot_window,
+                             save_to_filepath=save_to_filepath)
+        self.plot_generator = pgen
 
     def on_epoch_end(self, epoch, logs={}):
         super(Plotter, self).on_epoch_end(epoch, logs)
         dv = self.params['do_validation']
         sa = self.params['show_accuracy']
-        
-        loss = self.loss
+
+        train_loss = self.loss
         val_loss = self.validation_loss if dv else []
-        acc = self.accuracy if sa else []
+        train_acc = self.accuracy if sa else []
         val_acc = self.validation_accuracy if dv and sa else []
 
-        self.plot_generator.update(epoch, loss, acc, val_loss, val_acc)
-        
+        self.plot_generator.update(epoch, train_loss, train_acc,
+                                   val_loss, val_acc)
 
 class ModelCheckpoint(Callback):
     def __init__(self, filepath, verbose=0, save_best_only=False):

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -8,6 +8,7 @@ import time, json
 from collections import deque
 
 from .utils.generic_utils import Progbar
+from .utils.plotting_utils import PlotGenerator
 
 class CallbackList(object):
 
@@ -181,6 +182,40 @@ class History(Callback):
             if self.params['show_accuracy']:
                 self.validation_accuracy.append(val_acc)
 
+class Plotter(History):
+    def __init__(self, linestyles=['r-', 'b-', 'r:', 'b:'],
+                 linestyles_first_epoch=['rs-', 'b^-', 'r:', 'b:'],
+                 show_regressions=True,
+                 poly_forward_perc=0.1, poly_backward_perc=0.2,
+                 poly_n_forward_min=10, poly_n_backward_min=20,
+                 poly_degree=1,
+                 show_plot_window=True, save_to_filepath=None):
+        super(Plotter, self).__init__()
+        self.plot_generator = PlotGenerator(
+                                linestyles=linestyles,
+                                linestyles_first_epoch=linestyles_first_epoch,
+                                show_regressions=show_regressions,
+                                poly_forward_perc=poly_forward_perc,
+                                poly_backward_perc=poly_backward_perc,
+                                poly_n_forward_min=poly_n_forward_min,
+                                poly_n_backward_min=poly_n_backward_min,
+                                poly_degree=poly_degree,
+                                show_plot_window=show_plot_window,
+                                save_to_filepath=save_to_filepath
+                              )
+
+    def on_epoch_end(self, epoch, logs={}):
+        super(Plotter, self).on_epoch_end(epoch, logs)
+        dv = self.params['do_validation']
+        sa = self.params['show_accuracy']
+        
+        loss = self.loss
+        val_loss = self.validation_loss if dv else []
+        acc = self.accuracy if sa else []
+        val_acc = self.validation_accuracy if dv and sa else []
+
+        self.plot_generator.update(epoch, loss, acc, val_loss, val_acc)
+        
 
 class ModelCheckpoint(Callback):
     def __init__(self, filepath, verbose=0, save_best_only=False):

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -189,7 +189,7 @@ class Plotter(History):
                  linestyles=None, linestyles_first_epoch=None,
                  show_regressions=True,
                  poly_forward_perc=0.1, poly_backward_perc=0.2,
-                 poly_n_forward_min=10, poly_n_backward_min=20,
+                 poly_n_forward_min=5, poly_n_backward_min=10,
                  poly_degree=1):
         super(Plotter, self).__init__()
         pgen = PlotGenerator(linestyles=linestyles,

--- a/keras/utils/plotting_util.py
+++ b/keras/utils/plotting_util.py
@@ -1,0 +1,191 @@
+from __future__ import absolute_import
+
+import matplotlib.pyplot as plt
+import numpy as np
+from six.moves import range
+
+class Plotter(object):
+    def __init__(self,
+                 linestyles=["r-", "b-"],
+                 linestyles_first_epoch=["rs-", "b^-"],
+                 show_regressions=True,
+                 poly_forward_perc=0.1, poly_backward_perc=0.2,
+                 poly_n_forward_min=10, poly_n_backward_min=20,
+                 poly_degree=1,
+                 show_plot_window=True, save_to_filepath=None):
+        """Constructs the plotter.
+        Args:
+            linestyles: List of two string values containing the stylings
+                of the chart lines. The first value is for the training
+                line, the second for the validation line. Loss and accuracy
+                charts will both use that styling.
+            linestyles_first_epoch: Different stylings for the chart lines
+                for the very first epoch (no two points yet to draw a line).
+            show_regression: Whether or not to show a regression, indicating
+                where each line might end up in the future.
+            poly_forward_perc: Percentage value (e.g. 0.1 = 10%) indicating
+                for how far in the future each regression line will be
+                calculated. The percentage is relative to the current epoch.
+                E.g. if epoch is 100 and this value is 0.2, then the regression
+                will be calculated for 20 values in the future.
+            poly_backward_perc: Similar to poly_forward_perc. Percentage of
+                the data basis to use in order to calculate the regression.
+                E.g. if epoch is 100 and this value is 0.2, then the last
+                20 values will be used to predict the future values.
+            poly_n_forward_min: Minimum value for how far in the future
+                the regression values will be predicted for each line.
+                E.g. 10 means that there will always be at least 10 predicted
+                values, even for e.g. epoch 5.
+            poly_n_backward_min: Similar to poly_n_forward_min. Minimum
+                epochs to use backwards for predicting future values.
+            poly_degree: Degree of the polynomial to use when predicting
+                future values. Should usually be 1.
+        """
+        self.linestyles = linestyles
+        self.linestyles_first_epoch = linestyles_first_epoch
+        self.show_regressions = show_regressions
+        self.poly_forward_perc = 0.1
+        self.poly_backward_perc = 0.2
+        self.poly_backward_min = poly_n_backward_min
+        self.poly_forward_min = poly_n_forward_min
+        self.poly_degree = poly_degree
+        self.show_plot_window = show_plot_window
+        self.save_to_filepath = save_to_filepath
+        
+        # ----
+        # Initialize plots
+        # ----
+        fig, (ax1, ax2) = plt.subplots(ncols=2, figsize=(24, 8))
+        
+        # set_position is neccessary here in order to place the legend properly
+        box1, box2 = ax1.get_position(), ax2.get_position()
+        ax1.set_position([box1.x0, box1.y0 + box1.height * 0.1,
+                          box1.width, box1.height * 0.9])
+        ax2.set_position([box2.x0, box2.y0 + box2.height * 0.1,
+                          box2.width, box2.height * 0.9])
+        
+        self.fig = fig
+        self.ax1 = ax1
+        self.ax2 = ax2
+    
+    def update_plot(self, epoch,
+                    stats_train_loss, stats_train_acc,
+                    stats_val_loss, stats_val_acc):
+        self.redraw_plot()
+        
+        # show plot window or redraw an existing one
+        if self.show_plot_window:
+            plt.figure(self.fig.number)
+            #if epoch == 0:
+            plt.show(block=False)
+            #else:
+            plt.draw()
+        
+        # save
+        if self.save_to_filepath:
+            self._save_plot(self.save_to_filepath)
+    
+    def _save_plot(filepath):
+        self.fig.savefig(filepath)
+    
+    def _redraw_plot(self, epoch,
+                    stats_train_loss, stats_train_acc,
+                    stats_val_loss, stats_val_acc):
+        """Updates the charts in the current plotting window with new values.
+        Args:
+            epoch: The index of the current epoch, starting at 0.
+            stats_train_loss: All of the training loss values of each
+                epoch (list of floats).
+            stats_train_acc: All of the training accuracy values of each
+                epoch (list of floats).
+            stats_val_loss: All of the validation loss values of each
+                epoch (list of floats).
+            stats_val_acc: All of the validation accuracy values of each
+                epoch (list of floats).
+            save_plot_filepath: The full filepath of the file to which the
+                plot is ought to be saved, e.g. "/tmp/plot.png" or None if it
+                shouldnt be saved to a file.
+        Returns:
+            void
+        """
+        
+        ax1 = self.ax1
+        ax2 = self.ax2
+        
+        # List of each epoch (x-axis)
+        epochs = range(0, epoch+1)
+        
+        # Clear loss and accuracy charts
+        ax1.clear()
+        ax2.clear()
+        
+        # Set titles of charts (at the top)
+        ax1.set_title("loss")
+        ax2.set_title("accuracy")
+        
+        # Set the styles of the lines used in the charts
+        # r- => red line, b- => blue line,
+        # rs- => red line with squares for each data point,
+        # b^- => blue line with triangles for each data point
+        # Different line style for epochs after the  first one, because
+        # the very first epoch has only one data point and therefore no line
+        # and would be invisible without the changed style.
+        linestyles = self.linestyles if epoch > 0 else self.linestyles_first_epoch
+        
+        # Plot the lines
+        handle_tl, = ax1.plot(epochs, stats_train_loss, linestyles[0], label="train loss")
+        handle_vl, = ax1.plot(epochs, stats_val_loss, linestyles[1], label="val loss")
+        handle_ta, = ax2.plot(epochs, stats_train_acc, linestyles[0], label="train acc")
+        handle_va, = ax2.plot(epochs, stats_val_acc, linestyles[1], label="val acc")
+        
+        if epoch <= 0 or not self.show_regressions:
+            # First epoch, no linear regression yet
+            ax1.plot([], [], "r:", label="train loss regression")
+            ax1.plot([], [], "b:", label="val loss regression")
+            ax2.plot([], [], "r:", label="train acc regression")
+            ax2.plot([], [], "b:", label="val acc regression")
+        else:
+            # second epoch or later => do linear regression
+            # for future points of all lines
+            
+            # Number of epochs in the future.
+            # 10% of current epochs (e.g. 20 for 200) and minimum 10.
+            n_forward = int(max((epoch+1)*self.poly_forward_perc, self.poly_forward_min))
+            
+            # Based on that number of epochs in the past:
+            # 20% of current epochs (e.g. 20 for 100) and minimum 20.
+            n_backwards = int(max((epoch+1)*self.poly_backward_perc, self.poly_backward_min))
+            
+            # Degree of the polynom
+            poly_degree = 1
+            
+            # List of epochs for which to estimate/predict the likely value.
+            # (Not range(e+1, ...) so that the regression line is better
+            # connected to the line its based on (no obvious gap).)
+            future_epochs = [i for i in range(epoch, epoch + n_forward)]
+            
+            # Predicted values for each line
+            poly_train_loss = np.poly1d(np.polyfit(epochs[-n_backwards:], stats_train_loss[-n_backwards:], poly_degree))
+            poly_val_loss = np.poly1d(np.polyfit(epochs[-n_backwards:], stats_val_loss[-n_backwards:], poly_degree))
+            poly_train_acc = np.poly1d(np.polyfit(epochs[-n_backwards:], stats_train_acc[-n_backwards:], poly_degree))
+            poly_val_acc = np.poly1d(np.polyfit(epochs[-n_backwards:], stats_val_acc[-n_backwards:], poly_degree))
+            
+            # Plot each regression line
+            ax1.plot(future_epochs, [poly_train_loss(i) for i in future_epochs], "r:", label="train loss regression")
+            ax1.plot(future_epochs, [poly_val_loss(i) for i in future_epochs], "b:", label="val loss regression")
+            ax2.plot(future_epochs, [poly_train_acc(i) for i in future_epochs], "r:", label="train acc regression")
+            ax2.plot(future_epochs, [poly_val_acc(i) for i in future_epochs], "b:", label="val acc regression")
+        
+        # Add legend (below chart)
+        ax1.legend(["train loss", "val loss", "train loss regression", "val loss regression"], bbox_to_anchor=(0.7, -0.08), ncol=2)
+        ax2.legend(["train acc", "val acc", "train acc regression", "val acc regression"], bbox_to_anchor=(0.7, -0.08), ncol=2)
+        
+        # Labels for x and y axis
+        ax1.set_ylabel("loss")
+        ax1.set_xlabel("epoch")
+        ax2.set_ylabel("accuracy")
+        ax2.set_xlabel("epoch")
+        
+        # Show a grid in both charts
+        ax1.grid(True)
+        ax2.grid(True)

--- a/keras/utils/plotting_utils.py
+++ b/keras/utils/plotting_utils.py
@@ -164,9 +164,6 @@ class PlotGenerator(object):
         ax2.set_title('accuracy')
 
         # Set the styles of the lines used in the charts
-        # r- => red line, b- => blue line,
-        # rs- => red line with squares for each data point,
-        # b^- => blue line with triangles for each data point
         # Different line style for epochs after the  first one, because
         # the very first epoch has only one data point and therefore no line
         # and would be invisible without the changed style.
@@ -183,19 +180,24 @@ class PlotGenerator(object):
             ax2.plot(epochs, val_acc, linestyles[1], label='val acc')
 
         if self.show_regressions:
-            # Number of epochs in the future.
-            # 10% of current epochs (e.g. 20 for 200) and minimum 10.
+            # Compute the regression lines for the n_forward future epochs.
+            # n_forward is calculated relative to the current epoch
+            # (e.g. at epoch 100 compute 10 next, at 200 the 20 next ones...).
             n_forward = int(max((epoch+1)*self.poly_forward_perc,
                                 self.poly_forward_min))
 
-            # Based on that number of epochs in the past:
-            # 20% of current epochs (e.g. 20 for 100) and minimum 20.
+            # Compute regression lines based on n_backwards epochs
+            # in the past, e.g. based on the last 10 values.
+            # n_backwards is calculated relative to the current epoch
+            # (e.g. at epoch 100 compute based on the last 10 values,
+            # at 200 based on the last 20 values...).
             n_backwards = int(max((epoch+1)*self.poly_backward_perc,
                                   self.poly_backward_min))
 
             # List of epochs for which to estimate/predict the likely value.
-            # (Not range(e+1, ...) so that the regression line is better
-            # connected to the line its based on (no obvious gap).)
+            # (epoch..epoch+n_forward instead of epoch+1..epoch+n_forward
+            # so that the regression line is better connected to the line its
+            # based on (no obvious gap).)
             future_epochs = [i for i in range(epoch, epoch + n_forward)]
 
             self.plot_regression_line(ax1, train_loss, epochs, future_epochs,

--- a/keras/utils/plotting_utils.py
+++ b/keras/utils/plotting_utils.py
@@ -85,7 +85,7 @@ class PlotGenerator(object):
             self._save_plot(self.save_to_filepath)
 
 
-    def _save_plot(filepath):
+    def _save_plot(self, filepath):
         self.fig.savefig(filepath)
 
     def _redraw_plot(self, epoch,

--- a/keras/utils/plotting_utils.py
+++ b/keras/utils/plotting_utils.py
@@ -202,16 +202,16 @@ class PlotGenerator(object):
 
             self.plot_regression_line(ax1, train_loss, epochs, future_epochs,
                                       n_backwards, linestyles[2],
-                                      "train loss regression")
+                                      'train loss regression')
             self.plot_regression_line(ax1, val_loss, epochs, future_epochs,
                                       n_backwards, linestyles[3],
-                                      "val loss regression")
+                                      'val loss regression')
             self.plot_regression_line(ax2, train_acc, epochs, future_epochs,
                                       n_backwards, linestyles[2],
-                                      "train acc regression")
+                                      'train acc regression')
             self.plot_regression_line(ax2, val_acc, epochs, future_epochs,
                                       n_backwards, linestyles[3],
-                                      "val acc regression")
+                                      'val acc regression')
 
         # Add legend (below chart)
         ax1.legend(['train loss', 'val loss',

--- a/keras/utils/plotting_utils.py
+++ b/keras/utils/plotting_utils.py
@@ -35,7 +35,7 @@ class PlotGenerator(object):
                  linestyles_first_epoch=None,
                  show_regressions=True,
                  poly_forward_perc=0.1, poly_backward_perc=0.2,
-                 poly_n_forward_min=10, poly_n_backward_min=20,
+                 poly_n_forward_min=5, poly_n_backward_min=10,
                  poly_degree=1):
         """Constructs the plotter.
         Args:


### PR DESCRIPTION
This pull request adds a class `PlotGenerator` in `keras/utils/plotting_utils.py` (new file) and a callback `Plotter` to `keras/callbacks.py`. The `Plotter` callback inherits from the `History` callback and just sends history data for loss and accuracy to the `PlotGenerator`. The latter one then generates a plot that shows the training loss, validation loss, training accuracy and validation accuracy over time/epochs. The plot is automatically updated at the end of each epoch. The plot can be shown in a window and/or saved to a file. Regression is used by to predict the next couple of values for each line.

I added the plotter callback to both mnist examples.

Example image (mnist):
![plot2](https://cloud.githubusercontent.com/assets/11698516/8273153/94e0bee4-1860-11e5-90c1-5ff6365ee2d4.png)
I deactivated regression in that one, because it's not very helpful when values get close to 100% accuracy.

Example usage:

```python
from keras.callbacks import Plotter
# standard plot
model.fit(X_train, Y_train, callbacks=[Plotter()])
```

```python
from keras.callbacks import Plotter
# Dont show the plot window, but save to a file
model.fit(X_train, Y_train, callbacks=[Plotter(show_plot_window=False, save_to_filepath="/tmp/last_plot.png")])
```

```python
from keras.callbacks import Plotter
# No regression
model.fit(X_train, Y_train, callbacks=[Plotter(show_regressions=False)])
```