### PR TITLE
PEP8 style cleanup

### DIFF
--- a/keras/activations.py
+++ b/keras/activations.py
@@ -1,5 +1,8 @@
 from __future__ import absolute_import
+
 import theano.tensor as T
+
+from .utils.generic_utils import get_from_module
 
 def softmax(x):
     return T.nnet.softmax(x.reshape((-1, x.shape[-1]))).reshape(x.shape)
@@ -30,6 +33,5 @@ def linear(x):
     '''
     return x
 
-from .utils.generic_utils import get_from_module
 def get(identifier):
     return get_from_module(identifier, globals(), 'activation function')

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -1,11 +1,11 @@
 from __future__ import absolute_import
 from __future__ import print_function
-import theano
-import theano.tensor as T
-import numpy as np
-import warnings
-import time, json
 from collections import deque
+import warnings
+import time
+import json
+
+import numpy as np
 
 from .utils.generic_utils import Progbar
 
@@ -43,8 +43,9 @@ class CallbackList(object):
             callback.on_batch_begin(batch, logs)
         self._delta_ts_batch_begin.append(time.time() - t_before_callbacks)
         delta_t_median = np.median(self._delta_ts_batch_begin)
-        if self._delta_t_batch > 0. and delta_t_median > 0.95 * self._delta_t_batch \
-            and delta_t_median > 0.1:
+        if self._delta_t_batch > 0. and \
+                delta_t_median > 0.95 * self._delta_t_batch and \
+                delta_t_median > 0.1:
             warnings.warn('Method on_batch_begin() is slow compared '
                 'to the batch update (%f). Check your callbacks.' % delta_t_median)
         self._t_enter_batch = time.time()
@@ -56,8 +57,9 @@ class CallbackList(object):
             callback.on_batch_end(batch, logs)
         self._delta_ts_batch_end.append(time.time() - t_before_callbacks)
         delta_t_median = np.median(self._delta_ts_batch_end)
-        if self._delta_t_batch > 0. and delta_t_median > 0.95 * self._delta_t_batch \
-            and delta_t_median > 0.1:
+        if self._delta_t_batch > 0. and \
+                delta_t_median > 0.95 * self._delta_t_batch and \
+                delta_t_median > 0.1:
             warnings.warn('Method on_batch_end() is slow compared '
                 'to the batch update (%f). Check your callbacks.' % delta_t_median)
 
@@ -107,7 +109,8 @@ class BaseLogger(Callback):
     def on_epoch_begin(self, epoch, logs={}):
         if self.verbose:
             print('Epoch %d' % epoch)
-            self.progbar = Progbar(target=self.params['nb_sample'], \
+            self.progbar = Progbar(
+                target=self.params['nb_sample'],
                 verbose=self.verbose)
         self.seen = 0
         self.totals = {}
@@ -144,7 +147,6 @@ class BaseLogger(Callback):
 
 
 class History(Callback):
-
     def on_train_begin(self, logs={}):
         self.epoch = []
         self.history = {}
@@ -178,7 +180,7 @@ class History(Callback):
 class ModelCheckpoint(Callback):
     def __init__(self, filepath, monitor='val_loss', verbose=0, save_best_only=False):
         super(Callback, self).__init__()
-        
+
         self.monitor = monitor
         self.verbose = verbose
         self.filepath = filepath
@@ -189,7 +191,9 @@ class ModelCheckpoint(Callback):
         if self.save_best_only:
             current = logs.get(self.monitor)
             if current is None:
-                warnings.warn("Can save best model only with %s available, skipping." % (self.monitor), RuntimeWarning)
+                warnings.warn(
+                    "Can save best model only with %s available, skipping." % (
+                        self.monitor), RuntimeWarning)
             else:
                 if current < self.best:
                     if self.verbose > 0:
@@ -220,7 +224,7 @@ class EarlyStopping(Callback):
         current = logs.get(self.monitor)
         if current is None:
             warnings.warn("Early stopping requires %s available!" % (self.monitor), RuntimeWarning)
- 
+
         if current < self.best:
             self.best = current
             self.wait = 0
@@ -239,7 +243,6 @@ class RemoteMonitor(Callback):
     def on_epoch_begin(self, epoch, logs={}):
         self.seen = 0
         self.totals = {}
-        
 
     def on_batch_end(self, batch, logs={}):
         batch_size = logs.get('size', 0)
@@ -260,4 +263,7 @@ class RemoteMonitor(Callback):
         for k, v in self.logs:
             send[k] = v
 
-        r = requests.post(self.root + '/publish/epoch/end/', {'data':json.dumps(send)})
+        requests.post(
+            self.root + '/publish/epoch/end/',
+            {'data': json.dumps(send)}
+        )

--- a/keras/datasets/cifar.py
+++ b/keras/datasets/cifar.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 import sys
+
 import six.moves.cPickle
-from six.moves import range
 
 def load_batch(fpath, label_key='labels'):
     f = open(fpath, 'rb')

--- a/keras/datasets/cifar10.py
+++ b/keras/datasets/cifar10.py
@@ -9,7 +9,6 @@ def load_data():
     origin = "http://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz"
     path = get_file(dirname, origin=origin, untar=True)
 
-    nb_test_samples = 10000
     nb_train_samples = 50000
 
     X_train = np.zeros((nb_train_samples, 3, 32, 32), dtype="uint8")
@@ -18,13 +17,13 @@ def load_data():
     for i in range(1, 6):
         fpath = os.path.join(path, 'data_batch_' + str(i))
         data, labels = load_batch(fpath)
-        X_train[(i-1)*10000:i*10000, :, :, :] = data
-        y_train[(i-1)*10000:i*10000] = labels
-    
+        X_train[(i - 1) * 10000:i * 10000, :, :, :] = data
+        y_train[(i - 1) * 10000:i * 10000] = labels
+
     fpath = os.path.join(path, 'test_batch')
     X_test, y_test = load_batch(fpath)
 
     y_train = np.reshape(y_train, (len(y_train), 1))
     y_test = np.reshape(y_test, (len(y_test), 1))
 
-    return (X_train, y_train), (X_test, y_test) 
+    return (X_train, y_train), (X_test, y_test)

--- a/keras/datasets/cifar100.py
+++ b/keras/datasets/cifar100.py
@@ -12,16 +12,13 @@ def load_data(label_mode='fine'):
     origin = "http://www.cs.toronto.edu/~kriz/cifar-100-python.tar.gz"
     path = get_file(dirname, origin=origin, untar=True)
 
-    nb_test_samples = 10000
-    nb_train_samples = 50000
-
     fpath = os.path.join(path, 'train')
-    X_train, y_train = load_batch(fpath, label_key=label_mode+'_labels')
+    X_train, y_train = load_batch(fpath, label_key=label_mode + '_labels')
 
     fpath = os.path.join(path, 'test')
-    X_test, y_test = load_batch(fpath, label_key=label_mode+'_labels')
+    X_test, y_test = load_batch(fpath, label_key=label_mode + '_labels')
 
     y_train = np.reshape(y_train, (len(y_train), 1))
     y_test = np.reshape(y_test, (len(y_test), 1))
 
-    return (X_train, y_train), (X_test, y_test) 
+    return (X_train, y_train), (X_test, y_test)

--- a/keras/datasets/data_utils.py
+++ b/keras/datasets/data_utils.py
@@ -1,7 +1,10 @@
-from __future__ import absolute_import
-from __future__ import print_function
-import tarfile, inspect, os
+from __future__ import absolute_import, print_function
+
+import tarfile
+import os
+
 from six.moves.urllib.request import urlretrieve
+
 from ..utils.generic_utils import Progbar
 
 def get_file(fname, origin, untar=False):
@@ -16,18 +19,19 @@ def get_file(fname, origin, untar=False):
         fpath = os.path.join(datadir, fname)
 
     try:
-        f = open(fpath)
+        with open(fpath):
+            pass
     except:
-        print('Downloading data from',  origin)
-
+        print('Downloading data from %s' % (origin,))
         global progbar
         progbar = None
+
         def dl_progress(count, block_size, total_size):
             global progbar
             if progbar is None:
                 progbar = Progbar(total_size)
             else:
-                progbar.update(count*block_size)
+                progbar.update(count * block_size)
 
         urlretrieve(origin, fpath, dl_progress)
         progbar = None
@@ -41,4 +45,3 @@ def get_file(fname, origin, untar=False):
         return untar_fpath
 
     return fpath
-

--- a/keras/datasets/imdb.py
+++ b/keras/datasets/imdb.py
@@ -1,13 +1,16 @@
 from __future__ import absolute_import
-import six.moves.cPickle
 import gzip
-from .data_utils import get_file
-import random
+
+import six.moves.cPickle
 from six.moves import zip
 import numpy as np
 
-def load_data(path="imdb.pkl", nb_words=None, skip_top=0, maxlen=None, test_split=0.2, seed=113, 
-    start_char=1, oov_char=2, index_from=3):
+from .data_utils import get_file
+
+
+def load_data(
+        path="imdb.pkl", nb_words=None, skip_top=0, maxlen=None,
+        test_split=0.2, seed=113, start_char=1, oov_char=2, index_from=3):
 
     path = get_file(path, origin="https://s3.amazonaws.com/text-datasets/imdb.pkl")
 
@@ -56,11 +59,10 @@ def load_data(path="imdb.pkl", nb_words=None, skip_top=0, maxlen=None, test_spli
             nX.append(nx)
         X = nX
 
-    X_train = X[:int(len(X)*(1-test_split))]
-    y_train = labels[:int(len(X)*(1-test_split))]
+    X_train = X[:int(len(X) * (1 - test_split))]
+    y_train = labels[:int(len(X) * (1 - test_split))]
 
-    X_test = X[int(len(X)*(1-test_split)):]
-    y_test = labels[int(len(X)*(1-test_split)):]
+    X_test = X[int(len(X) * (1 - test_split)):]
+    y_test = labels[int(len(X) * (1 - test_split)):]
 
     return (X_train, y_train), (X_test, y_test)
-

--- a/keras/datasets/mnist.py
+++ b/keras/datasets/mnist.py
@@ -5,6 +5,9 @@ import six.moves.cPickle
 import sys
 
 def load_data(path="mnist.pkl.gz"):
+    '''
+    Returns two pairs of arrays ((X_train, y_train), (X_test, y_test))
+    '''
     path = get_file(path, origin="https://s3.amazonaws.com/img-datasets/mnist.pkl.gz")
 
     if path.endswith(".gz"):
@@ -18,5 +21,5 @@ def load_data(path="mnist.pkl.gz"):
         data = six.moves.cPickle.load(f, encoding="bytes")
 
     f.close()
-
-    return data # (X_train, y_train), (X_test, y_test)
+    # (X_train, y_train), (X_test, y_test)
+    return data

--- a/keras/datasets/reuters.py
+++ b/keras/datasets/reuters.py
@@ -1,45 +1,47 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import print_function
-from .data_utils import get_file
-import string
-import random
-import os
+from __future__ import absolute_import, print_function
+from os import listdir
+from os.path import join
+
 import six.moves.cPickle
 from six.moves import zip
 import numpy as np
 
-def make_reuters_dataset(path=os.path.join('datasets', 'temp', 'reuters21578'), min_samples_per_topic=15):
-    import re
-    from ..preprocessing.text import Tokenizer
+from .data_utils import get_file
+from ..preprocessing.text import Tokenizer
 
+REUTERS_PATH = join('datasets', 'temp', 'reuters21578')
+
+def make_reuters_dataset(
+        path=REUTERS_PATH,
+        min_samples_per_topic=15):
     wire_topics = []
     topic_counts = {}
     wire_bodies = []
 
-    for fname in os.listdir(path):
+    for fname in listdir(path):
         if 'sgm' in fname:
-            s = open(os.path.join(path, fname)).read()
-            tag = '<TOPICS>'
-            while tag in s:
-                s = s[s.find(tag)+len(tag):]
-                topics = s[:s.find('</')]
-                
-                if topics and not '</D><D>' in topics:
-                    topic = topics.replace('<D>', '').replace('</D>', '')
-                    wire_topics.append(topic)
-                    topic_counts[topic] = topic_counts.get(topic, 0) + 1
-                else:
-                    continue
+            with open(join(path, fname), 'r') as f:
+                s = f.read()
+                tag = '<TOPICS>'
+                while tag in s:
+                    s = s[s.find(tag) + len(tag):]
+                    topics = s[:s.find('</')]
+                    if topics and '</D><D>' not in topics:
+                        topic = topics.replace('<D>', '').replace('</D>', '')
+                        wire_topics.append(topic)
+                        topic_counts[topic] = topic_counts.get(topic, 0) + 1
+                    else:
+                        continue
 
-                bodytag = '<BODY>'
-                body = s[s.find(bodytag)+len(bodytag):]
-                body = body[:body.find('</')]
-                wire_bodies.append(body)
+                    bodytag = '<BODY>'
+                    body = s[s.find(bodytag) + len(bodytag):]
+                    body = body[:body.find('</')]
+                    wire_bodies.append(body)
 
     # only keep most common topics
     items = list(topic_counts.items())
-    items.sort(key = lambda x: x[1])
+    items.sort(key=lambda x: x[1])
     kept_topics = set()
     for x in items:
         print(x[0] + ': ' + str(x[1]))
@@ -75,17 +77,17 @@ def make_reuters_dataset(path=os.path.join('datasets', 'temp', 'reuters21578'), 
     reverse_word_index = dict([(v, k) for k, v in tokenizer.word_index.items()])
     print(' '.join(reverse_word_index[i] for i in X[10]))
 
-    dataset = (X, labels) 
+    dataset = (X, labels)
     print('-')
     print('Saving...')
-    six.moves.cPickle.dump(dataset, open(os.path.join('datasets', 'data', 'reuters.pkl'), 'w'))
-    six.moves.cPickle.dump(tokenizer.word_index, open(os.path.join('datasets', 'data', 'reuters_word_index.pkl'), 'w'))
+    with open(join('datasets', 'data', 'reuters.pkl'), 'w') as f:
+        six.moves.cPickle.dump(dataset, f)
+    with open(join('datasets', 'data', 'reuters_word_index.pkl'), 'w') as f:
+        six.moves.cPickle.dump(tokenizer.word_index, f)
 
-
-
-def load_data(path="reuters.pkl", nb_words=None, skip_top=0, maxlen=None, test_split=0.2, seed=113,
-    start_char=1, oov_char=2, index_from=3):
-
+def load_data(
+        path="reuters.pkl", nb_words=None, skip_top=0, maxlen=None,
+        test_split=0.2, seed=113, start_char=1, oov_char=2, index_from=3):
     path = get_file(path, origin="https://s3.amazonaws.com/text-datasets/reuters.pkl")
     f = open(path, 'rb')
 
@@ -129,11 +131,11 @@ def load_data(path="reuters.pkl", nb_words=None, skip_top=0, maxlen=None, test_s
             nX.append(nx)
         X = nX
 
-    X_train = X[:int(len(X)*(1-test_split))]
-    y_train = labels[:int(len(X)*(1-test_split))]
+    X_train = X[:int(len(X) * (1 - test_split))]
+    y_train = labels[:int(len(X) * (1 - test_split))]
 
-    X_test = X[int(len(X)*(1-test_split)):]
-    y_test = labels[int(len(X)*(1-test_split)):]
+    X_test = X[int(len(X) * (1 - test_split)):]
+    y_test = labels[int(len(X) * (1 - test_split)):]
 
     return (X_train, y_train), (X_test, y_test)
 

--- a/keras/initializations.py
+++ b/keras/initializations.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import
-import theano
-import theano.tensor as T
+
 import numpy as np
 
+from .utils.generic_utils import get_from_module
 from .utils.theano_utils import sharedX, shared_zeros, shared_ones
 
 def get_fans(shape):
@@ -36,7 +36,7 @@ def glorot_uniform(shape):
     fan_in, fan_out = get_fans(shape)
     s = np.sqrt(6. / (fan_in + fan_out))
     return uniform(shape, s)
-    
+
 def he_normal(shape):
     ''' Reference:  He et al., http://arxiv.org/abs/1502.01852
     '''
@@ -55,13 +55,14 @@ def orthogonal(shape, scale=1.1):
     flat_shape = (shape[0], np.prod(shape[1:]))
     a = np.random.normal(0.0, 1.0, flat_shape)
     u, _, v = np.linalg.svd(a, full_matrices=False)
-    q = u if u.shape == flat_shape else v # pick the one with the correct shape
+    q = u if u.shape == flat_shape else v  # pick the one with the correct shape
     q = q.reshape(shape)
     return sharedX(scale * q[:shape[0], :shape[1]])
 
 def identity(shape, scale=1):
     if len(shape) != 2 or shape[0] != shape[1]:
-        raise Exception("Identity matrix initialization can only be used for 2D square matrices")
+        raise Exception(
+            "Identity matrix initialization can only be used for 2D square matrices")
     else:
         return sharedX(scale * np.identity(shape[0]))
 
@@ -71,7 +72,5 @@ def zero(shape):
 def one(shape):
     return shared_ones(shape)
 
-
-from .utils.generic_utils import get_from_module
 def get(identifier):
     return get_from_module(identifier, globals(), 'initialization')

--- a/keras/layers/advanced_activations.py
+++ b/keras/layers/advanced_activations.py
@@ -1,9 +1,10 @@
+from __future__ import absolute_import, print_function
 from ..layers.core import Layer
 from ..utils.theano_utils import shared_zeros
 
 class LeakyReLU(Layer):
     def __init__(self, alpha=0.3):
-        super(LeakyReLU,self).__init__()
+        super(LeakyReLU, self).__init__()
         self.alpha = alpha
 
     def get_output(self, train):
@@ -11,18 +12,19 @@ class LeakyReLU(Layer):
         return ((X + abs(X)) / 2.0) + self.alpha * ((X - abs(X)) / 2.0)
 
     def get_config(self):
-        return {"name":self.__class__.__name__,
-            "alpha":self.alpha}
+        return {
+            "name": self.__class__.__name__,
+            "alpha": self.alpha}
 
 
 class PReLU(Layer):
     '''
