### PR TITLE
Match get_updates signature

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -139,7 +139,8 @@ class BaseLogger(Callback):
                 self.log_values.append((k, self.totals[k] / self.seen))
             if k in logs:
                 self.log_values.append((k, logs[k]))
-        self.progbar.update(self.seen, self.log_values)
+        if self.verbose:
+            self.progbar.update(self.seen, self.log_values)
 
 
 class History(Callback):

--- a/keras/optimizers.py
+++ b/keras/optimizers.py
@@ -16,7 +16,7 @@ def kl_divergence(p, p_hat):
 
 class Optimizer(object):
     
-    def get_updates(self, params, regularizers, constraints,  loss):
+    def get_updates(self, params, constraints, loss):
         raise NotImplementedError
 
     def get_gradients(self, loss, params):


### PR DESCRIPTION
Removing `regularizer` from `get_updates` signature in base class to match derived classes.