### PR TITLE
Fix memory leak

### DIFF
--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -312,13 +312,7 @@ class TimeDistributedDense(Layer):
 
     def get_output(self, train):
         X = self.get_input(train)
-
-        def act_func(X):
-            return self.activation(T.dot(X, self.W) + self.b)
-
-        output, _ = theano.scan(fn = act_func,
-                                sequences = X.dimshuffle(1,0,2),
-                                outputs_info=None)
+        output = self.activation(T.dot(X.dimshuffle(1,0,2), self.W) + self.b)
         return output.dimshuffle(1,0,2)
 
     def get_config(self):


### PR DESCRIPTION
The scan in get_output TimeDistributedDense leaked memory like crazy. Changing it to match get_output in Dense seems to have fixed the problem and behaves identically.