-        Reference: 
+        Reference:
             Delving Deep into Rectifiers: Surpassing Human-Level Performance on ImageNet Classification
                 http://arxiv.org/pdf/1502.01852v1.pdf
     '''
     def __init__(self, input_shape):
-        super(PReLU,self).__init__()
+        super(PReLU, self).__init__()
         self.alphas = shared_zeros(input_shape)
         self.params = [self.alphas]
         self.input_shape = input_shape
@@ -34,5 +36,7 @@ class PReLU(Layer):
         return pos + neg
 
     def get_config(self):
-        return {"name":self.__class__.__name__,
-        "input_shape":self.input_shape}
+        return {
+            "name": self.__class__.__name__,
+            "input_shape": self.input_shape
+        }

--- a/keras/layers/containers.py
+++ b/keras/layers/containers.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
 import theano.tensor as T
 from ..layers.core import Layer, Merge
@@ -79,8 +78,10 @@ class Sequential(Layer):
             weights = weights[nb_param:]
 
     def get_config(self):
-        return {"name":self.__class__.__name__,
-            "layers":[layer.get_config() for layer in self.layers]}
+        return {
+            "name": self.__class__.__name__,
+            "layers": [layer.get_config() for layer in self.layers]
+        }
 
 
 class Graph(Layer):
@@ -100,15 +101,15 @@ class Graph(Layer):
             - set_weights
     '''
     def __init__(self):
