### PR TITLE
Add h5py to the install dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,6 @@ setup(name = 'Keras',
       url = 'https://github.com/fchollet/keras',
       download_url = 'https://github.com/fchollet/keras/tarball/0.1.1',
       license = 'MIT',
-      install_requires = ['theano', 'pyyaml'],
+      install_requires = ['theano', 'pyyaml', 'h5py'],
       packages = find_packages(),
 )


### PR DESCRIPTION
Hi Francois,

Tests fail due to missing h5py.
