### PR TITLE
Fix mistakes in uniform initializations equations

### DIFF
--- a/keras/initializations.py
+++ b/keras/initializations.py
@@ -22,7 +22,7 @@ def lecun_uniform(shape):
         http://yann.lecun.com/exdb/publis/pdf/lecun-98b.pdf
     '''
     fan_in, fan_out = get_fans(shape)
-    scale = 1./np.sqrt(fan_in)
+    scale = np.sqrt(3. / fan_in)
     return uniform(shape, scale)
 
 def glorot_normal(shape):
@@ -34,7 +34,7 @@ def glorot_normal(shape):
 
 def glorot_uniform(shape):
     fan_in, fan_out = get_fans(shape)
-    s = np.sqrt(2. / (fan_in + fan_out))
+    s = np.sqrt(6. / (fan_in + fan_out))
     return uniform(shape, s)
     
 def he_normal(shape):
@@ -46,7 +46,7 @@ def he_normal(shape):
 
 def he_uniform(shape):
     fan_in, fan_out = get_fans(shape)
-    s = np.sqrt(2. / fan_in)
+    s = np.sqrt(6. / fan_in)
     return uniform(shape, s)
 
 def orthogonal(shape, scale=1.1):


### PR DESCRIPTION
Standard deviation values were being passed as scale values for uniform distributions. 
But the relationship is: scale = standard deviation * sqrt(3).
So, the s values in glorot_uniform, lecun_uniform, and he_uniform should have been multiplied by sqrt(3) before being passed into uniform() function. Now it is fixed.