-        self.namespace = set() # strings
-        self.nodes = {} # layer-like
-        self.inputs = {} # layer-like
-        self.input_order = [] # strings
-        self.outputs = {} # layer-like
-        self.output_order = [] # strings
-        self.input_config = [] # dicts
-        self.output_config = [] # dicts
-        self.node_config = [] # dicts
+        self.namespace = set()  # strings
+        self.nodes = {}  # layer-like
+        self.inputs = {}  # layer-like
+        self.input_order = []  # strings
+        self.outputs = {}  # layer-like
+        self.output_order = []  # strings
+        self.input_config = []  # dicts
+        self.output_config = []  # dicts
+        self.node_config = []  # dicts
 
         self.params = []
         self.regularizers = []
@@ -141,7 +142,7 @@ class Graph(Layer):
             raise Exception('Duplicate node identifier: ' + name)
         self.namespace.add(name)
         self.input_order.append(name)
-        layer = Layer() # empty layer
+        layer = Layer()  # empty layer
         if dtype == 'float':
             layer.input = ndim_tensor(ndim)
         else:
@@ -151,7 +152,8 @@ class Graph(Layer):
                 raise Exception('Type "int" can only be used with ndim==2.')
         layer.input.name = name
         self.inputs[name] = layer
-        self.input_config.append({'name':name, 'ndim':ndim, 'dtype':dtype})
+        self.input_config.append({
+            'name': name, 'ndim': ndim, 'dtype': dtype})
 
     def add_node(self, layer, name, input=None, inputs=[], merge_mode='concat'):
         if hasattr(layer, 'set_name'):
@@ -179,7 +181,8 @@ class Graph(Layer):
 
         self.namespace.add(name)
         self.nodes[name] = layer
-        self.node_config.append({'name':name, 'input':input, 'inputs':inputs, 'merge_mode':merge_mode})
+        self.node_config.append({
+            'name': name, 'input': input, 'inputs': inputs, 'merge_mode': merge_mode})
         params, regularizers, constraints = layer.get_params()
         self.params += params
         self.regularizers += regularizers
@@ -205,13 +208,18 @@ class Graph(Layer):
             self.outputs[name] = merge
         self.namespace.add(name)
         self.output_order.append(name)
-        self.output_config.append({'name':name, 'input':input, 'inputs':inputs, 'merge_mode':merge_mode})
+        self.output_config.append({
+            'name': name, 'input': input, 'inputs': inputs, 'merge_mode': merge_mode})
 
     def get_config(self):
-        return {"name":self.__class__.__name__,
-            "input_config":self.input_config,
-            "node_config":self.node_config,
-            "output_config":self.output_config,
-            "input_order":self.input_order,
-            "output_order":self.output_order,
-            "nodes":dict([(c["name"], self.nodes[c["name"]].get_config()) for c in self.node_config])}
+        return {
+            "name": self.__class__.__name__,
+            "input_config": self.input_config,
+            "node_config": self.node_config,
+            "output_config": self.output_config,
+            "input_order": self.input_order,
+            "output_order": self.output_order,
+            "nodes": dict([
+                (c["name"], self.nodes[c["name"]].get_config())
+                for c in self.node_config])
+        }

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -11,14 +11,16 @@ from ..layers.core import Layer
 
 class Convolution1D(Layer):
     def __init__(self, input_dim, nb_filter, filter_length,
-        init='uniform', activation='linear', weights=None,
-        border_mode='valid', subsample_length=1,
-        W_regularizer=None, b_regularizer=None, activity_regularizer=None, W_constraint=None, b_constraint=None):
+                 init='uniform', activation='linear', weights=None,
+                 border_mode='valid', subsample_length=1,
+                 W_regularizer=None, b_regularizer=None,
+                 activity_regularizer=None, W_constraint=None,
+                 b_constraint=None):
 
         if border_mode not in {'valid', 'full'}:
             raise Exception('Invalid border mode for Convolution1D:', border_mode)
 
-        super(Convolution1D,self).__init__()
+        super(Convolution1D, self).__init__()
         self.nb_filter = nb_filter
         self.input_dim = input_dim
         self.filter_length = filter_length
@@ -67,24 +69,26 @@ class Convolution1D(Layer):
         return theano.tensor.reshape(output, (output.shape[0], output.shape[1], output.shape[2])).dimshuffle(0, 2, 1)
 
     def get_config(self):
-        return {"name":self.__class__.__name__,
-            "input_dim":self.input_dim,
-            "nb_filter":self.nb_filter,
-            "filter_length":self.filter_length,
-            "init":self.init.__name__,
-            "activation":self.activation.__name__,
-            "border_mode":self.border_mode,
-            "subsample_length":self.subsample_length,
-            "W_regularizer":self.W_regularizer.get_config() if self.W_regularizer else None,
-            "b_regularizer":self.b_regularizer.get_config() if self.b_regularizer else None,
-            "activity_regularizer":self.activity_regularizer.get_config() if self.activity_regularizer else None,
-            "W_constraint":self.W_constraint.get_config() if self.W_constraint else None,
-            "b_constraint":self.b_constraint.get_config() if self.b_constraint else None}
+        return {
+            "name": self.__class__.__name__,
+            "input_dim": self.input_dim,
+            "nb_filter": self.nb_filter,
+            "filter_length": self.filter_length,
+            "init": self.init.__name__,
+            "activation": self.activation.__name__,
+            "border_mode": self.border_mode,
+            "subsample_length": self.subsample_length,
+            "W_regularizer": self.W_regularizer.get_config() if self.W_regularizer else None,
+            "b_regularizer": self.b_regularizer.get_config() if self.b_regularizer else None,
+            "activity_regularizer": self.activity_regularizer.get_config() if self.activity_regularizer else None,
+            "W_constraint": self.W_constraint.get_config() if self.W_constraint else None,
+            "b_constraint": self.b_constraint.get_config() if self.b_constraint else None
+        }
 
 
 class MaxPooling1D(Layer):
     def __init__(self, pool_length=2, stride=None, ignore_border=True):
-        super(MaxPooling1D,self).__init__()
+        super(MaxPooling1D, self).__init__()
         self.pool_length = pool_length
         self.stride = stride
         if self.stride:
@@ -104,24 +108,25 @@ class MaxPooling1D(Layer):
         return theano.tensor.reshape(output, (output.shape[0], output.shape[1], output.shape[2]))
 
     def get_config(self):
-        return {"name":self.__class__.__name__,
-                "stride":self.stride,
-                "pool_length":self.pool_length,
-                "ignore_border":self.ignore_border,
-                "subsample_length": self.subsample_length}
-
-
+        return {
+            "name": self.__class__.__name__,
+            "stride": self.stride,
+            "pool_length": self.pool_length,
+            "ignore_border": self.ignore_border,
+            "subsample_length": self.subsample_length
+        }
 
 class Convolution2D(Layer):
     def __init__(self, nb_filter, stack_size, nb_row, nb_col,
-        init='glorot_uniform', activation='linear', weights=None,
-        border_mode='valid', subsample=(1, 1),
-        W_regularizer=None, b_regularizer=None, activity_regularizer=None, W_constraint=None, b_constraint=None):
+                 init='glorot_uniform', activation='linear', weights=None,
+                 border_mode='valid', subsample=(1, 1),
+                 W_regularizer=None, b_regularizer=None, activity_regularizer=None,
+                 W_constraint=None, b_constraint=None):
 
         if border_mode not in {'valid', 'full', 'same'}:
             raise Exception('Invalid border mode for Convolution2D:', border_mode)
 
