### PR TITLE
Remove time_distributed_softmax in favour of softmax

### DIFF
--- a/docs/sources/activations.md
+++ b/docs/sources/activations.md
@@ -26,8 +26,7 @@ model.add(Activation(tanh))
 
 ## Available activations
 
-- __softmax__: Should only be applied to 2D layers (expected shape: `(nb_samples, nb_dims)`).
-- __time_distributed_softmax__: Softmax applied to every sample at every timestep of a layer of shape `(nb_samples, nb_timesteps, nb_dims)`.
+- __softmax__: Softmax applied across inputs last dimension. Expects shape either `(nb_samples, nb_timesteps, nb_dims)` or `(nb_samples, nb_dims)`.
 - __softplus__
 - __relu__
 - __tanh__

--- a/keras/activations.py
+++ b/keras/activations.py
@@ -4,12 +4,12 @@ import theano.tensor as T
 import types
 
 def softmax(x):
-    return T.nnet.softmax(x)
+    return T.nnet.softmax(x.reshape((-1,x.shape[-1]))).reshape(x.shape)
 
 def time_distributed_softmax(x):
-    xshape = x.shape
-    X = x.reshape((xshape[0] * xshape[1], xshape[2]))
-    return T.nnet.softmax(X).reshape(xshape)
+    import warnings
+    warnings.warn("time_distributed_softmax is deprecated. Just use softmax!", DeprecationWarning)
+    return softmax(x)
 
 def softplus(x):
     return T.nnet.softplus(x)


### PR DESCRIPTION
There is no reason to have two different functions for this! The softmax
function can just be configured to always perform the softmax across the
trailing dimension (i.e. nb_dimensions)