### PR TITLE
Implementations of additional RNN architectures

### DIFF
--- a/docs/sources/layers/recurrent.md
+++ b/docs/sources/layers/recurrent.md
@@ -128,6 +128,39 @@ Long-Short Term Memory unit - Hochreiter 1997.
     - [Long short-term memory](http://deeplearning.cs.cmu.edu/pdfs/Hochreiter97_lstm.pdf) (original 1997 paper)
     - [Learning to forget: Continual prediction with LSTM](http://www.mitpressjournals.org/doi/pdf/10.1162/089976600300015015)
     - [Supervised sequence labelling with recurrent neural networks](http://www.cs.toronto.edu/~graves/preprint.pdf)
+
+---
+
+## MutatedRNN_1, MutatedRNN_2, MutatedRNN_3
+
+```python
+keras.layers.recurrent.MutatedRNN_1(input_dim, output_dim=128, 
+        init='glorot_uniform', inner_init='orthogonal', 
+        activation='tanh', inner_activation='sigmoid',
+        weights=None, truncate_gradient=-1, return_sequences=False)
+```
+
+Top 3 RNN architectures evolved from the evaluation of thousands of models. Serves as alternatives to LSTMs and GRUs. Corresponds to `MUT1`, `MUT2`, and `MUT3` architectures described in the paper: An Empirical Exploration of Recurrent Network Architectures, Jozefowicz et al. 2015. Note that `input_dim` and `output_dim` must be equal in the `MUT1` and `MUT2` architectures.
+
+- __Input shape__: 3D tensor with shape: `(nb_samples, timesteps, input_dim)`.
+
+- __Output shape__:
+    - if `return_sequences`: 3D tensor with shape: `(nb_samples, timesteps, ouput_dim)`.
+    - else: 2D tensor with shape: `(nb_samples, output_dim)`.
+
+- __Arguments__:
+    - __input_dim__: dimension of the input.
+    - __output_dim__: dimension of the internal projections and the final output.
+    - __init__: weight initialization function for the output cell. Can be the name of an existing function (str), or a Theano function (see: [initializations](../initializations.md)).
+    - __inner_init__: weight initialization function for the inner cells.
+    - __activation__: activation function for the output. Can be the name of an existing function (str), or a Theano function (see: [activations](../activations.md)).
+    - __inner_activation__: activation function for the inner cells.
+    - __weights__: list of numpy arrays to set as initial weights. The list should have 9 elements.
+    - __truncate_gradient__: Number of steps to use in truncated BPTT. See: [Theano "scan"](http://deeplearning.net/software/theano/library/scan.html).
+    - __return_sequences__: Boolean. Whether to return the last output in the output sequence, or the full sequence.
+
+- __References__: 
+    - [An Empirical Exploration of Recurrent Network Architectures](http://www.jmlr.org/proceedings/papers/v37/jozefowicz15.pdf)
             
             
                 

--- a/docs/sources/layers/recurrent.md
+++ b/docs/sources/layers/recurrent.md
@@ -131,16 +131,16 @@ Long-Short Term Memory unit - Hochreiter 1997.
 
 ---
 
-## MutatedRNN_1, MutatedRNN_2, MutatedRNN_3
+## JZS1, JZS2, JZS3
 
 ```python
-keras.layers.recurrent.MutatedRNN_1(input_dim, output_dim=128, 
+keras.layers.recurrent.JZS1(input_dim, output_dim=128, 
         init='glorot_uniform', inner_init='orthogonal', 
         activation='tanh', inner_activation='sigmoid',
         weights=None, truncate_gradient=-1, return_sequences=False)
 ```
 
-Top 3 RNN architectures evolved from the evaluation of thousands of models. Serves as alternatives to LSTMs and GRUs. Corresponds to `MUT1`, `MUT2`, and `MUT3` architectures described in the paper: An Empirical Exploration of Recurrent Network Architectures, Jozefowicz et al. 2015. Note that `input_dim` and `output_dim` must be equal in the `MUT1` and `MUT2` architectures.
+Top 3 RNN architectures evolved from the evaluation of thousands of models. Serves as alternatives to LSTMs and GRUs. Corresponds to `MUT1`, `MUT2`, and `MUT3` architectures described in the paper: An Empirical Exploration of Recurrent Network Architectures, Jozefowicz et al. 2015.
 
 - __Input shape__: 3D tensor with shape: `(nb_samples, timesteps, input_dim)`.
 

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -369,7 +369,7 @@ class LSTM(Layer):
 
 
 
-class MutatedRNN_1(Layer):
+class JZS1(Layer):
     '''
         Evolved recurrent neural network architectures from the evaluation of thousands
         of models, serving as alternatives to LSTMs and GRUs. See Jozefowicz et al. 2015.
@@ -394,14 +394,11 @@ class MutatedRNN_1(Layer):
         activation='tanh', inner_activation='sigmoid',
         weights=None, truncate_gradient=-1, return_sequences=False):
 
-        super(MutatedRNN_1,self).__init__()
+        super(JZS1,self).__init__()
         self.input_dim = input_dim
         self.output_dim = output_dim
         self.truncate_gradient = truncate_gradient
         self.return_sequences = return_sequences
-        
-        if self.input_dim != self.output_dim:
-            raise Exception('input_dim must equal output_dim for this architecture')
 
         self.init = initializations.get(init)
         self.inner_init = initializations.get(inner_init)
@@ -418,6 +415,11 @@ class MutatedRNN_1(Layer):
 
         self.U_h = self.inner_init((self.output_dim, self.output_dim))
         self.b_h = shared_zeros((self.output_dim))
+
+        # P_h used to project X onto different dimension
+        P = np.ones((self.input_dim, self.output_dim), dtype=theano.config.floatX)
+        P = P / np.linalg.norm(P, axis=0)
+        self.Pmat = theano.shared(P, name=None)
 
         self.params = [
             self.W_z, self.b_z,
@@ -444,7 +446,7 @@ class MutatedRNN_1(Layer):
 
         x_z = T.dot(X, self.W_z) + self.b_z
         x_r = T.dot(X, self.W_r) + self.b_r
-        x_h = T.tanh(X) + self.b_h
+        x_h = T.tanh(T.dot(X, self.Pmat)) + self.b_h
         outputs, updates = theano.scan(
             self._step, 
             sequences=[x_z, x_r, x_h], 
@@ -469,7 +471,7 @@ class MutatedRNN_1(Layer):
 
 
 
-class MutatedRNN_2(Layer):
+class JZS2(Layer):
     '''
         Evolved recurrent neural network architectures from the evaluation of thousands
         of models, serving as alternatives to LSTMs and GRUs. See Jozefowicz et al. 2015.
@@ -494,14 +496,11 @@ class MutatedRNN_2(Layer):
         activation='tanh', inner_activation='sigmoid',
         weights=None, truncate_gradient=-1, return_sequences=False):
 
-        super(MutatedRNN_2,self).__init__()
+        super(JZS2,self).__init__()
         self.input_dim = input_dim
         self.output_dim = output_dim
         self.truncate_gradient = truncate_gradient
         self.return_sequences = return_sequences
-        
-        if self.input_dim != self.output_dim:
-            raise Exception('input_dim must equal output_dim for this architecture')
 
         self.init = initializations.get(init)
         self.inner_init = initializations.get(inner_init)
@@ -519,6 +518,11 @@ class MutatedRNN_2(Layer):
         self.W_h = self.init((self.input_dim, self.output_dim))
         self.U_h = self.inner_init((self.output_dim, self.output_dim))
         self.b_h = shared_zeros((self.output_dim))
+
+        # P_h used to project X onto different dimension
+        P = np.ones((self.input_dim, self.output_dim), dtype=theano.config.floatX)
+        P = P / np.linalg.norm(P, axis=0)
+        self.Pmat = theano.shared(P, name=None)
 
         self.params = [
             self.W_z, self.U_z, self.b_z,
@@ -544,7 +548,7 @@ class MutatedRNN_2(Layer):
         X = X.dimshuffle((1,0,2)) 
 
         x_z = T.dot(X, self.W_z) + self.b_z
-        x_r = X + self.b_r
+        x_r = T.dot(X, self.Pmat) + self.b_r
         x_h = T.dot(X, self.W_h) + self.b_h
         outputs, updates = theano.scan(
             self._step, 
@@ -570,7 +574,7 @@ class MutatedRNN_2(Layer):
 
 
 
-class MutatedRNN_3(Layer):
+class JZS3(Layer):
     '''
         Evolved recurrent neural network architectures from the evaluation of thousands
         of models, serving as alternatives to LSTMs and GRUs. See Jozefowicz et al. 2015.
@@ -595,7 +599,7 @@ class MutatedRNN_3(Layer):
         activation='tanh', inner_activation='sigmoid',
         weights=None, truncate_gradient=-1, return_sequences=False):
 
-        super(MutatedRNN_3,self).__init__()
+        super(JZS3,self).__init__()
         self.input_dim = input_dim
         self.output_dim = output_dim
         self.truncate_gradient = truncate_gradient

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -366,5 +366,306 @@ class LSTM(Layer):
             "inner_activation":self.inner_activation.__name__,
             "truncate_gradient":self.truncate_gradient,
             "return_sequences":self.return_sequences}
+
+
+
+class MutatedRNN_1(Layer):
+    '''
+        Evolved recurrent neural network architectures from the evaluation of thousands
+        of models, serving as alternatives to LSTMs and GRUs. See Jozefowicz et al. 2015.
         
+        This corresponds to the `MUT1` architecture described in the paper.
+        
+        Takes inputs with shape:
+        (nb_samples, max_sample_length (samples shorter than this are padded with zeros at the end), input_dim)
+        
+        and returns outputs with shape:
+        if not return_sequences:
+            (nb_samples, output_dim)
+        if return_sequences:
+            (nb_samples, max_sample_length, output_dim)
+        
+        References:
+            An Empirical Exploration of Recurrent Network Architectures
+                http://www.jmlr.org/proceedings/papers/v37/jozefowicz15.pdf
+    '''
+    def __init__(self, input_dim, output_dim=128, 
+        init='glorot_uniform', inner_init='orthogonal',
+        activation='tanh', inner_activation='sigmoid',
+        weights=None, truncate_gradient=-1, return_sequences=False):
+
+        super(MutatedRNN_1,self).__init__()
+        self.input_dim = input_dim
+        self.output_dim = output_dim
+        self.truncate_gradient = truncate_gradient
+        self.return_sequences = return_sequences
+        
+        if self.input_dim != self.output_dim:
+            raise Exception('input_dim must equal output_dim for this architecture')
+
+        self.init = initializations.get(init)
+        self.inner_init = initializations.get(inner_init)
+        self.activation = activations.get(activation)
+        self.inner_activation = activations.get(inner_activation)
+        self.input = T.tensor3()
+
+        self.W_z = self.init((self.input_dim, self.output_dim))
+        self.b_z = shared_zeros((self.output_dim))
+
+        self.W_r = self.init((self.input_dim, self.output_dim))
+        self.U_r = self.inner_init((self.output_dim, self.output_dim))
+        self.b_r = shared_zeros((self.output_dim))
+
+        self.U_h = self.inner_init((self.output_dim, self.output_dim))
+        self.b_h = shared_zeros((self.output_dim))
+
+        self.params = [
+            self.W_z, self.b_z,
+            self.W_r, self.U_r, self.b_r,
+            self.U_h, self.b_h,
+        ]
+
+        if weights is not None:
+            self.set_weights(weights)
+
+    def _step(self, 
+        xz_t, xr_t, xh_t, 
+        h_tm1, 
+        u_r, u_h):
+        z = self.inner_activation(xz_t)
+        r = self.inner_activation(xr_t + T.dot(h_tm1, u_r))
+        hh_t = self.activation(xh_t + T.dot(r * h_tm1, u_h))
+        h_t = hh_t * z + h_tm1 * (1 - z)
+        return h_t
+
+    def get_output(self, train):
+        X = self.get_input(train) 
+        X = X.dimshuffle((1,0,2)) 
+
+        x_z = T.dot(X, self.W_z) + self.b_z
+        x_r = T.dot(X, self.W_r) + self.b_r
+        x_h = T.tanh(X) + self.b_h
+        outputs, updates = theano.scan(
+            self._step, 
+            sequences=[x_z, x_r, x_h], 
+            outputs_info=T.unbroadcast(alloc_zeros_matrix(X.shape[1], self.output_dim), 1),
+            non_sequences=[self.U_r, self.U_h],
+            truncate_gradient=self.truncate_gradient
+        )
+        if self.return_sequences:
+            return outputs.dimshuffle((1,0,2))
+        return outputs[-1]
+
+    def get_config(self):
+        return {"name":self.__class__.__name__,
+            "input_dim":self.input_dim,
+            "output_dim":self.output_dim,
+            "init":self.init.__name__,
+            "inner_init":self.inner_init.__name__,
+            "activation":self.activation.__name__,
+            "inner_activation":self.inner_activation.__name__,
+            "truncate_gradient":self.truncate_gradient,
+            "return_sequences":self.return_sequences}
+
+
+
+class MutatedRNN_2(Layer):
+    '''
+        Evolved recurrent neural network architectures from the evaluation of thousands
+        of models, serving as alternatives to LSTMs and GRUs. See Jozefowicz et al. 2015.
+        
+        This corresponds to the `MUT2` architecture described in the paper.
+        
+        Takes inputs with shape:
+        (nb_samples, max_sample_length (samples shorter than this are padded with zeros at the end), input_dim)
+        
+        and returns outputs with shape:
+        if not return_sequences:
+            (nb_samples, output_dim)
+        if return_sequences:
+            (nb_samples, max_sample_length, output_dim)
+        
+        References:
+            An Empirical Exploration of Recurrent Network Architectures
+                http://www.jmlr.org/proceedings/papers/v37/jozefowicz15.pdf
+    '''
+    def __init__(self, input_dim, output_dim=128, 
+        init='glorot_uniform', inner_init='orthogonal',
+        activation='tanh', inner_activation='sigmoid',
+        weights=None, truncate_gradient=-1, return_sequences=False):
+
+        super(MutatedRNN_2,self).__init__()
+        self.input_dim = input_dim
+        self.output_dim = output_dim
+        self.truncate_gradient = truncate_gradient
+        self.return_sequences = return_sequences
+        
+        if self.input_dim != self.output_dim:
+            raise Exception('input_dim must equal output_dim for this architecture')
+
+        self.init = initializations.get(init)
+        self.inner_init = initializations.get(inner_init)
+        self.activation = activations.get(activation)
+        self.inner_activation = activations.get(inner_activation)
+        self.input = T.tensor3()
+
+        self.W_z = self.init((self.input_dim, self.output_dim))
+        self.U_z = self.inner_init((self.output_dim, self.output_dim))
+        self.b_z = shared_zeros((self.output_dim))
+
+        self.U_r = self.inner_init((self.output_dim, self.output_dim))
+        self.b_r = shared_zeros((self.output_dim))
+
+        self.W_h = self.init((self.input_dim, self.output_dim))
+        self.U_h = self.inner_init((self.output_dim, self.output_dim))
+        self.b_h = shared_zeros((self.output_dim))
+
+        self.params = [
+            self.W_z, self.U_z, self.b_z,
+            self.U_r, self.b_r,
+            self.W_h, self.U_h, self.b_h,
+        ]
+
+        if weights is not None:
+            self.set_weights(weights)
+
+    def _step(self, 
+        xz_t, xr_t, xh_t, 
+        h_tm1, 
+        u_z, u_r, u_h):
+        z = self.inner_activation(xz_t + T.dot(h_tm1, u_z))
+        r = self.inner_activation(xr_t + T.dot(h_tm1, u_r))
+        hh_t = self.activation(xh_t + T.dot(r * h_tm1, u_h))
+        h_t = hh_t * z + h_tm1 * (1 - z)
+        return h_t
+
+    def get_output(self, train):
+        X = self.get_input(train) 
+        X = X.dimshuffle((1,0,2)) 
+
+        x_z = T.dot(X, self.W_z) + self.b_z
+        x_r = X + self.b_r
+        x_h = T.dot(X, self.W_h) + self.b_h
+        outputs, updates = theano.scan(
+            self._step, 
+            sequences=[x_z, x_r, x_h], 
+            outputs_info=T.unbroadcast(alloc_zeros_matrix(X.shape[1], self.output_dim), 1),
+            non_sequences=[self.U_z, self.U_r, self.U_h],
+            truncate_gradient=self.truncate_gradient
+        )
+        if self.return_sequences:
+            return outputs.dimshuffle((1,0,2))
+        return outputs[-1]
+
+    def get_config(self):
+        return {"name":self.__class__.__name__,
+            "input_dim":self.input_dim,
+            "output_dim":self.output_dim,
+            "init":self.init.__name__,
+            "inner_init":self.inner_init.__name__,
+            "activation":self.activation.__name__,
+            "inner_activation":self.inner_activation.__name__,
+            "truncate_gradient":self.truncate_gradient,
+            "return_sequences":self.return_sequences}
+
+
+
+class MutatedRNN_3(Layer):
+    '''
+        Evolved recurrent neural network architectures from the evaluation of thousands
+        of models, serving as alternatives to LSTMs and GRUs. See Jozefowicz et al. 2015.
+        
+        This corresponds to the `MUT3` architecture described in the paper.
+        
+        Takes inputs with shape:
+        (nb_samples, max_sample_length (samples shorter than this are padded with zeros at the end), input_dim)
+        
+        and returns outputs with shape:
+        if not return_sequences:
+            (nb_samples, output_dim)
+        if return_sequences:
+            (nb_samples, max_sample_length, output_dim)
+        
+        References:
+            An Empirical Exploration of Recurrent Network Architectures
+                http://www.jmlr.org/proceedings/papers/v37/jozefowicz15.pdf
+    '''
+    def __init__(self, input_dim, output_dim=128, 
+        init='glorot_uniform', inner_init='orthogonal',
+        activation='tanh', inner_activation='sigmoid',
+        weights=None, truncate_gradient=-1, return_sequences=False):
+
+        super(MutatedRNN_3,self).__init__()
+        self.input_dim = input_dim
+        self.output_dim = output_dim
+        self.truncate_gradient = truncate_gradient
+        self.return_sequences = return_sequences
+
+        self.init = initializations.get(init)
+        self.inner_init = initializations.get(inner_init)
+        self.activation = activations.get(activation)
+        self.inner_activation = activations.get(inner_activation)
+        self.input = T.tensor3()
+
+        self.W_z = self.init((self.input_dim, self.output_dim))
+        self.U_z = self.inner_init((self.output_dim, self.output_dim))
+        self.b_z = shared_zeros((self.output_dim))
+
+        self.W_r = self.init((self.input_dim, self.output_dim))
+        self.U_r = self.inner_init((self.output_dim, self.output_dim))
+        self.b_r = shared_zeros((self.output_dim))
+
+        self.W_h = self.init((self.input_dim, self.output_dim))
+        self.U_h = self.inner_init((self.output_dim, self.output_dim))
+        self.b_h = shared_zeros((self.output_dim))
+
+        self.params = [
+            self.W_z, self.U_z, self.b_z,
+            self.W_r, self.U_r, self.b_r,
+            self.W_h, self.U_h, self.b_h,
+        ]
+
+        if weights is not None:
+            self.set_weights(weights)
+
+    def _step(self, 
+        xz_t, xr_t, xh_t, 
+        h_tm1, 
+        u_z, u_r, u_h):
+        z = self.inner_activation(xz_t + T.dot(T.tanh(h_tm1), u_z))
+        r = self.inner_activation(xr_t + T.dot(h_tm1, u_r))
+        hh_t = self.activation(xh_t + T.dot(r * h_tm1, u_h))
+        h_t = hh_t * z + h_tm1 * (1 - z)
+        return h_t
+
+    def get_output(self, train):
+        X = self.get_input(train) 
+        X = X.dimshuffle((1,0,2)) 
+
+        x_z = T.dot(X, self.W_z) + self.b_z
+        x_r = T.dot(X, self.W_r) + self.b_r
+        x_h = T.dot(X, self.W_h) + self.b_h
+        outputs, updates = theano.scan(
+            self._step, 
+            sequences=[x_z, x_r, x_h], 
+            outputs_info=T.unbroadcast(alloc_zeros_matrix(X.shape[1], self.output_dim), 1),
+            non_sequences=[self.U_z, self.U_r, self.U_h],
+            truncate_gradient=self.truncate_gradient
+        )
+        if self.return_sequences:
+            return outputs.dimshuffle((1,0,2))
+        return outputs[-1]
+
+    def get_config(self):
+        return {"name":self.__class__.__name__,
+            "input_dim":self.input_dim,
+            "output_dim":self.output_dim,
+            "init":self.init.__name__,
+            "inner_init":self.inner_init.__name__,
+            "activation":self.activation.__name__,
+            "inner_activation":self.inner_activation.__name__,
+            "truncate_gradient":self.truncate_gradient,
+            "return_sequences":self.return_sequences}
+
+
 

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -416,10 +416,13 @@ class JZS1(Layer):
         self.U_h = self.inner_init((self.output_dim, self.output_dim))
         self.b_h = shared_zeros((self.output_dim))
 
-        # P_h used to project X onto different dimension
-        P = np.ones((self.input_dim, self.output_dim), dtype=theano.config.floatX)
-        P = P / np.linalg.norm(P, axis=0)
-        self.Pmat = theano.shared(P, name=None)
+        # P_h used to project X onto different dimension, using sparse random projections
+        if self.input_dim == self.output_dim:
+            self.Pmat = theano.shared(np.identity(self.output_dim), name=None)
+        else:
+            P = np.random.binomial(1, 0.5, size=(self.input_dim, self.output_dim)) * 2 - 1
+            P = 1 / np.sqrt(self.input_dim) * P
+            self.Pmat = theano.shared(P, name=None)
 
         self.params = [
             self.W_z, self.b_z,
@@ -519,10 +522,13 @@ class JZS2(Layer):
         self.U_h = self.inner_init((self.output_dim, self.output_dim))
         self.b_h = shared_zeros((self.output_dim))
 
-        # P_h used to project X onto different dimension
-        P = np.ones((self.input_dim, self.output_dim), dtype=theano.config.floatX)
-        P = P / np.linalg.norm(P, axis=0)
-        self.Pmat = theano.shared(P, name=None)
+        # P_h used to project X onto different dimension, using sparse random projections
+        if self.input_dim == self.output_dim:
+            self.Pmat = theano.shared(np.identity(self.output_dim), name=None)
+        else:
+            P = np.random.binomial(1, 0.5, size=(self.input_dim, self.output_dim)) * 2 - 1
+            P = 1 / np.sqrt(self.input_dim) * P
+            self.Pmat = theano.shared(P, name=None)
 
         self.params = [
             self.W_z, self.U_z, self.b_z,

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -418,9 +418,9 @@ class JZS1(Layer):
 
         # P_h used to project X onto different dimension, using sparse random projections
         if self.input_dim == self.output_dim:
-            self.Pmat = theano.shared(np.identity(self.output_dim), name=None)
+            self.Pmat = theano.shared(np.identity(self.output_dim, dtype=theano.config.floatX), name=None)
         else:
-            P = np.random.binomial(1, 0.5, size=(self.input_dim, self.output_dim)) * 2 - 1
+            P = np.random.binomial(1, 0.5, size=(self.input_dim, self.output_dim)).astype(theano.config.floatX) * 2 - 1
             P = 1 / np.sqrt(self.input_dim) * P
             self.Pmat = theano.shared(P, name=None)
 
@@ -524,9 +524,9 @@ class JZS2(Layer):
 
         # P_h used to project X onto different dimension, using sparse random projections
         if self.input_dim == self.output_dim:
-            self.Pmat = theano.shared(np.identity(self.output_dim), name=None)
+            self.Pmat = theano.shared(np.identity(self.output_dim, dtype=theano.config.floatX), name=None)
         else:
-            P = np.random.binomial(1, 0.5, size=(self.input_dim, self.output_dim)) * 2 - 1
+            P = np.random.binomial(1, 0.5, size=(self.input_dim, self.output_dim)).astype(theano.config.floatX) * 2 - 1
             P = 1 / np.sqrt(self.input_dim) * P
             self.Pmat = theano.shared(P, name=None)
 


### PR DESCRIPTION
Reference: An Empirical Exploration of Recurrent Network Architectures, Jozefowicz et al. 2015. http://www.jmlr.org/proceedings/papers/v37/jozefowicz15.pdf

They describe top RNN architectures evolved through the evaluation of thousands of models,  serving as alternatives to LSTMs and GRUs. These classes, `MutatedRNN_1`, `MutatedRNN_2`, `MutatedRNN_3` correspond to the `MUT1`, `MUT2`, and `MUT3` architectures described in the paper. Note that `input_dim` and `output_dim` must be equal in the `MUT1` and `MUT2` architectures.

I originally tried to implement these in a single class, but had to split them out.

In my tests on the IMDB dataset, everything being equal, these do improve on LSTM and GRU, particularly `MutatedRNN_1`.