-        super(Convolution2D,self).__init__()
+        super(Convolution2D, self).__init__()
         self.init = initializations.get(init)
         self.activation = activations.get(activation)
         self.subsample = subsample
@@ -179,44 +184,46 @@ class Convolution2D(Layer):
 
         return self.activation(conv_out + self.b.dimshuffle('x', 0, 'x', 'x'))
 
-
     def get_config(self):
-        return {"name":self.__class__.__name__,
-            "nb_filter":self.nb_filter,
-            "stack_size":self.stack_size,
-            "nb_row":self.nb_row,
-            "nb_col":self.nb_col,
-            "init":self.init.__name__,
-            "activation":self.activation.__name__,
-            "border_mode":self.border_mode,
-            "subsample":self.subsample,
-            "W_regularizer":self.W_regularizer.get_config() if self.W_regularizer else None,
-            "b_regularizer":self.b_regularizer.get_config() if self.b_regularizer else None,
-            "activity_regularizer":self.activity_regularizer.get_config() if self.activity_regularizer else None,
-            "W_constraint":self.W_constraint.get_config() if self.W_constraint else None,
-            "b_constraint":self.b_constraint.get_config() if self.b_constraint else None}
+        return {
+            "name": self.__class__.__name__,
+            "nb_filter": self.nb_filter,
+            "stack_size": self.stack_size,
+            "nb_row": self.nb_row,
+            "nb_col": self.nb_col,
+            "init": self.init.__name__,
+            "activation": self.activation.__name__,
+            "border_mode": self.border_mode,
+            "subsample": self.subsample,
+            "W_regularizer": self.W_regularizer.get_config() if self.W_regularizer else None,
+            "b_regularizer": self.b_regularizer.get_config() if self.b_regularizer else None,
+            "activity_regularizer": self.activity_regularizer.get_config() if self.activity_regularizer else None,
+            "W_constraint": self.W_constraint.get_config() if self.W_constraint else None,
+            "b_constraint": self.b_constraint.get_config() if self.b_constraint else None
+        }
 
 
 class MaxPooling2D(Layer):
     def __init__(self, poolsize=(2, 2), stride=None, ignore_border=True):
-        super(MaxPooling2D,self).__init__()
+        super(MaxPooling2D, self).__init__()
         self.input = T.tensor4()
         self.poolsize = poolsize
         self.stride = stride
         self.ignore_border = ignore_border
 
-
     def get_output(self, train):
         X = self.get_input(train)
-        output = downsample.max_pool_2d(X, ds=self.poolsize, st=self.stride, ignore_border=self.ignore_border)
+        output = downsample.max_pool_2d(
+            X, ds=self.poolsize, st=self.stride, ignore_border=self.ignore_border)
         return output
 
     def get_config(self):
-        return {"name":self.__class__.__name__,
-                "poolsize":self.poolsize,
-                "ignore_border":self.ignore_border,
-                "stride": self.stride}
-
+        return {
+            "name": self.__class__.__name__,
+            "poolsize": self.poolsize,
+            "ignore_border": self.ignore_border,
+            "stride": self.stride
+        }
 
 class ZeroPadding2D(Layer):
     def __init__(self, width=1):
@@ -226,13 +233,25 @@ class ZeroPadding2D(Layer):
 
     def get_output(self, train):
         X = self.get_input(train)
-        width =  self.width
+        width = self.width
         in_shape = X.shape
-        out_shape = (in_shape[0], in_shape[1], in_shape[2] + 2 * width, in_shape[3] + 2 * width)
+
+        out_shape = (
+            in_shape[0],
+            in_shape[1],
+            in_shape[2] + 2 * width,
+            in_shape[3] + 2 * width
+        )
         out = T.zeros(out_shape)
-        indices = (slice(None), slice(None), slice(width, in_shape[2] + width), slice(width, in_shape[3] + width))
+        indices = (
+            slice(None),
+            slice(None),
+            slice(width, in_shape[2] + width),
+            slice(width, in_shape[3] + width))
         return T.set_subtensor(out[indices], X)
 
     def get_config(self):
-        return {"name":self.__class__.__name__,
-                "width":self.width}
+        return {
+            "name": self.__class__.__name__,
+            "width": self.width
+        }

--- a/keras/layers/noise.py
+++ b/keras/layers/noise.py
@@ -1,8 +1,9 @@
-from __future__ import absolute_import
-from .core import srng, MaskedLayer
+from __future__ import absolute_import, print_function
+
 import theano
 import theano.tensor as T
 
+from .core import srng, MaskedLayer
 class GaussianNoise(MaskedLayer):
     '''
         Corruption process with GaussianNoise
@@ -20,28 +21,36 @@ class GaussianNoise(MaskedLayer):
                              dtype=theano.config.floatX)
 
     def get_config(self):
-        return {"name":self.__class__.__name__,
-            "sigma":self.sigma}
+        return {
+            "name": self.__class__.__name__,
+            "sigma": self.sigma
+        }
 
 class GaussianDropout(MaskedLayer):
     '''
         Multiplicative Gaussian Noise
-        Reference: 
+        Reference:
             Dropout: A Simple Way to Prevent Neural Networks from Overfitting
             Srivastava, Hinton, et al. 2014
             http://www.cs.toronto.edu/~rsalakhu/papers/srivastava14a.pdf
     '''
     def __init__(self, p):
-        super(GaussianDropout,self).__init__()
+        super(GaussianDropout, self).__init__()
         self.p = p
 
     def get_output(self, train):
         X = self.get_input(train)
         if train:
             # self.p refers to drop probability rather than retain probability (as in paper) to match Dropout layer syntax
-            X *= srng.normal(size=X.shape, avg=1.0, std=T.sqrt(self.p / (1.0 - self.p)), dtype=theano.config.floatX)
+            X *= srng.normal(
+                size=X.shape,
+                avg=1.0,
+                std=T.sqrt(self.p / (1.0 - self.p)),
+                dtype=theano.config.floatX)
         return X
 
     def get_config(self):
-        return {"name":self.__class__.__name__,
-            "p":self.p}
+        return {
+            "name": self.__class__.__name__,
+            "p": self.p
+        }

--- a/keras/layers/normalization.py
+++ b/keras/layers/normalization.py
@@ -16,7 +16,7 @@ class BatchNormalization(Layer):
             momentum: momentum term in the computation of a running estimate of the mean and std of the data
     '''
     def __init__(self, input_shape, epsilon=1e-6, mode=0, momentum=0.9, weights=None):
-        super(BatchNormalization,self).__init__()
+        super(BatchNormalization, self).__init__()
         self.init = initializations.get("uniform")
         self.input_shape = input_shape
         self.epsilon = epsilon
@@ -40,7 +40,7 @@ class BatchNormalization(Layer):
             if train:
                 m = X.mean(axis=0)
                 # manual computation of std to prevent NaNs
-                std = T.mean((X-m)**2 + self.epsilon, axis=0) ** 0.5
+                std = T.mean((X - m)**2 + self.epsilon, axis=0) ** 0.5
                 X_normed = (X - m) / (std + self.epsilon)
 
                 if self.running_mean is None:
@@ -48,9 +48,9 @@ class BatchNormalization(Layer):
                     self.running_std = std
                 else:
                     self.running_mean *= self.momentum
-                    self.running_mean += (1-self.momentum) * m
+                    self.running_mean += (1 - self.momentum) * m
                     self.running_std *= self.momentum
-                    self.running_std += (1-self.momentum) * std
+                    self.running_std += (1 - self.momentum) * std
             else:
                 X_normed = (X - self.running_mean) / (self.running_std + self.epsilon)
 
@@ -63,10 +63,12 @@ class BatchNormalization(Layer):
         return out
 
     def get_config(self):
-        return {"name":self.__class__.__name__,
-            "input_shape":self.input_shape,
-            "epsilon":self.epsilon,
-            "mode":self.mode}
+        return {
+            "name": self.__class__.__name__,
+            "input_shape": self.input_shape,
+            "epsilon": self.epsilon,
+            "mode": self.mode
+        }
 
 
 class LRN2D(Layer):
@@ -89,17 +91,19 @@ class LRN2D(Layer):
         b, ch, r, c = X.shape
         half_n = self.n // 2
         input_sqr = T.sqr(X)
-        extra_channels = T.alloc(0., b, ch + 2*half_n, r, c)
-        input_sqr = T.set_subtensor(extra_channels[:, half_n:half_n+ch, :, :], input_sqr)
+        extra_channels = T.alloc(0., b, ch + 2 * half_n, r, c)
+        input_sqr = T.set_subtensor(extra_channels[:, half_n:half_n + ch, :, :], input_sqr)
         scale = self.k
         for i in range(self.n):
-            scale += self.alpha * input_sqr[:, i:i+ch, :, :]
+            scale += self.alpha * input_sqr[:, i:i + ch, :, :]
         scale = scale ** self.beta
         return X / scale
 
     def get_config(self):
