### PR TITLE
utils/generic_utils: fix unicode strings problem

### DIFF
--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -2,9 +2,10 @@ from __future__ import absolute_import
 import numpy as np
 import time
 import sys
+import six
 
 def get_from_module(identifier, module_params, module_name, instantiate=False):
-    if isinstance(identifier, basestring):
+    if isinstance(identifier, six.string_types):
         res = module_params.get(identifier)
         if not res:
             raise Exception('Invalid ' + str(module_name) + ': ' + str(identifier))

--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -4,7 +4,7 @@ import time
 import sys
 
 def get_from_module(identifier, module_params, module_name, instantiate=False):
-    if type(identifier) is str:
+    if isinstance(identifier, basestring):
         res = module_params.get(identifier)
         if not res:
             raise Exception('Invalid ' + str(module_name) + ': ' + str(identifier))


### PR DESCRIPTION
in get_from_module(), a unicode identifier should be treated as a str
type.

Signed-off-by: Amit Beka <amit.beka@gmail.com>