### PR TITLE
layers.core: add Masking layer

### DIFF
--- a/docs/sources/layers/core.md
+++ b/docs/sources/layers/core.md
@@ -357,3 +357,10 @@ model.compile(loss='categorical_crossentropy', optimizer='rmsprop')
 model.fit([X_train, X_train], Y_train, batch_size=128, nb_epoch=20, validation_data=([X_test, X_test], Y_test))
 ```
 
+## Masking
+```python
+keras.layers.core.Masking(mask_value=0)
+```
+
+Create a mask for the input data by using `mask_value` as the padding value which should be masked out.
+Works with sequences only, given an input of dimensions `(nb_samples, timesteps, input_dim)`, return the input untouched as output, and supply a mask of shape `(nb_samples, timesteps)` where all timesteps which had all values set to `mask_value` are masked out (0).

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -116,6 +116,33 @@ class MaskedLayer(Layer):
         return self.get_input_mask(train)
 
 
+class Masking(MaskedLayer):
+    """Mask an input sequence by using a mask value to identify padding.
+
+    This layer copies the input to the output layer, while creating an output mask in the process.
+    This layer is only available with sequences, so its input should be the in
+    the shape (nb_samples, timesteps, input_dim) and its output is of the shape
+    (nb_samples, timesteps).
+
+    At each timestep, if the values all equal `mask_value`, then the timestep
+    mask is zero (skipped), otherwise it is 1.
+
+    """
+
+    def __init__(self, mask_value=0):
+        super(Masking, self).__init__()
+        self.mask_value = mask_value
+        self.input = T.tensor3()
+
+    def get_output_mask(self, train=False):
+        X = self.get_input(train)
+        return T.any(T.ones_like(X) * (1 - T.eq(X, self.mask_value)), axis=-1)
+
+    def get_config(self):
+        return dict(super(Masking, self).get_config(),
+                    mask_value=self.mask_value)
+
+
 class Merge(object):
     def __init__(self, layers, mode='sum'):
         ''' Merge the output of a list of layers or containers into a single tensor.

--- a/tests/auto/keras/layers/test_core.py
+++ b/tests/auto/keras/layers/test_core.py
@@ -116,5 +116,34 @@ class TestConfigParams(unittest.TestCase):
         self._runner(layer)
 
 
+class TestMasking(unittest.TestCase):
+    """Test the Masking class"""
+
+    def test_sequences(self):
+        """Test masking sequences with zeroes as padding"""
+        # integer inputs, one per timestep, like embeddings
+        layer = core.Masking()
+        func = theano.function([layer.input], layer.get_output_mask())
+        self.assertTrue(np.all(
+            # get mask for this input
+            func(np.array(
+            [[[1], [2], [3], [0]],
+             [[0], [4], [5], [0]]], dtype=np.int32)) ==
+            # This is the expected output mask, one dimension less
+            np.array([[1, 1, 1, 0], [0, 1, 1, 0]])))
+
+    def test_non_zero(self):
+        """Test masking with non-zero mask value"""
+        layer = core.Masking(5)
+        func = theano.function([layer.input], layer.get_output_mask())
+        self.assertTrue(np.all(
+            # get mask for this input, if not all the values are 5, shouldn't masked
+            func(np.array(
+            [[[1, 1], [2, 1], [3, 1], [5, 5]],
+             [[1, 5], [5, 0], [0, 0], [0, 0]]], dtype=np.int32)) ==
+            # This is the expected output mask, one dimension less
+            np.array([[1, 1, 1, 0], [1, 1, 1, 1]])))
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Support masking of sequences without the Embedding layer, by masking out timesteps whose values equal a specific mask_value (default 0).

Signed-off-by: Amit Beka <amit.beka@gmail.com>