-        return {"name":self.__class__.__name__,
-            "alpha":self.alpha,
-            "k":self.k,
-            "beta":self.beta,
-            "n": self.n}
+        return {
+            "name": self.__class__.__name__,
+            "alpha": self.alpha,
+            "k": self.k,
+            "beta": self.beta,
+            "n": self.n
+        }

--- a/keras/objectives.py
+++ b/keras/objectives.py
@@ -1,8 +1,10 @@
 from __future__ import absolute_import
+
 import theano
 import theano.tensor as T
 import numpy as np
-from six.moves import range
+
+from .utils.generic_utils import get_from_module
 
 if theano.config.floatX == 'float64':
     epsilon = 1.0e-9
@@ -32,7 +34,7 @@ def categorical_crossentropy(y_true, y_pred):
     '''
     y_pred = T.clip(y_pred, epsilon, 1.0 - epsilon)
     # scale preds so that the class probas of each sample sum to 1
-    y_pred /= y_pred.sum(axis=-1, keepdims=True) 
+    y_pred /= y_pred.sum(axis=-1, keepdims=True)
     cce = T.nnet.categorical_crossentropy(y_pred, y_true)
     return cce
 
@@ -47,7 +49,5 @@ mae = MAE = mean_absolute_error
 mape = MAPE = mean_absolute_percentage_error
 msle = MSLE = mean_squared_logarithmic_error
 
-from .utils.generic_utils import get_from_module
 def get(identifier):
     return get_from_module(identifier, globals(), 'objective')
-

--- a/keras/optimizers.py
+++ b/keras/optimizers.py
@@ -1,10 +1,11 @@
 from __future__ import absolute_import
+
 import theano
 import theano.tensor as T
-import numpy as np
-
-from .utils.theano_utils import shared_zeros, shared_scalar
 from six.moves import zip
+
+from .utils.generic_utils import get_from_module
+from .utils.theano_utils import shared_zeros, shared_scalar
 
 def clip_norm(g, c, n):
     if c > 0:
@@ -15,7 +16,6 @@ def kl_divergence(p, p_hat):
     return p_hat - p + p * T.log(p / p_hat)
 
 class Optimizer(object):
-    
     def get_updates(self, params, constraints, loss):
         raise NotImplementedError
 
@@ -30,7 +30,7 @@ class Optimizer(object):
         return grads
 
     def get_config(self):
-        return {"name":self.__class__.__name__}
+        return {"name": self.__class__.__name__}
 
 class SGD(Optimizer):
 
@@ -45,24 +45,26 @@ class SGD(Optimizer):
         updates = [(self.iterations, self.iterations + 1.)]
 
         for p, g, c in zip(params, grads, constraints):
-            m = shared_zeros(p.get_value().shape) # momentum
-            v = self.momentum * m - lr * g # velocity
-            updates.append((m, v)) 
+            m = shared_zeros(p.get_value().shape)  # momentum
+            v = self.momentum * m - lr * g  # velocity
+            updates.append((m, v))
 
             if self.nesterov:
                 new_p = p + self.momentum * v - lr * g
             else:
                 new_p = p + v
 
-            updates.append((p, c(new_p))) # apply constraints
+            updates.append((p, c(new_p)))  # apply constraints
         return updates
 
     def get_config(self):
-        return {"name":self.__class__.__name__,
-            "lr":self.lr,
-            "momentum":self.momentum,
-            "decay":self.decay,
-            "nesterov":self.nesterov}
+        return {
+            "name": self.__class__.__name__,
+            "lr": self.lr,
+            "momentum": self.momentum,
+            "decay": self.decay,
+            "nesterov": self.nesterov
+        }
 
 
 class RMSprop(Optimizer):
@@ -77,19 +79,21 @@ class RMSprop(Optimizer):
         updates = []
 
         for p, g, a, c in zip(params, grads, accumulators, constraints):
-            new_a = self.rho * a + (1 - self.rho) * g ** 2 # update accumulator
+            new_a = self.rho * a + (1 - self.rho) * g ** 2  # update accumulator
             updates.append((a, new_a))
 
             new_p = p - self.lr * g / T.sqrt(new_a + self.epsilon)
-            updates.append((p, c(new_p))) # apply constraints
-            
+            updates.append((p, c(new_p)))  # apply constraints
+
         return updates
 
     def get_config(self):
-        return {"name":self.__class__.__name__,
-            "lr":self.lr,
-            "rho":self.rho,
-            "epsilon":self.epsilon}
+        return {
+            "name": self.__class__.__name__,
+            "lr": self.lr,
+            "rho": self.rho,
+            "epsilon": self.epsilon
+        }
 
 class Adagrad(Optimizer):
 
@@ -103,17 +107,19 @@ class Adagrad(Optimizer):
         updates = []
 
         for p, g, a, c in zip(params, grads, accumulators, constraints):
-            new_a = a + g ** 2 # update accumulator
+            new_a = a + g ** 2  # update accumulator
             updates.append((a, new_a))
 
             new_p = p - self.lr * g / T.sqrt(new_a + self.epsilon)
-            updates.append((p, c(new_p))) # apply constraints
+            updates.append((p, c(new_p)))  # apply constraints
         return updates
 
     def get_config(self):
-        return {"name":self.__class__.__name__,
-            "lr":self.lr,
-            "epsilon":self.epsilon}
+        return {
+            "name": self.__class__.__name__,
+            "lr": self.lr,
+            "epsilon": self.epsilon
+        }
 
 class Adadelta(Optimizer):
     '''
@@ -129,15 +135,16 @@ class Adadelta(Optimizer):
         delta_accumulators = [shared_zeros(p.get_value().shape) for p in params]
         updates = []
 
-        for p, g, a, d_a, c in zip(params, grads, accumulators, delta_accumulators, constraints):
-            new_a = self.rho * a + (1 - self.rho) * g ** 2 # update accumulator
+        for p, g, a, d_a, c in zip(
+                params, grads, accumulators, delta_accumulators, constraints):
+            new_a = self.rho * a + (1 - self.rho) * g ** 2  # update accumulator
             updates.append((a, new_a))
 
             # use the new accumulator and the *old* delta_accumulator
             update = g * T.sqrt(d_a + self.epsilon) / T.sqrt(new_a + self.epsilon)
 
             new_p = p - self.lr * update
-            updates.append((p, c(new_p))) # apply constraints
+            updates.append((p, c(new_p)))  # apply constraints
 
             # update delta_accumulator
             new_d_a = self.rho * d_a + (1 - self.rho) * update ** 2
@@ -145,10 +152,12 @@ class Adadelta(Optimizer):
         return updates
 
     def get_config(self):
-        return {"name":self.__class__.__name__,
-            "lr":self.lr,
-            "rho":self.rho,
-            "epsilon":self.epsilon}
+        return {
+            "name": self.__class__.__name__,
+            "lr": self.lr,
+            "rho": self.rho,
+            "epsilon": self.epsilon
+        }
 
 class Adam(Optimizer):
     '''
@@ -158,45 +167,48 @@ class Adam(Optimizer):
 
         lambda is renamed kappa.
     '''
-    def __init__(self, lr=0.001, beta_1=0.9, beta_2=0.999, epsilon=1e-8, kappa=1-1e-8, *args, **kwargs):
+    def __init__(self, lr=0.001, beta_1=0.9, beta_2=0.999, epsilon=1e-8,
+                 kappa=1 - 1e-8, *args, **kwargs):
         self.__dict__.update(kwargs)
         self.__dict__.update(locals())
         self.iterations = shared_scalar(0)
 
     def get_updates(self, params, constraints, loss):
         grads = self.get_gradients(loss, params)
-        updates = [(self.iterations, self.iterations+1.)]
+        updates = [(self.iterations, self.iterations + 1.0)]
 
         i = self.iterations
-        beta_1_t = self.beta_1 * (self.kappa**i)
+        beta_1_t = self.beta_1 * (self.kappa ** i)
 
         # the update below seems missing from the paper, but is obviously required
-        beta_2_t = self.beta_2 * (self.kappa**i) 
+        beta_2_t = self.beta_2 * (self.kappa ** i)
 
         for p, g, c in zip(params, grads, constraints):
-            m = theano.shared(p.get_value() * 0.) # zero init of moment
-            v = theano.shared(p.get_value() * 0.) # zero init of velocity
+            m = theano.shared(p.get_value() * 0.)  # zero init of moment
+            v = theano.shared(p.get_value() * 0.)  # zero init of velocity
 
             m_t = (beta_1_t * m) + (1 - beta_1_t) * g
-            v_t = (beta_2_t * v) + (1 - beta_2_t) * (g**2)
+            v_t = (beta_2_t * v) + (1 - beta_2_t) * (g ** 2)
 
             m_b_t = m_t / (1 - beta_1_t)
             v_b_t = v_t / (1 - beta_2_t)
 
             p_t = p - self.lr * m_b_t / (T.sqrt(v_b_t) + self.epsilon)
