### PR TITLE
logging module instead of print()s

### DIFF
--- a/keras/__init__.py
+++ b/keras/__init__.py
@@ -1,16 +1,16 @@
 import logging
+import sys
 
 # package-global logger
 logger = logging.getLogger('keras')
 
-# set up basic logger to behave like print()
-# this will be done on first import of a Keras module, but only if there 
-# is no existing logger configuration
-# to use a different configuration; first clear the handlers set here using 
-#    logging.getLogger('').handlers = []
-#    logging.basicConfig(...)
-if not logging.getLogger('').handlers:
-    logging.basicConfig(format='%(message)s', level=logging.INFO)
+# set up logger to behave like print() by default (without client having to do anything)
+if not logger.handlers:
+    hdlr = logging.StreamHandler(sys.stdout)
+    fmt = logging.Formatter('%(message)s', None)
+    hdlr.setFormatter(fmt)
+    logger.addHandler(hdlr)
+    logger.setLevel(logging.INFO)
 
 # make warnings issued with the warnings module be handled by logging infrastructure
 logging.captureWarnings(True)

--- a/keras/__init__.py
+++ b/keras/__init__.py
@@ -1,0 +1,16 @@
+import logging
+
+# package-global logger
+logger = logging.getLogger('keras')
+
+# set up basic logger to behave like print()
+# this will be done on first import of a Keras module, but only if there 
+# is no existing logger configuration
+# to use a different configuration; first clear the handlers set here using 
+#    logging.getLogger('').handlers = []
+#    logging.basicConfig(...)
+if not logging.getLogger('').handlers:
+    logging.basicConfig(format='%(message)s', level=logging.INFO)
+
+# make warnings issued with the warnings module be handled by logging infrastructure
+logging.captureWarnings(True)

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-from __future__ import print_function
 import theano
 import theano.tensor as T
 import numpy as np
@@ -7,6 +6,7 @@ import warnings
 import time, json
 from collections import deque
 
+from . import logger
 from .utils.generic_utils import Progbar
 
 class CallbackList(object):
@@ -106,7 +106,7 @@ class BaseLogger(Callback):
 
     def on_epoch_begin(self, epoch, logs={}):
         if self.verbose:
-            print('Epoch %d' % epoch)
+            logger.info('Epoch %d' % epoch)
             self.progbar = Progbar(target=self.params['nb_sample'], \
                 verbose=self.verbose)
         self.seen = 0
@@ -192,16 +192,16 @@ class ModelCheckpoint(Callback):
             else:
                 if current < self.best:
                     if self.verbose > 0:
-                        print("Epoch %05d: %s improved from %0.5f to %0.5f, saving model to %s"
-                            % (epoch, self.monitor, self.best, current, self.filepath))
+                        logger.info("Epoch %05d: %s improved from %0.5f to %0.5f, saving model to %s", 
+                            epoch, self.monitor, self.best, current, self.filepath)
                     self.best = current
                     self.model.save_weights(self.filepath, overwrite=True)
                 else:
                     if self.verbose > 0:
-                        print("Epoch %05d: %s did not improve" % (epoch, self.monitor))
+                        logger.info("Epoch %05d: %s did not improve", epoch, self.monitor)
         else:
             if self.verbose > 0:
-                print("Epoch %05d: saving model to %s" % (epoch, self.filepath))
+                logger.info("Epoch %05d: saving model to %s", epoch, self.filepath)
             self.model.save_weights(self.filepath, overwrite=True)
 
 
@@ -226,7 +226,7 @@ class EarlyStopping(Callback):
         else:
             if self.wait >= self.patience:
                 if self.verbose > 0:
-                    print("Epoch %05d: early stopping" % (epoch))
+                    logger.info("Epoch %05d: early stopping" % (epoch))
                 self.model.stop_training = True
             self.wait += 1
 

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -192,8 +192,8 @@ class ModelCheckpoint(Callback):
             else:
                 if current < self.best:
                     if self.verbose > 0:
-                        logger.info("Epoch %05d: %s improved from %0.5f to %0.5f, saving model to %s" % 
-                            (epoch, self.monitor, self.best, current, self.filepath))
+                        logger.info("Epoch %05d: %s improved from %0.5f to %0.5f, saving model to %s"
+                            % (epoch, self.monitor, self.best, current, self.filepath))
                     self.best = current
                     self.model.save_weights(self.filepath, overwrite=True)
                 else:

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -192,16 +192,16 @@ class ModelCheckpoint(Callback):
             else:
                 if current < self.best:
                     if self.verbose > 0:
-                        logger.info("Epoch %05d: %s improved from %0.5f to %0.5f, saving model to %s", 
-                            epoch, self.monitor, self.best, current, self.filepath)
+                        logger.info("Epoch %05d: %s improved from %0.5f to %0.5f, saving model to %s" % 
+                            (epoch, self.monitor, self.best, current, self.filepath))
                     self.best = current
                     self.model.save_weights(self.filepath, overwrite=True)
                 else:
                     if self.verbose > 0:
-                        logger.info("Epoch %05d: %s did not improve", epoch, self.monitor)
+                        logger.info("Epoch %05d: %s did not improve" % (epoch, self.monitor))
         else:
             if self.verbose > 0:
-                logger.info("Epoch %05d: saving model to %s", epoch, self.filepath)
+                logger.info("Epoch %05d: saving model to %s" % (epoch, self.filepath))
             self.model.save_weights(self.filepath, overwrite=True)
 
 

--- a/keras/datasets/data_utils.py
+++ b/keras/datasets/data_utils.py
@@ -18,7 +18,7 @@ def get_file(fname, origin, untar=False):
     try:
         f = open(fpath)
     except:
-        logger.info('Downloading data from %s',  origin)
+        logger.info('Downloading data from %s' % origin)
 
         global progbar
         progbar = None

--- a/keras/datasets/data_utils.py
+++ b/keras/datasets/data_utils.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import
-from __future__ import print_function
 import tarfile, inspect, os
 from six.moves.urllib.request import urlretrieve
 from ..utils.generic_utils import Progbar
+from .. import logger
 
 def get_file(fname, origin, untar=False):
     datadir = os.path.expanduser(os.path.join('~', '.keras', 'datasets'))
@@ -18,7 +18,7 @@ def get_file(fname, origin, untar=False):
     try:
         f = open(fpath)
     except:
-        print('Downloading data from',  origin)
+        logger.info('Downloading data from %s',  origin)
 
         global progbar
         progbar = None
@@ -34,7 +34,7 @@ def get_file(fname, origin, untar=False):
 
     if untar:
         if not os.path.exists(untar_fpath):
-            print('Untaring file...')
+            logger.info('Untaring file...')
             tfile = tarfile.open(fpath, 'r:gz')
             tfile.extractall(path=datadir)
             tfile.close()

--- a/keras/datasets/reuters.py
+++ b/keras/datasets/reuters.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
-from __future__ import print_function
 from .data_utils import get_file
 import string
 import random
@@ -12,6 +11,7 @@ import numpy as np
 def make_reuters_dataset(path=os.path.join('datasets', 'temp', 'reuters21578'), min_samples_per_topic=15):
     import re
     from ..preprocessing.text import Tokenizer
+    from .. import logger
 
     wire_topics = []
     topic_counts = {}
