### PR TITLE
Add a name parameter to Dense.__init__

### DIFF
--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -245,7 +245,7 @@ class Dense(Layer):
         Just your regular fully connected NN layer.
     '''
     def __init__(self, input_dim, output_dim, init='glorot_uniform', activation='linear', weights=None, 
-        W_regularizer=None, b_regularizer=None, W_constraint=None, b_constraint=None):
+        W_regularizer=None, b_regularizer=None, W_constraint=None, b_constraint=None, name=None):
 
         super(Dense,self).__init__()
         self.init = initializations.get(init)
@@ -256,6 +256,9 @@ class Dense(Layer):
         self.input = T.matrix()
         self.W = self.init((self.input_dim, self.output_dim))
         self.b = shared_zeros((self.output_dim))
+        if name is not None:
+            self.W.name = '%s_W' % name
+            self.b.name = '%s_b' % name
 
         self.params = [self.W, self.b]
 


### PR DESCRIPTION
When debugging theano errors, if the error message contains a variable name, it will print something like ``<CudaNdarrayType(float32, matrix)>``, which is not very useful. With this change, a ``name`` parameter can be supplied to ``Dense.__init__`` function and the variables of the layer will be named with 'layername_varname' which make debugging easier.

For example, a theano error message before this change :

```
DisconnectedInputError: grad method was asked to compute the gradient with respect to a variable 
that is not part of the computational graph of the cost, or is used only by a non-differentiable 
operator: <CudaNdarrayType(float32, matrix)>
```

And after (with my layer named 'in0') :

```
DisconnectedInputError: grad method was asked to compute the gradient with respect to a variable 
that is not part of the computational graph of the cost, or is used only by a non-differentiable 
operator: in0_W
```


For now, this only changes ``Dense.__init__``, but if you think this is an interesting change, I'll add the same parameter to other layers.