-            
+
             updates.append((m, m_t))
             updates.append((v, v_t))
-            updates.append((p, c(p_t))) # apply constraints
+            updates.append((p, c(p_t)))  # apply constraints
         return updates
 
     def get_config(self):
-        return {"name":self.__class__.__name__,
-            "lr":self.lr,
-            "beta_1":self.beta_1,
-            "beta_2":self.beta_2,
-            "epsilon":self.epsilon,
-            "kappa":self.kappa}
+        return {
+            "name": self.__class__.__name__,
+            "lr": self.lr,
+            "beta_1": self.beta_1,
+            "beta_2": self.beta_2,
+            "epsilon": self.epsilon,
+            "kappa": self.kappa
+        }
 
 # aliases
 sgd = SGD
@@ -205,6 +217,7 @@ adagrad = Adagrad
 adadelta = Adadelta
 adam = Adam
 
-from .utils.generic_utils import get_from_module
 def get(identifier, kwargs=None):
-    return get_from_module(identifier, globals(), 'optimizer', instantiate=True, kwargs=kwargs)
+    return get_from_module(
+        identifier, globals(), 'optimizer',
+        instantiate=True, kwargs=kwargs)

--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -1,12 +1,13 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
+from os import listdir
+from os.path import isfile, join
+import random
+import re
+import math
 
 import numpy as np
 from scipy import ndimage
 from scipy import linalg
-
-from os import listdir
-from os.path import isfile, join
-import random, math
 from six.moves import range
 
 '''
@@ -16,31 +17,26 @@ from six.moves import range
 
 def random_rotation(x, rg, fill_mode="nearest", cval=0.):
     angle = random.uniform(-rg, rg)
-    x = ndimage.interpolation.rotate(x, angle, axes=(1,2), reshape=False, mode=fill_mode, cval=cval)
+    x = ndimage.interpolation.rotate(
+        x, angle, axes=(1, 2), reshape=False, mode=fill_mode, cval=cval)
     return x
 
 def random_shift(x, wrg, hrg, fill_mode="nearest", cval=0.):
     crop_left_pixels = 0
-    crop_right_pixels = 0
     crop_top_pixels = 0
-    crop_bottom_pixels = 0
-
-    original_w = x.shape[1]
-    original_h = x.shape[2]
 
     if wrg:
         crop = random.uniform(0., wrg)
         split = random.uniform(0, 1)
-        crop_left_pixels = int(split*crop*x.shape[1])
-        crop_right_pixels = int((1-split)*crop*x.shape[1])
+        crop_left_pixels = int(split * crop * x.shape[1])
 
     if hrg:
         crop = random.uniform(0., hrg)
         split = random.uniform(0, 1)
-        crop_top_pixels = int(split*crop*x.shape[2])
-        crop_bottom_pixels = int((1-split)*crop*x.shape[2])
+        crop_top_pixels = int(split * crop * x.shape[2])
 
-    x = ndimage.interpolation.shift(x, (0, crop_left_pixels, crop_top_pixels), mode=fill_mode, cval=cval)
+    x = ndimage.interpolation.shift(
+        x, (0, crop_left_pixels, crop_top_pixels), mode=fill_mode, cval=cval)
     return x
 
 def horizontal_flip(x):
@@ -66,18 +62,17 @@ def random_channel_shift(x, rg):
     # TODO
     pass
 
-def random_zoom(x, rg, fill_mode="nearest", cval=0.):
-    zoom_w = random.uniform(1.-rg, 1.)
-    zoom_h = random.uniform(1.-rg, 1.)
-    x = ndimage.interpolation.zoom(x, zoom=(1., zoom_w, zoom_h), mode=fill_mode, cval=cval)
-    return x # shape of result will be different from shape of input!
-
-
-
+def random_zoom(x, rg, fill_mode="nearest", cval=0.0):
+    zoom_w = random.uniform(1.0 - rg, 1.0)
+    zoom_h = random.uniform(1.0 - rg, 1.0)
+    x = ndimage.interpolation.zoom(
+        x, zoom=(1.0, zoom_w, zoom_h), mode=fill_mode, cval=cval)
+    # shape of result will be different from shape of input!
+    return x
 
 def array_to_img(x, scale=True):
     from PIL import Image
-    x = x.transpose(1, 2, 0) 
+    x = x.transpose(1, 2, 0)
     if scale:
         x += max(-np.min(x), 0)
         x /= np.max(x)
@@ -87,12 +82,11 @@ def array_to_img(x, scale=True):
         return Image.fromarray(x.astype("uint8"), "RGB")
     else:
         # grayscale
-        return Image.fromarray(x[:,:,0].astype("uint8"), "L")
-
+        return Image.fromarray(x[:, :, 0].astype("uint8"), "L")
 
 def img_to_array(img):
     x = np.asarray(img, dtype='float32')
-    if len(x.shape)==3:
+    if len(x.shape) == 3:
         # RGB: height, width, channel -> channel, height, width
         x = x.transpose(2, 0, 1)
     else:
@@ -100,48 +94,45 @@ def img_to_array(img):
         x = x.reshape((1, x.shape[0], x.shape[1]))
     return x
 
-
 def load_img(path, grayscale=False):
     from PIL import Image
     img = Image.open(open(path))
     if grayscale:
         img = img.convert('L')
-    else: # Assure 3 channel even when loaded image is grayscale
+    else:  # Assure 3 channel even when loaded image is grayscale
         img = img.convert('RGB')
     return img
 
-
 def list_pictures(directory, ext='jpg|jpeg|bmp|png'):
-    return [join(directory,f) for f in listdir(directory) \
-        if isfile(join(directory,f)) and re.match('([\w]+\.(?:' + ext + '))', f)]
-
+    return [
+        join(directory, f)
+        for f in listdir(directory)
+        if isfile(join(directory, f)) and re.match('([\w]+\.(?:' + ext + '))', f)]
 
 
 class ImageDataGenerator(object):
     '''
