### PR TITLE
Yaml support for Keras Sequential models

### DIFF
--- a/keras/constraints.py
+++ b/keras/constraints.py
@@ -37,3 +37,7 @@ identity = Constraint
 maxnorm = MaxNorm
 nonneg = NonNeg
 unitnorm = UnitNorm
+
+from .utils.generic_utils import get_from_module
+def get(identifier):
+    return get_from_module(identifier, globals(), 'constraint', instantiate=True)

--- a/keras/constraints.py
+++ b/keras/constraints.py
@@ -7,6 +7,9 @@ class Constraint(object):
     def __call__(self, p):
         return p
 
+    def get_config(self):
+        return {"name":self.__class__.__name__}
+
 class MaxNorm(Constraint):
     def __init__(self, m=2):
         self.m = m
@@ -16,6 +19,10 @@ class MaxNorm(Constraint):
         desired = T.clip(norms, 0, self.m)
         p = p * (desired / (1e-7 + norms))
         return p
+
+    def get_config(self):
+        return {"name":self.__class__.__name__,
+            "m":self.m}
 
 class NonNeg(Constraint):
     def __call__(self, p):

--- a/keras/constraints.py
+++ b/keras/constraints.py
@@ -39,5 +39,5 @@ nonneg = NonNeg
 unitnorm = UnitNorm
 
 from .utils.generic_utils import get_from_module
-def get(identifier):
-    return get_from_module(identifier, globals(), 'constraint', instantiate=True)
+def get(identifier, kwargs=None):
+    return get_from_module(identifier, globals(), 'constraint', instantiate=True, kwargs=kwargs)

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -5,16 +5,15 @@ import theano
 import theano.tensor as T
 from theano.tensor.signal import downsample
 
-from .. import activations, initializations
+from .. import activations, initializations, regularizers, constraints
 from ..utils.theano_utils import shared_zeros
 from ..layers.core import Layer
-
 
 class Convolution1D(Layer):
     def __init__(self, input_dim, nb_filter, filter_length,
         init='uniform', activation='linear', weights=None,
         border_mode='valid', subsample_length=1,
-        W_regularizer=None, b_regularizer=None, activity_regularizer=None, W_constraint=None, b_constraint=None):
+        W_regularizer='identity', b_regularizer='identity', activity_regularizer='identity', W_constraint='identity', b_constraint='identity'):
 
         super(Convolution1D,self).__init__()
 
@@ -35,17 +34,22 @@ class Convolution1D(Layer):
         self.params = [self.W, self.b]
 
         self.regularizers = []
-        if W_regularizer:
-            W_regularizer.set_param(self.W)
-            self.regularizers.append(W_regularizer)
-        if b_regularizer:
-            b_regularizer.set_param(self.b)
-            self.regularizers.append(b_regularizer)
-        if activity_regularizer:
-            activity_regularizer.set_layer(self)
-            self.regularizers.append(activity_regularizer)
 
-        self.constraints = [W_constraint, b_constraint]
+        self.W_regularizer = regularizers.get(W_regularizer)
+        self.W_regularizer.set_param(self.W)
+        self.regularizers.append(self.W_regularizer)
+
+        self.b_regularizer = regularizers.get(b_regularizer)
+        self.b_regularizer.set_param(self.b)
+        self.regularizers.append(self.b_regularizer)
+
+        self.activity_regularizer = regularizers.get(activity_regularizer)
+        self.activity_regularizer.set_layer(self)
+        self.regularizers.append(self.activity_regularizer)
+
+        self.W_constraint = constraints.get(W_constraint)
+        self.b_constraint = constraints.get(b_constraint)
+        self.constraints = [self.W_constraint, self.b_constraint]
 
         if weights is not None:
             self.set_weights(weights)
@@ -65,7 +69,12 @@ class Convolution1D(Layer):
             "init":self.init.__name__,
             "activation":self.activation.__name__,
             "border_mode":self.border_mode,
-            "subsample_length":self.subsample_length}
+            "subsample_length":self.subsample_length,
+            "W_regularizer":self.W_regularizer.get_config(),
+            "b_regularizer":self.b_regularizer.get_config(),
+            "activity_regularizer":self.activity_regularizer.get_config(),
+            "W_constraint":self.W_constraint.get_config(),
+            "b_constraint":self.b_constraint.get_config()}
 
 
 class MaxPooling1D(Layer):
@@ -102,7 +111,7 @@ class Convolution2D(Layer):
     def __init__(self, nb_filter, stack_size, nb_row, nb_col,
         init='glorot_uniform', activation='linear', weights=None,
         border_mode='valid', subsample=(1, 1),
-        W_regularizer=None, b_regularizer=None, activity_regularizer=None, W_constraint=None, b_constraint=None):
+        W_regularizer='identity', b_regularizer='identity', activity_regularizer='identity', W_constraint='identity', b_constraint='identity'):
 
         super(Convolution2D,self).__init__()
         self.init = initializations.get(init)
