### PR TITLE
CropImages to maintain sizes in CNN

### DIFF
--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -197,8 +197,24 @@ class ZeroPadding2D(Layer):
         return {"name":self.__class__.__name__,
                 "width":self.width}
 
+class CropImage(Layer):
+    # take a 4D tensor with (nb_samples, nb_chanels, height, width) and return a smaller tensor
+    # that has (nb_samples, nb_chanels, height-2*crop, width-2*crop)
+    # Cropped images are centered
+    def __init__(self, crop=1):
+        super(CropImage, self).__init__()
+        self.crop = crop
+        self.input = T.tensor4()
 
+    def get_output(self, train):
+        X = self.get_input(train)
+        crop = self.crop
+        return X[:,:,crop:-crop,crop:-crop]
 
+    def get_config(self):
+        return {"name":self.__class__.__name__,
+                "crop":self.crop}
+        
 # class Convolution3D: TODO
 
 # class MaxPooling3D: TODO


### PR DESCRIPTION
Convolution2D only has border_mode='Full' or 'valid' and the image size changes upon convolution. I added a layer that allows to shrink the image after using Convolution2D with border_mode='Full' back to the original size (before the Convolution2D)

Example, assume images are 28x28 as in the mnist example

model.add(Convolution2D(32, 1, 3, 3, border_mode='full'))   # images are now 30x30 
model.add(Activation('relu'))
model.add(CropImage(1))                                     # images are now 28x28

Thanks for a great package