-        Generate minibatches with 
+        Generate minibatches with
         realtime data augmentation.
     '''
-    def __init__(self, 
-            featurewise_center=True, # set input mean to 0 over the dataset
-            samplewise_center=False, # set each sample mean to 0
-            featurewise_std_normalization=True, # divide inputs by std of the dataset
-            samplewise_std_normalization=False, # divide each input by its std
-
-            zca_whitening=False, # apply ZCA whitening
-            rotation_range=0., # degrees (0 to 180)
-            width_shift_range=0., # fraction of total width
-            height_shift_range=0., # fraction of total height
+    def __init__(self,
+            featurewise_center=True,  # set input mean to 0 over the dataset
+            samplewise_center=False,  # set each sample mean to 0
+            featurewise_std_normalization=True,  # divide inputs by std of the dataset
+            samplewise_std_normalization=False,  # divide each input by its std
+            zca_whitening=False,  # apply ZCA whitening
+            rotation_range=0.0,  # degrees (0 to 180)
+            width_shift_range=0.0,  # fraction of total width
+            height_shift_range=0.0,  # fraction of total height
             horizontal_flip=False,
-            vertical_flip=False,
-        ):
+            vertical_flip=False):
         self.__dict__.update(locals())
         self.mean = None
         self.std = None
         self.principal_components = None
 
-
-    def flow(self, X, y, batch_size=32, shuffle=False, seed=None, save_to_dir=None, save_prefix="", save_format="jpeg"):
+    def flow(self, X, y, batch_size=32, shuffle=False, seed=None,
+             save_to_dir=None, save_prefix="", save_format="jpeg"):
         if seed:
             random.seed(seed)
 
@@ -152,17 +143,17 @@ class ImageDataGenerator(object):
             np.random.seed(seed)
             np.random.shuffle(y)
 
-        nb_batch = int(math.ceil(float(X.shape[0])/batch_size))
+        nb_batch = int(math.ceil(float(X.shape[0]) / batch_size))
         for b in range(nb_batch):
-            batch_end = (b+1)*batch_size
+            batch_end = (b + 1) * batch_size
             if batch_end > X.shape[0]:
-                nb_samples = X.shape[0] - b*batch_size
+                nb_samples = X.shape[0] - b * batch_size
             else:
                 nb_samples = batch_size
 
-            bX = np.zeros(tuple([nb_samples]+list(X.shape)[1:]))
+            bX = np.zeros(tuple([nb_samples] + list(X.shape)[1:]))
             for i in range(nb_samples):
-                x = X[b*batch_size+i]
+                x = X[b * batch_size + i]
                 x = self.random_transform(x.astype("float32"))
                 x = self.standardize(x)
                 bX[i] = x
@@ -172,8 +163,7 @@ class ImageDataGenerator(object):
                     img = array_to_img(bX[i], scale=True)
                     img.save(save_to_dir + "/" + save_prefix + "_" + str(i) + "." + save_format)
 
-            yield bX, y[b*batch_size:b*batch_size+nb_samples]
-
+            yield bX, y[b * batch_size:b * batch_size + nb_samples]
 
     def standardize(self, x):
         if self.featurewise_center:
@@ -182,7 +172,7 @@ class ImageDataGenerator(object):
             x /= self.std
 
         if self.zca_whitening:
-            flatx = np.reshape(x, (x.shape[0]*x.shape[1]*x.shape[2]))
+            flatx = np.reshape(x, (x.shape[0] * x.shape[1] * x.shape[2]))
             whitex = np.dot(flatx, self.principal_components)
             x = np.reshape(whitex, (x.shape[0], x.shape[1], x.shape[2]))
 
@@ -192,7 +182,6 @@ class ImageDataGenerator(object):
             x /= np.std(x)
 
         return x
-
 
     def random_transform(self, x):
         if self.rotation_range:
@@ -213,24 +202,22 @@ class ImageDataGenerator(object):
         # channel shifting
         return x
 
-
-    def fit(self, X, 
-            augment=False, # fit on randomly augmented samples
-            rounds=1, # if augment, how many augmentation passes over the data do we use
-            seed=None
-        ):
+    def fit(self, X,
+            augment=False,  # fit on randomly augmented samples
+            rounds=1,  # if augment, how many augmentation passes over the data do we use
+            seed=None):
         '''
             Required for featurewise_center, featurewise_std_normalization and zca_whitening.
         '''
         X = np.copy(X)
-        
+
         if augment:
-            aX = np.zeros(tuple([rounds*X.shape[0]]+list(X.shape)[1:]))
+            aX = np.zeros(tuple([rounds * X.shape[0]] + list(X.shape)[1:]))
             for r in range(rounds):
                 for i in range(X.shape[0]):
                     img = array_to_img(X[i])
                     img = self.random_transform(img)
-                    aX[i+r*X.shape[0]] = img_to_array(img)
+                    aX[i + r * X.shape[0]] = img_to_array(img)
             X = aX
 
         if self.featurewise_center:
@@ -241,10 +228,8 @@ class ImageDataGenerator(object):
             X /= self.std
 
         if self.zca_whitening:
-            flatX = np.reshape(X, (X.shape[0], X.shape[1]*X.shape[2]*X.shape[3]))
+            flatX = np.reshape(X, (X.shape[0], X.shape[1] * X.shape[2] * X.shape[3]))
             fudge = 10e-6
             sigma = np.dot(flatX.T, flatX) / flatX.shape[1]
             U, S, V = linalg.svd(sigma)
             self.principal_components = np.dot(np.dot(U, np.diag(1. / np.sqrt(S + fudge))), U.T)
-
-

--- a/keras/preprocessing/sequence.py
+++ b/keras/preprocessing/sequence.py
@@ -1,12 +1,13 @@
-from __future__ import absolute_import
 # -*- coding: utf-8 -*-
-import numpy as np
+from __future__ import absolute_import, print_function
 import random
+
+import numpy as np
 from six.moves import range
 
 def pad_sequences(sequences, maxlen=None, dtype='int32', padding='pre', truncating='pre', value=0.):
     """
-        Pad each sequence to the same length: 
+        Pad each sequence to the same length:
         the length of the longuest sequence.
 
         If maxlen is provided, any sequence longer
@@ -45,11 +46,11 @@ def make_sampling_table(size, sampling_factor=1e-5):
         This generates an array where the ith element
         is the probability that a word of rank i would be sampled,
         according to the sampling distribution used in word2vec.
-        
+
         The word2vec formula is:
             p(word) = min(1, sqrt(word.frequency/sampling_factor) / (word.frequency/sampling_factor))
 
-        We assume that the word frequencies follow Zipf's law (s=1) to derive 
+        We assume that the word frequencies follow Zipf's law (s=1) to derive
         a numerical approximation of frequency(rank):
            frequency(rank) ~ 1/(rank * (log(rank) + gamma) + 1/2 - 1/(12*rank))
         where gamma is the Euler-Mascheroni constant.
@@ -57,16 +58,15 @@ def make_sampling_table(size, sampling_factor=1e-5):
     gamma = 0.577
     rank = np.array(list(range(size)))
     rank[0] = 1
-    inv_fq = rank * (np.log(rank) + gamma) + 0.5 - 1./(12.*rank)
+    inv_fq = rank * (np.log(rank) + gamma) + 0.5 - 1.0 / (12.0 * rank)
     f = sampling_factor * inv_fq
-    return np.minimum(1., f / np.sqrt(f))
+    return np.minimum(1.0, f / np.sqrt(f))
 
 
-def skipgrams(sequence, vocabulary_size, 
-    window_size=4, negative_samples=1., shuffle=True, 
-    categorical=False, sampling_table=None):
-    ''' 
-        Take a sequence (list of indexes of words), 
+def skipgrams(sequence, vocabulary_size, window_size=4, negative_samples=1.0,
+              shuffle=True, categorical=False, sampling_table=None):
+    '''
+        Take a sequence (list of indexes of words),
         returns couples of [word_index, other_word index] and labels (1s or 0s),
         where label = 1 if 'other_word' belongs to the context of 'word',
         and label=0 if 'other_word' is ramdomly sampled
@@ -74,7 +74,7 @@ def skipgrams(sequence, vocabulary_size,
         @param vocabulary_size: int. maximum possible word index + 1
         @param window_size: int. actually half-window. The window of a word wi will be [i-window_size, i+window_size+1]
         @param negative_samples: float >= 0. 0 for no negative (=random) samples. 1 for same number as positive samples. etc.
-        @param categorical: bool. if False, labels will be integers (eg. [0, 1, 1 .. ]), 
+        @param categorical: bool. if False, labels will be integers (eg. [0, 1, 1 .. ]),
             if True labels will be categorical eg. [[1,0],[0,1],[0,1] .. ]
 
         Note: by convention, index 0 in the vocabulary is a non-word and will be skipped.
@@ -88,8 +88,8 @@ def skipgrams(sequence, vocabulary_size,
             if sampling_table[wi] < random.random():
                 continue
 
-        window_start = max(0, i-window_size)
-        window_end = min(len(sequence), i+window_size+1)
+        window_start = max(0, i - window_size)
+        window_end = min(len(sequence), i + window_size + 1)
         for j in range(window_start, window_end):
             if j != i:
                 wj = sequence[j]
@@ -97,7 +97,7 @@ def skipgrams(sequence, vocabulary_size,
                     continue
                 couples.append([wi, wj])
                 if categorical:
-                    labels.append([0,1])
+                    labels.append([0, 1])
                 else:
                     labels.append(1)
 
@@ -106,14 +106,16 @@ def skipgrams(sequence, vocabulary_size,
         words = [c[0] for c in couples]
         random.shuffle(words)
 
-        couples += [[words[i%len(words)], random.randint(1, vocabulary_size-1)] for i in range(nb_negative_samples)]
+        couples += [[
+            words[i % len(words)], random.randint(1, vocabulary_size - 1)]
+            for i in range(nb_negative_samples)]
         if categorical:
-            labels += [[1,0]]*nb_negative_samples
+            labels += [[1, 0]] * nb_negative_samples
         else:
-            labels += [0]*nb_negative_samples
+            labels += [0] * nb_negative_samples
 
     if shuffle:
-        seed = random.randint(0,10e6)
+        seed = random.randint(0, 10e6)
         random.seed(seed)
         random.shuffle(couples)
         random.seed(seed)

--- a/keras/preprocessing/text.py
+++ b/keras/preprocessing/text.py
@@ -3,9 +3,10 @@
     These preprocessing utils would greatly benefit
     from a fast Cython rewrite.
 '''
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
+import string
+import sys
 
-import string, sys
 import numpy as np
 from six.moves import range
 from six.moves import zip
@@ -26,14 +27,14 @@ def text_to_word_sequence(text, filters=base_filter(), lower=True, split=" "):
     '''
     if lower:
         text = text.lower()
-    text = text.translate(maketrans(filters, split*len(filters)))
+    text = text.translate(maketrans(filters, split * len(filters)))
     seq = text.split(split)
     return [_f for _f in seq if _f]
 
 
 def one_hot(text, n, filters=base_filter(), lower=True, split=" "):
     seq = text_to_word_sequence(text)
-    return [(abs(hash(w))%(n-1)+1) for w in seq]
+    return [(abs(hash(w)) % (n - 1) + 1) for w in seq]
 
 
 class Tokenizer(object):
@@ -67,18 +68,18 @@ class Tokenizer(object):
                     self.word_docs[w] = 1
 
         wcounts = list(self.word_counts.items())
-        wcounts.sort(key = lambda x: x[1], reverse=True)
+        wcounts.sort(key=lambda x: x[1], reverse=True)
         sorted_voc = [wc[0] for wc in wcounts]
-        self.word_index = dict(list(zip(sorted_voc, list(range(1, len(sorted_voc)+1)))))
+        self.word_index = dict(
+            list(zip(sorted_voc, list(range(1, len(sorted_voc) + 1)))))
 
         self.index_docs = {}
         for w, c in list(self.word_docs.items()):
             self.index_docs[self.word_index[w]] = c
 
-
     def fit_on_sequences(self, sequences):
         '''