@@ -123,17 +132,22 @@ class Convolution2D(Layer):
         self.params = [self.W, self.b]
 
         self.regularizers = []
-        if W_regularizer:
-            W_regularizer.set_param(self.W)
-            self.regularizers.append(W_regularizer)
-        if b_regularizer:
-            b_regularizer.set_param(self.b)
-            self.regularizers.append(b_regularizer)
-        if activity_regularizer:
-            activity_regularizer.set_layer(self)
-            self.regularizers.append(activity_regularizer)
 
-        self.constraints = [W_constraint, b_constraint]
+        self.W_regularizer = regularizers.get(W_regularizer)
+        self.W_regularizer.set_param(self.W)
+        self.regularizers.append(self.W_regularizer)
+
+        self.b_regularizer = regularizers.get(b_regularizer)
+        self.b_regularizer.set_param(self.b)
+        self.regularizers.append(self.b_regularizer)
+
+        self.activity_regularizer = regularizers.get(activity_regularizer)
+        self.activity_regularizer.set_layer(self)
+        self.regularizers.append(self.activity_regularizer)
+
+        self.W_constraint = constraints.get(W_constraint)
+        self.b_constraint = constraints.get(b_constraint)
+        self.constraints = [self.W_constraint, self.b_constraint]
 
         if weights is not None:
             self.set_weights(weights)
@@ -154,7 +168,12 @@ class Convolution2D(Layer):
             "init":self.init.__name__,
             "activation":self.activation.__name__,
             "border_mode":self.border_mode,
-            "subsample":self.subsample}
+            "subsample":self.subsample,
+            "W_regularizer":self.W_regularizer.get_config(),
+            "b_regularizer":self.b_regularizer.get_config(),
+            "activity_regularizer":self.activity_regularizer.get_config(),
+            "W_constraint":self.W_constraint.get_config(),
+            "b_constraint":self.b_constraint.get_config()}
 
 
 class MaxPooling2D(Layer):

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -13,7 +13,7 @@ class Convolution1D(Layer):
     def __init__(self, input_dim, nb_filter, filter_length,
         init='uniform', activation='linear', weights=None,
         border_mode='valid', subsample_length=1,
-        W_regularizer='identity', b_regularizer='identity', activity_regularizer='identity', W_constraint='identity', b_constraint='identity'):
+        W_regularizer=None, b_regularizer=None, activity_regularizer=None, W_constraint=None, b_constraint=None):
 
         super(Convolution1D,self).__init__()
 
@@ -36,16 +36,19 @@ class Convolution1D(Layer):
         self.regularizers = []
 
         self.W_regularizer = regularizers.get(W_regularizer)
-        self.W_regularizer.set_param(self.W)
-        self.regularizers.append(self.W_regularizer)
+        if self.W_regularizer:
+            self.W_regularizer.set_param(self.W)
+            self.regularizers.append(self.W_regularizer)
 
         self.b_regularizer = regularizers.get(b_regularizer)
-        self.b_regularizer.set_param(self.b)
-        self.regularizers.append(self.b_regularizer)
+        if self.b_regularizer:
+            self.b_regularizer.set_param(self.b)
+            self.regularizers.append(self.b_regularizer)
 
         self.activity_regularizer = regularizers.get(activity_regularizer)
-        self.activity_regularizer.set_layer(self)
-        self.regularizers.append(self.activity_regularizer)
+        if self.activity_regularizer:
+            self.activity_regularizer.set_layer(self)
+            self.regularizers.append(self.activity_regularizer)
 
         self.W_constraint = constraints.get(W_constraint)
         self.b_constraint = constraints.get(b_constraint)
@@ -70,11 +73,11 @@ class Convolution1D(Layer):
             "activation":self.activation.__name__,
             "border_mode":self.border_mode,
             "subsample_length":self.subsample_length,
-            "W_regularizer":self.W_regularizer.get_config(),
-            "b_regularizer":self.b_regularizer.get_config(),
-            "activity_regularizer":self.activity_regularizer.get_config(),
-            "W_constraint":self.W_constraint.get_config(),
-            "b_constraint":self.b_constraint.get_config()}
+            "W_regularizer":self.W_regularizer.get_config() if self.W_regularizer else None,
+            "b_regularizer":self.b_regularizer.get_config() if self.b_regularizer else None,
+            "activity_regularizer":self.activity_regularizer.get_config() if self.activity_regularizer else None,
+            "W_constraint":self.W_constraint.get_config() if self.W_constraint else None,
+            "b_constraint":self.b_constraint.get_config() if self.b_constraint else None}
 
 
 class MaxPooling1D(Layer):
