### PR TITLE
implement batch shuffle

### DIFF
--- a/docs/sources/models.md
+++ b/docs/sources/models.md
@@ -24,7 +24,7 @@ model = keras.models.Sequential()
             - __callbacks__: `keras.callbacks.Callback` list. List of callbacks to apply during training. See [callbacks](callbacks.md).
             - __validation_split__: float (0. < x < 1). Fraction of the data to use as held-out validation data.
             - __validation_data__: tuple (X, y) to be used as held-out validation data. Will override validation_split.
-            - __shuffle__: boolean. Whether to shuffle the samples at each epoch.
+            - __shuffle__: boolean or str (for 'batch'). Whether to shuffle the samples at each epoch. 'batch' is a special option for dealing with the limitations of HDF5 data; it shuffles in batch-sized chunks.
             - __show_accuracy__: boolean. Whether to display class accuracy in the logs to stdout at each epoch.
             - __class_weight__: dictionary mapping classes to a weight value, used for scaling the loss function (during training only).
             - __sample_weight__: list or numpy array with 1:1 mapping to the training samples, used for scaling the loss function (during training only).

--- a/keras/models.py
+++ b/keras/models.py
@@ -23,6 +23,17 @@ def standardize_y(y):
         y = np.expand_dims(y, 1)
     return y
 
+def batch_shuffle(index_array, batch_size):
+    batch_count = int(len(index_array)/batch_size)
+    # to reshape we need to be cleanly divisible by batch size
+    # we stash extra items and reappend them after shuffling
+    last_batch = index_array[batch_count*batch_size:]
+    index_array = index_array[:batch_count*batch_size]
+    index_array = index_array.reshape((batch_count, batch_size))
+    np.random.shuffle(index_array)
+    index_array = index_array.flatten()
+    return np.append(index_array, last_batch)
+
 
 def make_batches(size, batch_size):
     nb_batch = int(np.ceil(size/float(batch_size)))
@@ -120,7 +131,9 @@ class Model(object):
         self.stop_training = False
         for epoch in range(nb_epoch):
             callbacks.on_epoch_begin(epoch)
-            if shuffle:
+            if shuffle == 'batch':
+                index_array = batch_shuffle(index_array, batch_size)
+            elif shuffle:
                 np.random.shuffle(index_array)
 
             batches = make_batches(nb_train_sample, batch_size)

--- a/keras/models.py
+++ b/keras/models.py
@@ -139,7 +139,13 @@ class Model(object):
             batches = make_batches(nb_train_sample, batch_size)
             for batch_index, (batch_start, batch_end) in enumerate(batches):
                 batch_ids = index_array[batch_start:batch_end]
-                ins_batch = slice_X(ins, batch_ids)
+                try:
+                    ins_batch = slice_X(ins, batch_ids)
+                except TypeError as err:
+                    print(
+                        '\n!! TypeError while preparing batch.',
+                        'If using HDF5 input data, pass shuffle=\'batch\'.\n')
+                    raise
 
                 batch_logs = {}
                 batch_logs['batch'] = batch_index


### PR DESCRIPTION
I'm currently using the `io_utils.HDF5Matrix` class, but HDF5 does not support array-indexing unless the indicies are in ascending order. This breaks shuffling. 

The solution I've been using is to add a 'batch' option to the shuffle argument; this shuffles in chunks dictated by the batch size. Essentially items within a batch aren't shuffled, but the order of batches _is_.

There's one slightly funny detail: if the number of items does not divide by the batch size the last batch is left in place.



