### PR TITLE
Add parametric softplus non-linearity

### DIFF
--- a/docs/sources/layers/advanced_activations.md
+++ b/docs/sources/layers/advanced_activations.md
@@ -33,3 +33,23 @@ Parametrized linear unit. Similar to a LeakyReLU, where each input unit has its 
 
 - __References__:
     - [Delving Deep into Rectifiers: Surpassing Human-Level Performance on ImageNet Classification](http://arxiv.org/pdf/1502.01852v1.pdf)
+
+---
+
+## ParametricSoftplus
+
+```python
+keras.layers.advanced_activations.ParametricSoftplus(input_shape)
+```
+
+Parametric Softplus of the form: (`f(x) = alpha * (1 + exp(beta * x))`). This is essentially a smooth version of ReLU where the parameters control the sharpness of the rectification. The parameters are initialized to more closely approximate a ReLU than the standard `softplus`: `alpha` initialized to `0.2` and `beta`  initialized to `5.0`. The parameters are fit separately for each hidden unit.
+
+- __Input shape__: Same as `input_shape`. This layer cannot be used as first layer in a model.
+
+- __Output shape__: Same as input.
+
+- __Arguments__:
+    - __input_shape__: tuple.
+
+- __References__:
+    - [Inferring Nonlinear Neuronal Computation Based on Physiologically Plausible Inputs](http://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1003143)

--- a/keras/layers/advanced_activations.py
+++ b/keras/layers/advanced_activations.py
@@ -1,8 +1,8 @@
-from ..layers.core import Layer
+from ..layers.core import Layer, MaskedLayer
 from ..utils.theano_utils import shared_zeros, shared_ones, shared_scalars
 import theano.tensor as T
 
-class LeakyReLU(Layer):
+class LeakyReLU(MaskedLayer):
     def __init__(self, alpha=0.3):
         super(LeakyReLU,self).__init__()
         self.alpha = alpha
@@ -16,7 +16,7 @@ class LeakyReLU(Layer):
             "alpha":self.alpha}
 
 
-class PReLU(Layer):
+class PReLU(MaskedLayer):
     '''
         Reference: 
             Delving Deep into Rectifiers: Surpassing Human-Level Performance on ImageNet Classification
@@ -39,16 +39,16 @@ class PReLU(Layer):
         "input_shape":self.input_shape}
 
 
-class Psoftplus(Layer):
+class ParametricSoftplus(MaskedLayer):
     '''
-        Parametric softplus of the form: alpha * (1 + exp(beta * X))
+        Parametric Softplus of the form: alpha * (1 + exp(beta * X))
 
         Reference:
             Inferring Nonlinear Neuronal Computation Based on Physiologically Plausible Inputs
             http://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1003143
     '''
     def __init__(self, input_shape):
-        super(Psoftplus,self).__init__()
+        super(ParametricSoftplus,self).__init__()
         self.alphas = shared_scalars(input_shape, 0.2)
         self.betas = shared_scalars(input_shape, 5.0)
         self.params = [self.alphas, self.betas]

--- a/keras/layers/advanced_activations.py
+++ b/keras/layers/advanced_activations.py
@@ -1,5 +1,6 @@
 from ..layers.core import Layer
 from ..utils.theano_utils import shared_zeros, shared_ones
+import theano.tensor as T
 
 class LeakyReLU(Layer):
     def __init__(self, alpha=0.3):

--- a/keras/layers/advanced_activations.py
+++ b/keras/layers/advanced_activations.py
@@ -47,10 +47,12 @@ class ParametricSoftplus(MaskedLayer):
             Inferring Nonlinear Neuronal Computation Based on Physiologically Plausible Inputs
             http://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1003143
     '''
-    def __init__(self, input_shape):
+    def __init__(self, input_shape, alpha_init=0.2, beta_init=5.0):
         super(ParametricSoftplus,self).__init__()
-        self.alphas = shared_scalars(input_shape, 0.2)
-        self.betas = shared_scalars(input_shape, 5.0)
+        self.alpha_init = alpha_init
+        self.beta_init = beta_init
+        self.alphas = shared_scalars(input_shape, alpha_init)
+        self.betas = shared_scalars(input_shape, beta_init)
         self.params = [self.alphas, self.betas]
         self.input_shape = input_shape
 
@@ -60,4 +62,6 @@ class ParametricSoftplus(MaskedLayer):
 
     def get_config(self):
         return {"name":self.__class__.__name__,
-            "input_shape":self.input_shape}
+            "input_shape":self.input_shape,
+            "alpha_init":self.alpha_init,
+            "beta_init":self.beta_init}

--- a/keras/layers/advanced_activations.py
+++ b/keras/layers/advanced_activations.py
@@ -1,5 +1,5 @@
 from ..layers.core import Layer
-from ..utils.theano_utils import shared_zeros
+from ..utils.theano_utils import shared_zeros, shared_ones
 
 class LeakyReLU(Layer):
     def __init__(self, alpha=0.3):
@@ -36,3 +36,27 @@ class PReLU(Layer):
     def get_config(self):
         return {"name":self.__class__.__name__,
         "input_shape":self.input_shape}
+
+
+class Psoftplus(Layer):
+    '''
+        Parametric softplus of the form: alpha * (1 + exp(beta * X))
+
+        Reference:
+            Inferring Nonlinear Neuronal Computation Based on Physiologically Plausible Inputs
+            http://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1003143
+    '''
+    def __init__(self, input_shape):
+        super(Psoftplus,self).__init__()
+        self.alphas = shared_ones(input_shape)
+        self.betas = shared_ones(input_shape)
+        self.params = [self.alphas, self.betas]
+        self.input_shape = input_shape
+
+    def get_output(self, train):
+        X = self.get_input(train)
+        return T.nnet.softplus(self.betas * X) * self.alphas
+
+    def get_config(self):
+        return {"name":self.__class__.__name__,
+            "input_shape":self.input_shape}

--- a/keras/layers/advanced_activations.py
+++ b/keras/layers/advanced_activations.py
@@ -1,5 +1,5 @@
 from ..layers.core import Layer
-from ..utils.theano_utils import shared_zeros, shared_ones
+from ..utils.theano_utils import shared_zeros, shared_ones, shared_scalars
 import theano.tensor as T
 
 class LeakyReLU(Layer):
@@ -49,8 +49,8 @@ class Psoftplus(Layer):
     '''
     def __init__(self, input_shape):
         super(Psoftplus,self).__init__()
-        self.alphas = shared_ones(input_shape)
-        self.betas = shared_ones(input_shape)
+        self.alphas = shared_scalars(input_shape, 0.2)
+        self.betas = shared_scalars(input_shape, 5.0)
         self.params = [self.alphas, self.betas]
         self.input_shape = input_shape
 

--- a/keras/utils/theano_utils.py
+++ b/keras/utils/theano_utils.py
@@ -18,6 +18,9 @@ def shared_scalar(val=0., dtype=theano.config.floatX, name=None):
 def shared_ones(shape, dtype=theano.config.floatX, name=None):
     return sharedX(np.ones(shape), dtype=dtype, name=name)
 
+def shared_scalars(shape, val, dtype=theano.config.floatX, name=None):
+    return sharedX(np.ones(shape)*val, dtype=dtype, name=name)
+
 def alloc_zeros_matrix(*dims):
     return T.alloc(np.cast[theano.config.floatX](0.), *dims)
 


### PR DESCRIPTION
This is meant to complement this PR: https://github.com/fchollet/keras/pull/421
This non-linearity is useful for modeling neural activity, especially when combined with Poisson loss.

With these additions it is possible to implement all of the models from this paper in keras:
http://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1003143