@@ -111,7 +114,7 @@ class Convolution2D(Layer):
     def __init__(self, nb_filter, stack_size, nb_row, nb_col,
         init='glorot_uniform', activation='linear', weights=None,
         border_mode='valid', subsample=(1, 1),
-        W_regularizer='identity', b_regularizer='identity', activity_regularizer='identity', W_constraint='identity', b_constraint='identity'):
+        W_regularizer=None, b_regularizer=None, activity_regularizer=None, W_constraint=None, b_constraint=None):
 
         super(Convolution2D,self).__init__()
         self.init = initializations.get(init)
@@ -134,16 +137,19 @@ class Convolution2D(Layer):
         self.regularizers = []
 
         self.W_regularizer = regularizers.get(W_regularizer)
-        self.W_regularizer.set_param(self.W)
-        self.regularizers.append(self.W_regularizer)
+        if self.W_regularizer:
+            self.W_regularizer.set_param(self.W)
+            self.regularizers.append(self.W_regularizer)
 
         self.b_regularizer = regularizers.get(b_regularizer)
-        self.b_regularizer.set_param(self.b)
-        self.regularizers.append(self.b_regularizer)
+        if self.b_regularizer:
+            self.b_regularizer.set_param(self.b)
+            self.regularizers.append(self.b_regularizer)
 
         self.activity_regularizer = regularizers.get(activity_regularizer)
-        self.activity_regularizer.set_layer(self)
-        self.regularizers.append(self.activity_regularizer)
+        if self.activity_regularizer:
+            self.activity_regularizer.set_layer(self)
+            self.regularizers.append(self.activity_regularizer)
 
         self.W_constraint = constraints.get(W_constraint)
         self.b_constraint = constraints.get(b_constraint)
@@ -169,11 +175,11 @@ class Convolution2D(Layer):
             "activation":self.activation.__name__,
             "border_mode":self.border_mode,
             "subsample":self.subsample,
-            "W_regularizer":self.W_regularizer.get_config(),
-            "b_regularizer":self.b_regularizer.get_config(),
-            "activity_regularizer":self.activity_regularizer.get_config(),
-            "W_constraint":self.W_constraint.get_config(),
-            "b_constraint":self.b_constraint.get_config()}
+            "W_regularizer":self.W_regularizer.get_config() if self.W_regularizer else None,
+            "b_regularizer":self.b_regularizer.get_config() if self.b_regularizer else None,
+            "activity_regularizer":self.activity_regularizer.get_config() if self.activity_regularizer else None,
+            "W_constraint":self.W_constraint.get_config() if self.W_constraint else None,
+            "b_constraint":self.b_constraint.get_config() if self.b_constraint else None}
 
 
 class MaxPooling2D(Layer):

--- a/keras/layers/embeddings.py
+++ b/keras/layers/embeddings.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 import theano
 import theano.tensor as T
 
-from .. import activations, initializations
+from .. import activations, initializations, regularizers, constraints
 from ..layers.core import Layer, MaskedLayer
 from ..utils.theano_utils import sharedX
 
@@ -18,7 +18,7 @@ class Embedding(Layer):
         @out_dim: size of dense representation
     '''
     def __init__(self, input_dim, output_dim, init='uniform',
-        W_regularizer=None, activity_regularizer=None, W_constraint=None,
+        W_regularizer='identity', activity_regularizer='identity', W_constraint='identity',
         mask_zero=False, weights=None):
 
         super(Embedding,self).__init__()
@@ -31,15 +31,19 @@ class Embedding(Layer):
         self.mask_zero = mask_zero
 
         self.params = [self.W]
-        self.constraints = [W_constraint]
+
+        self.W_constraint = constraints.get(W_constraint)
+        self.constraints = [self.W_constraint]
 
         self.regularizers = []
-        if W_regularizer:
-            W_regularizer.set_param(self.W)
-            self.regularizers.append(W_regularizer)
-        if activity_regularizer:
-            activity_regularizer.set_layer(self)
-            self.regularizers.append(activity_regularizer)
+
+        self.W_regularizer = regularizers.get(W_regularizer)
+        self.W_regularizer.set_param(self.W)
+        self.regularizers.append(self.W_regularizer)
+
+        self.activity_regularizer = regularizers.get(activity_regularizer)
+        self.activity_regularizer.set_layer(self)
+        self.regularizers.append(self.activity_regularizer)
 
         if weights is not None:
             self.set_weights(weights)
@@ -60,7 +64,10 @@ class Embedding(Layer):
         return {"name":self.__class__.__name__,
             "input_dim":self.input_dim,
             "output_dim":self.output_dim,
-            "init":self.init.__name__}
+            "init":self.init.__name__,
+            "activity_regularizer":self.activity_regularizer.get_config(),
+            "W_regularizer":self.W_regularizer.get_config(),
+            "W_constraint":self.W_constraint.get_config()}
 
 
 class WordContextProduct(Layer):

--- a/keras/layers/embeddings.py
+++ b/keras/layers/embeddings.py
@@ -18,7 +18,7 @@ class Embedding(Layer):
         @out_dim: size of dense representation
     '''
     def __init__(self, input_dim, output_dim, init='uniform',
-        W_regularizer='identity', activity_regularizer='identity', W_constraint='identity',
+        W_regularizer=None, activity_regularizer=None, W_constraint=None,
         mask_zero=False, weights=None):
 
         super(Embedding,self).__init__()
