### PR TITLE
Initialize forget biases on LSTM to 1. by default

### DIFF
--- a/examples/imdb_lstm.py
+++ b/examples/imdb_lstm.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 import numpy as np
-np.random.seed(1337) # for reproducibility
+#np.random.seed(1337) # for reproducibility
 
 from keras.preprocessing import sequence
 from keras.optimizers import SGD, RMSprop, Adagrad
@@ -48,7 +48,7 @@ print('X_test shape:', X_test.shape)
 
 print('Build model...')
 model = Sequential()
-model.add(Embedding(max_features, 128))
+model.add(Embedding(max_features, 128, mask_zero=True))
 model.add(LSTM(128, 128)) # try using a GRU instead, for fun
 model.add(Dropout(0.5))
 model.add(Dense(128, 1))

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -5,7 +5,7 @@ import theano.tensor as T
 import numpy as np
 
 from .. import activations, initializations
-from ..utils.theano_utils import shared_scalar, shared_zeros, alloc_zeros_matrix
+from ..utils.theano_utils import sharedX, shared_scalar, shared_zeros, shared_ones, alloc_zeros_matrix
 from ..layers.core import Layer, MaskedLayer
 from six.moves import range
 
@@ -324,7 +324,7 @@ class LSTM(Recurrent):
     def __init__(self, input_dim, output_dim=128, 
         init='glorot_uniform', inner_init='orthogonal', 
         activation='tanh', inner_activation='hard_sigmoid',
-        weights=None, truncate_gradient=-1, return_sequences=False):
+        weights=None, initial_forget_bias=1., truncate_gradient=-1, return_sequences=False):
     
         super(LSTM,self).__init__()
         self.input_dim = input_dim
@@ -344,7 +344,7 @@ class LSTM(Recurrent):
 
         self.W_f = self.init((self.input_dim, self.output_dim))
         self.U_f = self.inner_init((self.output_dim, self.output_dim))
-        self.b_f = shared_zeros((self.output_dim))
+        self.b_f = sharedX(np.ones(self.output_dim) * initial_forget_bias)
 
         self.W_c = self.init((self.input_dim, self.output_dim))
         self.U_c = self.inner_init((self.output_dim, self.output_dim))


### PR DESCRIPTION
See http://www.jmlr.org/proceedings/papers/v37/jozefowicz15.pdf where they recommend using an initial forget-gate bias of 1.0.

This appears to improve performance on the IMDB example significantly. I ran 2 experiments and got accuracies of `0.8408` and  `0.8360`.

You can always pass in 0 if you want the old behaviour.