### PR TITLE
Minor code changes in `Model`

### DIFF
--- a/keras/models.py
+++ b/keras/models.py
@@ -207,17 +207,16 @@ class Model(object):
 
                 callbacks.on_batch_end(batch_index, batch_logs)
                 
-                if batch_index == len(batches) - 1: # last batch
-                    # validation
-                    epoch_logs = {}
-                    if do_validation:
-                        if show_accuracy:
-                            val_loss, val_acc = self.evaluate(X_val, y_val, batch_size=batch_size, \
-                                verbose=0, show_accuracy=True)
-                            epoch_logs['val_accuracy'] = val_acc
-                        else:
-                            val_loss = self.evaluate(X_val, y_val, batch_size=batch_size, verbose=0)
-                        epoch_logs['val_loss'] = val_loss
+            # validation
+            epoch_logs = {}
+            if do_validation:
+                if show_accuracy:
+                    val_loss, val_acc = self.evaluate(X_val, y_val, batch_size=batch_size, \
+                        verbose=0, show_accuracy=True)
+                    epoch_logs['val_accuracy'] = val_acc
+                else:
+                    val_loss = self.evaluate(X_val, y_val, batch_size=batch_size, verbose=0)
+                epoch_logs['val_loss'] = val_loss
 
             callbacks.on_epoch_end(epoch, epoch_logs)
             if self.stop_training:

--- a/keras/models.py
+++ b/keras/models.py
@@ -102,8 +102,10 @@ class Model(object):
 
         self._train = theano.function(train_ins, train_loss, 
             updates=updates, allow_input_downcast=True, mode=theano_mode)
-        self._train_with_acc = theano.function(train_ins, [train_loss, train_accuracy], 
-            updates=updates, allow_input_downcast=True, mode=theano_mode)
+        # self._train_with_acc = theano.function(train_ins, [train_loss, train_accuracy], 
+        #     updates=updates, allow_input_downcast=True, mode=theano_mode)
+        self._train_accuracy = theano.function(train_ins, train_accuracy,
+            allow_input_downcast=True, mode=theano_mode)
         self._predict = theano.function(predict_ins, self.y_test, 
             allow_input_downcast=True, mode=theano_mode)
         self._test = theano.function(test_ins, test_score, 
@@ -112,15 +114,12 @@ class Model(object):
             allow_input_downcast=True, mode=theano_mode)
 
 
-    def train(self, X, y, accuracy=False):
+    def train(self, X, y):
         X = standardize_X(X)
         y = standardize_y(y)
-
         ins = X + [y]
-        if accuracy:
-            return self._train_with_acc(*ins)
-        else:
-            return self._train(*ins)
+        
+        return self._train(*ins)
         
 
     def test(self, X, y, accuracy=False):
@@ -197,13 +196,12 @@ class Model(object):
                 batch_logs['size'] = len(batch_ids)
                 callbacks.on_batch_begin(batch_index, batch_logs)
 
-                ins = X_batch + [y_batch]
-                if show_accuracy:
-                    loss, acc = self._train_with_acc(*ins)
-                    batch_logs['accuracy'] = acc
-                else:
-                    loss = self._train(*ins)
+                loss = self.train(X_batch, y_batch)
                 batch_logs['loss'] = loss
+                if show_accuracy:
+                    ins = X_batch + [y_batch]
+                    acc = self._train_accuracy(*ins)
+                    batch_logs['accuracy'] = acc
 
                 callbacks.on_batch_end(batch_index, batch_logs)
                 

--- a/keras/models.py
+++ b/keras/models.py
@@ -102,8 +102,6 @@ class Model(object):
 
         self._train = theano.function(train_ins, train_loss, 
             updates=updates, allow_input_downcast=True, mode=theano_mode)