@@ -38,12 +38,14 @@ class Embedding(Layer):
         self.regularizers = []
 
         self.W_regularizer = regularizers.get(W_regularizer)
-        self.W_regularizer.set_param(self.W)
-        self.regularizers.append(self.W_regularizer)
+        if self.W_regularizer:
+            self.W_regularizer.set_param(self.W)
+            self.regularizers.append(self.W_regularizer)
 
         self.activity_regularizer = regularizers.get(activity_regularizer)
-        self.activity_regularizer.set_layer(self)
-        self.regularizers.append(self.activity_regularizer)
+        if self.activity_regularizer:
+            self.activity_regularizer.set_layer(self)
+            self.regularizers.append(self.activity_regularizer)
 
         if weights is not None:
             self.set_weights(weights)
@@ -65,9 +67,9 @@ class Embedding(Layer):
             "input_dim":self.input_dim,
             "output_dim":self.output_dim,
             "init":self.init.__name__,
-            "activity_regularizer":self.activity_regularizer.get_config(),
-            "W_regularizer":self.W_regularizer.get_config(),
-            "W_constraint":self.W_constraint.get_config()}
+            "activity_regularizer":self.activity_regularizer.get_config() if self.activity_regularizer else None,
+            "W_regularizer":self.W_regularizer.get_config() if self.W_regularizer else None,
+            "W_constraint":self.W_constraint.get_config() if self.W_constraint else None}
 
 
 class WordContextProduct(Layer):

--- a/keras/layers/noise.py
+++ b/keras/layers/noise.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from .core import srng, MaskedLayer
 import theano
+import theano.tensor as T
 
 class GaussianNoise(MaskedLayer):
     '''
@@ -22,7 +23,7 @@ class GaussianNoise(MaskedLayer):
         return {"name":self.__class__.__name__,
             "sigma":self.sigma}
 
-class GaussianDropout(Layer):
+class GaussianDropout(MaskedLayer):
     '''
         Multiplicative Gaussian Noise
         Reference: 

--- a/keras/models.py
+++ b/keras/models.py
@@ -268,6 +268,7 @@ class Sequential(Model, containers.Sequential):
         else:
             raise Exception("Invalid class mode:" + str(class_mode))
         self.class_mode = class_mode
+        self.theano_mode = theano_mode
 
         for r in self.regularizers:
             train_loss = r(train_loss)

--- a/keras/models.py
+++ b/keras/models.py
@@ -88,24 +88,24 @@ def standardize_weights(y, sample_weight=None, class_weight=None):
     else:
         return np.ones(y.shape[:-1] + (1,))
 
-def sequential_from_yaml(yamlString):
+def sequential_from_yaml(yaml_string):
     '''
         Returns a compiled Sequential model generated from a local yaml file,
         which is either created by hand or from Sequential.to_yaml
     '''
-    modelYaml = yaml.load(yamlString)
+    model_yaml = yaml.load(yaml_string)
     model = Sequential()
 
-    class_mode = modelYaml.get('class_mode')
-    theano_mode = modelYaml.get('theano_mode')
-    loss = globals()[modelYaml.get('loss')]
+    class_mode = model_yaml.get('class_mode')
+    theano_mode = model_yaml.get('theano_mode')
+    loss = globals()[model_yaml.get('loss')]
 
-    optim = modelYaml.get('optimizer')
-    optimName = optim.get('name')
+    optim = model_yaml.get('optimizer')
+    optim_name = optim.get('name')
     optim.pop('name')
-    optimizer = globals()[optimName](**optim)
+    optimizer = globals()[optim_name](**optim)
 
-    layers = modelYaml.get('layers')
+    layers = model_yaml.get('layers')
     for layer in layers:
         name = layer.get('name')
         layer.pop('name')
@@ -119,15 +119,15 @@ def sequential_from_yaml(yamlString):
                 vname = v.get('name')
                 v.pop('name')
                 layer[k] = globals()[vname](**v)
-        initLayer = globals()[name](**layer)
+        init_layer = globals()[name](**layer)
         if hasParams:
-            shapedParams = []
+            shaped_params = []
             for param in params:
                 data = np.asarray(param.get('data'))
                 shape = tuple(param.get('shape'))