-            required before using sequences_to_matrix 
+            required before using sequences_to_matrix
             (if fit_on_texts was never called)
         '''
         self.document_count = len(sequences)
@@ -90,7 +91,6 @@ class Tokenizer(object):
                     self.index_docs[i] = 1
                 else:
                     self.index_docs[i] += 1
-
 
     def texts_to_sequences(self, texts):
         '''
@@ -125,7 +125,6 @@ class Tokenizer(object):
                     else:
                         vect.append(i)
             yield vect
-
 
     def texts_to_matrix(self, texts, mode="binary"):
         '''
@@ -165,21 +164,13 @@ class Tokenizer(object):
                 if mode == "count":
                     X[i][j] = c
                 elif mode == "freq":
-                    X[i][j] = c/len(seq)
+                    X[i][j] = c / float(len(seq))
                 elif mode == "binary":
                     X[i][j] = 1
                 elif mode == "tfidf":
-                    tf = np.log(c/len(seq))
-                    df = (1 + np.log(1 + self.index_docs.get(j, 0)/(1 + self.document_count)))
+                    tf = np.log(c / float(len(seq)))
+                    df = (1 + np.log(1 + self.index_docs.get(j, 0) / (1 + self.document_count)))
                     X[i][j] = tf / df
                 else:
                     raise Exception("Unknown vectorization mode: " + str(mode))
         return X
-
-
-
-                
-
-
-
-    

--- a/keras/regularizers.py
+++ b/keras/regularizers.py
@@ -1,5 +1,8 @@
 from __future__ import absolute_import
+
 import theano.tensor as T
+
+from .utils.generic_utils import get_from_module
 
 class Regularizer(object):
     def set_param(self, p):
@@ -12,7 +15,7 @@ class Regularizer(object):
         return loss
 
     def get_config(self):
-        return {"name":self.__class__.__name__}
+        return {"name": self.__class__.__name__}
 
 class WeightRegularizer(Regularizer):
     def __init__(self, l1=0., l2=0.):
@@ -28,9 +31,11 @@ class WeightRegularizer(Regularizer):
         return loss
 
     def get_config(self):
-        return {"name":self.__class__.__name__,
-            "l1":self.l1,
-            "l2":self.l2}
+        return {
+            "name": self.__class__.__name__,
+            "l1": self.l1,
+            "l2": self.l2
+        }
 
 class ActivityRegularizer(Regularizer):
     def __init__(self, l1=0., l2=0.):
@@ -44,11 +49,13 @@ class ActivityRegularizer(Regularizer):
         loss += self.l1 * T.sum(T.mean(abs(self.layer.get_output(True)), axis=0))
         loss += self.l2 * T.sum(T.mean(self.layer.get_output(True) ** 2, axis=0))
         return loss
-    
+
     def get_config(self):
-        return {"name":self.__class__.__name__,
-            "l1":self.l1,
-            "l2":self.l2}
+        return {
+            "name": self.__class__.__name__,
+            "l1": self.l1,
+            "l2": self.l2
+        }
 
 def l1(l=0.01):
     return WeightRegularizer(l1=l)
@@ -70,6 +77,7 @@ def activity_l1l2(l1=0.01, l2=0.01):
 
 identity = Regularizer
 
-from .utils.generic_utils import get_from_module
+
 def get(identifier, kwargs=None):
-    return get_from_module(identifier, globals(), 'regularizer', instantiate=True, kwargs=kwargs)
+    return get_from_module(
+        identifier, globals(), 'regularizer', instantiate=True, kwargs=kwargs)

--- a/keras/utils/dot_utils.py
+++ b/keras/utils/dot_utils.py
@@ -23,7 +23,8 @@ class Grapher(object):
         return self.names[model]
 
     def add_edge(self, f, t, graph):
-        if f: graph.add_edge(pydot.Edge(f, t))
+        if f:
+            graph.add_edge(pydot.Edge(f, t))
         return t
 
     def add_model(self, model, graph, parent=None):

--- a/keras/utils/io_utils.py
+++ b/keras/utils/io_utils.py
@@ -4,7 +4,6 @@ import numpy as np
 from collections import defaultdict
 
 class HDF5Matrix:
-    
     refs = defaultdict(int)
 
     def __init__(self, datapath, dataset, start, end, normalizer=None):
@@ -17,19 +16,19 @@ class HDF5Matrix:
         self.end = end
         self.data = f[dataset]
         self.normalizer = normalizer
-    
+
     def __len__(self):
         return self.end - self.start
 
     def __getitem__(self, key):
         if isinstance(key, slice):
             if key.stop + self.start <= self.end:
-                idx = slice(key.start+self.start, key.stop + self.start)
+                idx = slice(key.start + self.start, key.stop + self.start)
             else:
                 raise IndexError
         elif isinstance(key, int):
             if key + self.start < self.end:
-                idx = key+self.start
+                idx = key + self.start
             else:
                 raise IndexError
         elif isinstance(key, np.ndarray):
@@ -64,7 +63,7 @@ def load_array(name):
     import tables
     f = tables.open_file(name)
     array = f.root.data
-    a=np.empty(shape=array.shape, dtype=array.dtype)
-    a[:]=array[:]
+    a = np.empty(shape=array.shape, dtype=array.dtype)
+    a[:] = array[:]
     f.close()
     return a

--- a/keras/utils/np_utils.py
+++ b/keras/utils/np_utils.py
@@ -1,8 +1,8 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
+
 import numpy as np
 import scipy as sp
-from six.moves import range
-from six.moves import zip
+from six.moves import range, zip
 
 def to_categorical(y, nb_classes=None):
     '''Convert class vector (integers from 0 to nb_classes)
@@ -10,7 +10,7 @@ def to_categorical(y, nb_classes=None):
     '''
     y = np.asarray(y, dtype='int32')
     if not nb_classes:
-        nb_classes = np.max(y)+1
+        nb_classes = np.max(y) + 1
     Y = np.zeros((len(y), nb_classes))
     for i in range(len(y)):
         Y[i, y[i]] = 1.
@@ -18,25 +18,25 @@ def to_categorical(y, nb_classes=None):
 
 def normalize(a, axis=-1, order=2):
     l2 = np.atleast_1d(np.linalg.norm(a, order, axis))
-    l2[l2==0] = 1
+    l2[l2 == 0] = 1
     return a / np.expand_dims(l2, axis)
 
 def binary_logloss(p, y):
     epsilon = 1e-15
     p = sp.maximum(epsilon, p)
-    p = sp.minimum(1-epsilon, p)
-    res = sum(y*sp.log(p) + sp.subtract(1,y)*sp.log(sp.subtract(1,p)))
-    res *= -1.0/len(y)
+    p = sp.minimum(1 - epsilon, p)
+    res = sum(y * sp.log(p) + sp.subtract(1, y) * sp.log(sp.subtract(1, p)))
+    res *= -1.0 / len(y)
     return res
 
 def multiclass_logloss(P, Y):
     score = 0.
-    npreds = [P[i][Y[i]-1] for i in range(len(Y))]
-    score = -(1./len(Y)) * np.sum(np.log(npreds))
+    npreds = [P[i][Y[i] - 1] for i in range(len(Y))]
+    score = -(1.0 / len(Y)) * np.sum(np.log(npreds))
     return score
 
 def accuracy(p, y):
-    return np.mean([a==b for a, b in zip(p, y)])
+    return np.mean([a == b for a, b in zip(p, y)])
 
 def probas_to_classes(y_pred):
     if len(y_pred.shape) > 1 and y_pred.shape[1] > 1:

--- a/keras/utils/test_utils.py
+++ b/keras/utils/test_utils.py
@@ -1,10 +1,13 @@
+from __future__ import absolute_import, print_function
+
 import numpy as np
 
-def get_test_data(nb_train=1000, nb_test=500, input_shape=(10,), output_shape=(2,), 
-    classification=True, nb_class=2):
+def get_test_data(
+        nb_train=1000, nb_test=500, input_shape=(10,), output_shape=(2,),
+        classification=True, nb_class=2):
     '''
-        classification=True overrides output_shape 
-        (i.e. output_shape is set to (1,)) and the output 
+        classification=True overrides output_shape
+        (i.e. output_shape is set to (1,)) and the output
         consists in integers in [0, nb_class-1].
 
         Otherwise: float output with shape output_shape.

--- a/keras/utils/theano_utils.py
+++ b/keras/utils/theano_utils.py
@@ -1,4 +1,5 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
+
 import numpy as np
 import theano
 import theano.tensor as T


### PR DESCRIPTION
I started working on a branch to add bidirectional RNNs but in the process got distracted by the loose and varying style across some of the files in Keras. I'm not sure how welcome nitpicky style PRs are in Keras, but hopefully this is useful or at least tolerated:

* removed unused imports
* deleted assignments to unused variables
* broke up longer lines (not sticking strictly to an 80 character limit but tried to split up anything that I found hard to read)
* add spaces between arithmetic operators
* grouped imports into (1) core library (2) external libraries (3) relative package imports 
* open files using `with` contexts