@@ -42,11 +42,11 @@ def make_reuters_dataset(path=os.path.join('datasets', 'temp', 'reuters21578'), 
     items.sort(key = lambda x: x[1])
     kept_topics = set()
     for x in items:
-        print(x[0] + ': ' + str(x[1]))
+        logger.info(x[0] + ': ' + str(x[1]))
         if x[1] >= min_samples_per_topic:
             kept_topics.add(x[0])
-    print('-')
-    print('Kept topics:', len(kept_topics))
+    logger.info('-')
+    logger.info('Kept topics:', len(kept_topics))
 
     # filter wires with rare topics
     kept_wires = []
@@ -68,16 +68,16 @@ def make_reuters_dataset(path=os.path.join('datasets', 'temp', 'reuters21578'), 
     tokenizer.fit_on_texts(kept_wires)
     X = tokenizer.texts_to_sequences(kept_wires)
 
-    print('Sanity check:')
+    logger.info('Sanity check:')
     for w in ["banana", "oil", "chocolate", "the", "dsft"]:
-        print('...index of', w, ':', tokenizer.word_index.get(w))
-    print('text reconstruction:')
+        logger.info('...index of %s : %d', w, tokenizer.word_index.get(w))
+    logger.info('text reconstruction:')
     reverse_word_index = dict([(v, k) for k, v in tokenizer.word_index.items()])
-    print(' '.join(reverse_word_index[i] for i in X[10]))
+    logger.info(' '.join(reverse_word_index[i] for i in X[10]))
 
     dataset = (X, labels) 
-    print('-')
-    print('Saving...')
+    logger.info('-')
+    logger.info('Saving...')
     six.moves.cPickle.dump(dataset, open(os.path.join('datasets', 'data', 'reuters.pkl'), 'w'))
     six.moves.cPickle.dump(tokenizer.word_index, open(os.path.join('datasets', 'data', 'reuters_word_index.pkl'), 'w'))
 

--- a/keras/datasets/reuters.py
+++ b/keras/datasets/reuters.py
@@ -46,7 +46,7 @@ def make_reuters_dataset(path=os.path.join('datasets', 'temp', 'reuters21578'), 
         if x[1] >= min_samples_per_topic:
             kept_topics.add(x[0])
     logger.info('-')
-    logger.info('Kept topics:', len(kept_topics))
+    logger.info('Kept topics: %d' % len(kept_topics))
 
     # filter wires with rare topics
     kept_wires = []
@@ -70,7 +70,7 @@ def make_reuters_dataset(path=os.path.join('datasets', 'temp', 'reuters21578'), 
 
     logger.info('Sanity check:')
     for w in ["banana", "oil", "chocolate", "the", "dsft"]:
-        logger.info('...index of %s : %d', w, tokenizer.word_index.get(w))
+        logger.info('...index of %s : %d' % (w, tokenizer.word_index.get(w)))
     logger.info('text reconstruction:')
     reverse_word_index = dict([(v, k) for k, v in tokenizer.word_index.items()])
     logger.info(' '.join(reverse_word_index[i] for i in X[10]))

--- a/keras/layers/containers.py
+++ b/keras/layers/containers.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
-from __future__ import print_function
 
 import theano.tensor as T
 from ..layers.core import Layer, Merge

--- a/keras/models.py
+++ b/keras/models.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-from __future__ import print_function
 import theano
 import theano.tensor as T
 import numpy as np
@@ -10,6 +9,7 @@ from . import objectives
 from . import regularizers
 from . import constraints
 from . import callbacks as cbks
+from . import logger
 import time, copy, pprint
 from .utils.generic_utils import Progbar, printv
 from .layers import containers
@@ -87,14 +87,14 @@ class Model(object):
         if val_f and val_ins:
             do_validation = True
             if verbose:
-                print("Train on %d samples, validate on %d samples" % (len(ins[0]), len(val_ins[0])))
+                logger.info("Train on %d samples, validate on %d samples", len(ins[0]), len(val_ins[0]))
         else:
             if 0 < validation_split < 1:
                 do_validation = True
                 split_at = int(len(ins[0]) * (1 - validation_split))
                 (ins, val_ins) = (slice_X(ins, 0, split_at), slice_X(ins, split_at))
                 if verbose:
-                    print("Train on %d samples, validate on %d samples" % (len(ins[0]), len(val_ins[0])))
+                    logger.info("Train on %d samples, validate on %d samples", len(ins[0]), len(val_ins[0]))
 
         nb_train_sample = len(ins[0])
         index_array = np.arange(nb_train_sample)
@@ -433,7 +433,7 @@ class Sequential(Model, containers.Sequential):
                 overwrite = get_input('Enter "y" (overwrite) or "n" (cancel).')
             if overwrite == 'n':
                 return
-            print('[TIP] Next time specify overwrite=True in save_weights!')
+            logger.info('[TIP] Next time specify overwrite=True in save_weights!')
 
         f = h5py.File(filepath, 'w')
         f.attrs['nb_layers'] = len(self.layers)
@@ -562,7 +562,7 @@ class Graph(Model, containers.Graph):
                 overwrite = get_input('Enter "y" (overwrite) or "n" (cancel).')
             if overwrite == 'n':
                 return
-            print('[TIP] Next time specify overwrite=True in save_weights!')
+            logger.info('[TIP] Next time specify overwrite=True in save_weights!')
 
         f = h5py.File(filepath, 'w')
         g = f.create_group('graph')
@@ -588,5 +588,5 @@ class Graph(Model, containers.Graph):
         config = super(Graph, self).get_config()
         if verbose:
             pp = pprint.PrettyPrinter(indent=4)
-            pp.pprint(config)
+            logger.info(pp.pformat(config))
         return config

--- a/keras/models.py
+++ b/keras/models.py
@@ -87,14 +87,14 @@ class Model(object):
         if val_f and val_ins:
             do_validation = True
             if verbose:
-                logger.info("Train on %d samples, validate on %d samples", len(ins[0]), len(val_ins[0]))
+                logger.info("Train on %d samples, validate on %d samples" % (len(ins[0]), len(val_ins[0])))
         else:
             if 0 < validation_split < 1:
                 do_validation = True
                 split_at = int(len(ins[0]) * (1 - validation_split))
                 (ins, val_ins) = (slice_X(ins, 0, split_at), slice_X(ins, split_at))
                 if verbose:
-                    logger.info("Train on %d samples, validate on %d samples", len(ins[0]), len(val_ins[0]))
+                    logger.info("Train on %d samples, validate on %d samples" % (len(ins[0]), len(val_ins[0])))
 
         nb_train_sample = len(ins[0])
         index_array = np.arange(nb_train_sample)

--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -4,6 +4,8 @@ import time
 import sys
 import six
 
+from .. import logger
+
 def get_from_module(identifier, module_params, module_name, instantiate=False):
     if isinstance(identifier, six.string_types):
         res = module_params.get(identifier)
@@ -21,23 +23,23 @@ def make_tuple(*args):
 def printv(v, prefix=''):
     if type(v) == dict:
         if 'name' in v:
-            print(prefix + '#' + v['name'])
+            logger.info(prefix + '#' + v['name'])
             del v['name']
         prefix += '...'
         for nk, nv in v.items():
             if type(nv) in [dict, list]:
-                print(prefix + nk + ':')
+                logger.info(prefix + nk + ':')
                 printv(nv, prefix)
             else:
-                print(prefix + nk + ':' + str(nv))
+                logger.info(prefix + nk + ':' + str(nv))
     elif type(v) == list:
         prefix += '...'
         for i, nv in enumerate(v):
-            print(prefix + '#' + str(i))
+            logger.info(prefix + '#' + str(i))
             printv(nv, prefix) 
     else:
         prefix += '...'
-        print(prefix + str(v))
+        logger.info(prefix + str(v))
 
 class Progbar(object):
     def __init__(self, target, width=30, verbose=1):
@@ -111,14 +113,16 @@ class Progbar(object):
             sys.stdout.flush()
 
             if current >= self.target:
-                sys.stdout.write("\n")
+                sys.stdout.write("\r")
+                sys.stdout.flush()
+                logger.info(bar + info)
 
         if self.verbose == 2:
             if current >= self.target:
                 info = '%ds' % (now - self.start)
                 for k in self.unique_values:
                     info += ' - %s: %.4f' % (k, self.sum_values[k][0]/ max(1, self.sum_values[k][1]))
-                sys.stdout.write(info + "\n")
+                logger.info(info)
 
 
     def add(self, n, values=[]):


### PR DESCRIPTION
Changed all print() calls in the package (not examples, tests) to use Python's built-in logging module.
In my case because I wanted to log all output of Keras to a file.

Added a package-global logger to keras/__init__.py, with some code to setup the logger to behave like print() by default without the user having to do anything.
Then all calls to print() where changed logger.info() calls.
Changed string formatting to % in all cases, although logging functions also support formatting string with remaining passed arguments.