-                shapedParams.append(data.reshape(shape))
-            initLayer.set_weights(shapedParams)
-        model.add(initLayer)
+                shaped_params.append(data.reshape(shape))
+            init_layer.set_weights(shaped_params)
+        model.add(init_layer)
 
     model.compile(loss=loss, optimizer=optimizer, class_mode=class_mode, theano_mode=theano_mode)
     return model

--- a/keras/models.py
+++ b/keras/models.py
@@ -237,6 +237,8 @@ class Sequential(Model, containers.Sequential):
 
     def compile(self, optimizer, loss, class_mode="categorical", theano_mode=None):
         self.optimizer = optimizers.get(optimizer)
+
+        self.unweighted_loss = objectives.get(loss)
         self.loss = weighted_objective(objectives.get(loss))
 
         # input of model

--- a/keras/models.py
+++ b/keras/models.py
@@ -522,25 +522,25 @@ class Sequential(Model, containers.Sequential):
         f.close()
 
 
-    def to_yaml(self, storeParams=True):
+    def to_yaml(self, store_params=True):
         '''
             Stores compiled Sequential model to yaml string, optionally storing all learnable parameters
         '''
-        modelDict = {}
-        modelDict['class_mode'] = self.class_mode
-        modelDict['theano_mode'] = self.theano_mode
-        modelDict['loss'] = self.unweighted_loss.__name__
-        modelDict['optimizer'] = self.optimizer.get_config()
+        model_dict = {}
+        model_dict['class_mode'] = self.class_mode
+        model_dict['theano_mode'] = self.theano_mode
+        model_dict['loss'] = self.unweighted_loss.__name__
+        model_dict['optimizer'] = self.optimizer.get_config()
 
         layers = []
         for layer in self.layers:
-            layerConf = layer.get_config()
-            if storeParams:
-                layerConf['parameters'] = [{'shape':list(param.get_value().shape), 'data':param.get_value().tolist()} for param in layer.params]
-            layers.append(layerConf)
-        modelDict['layers'] = layers
+            layer_conf = layer.get_config()
+            if store_params:
+                layer_conf['parameters'] = [{'shape':list(param.get_value().shape), 'data':param.get_value().tolist()} for param in layer.params]
+            layers.append(layer_conf)
+        model_dict['layers'] = layers
 
-        return yaml.dump(modelDict)
+        return yaml.dump(model_dict)
 
 
 class Graph(Model, containers.Graph):

--- a/keras/models.py
+++ b/keras/models.py
@@ -88,13 +88,12 @@ def standardize_weights(y, sample_weight=None, class_weight=None):
     else:
         return np.ones(y.shape[:-1] + (1,))
 
-def sequential_from_yaml(pathToYaml):
+def sequential_from_yaml(yamlString):
     '''
         Returns a compiled Sequential model generated from a local yaml file,
         which is either created by hand or from Sequential.to_yaml
     '''
-    stream = open(pathToYaml, 'r')
-    modelYaml = yaml.load(stream)
+    modelYaml = yaml.load(yamlString)
     model = Sequential()
 
     class_mode = modelYaml.get('class_mode')
@@ -523,9 +522,9 @@ class Sequential(Model, containers.Sequential):
         f.close()
 
 
-    def to_yaml(self, fileName, storeParams=True):
+    def to_yaml(self, storeParams=True):
         '''
-            Stores compiled Sequential model to local file, optionally storing all learnable parameters
+            Stores compiled Sequential model to yaml string, optionally storing all learnable parameters
         '''
         modelDict = {}
         modelDict['class_mode'] = self.class_mode
@@ -541,8 +540,7 @@ class Sequential(Model, containers.Sequential):
             layers.append(layerConf)
         modelDict['layers'] = layers
 
-        with open(fileName, 'w') as outfile:
-            outfile.write(yaml.dump(modelDict, default_flow_style=True))
+        return yaml.dump(modelDict)
 
 
 class Graph(Model, containers.Graph):

--- a/keras/optimizers.py
+++ b/keras/optimizers.py
@@ -29,6 +29,8 @@ class Optimizer(object):
 
         return grads
 
+    def get_config(self):
+        return {"name":self.__class__.__name__}
 
 class SGD(Optimizer):
 
@@ -55,6 +57,13 @@ class SGD(Optimizer):
             updates.append((p, c(new_p))) # apply constraints
         return updates
 
+    def get_config(self):
+        return {"name":self.__class__.__name__,
+            "lr":self.lr,
+            "momentum":self.momentum,
+            "decay":self.decay,
+            "nesterov":self.nesterov}
+
 
 class RMSprop(Optimizer):
 
@@ -76,6 +85,11 @@ class RMSprop(Optimizer):
             
         return updates
 