-        # self._train_with_acc = theano.function(train_ins, [train_loss, train_accuracy], 
-        #     updates=updates, allow_input_downcast=True, mode=theano_mode)
         self._train_accuracy = theano.function(train_ins, train_accuracy,
             allow_input_downcast=True, mode=theano_mode)
         self._predict = theano.function(predict_ins, self.y_test, 
@@ -166,7 +164,8 @@ class Model(object):
 
         if verbose:
             callbacks = [cbks.BaseLogger()] + callbacks
-        callbacks = cbks.CallbackList([cbks.History()] + callbacks)
+        history = cbks.History()
+        callbacks = cbks.CallbackList([history] + callbacks)
 
         callbacks._set_model(self)
         callbacks._set_params({
@@ -221,7 +220,8 @@ class Model(object):
                 break
 
         callbacks.on_train_end()
-        return callbacks.callbacks[0] # return history
+        
+        return history
 
     def predict(self, X, batch_size=128, verbose=1):
         X = standardize_X(X)

--- a/keras/models.py
+++ b/keras/models.py
@@ -201,16 +201,17 @@ class Model(object):
 
                 callbacks.on_batch_end(batch_index, batch_logs)
                 
-            # validation
-            epoch_logs = {}
-            if do_validation:
-                if show_accuracy:
-                    val_loss, val_acc = self.evaluate(X_val, y_val, batch_size=batch_size, \
-                        verbose=0, show_accuracy=True)
-                    epoch_logs['val_accuracy'] = val_acc
-                else:
-                    val_loss = self.evaluate(X_val, y_val, batch_size=batch_size, verbose=0)
-                epoch_logs['val_loss'] = val_loss
+                if batch_index == len(batches) - 1: # last batch
+                    # validation
+                    epoch_logs = {}
+                    if do_validation:
+                        if show_accuracy:
+                            val_loss, val_acc = self.evaluate(X_val, y_val, batch_size=batch_size, \
+                                verbose=0, show_accuracy=True)
+                            epoch_logs['val_accuracy'] = val_acc
+                        else:
+                            val_loss = self.evaluate(X_val, y_val, batch_size=batch_size, verbose=0)
+                        epoch_logs['val_loss'] = val_loss
 
             callbacks.on_epoch_end(epoch, epoch_logs)
             if self.stop_training:

--- a/keras/models.py
+++ b/keras/models.py
@@ -191,7 +191,6 @@ class Model(object):
                 y_batch = y[batch_ids]
 
                 batch_logs = {}
-                batch_logs['batch'] = batch_index
                 batch_logs['size'] = len(batch_ids)
                 callbacks.on_batch_begin(batch_index, batch_logs)
 
@@ -220,7 +219,7 @@ class Model(object):
                 break
 
         callbacks.on_train_end()
-        
+
         return history
 
     def predict(self, X, batch_size=128, verbose=1):


### PR DESCRIPTION
A few (minor) changes to the `Model` class, mostly to make use of already existing code and avoid duplicates.
- Move the evaluation on the validation set in the epoch loop (rather than in the batch loop for the last batch).
- Remove the batch index from the logs given to the `on_batch_begin()` and `on_batch_end()` callbacks -- duplicate from the `batch` input.
- Make the `history` callback explicit for clarity.
- Use the methods `Model.train()` and `Model.test()` in the `Model.fit()` and `Model.evaluate()` loops. As a consequence I separated explicitly the loss function and the accuracy function -- eg. instead of having `Model._train()` *or* `Model._train_with_acc()` there are `Model._train()` *and* `Model._train_accuracy()` to compute the accuracy separately.

This last point is actually a preparation for a next step: remove the accuracy computation from `Model`. I think it would be more flexible to have the metrics computation completely separated from the model, inspired by [what scikit-learn is doing](http://scikit-learn.org/stable/modules/classes.html#module-sklearn.metrics). And one could compute the metrics during training with callbacks. This would also allow the user to define her own metrics of interest (maybe she is not interested in the accuracy but in the precision per class, F1, BLEU, etc... motivated by https://github.com/fchollet/keras/issues/254#issuecomment-114418526).

Known issue with this PR:
- ~~The progress bar in `verbose=1` does not update for the last batch of every epoch (it may appear as computational *lag* but everything is fine)~~ (see tristandeleu/keras#1)