+    def get_config(self):
+        return {"name":self.__class__.__name__,
+            "lr":self.lr,
+            "rho":self.rho,
+            "epsilon":self.epsilon}
 
 class Adagrad(Optimizer):
 
@@ -96,6 +110,10 @@ class Adagrad(Optimizer):
             updates.append((p, c(new_p))) # apply constraints
         return updates
 
+    def get_config(self):
+        return {"name":self.__class__.__name__,
+            "lr":self.lr,
+            "epsilon":self.epsilon}
 
 class Adadelta(Optimizer):
     '''
@@ -126,6 +144,11 @@ class Adadelta(Optimizer):
             updates.append((d_a, new_d_a))
         return updates
 
+    def get_config(self):
+        return {"name":self.__class__.__name__,
+            "lr":self.lr,
+            "rho":self.rho,
+            "epsilon":self.epsilon}
 
 class Adam(Optimizer):
     '''
@@ -166,6 +189,14 @@ class Adam(Optimizer):
             updates.append((v, v_t))
             updates.append((p, c(p_t))) # apply constraints
         return updates
+
+    def get_config(self):
+        return {"name":self.__class__.__name__,
+            "lr":self.lr,
+            "beta_1":self.beta_1,
+            "beta_2":self.beta_2,
+            "epsilon":self.epsilon,
+            "kappa":self.kappa}
 
 # aliases
 sgd = SGD

--- a/keras/optimizers.py
+++ b/keras/optimizers.py
@@ -206,5 +206,5 @@ adadelta = Adadelta
 adam = Adam
 
 from .utils.generic_utils import get_from_module
-def get(identifier):
-    return get_from_module(identifier, globals(), 'optimizer', instantiate=True)
+def get(identifier, kwargs=None):
+    return get_from_module(identifier, globals(), 'optimizer', instantiate=True, kwargs=kwargs)

--- a/keras/regularizers.py
+++ b/keras/regularizers.py
@@ -11,6 +11,8 @@ class Regularizer(object):
     def __call__(self, loss):
         return loss
 
+    def get_config(self):
+        return {"name":self.__class__.__name__}
 
 class WeightRegularizer(Regularizer):
     def __init__(self, l1=0., l2=0.):
@@ -25,6 +27,10 @@ class WeightRegularizer(Regularizer):
         loss += T.sum(self.p ** 2) * self.l2
         return loss
 
+    def get_config(self):
+        return {"name":self.__class__.__name__,
+            "l1":self.l1,
+            "l2":self.l2}
 
 class ActivityRegularizer(Regularizer):
     def __init__(self, l1=0., l2=0.):
@@ -38,7 +44,11 @@ class ActivityRegularizer(Regularizer):
         loss += self.l1 * T.sum(T.mean(abs(self.layer.get_output(True)), axis=0))
         loss += self.l2 * T.sum(T.mean(self.layer.get_output(True) ** 2, axis=0))
         return loss
-
+    
+    def get_config(self):
+        return {"name":self.__class__.__name__,
+            "l1":self.l1,
+            "l2":self.l2}
 
 def l1(l=0.01):
     return WeightRegularizer(l1=l)

--- a/keras/regularizers.py
+++ b/keras/regularizers.py
@@ -71,5 +71,5 @@ def activity_l1l2(l1=0.01, l2=0.01):
 identity = Regularizer
 
 from .utils.generic_utils import get_from_module
-def get(identifier):
-    return get_from_module(identifier, globals(), 'regularizer', instantiate=True)
+def get(identifier, kwargs=None):
+    return get_from_module(identifier, globals(), 'regularizer', instantiate=True, kwargs=kwargs)

--- a/keras/regularizers.py
+++ b/keras/regularizers.py
@@ -69,3 +69,7 @@ def activity_l1l2(l1=0.01, l2=0.01):
     return ActivityRegularizer(l1=l1, l2=l2)
 
 identity = Regularizer
+
+from .utils.generic_utils import get_from_module
+def get(identifier):
+    return get_from_module(identifier, globals(), 'regularizer', instantiate=True)

--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -4,13 +4,15 @@ import time
 import sys
 import six
 
-def get_from_module(identifier, module_params, module_name, instantiate=False):
+def get_from_module(identifier, module_params, module_name, instantiate=False, kwargs=None):
     if isinstance(identifier, six.string_types):
         res = module_params.get(identifier)
         if not res:
             raise Exception('Invalid ' + str(module_name) + ': ' + str(identifier))
-        if instantiate:
+        if instantiate and not kwargs:
             return res()
+        elif instantiate and kwargs:
+            return res(**kwargs)
         else:
             return res
     return identifier

--- a/keras/utils/layer_utils.py
+++ b/keras/utils/layer_utils.py
@@ -1,0 +1,81 @@
+import inspect
+import numpy as np
+
+from ..layers.advanced_activations import LeakyReLU, PReLU
+from ..layers.core import Dense, Merge, Dropout, Activation, Reshape, Flatten, RepeatVector, Layer
+from ..layers.core import ActivityRegularization, TimeDistributedDense, AutoEncoder, MaxoutDense
+from ..layers.embeddings import Embedding, WordContextProduct
+from ..layers.noise import GaussianNoise, GaussianDropout
+from ..layers.normalization import BatchNormalization
+from ..layers.recurrent import SimpleRNN, SimpleDeepRNN, GRU, LSTM, JZS1, JZS2, JZS3
+from ..layers import containers
+
+from .. import regularizers
+from .. import constraints
+
+
+def from_yaml(layer_dict):
+    name = layer_dict.get('name')
+    hasParams = False
+    if name == 'Merge':
+        mode = layer_dict.get('mode')
+        layers = layer_dict.get('layers')
+        layer_list = []
+        for layer in layers:
+            init_layer = from_yaml(layer)
+            layer_list.append(init_layer)
+        merge_layer = Merge(layer_list, mode)
+        return merge_layer
+    elif name == 'Sequential':
+        layers = layer_dict.get('layers')
+        layer_list = []
+        for layer in layers:
+            init_layer = from_yaml(layer)
+            layer_list.append(init_layer)
+        seq_layer = containers.Sequential(layer_list)
+        return seq_layer
+    elif name == 'Graph':
+        graph_layer = containers.Graph()
+        inputs = layer_dict.get('inputs')
+        for input in inputs:
+            graph_layer.add_input(**input)
+        nodes = layer_dict.get('nodes')
+        for node in nodes:
+            layer_conf = node.get('layer')
+            layer = from_yaml(layer_conf)
+            node['layer'] = layer
+            graph_layer.add_node(**node)
+        outputs = layer_dict.get('outputs')
+        for output in outputs:
+            graph_layer.add_output(**output)
+        return graph_layer
+    else: # The case in which layer_dict represents an "atomic" layer
+        layer_dict.pop('name')
+        if layer_dict.has_key('parameters'):
+            params = layer_dict.get('parameters')
+            layer_dict.pop('parameters')
+            hasParams = True
+        for k, v in layer_dict.iteritems():
+        	# For now, this can only happen for regularizers and constraints
+            if isinstance(v, dict):
+                vname = v.get('name')
+                v.pop('name')
+                if vname in [x for x,y in inspect.getmembers(constraints, predicate=inspect.isclass)]:
+                	layer_dict[k] = constraints.get(vname, v)
+                if vname in [x for x,y in inspect.getmembers(regularizers, predicate=inspect.isclass)]:
+                	layer_dict[k] = regularizers.get(vname, v)
+                #layer_dict[k] = globals()[vname](**v)
+        base_layer = get_layer(name, layer_dict)
+        if hasParams:
+            shaped_params = []
+            for param in params:
+                data = np.asarray(param.get('data'))
+                shape = tuple(param.get('shape'))
+                shaped_params.append(data.reshape(shape))
+            base_layer.set_weights(shaped_params)
+        return base_layer
+
+
+from .generic_utils import get_from_module
+def get_layer(identifier, kwargs=None):
+    return get_from_module(identifier, globals(), 'layer', instantiate=True, kwargs=kwargs)

--- a/tests/manual/check_yaml.py
+++ b/tests/manual/check_yaml.py
@@ -1,0 +1,55 @@
+from __future__ import absolute_import
+from __future__ import print_function
+import numpy as np
+
+from keras.preprocessing import sequence
+from keras.optimizers import SGD, RMSprop, Adagrad
+from keras.utils import np_utils
+from keras.models import Sequential
+from keras.layers.core import Dense, Dropout, Activation
+from keras.layers.embeddings import Embedding
+from keras.layers.recurrent import LSTM, GRU
+from keras.datasets import imdb
+from keras.models import sequential_from_yaml
+
+'''
+This is essentially the IMDB test. Deserialized models should yield 
+the same config as the original one.
+'''
+
+max_features = 10000
+maxlen = 100 
+batch_size = 32
+
+(X_train, y_train), (X_test, y_test) = imdb.load_data(nb_words=max_features, test_split=0.2)
+
+X_train = sequence.pad_sequences(X_train, maxlen=maxlen)
+X_test = sequence.pad_sequences(X_test, maxlen=maxlen)
+
+model = Sequential()
+model.add(Embedding(max_features, 128))
+model.add(LSTM(128, 128)) 
+model.add(Dropout(0.5))
+model.add(Dense(128, 1))
+model.add(Activation('sigmoid'))
+
+model.compile(loss='binary_crossentropy', optimizer='adam', class_mode="binary")
+
+model.get_config(verbose=1)
+
+######################
+# save model to yaml #
+######################
+yamlString = model.to_yaml()
+
+recovered_model = sequential_from_yaml(yamlString)
+recovered_model.get_config(verbose=1)
+
+#####################################
+# save model w/o parameters to yaml #
+#####################################
+
+yaml_no_params = model.to_yaml(storeParams=False)
+
+no_param_model = sequential_from_yaml(yaml_no_params)
+no_param_model.get_config(verbose=1)

--- a/tests/manual/check_yaml.py
+++ b/tests/manual/check_yaml.py
@@ -2,15 +2,16 @@ from __future__ import absolute_import
 from __future__ import print_function
 import numpy as np
 
+from keras.utils.test_utils import get_test_data
 from keras.preprocessing import sequence
 from keras.optimizers import SGD, RMSprop, Adagrad
 from keras.utils import np_utils
-from keras.models import Sequential
-from keras.layers.core import Dense, Dropout, Activation
+from keras.models import Sequential, Graph
+from keras.layers.core import Dense, Dropout, Activation, Merge
 from keras.layers.embeddings import Embedding
 from keras.layers.recurrent import LSTM, GRU
 from keras.datasets import imdb
-from keras.models import sequential_from_yaml
+from keras.models import model_from_yaml
 
 '''
 This is essentially the IMDB test. Deserialized models should yield 
@@ -30,26 +31,78 @@ model = Sequential()
 model.add(Embedding(max_features, 128))
 model.add(LSTM(128, 128)) 
 model.add(Dropout(0.5))
-model.add(Dense(128, 1))
+model.add(Dense(128, 1, W_regularizer='identity', b_constraint='maxnorm'))
 model.add(Activation('sigmoid'))
 
-model.compile(loss='binary_crossentropy', optimizer='adam', class_mode="binary")
+#model.compile(loss='binary_crossentropy', optimizer='adam', class_mode="binary")
 
 model.get_config(verbose=1)
 
 ######################
 # save model to yaml #
 ######################
-yamlString = model.to_yaml()
+#yaml_string = model.to_yaml()
 
-recovered_model = sequential_from_yaml(yamlString)
-recovered_model.get_config(verbose=1)
+#recovered_model = model_from_yaml(yaml_string)
+#recovered_model.get_config(verbose=1)
 
 #####################################
 # save model w/o parameters to yaml #
 #####################################
 
-yaml_no_params = model.to_yaml(storeParams=False)
+yaml_no_params = model.to_yaml(store_params=False)
 
-no_param_model = sequential_from_yaml(yaml_no_params)
+no_param_model = model_from_yaml(yaml_no_params)
 no_param_model.get_config(verbose=1)
+
+######################################
+# save multi-branch sequential model #
+######################################
+
+seq = Sequential()
+seq.add(Merge([model, model], mode='sum'))
+seq.get_config(verbose=1)
+merge_yaml = seq.to_yaml(store_params=False)
+merge_model = model_from_yaml(merge_yaml)
+
+large_model = Sequential()
+large_model.add(Merge([seq,model], mode='concat'))
+large_model.get_config(verbose=1)
+large_model.to_yaml(store_params=False)
+
+####################
+# save graph model #
+####################
+
+X = np.random.random((100, 32))
+X2 = np.random.random((100, 32))
+y = np.random.random((100, 4))
+y2 = np.random.random((100,))
+
+(X_train, y_train), (X_test, y_test) = get_test_data(nb_train=1000, nb_test=200, input_shape=(32,),
+    classification=False, output_shape=(4,))
+
+graph = Graph()
+
+graph.add_input(name='input1', ndim=2)
+
+graph.add_node(Dense(32, 16), name='dense1', input='input1')
+graph.add_node(Dense(32, 4), name='dense2', input='input1')
+graph.add_node(Dense(16, 4), name='dense3', input='dense1')
+
+graph.add_output(name='output1', inputs=['dense2', 'dense3'], merge_mode='sum')
+graph.compile('rmsprop', {'output1':'mse'})
+
+graph.get_config(verbose=1)
+
+history = graph.fit({'input1':X_train, 'output1':y_train}, nb_epoch=10)
+original_pred = graph.predict({'input1':X_test})
+
+graph_yaml = graph.to_yaml(store_params=True)
+reloaded_graph = model_from_yaml(graph_yaml)
+reloaded_graph.get_config(verbose=1)
+
+reloaded_graph.compile('rmsprop', {'output1':'mse'})
+new_pred = reloaded_graph.predict({'input1':X_test})
+
+print(new_pred['output1'][3][1] == original_pred['output1'][3][1])


### PR DESCRIPTION
- Sequential now has to_yaml() method to dump models as yaml strings.
- models module has sequential_from_yaml() method to load from such strings
- Models can be stored with and without parameters.
- It's possible to (de-)serialize non-standard optimizers, constraints and regularizers.
- Includes a test that checks for equality of configs before and after serialization.