### PR TITLE
Proper handling of output values in Masking layer

### DIFF
--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -119,8 +119,8 @@ class MaskedLayer(Layer):
 class Masking(MaskedLayer):
     """Mask an input sequence by using a mask value to identify padding.
 
-    This layer copies the input to the output layer,
-    while creating an output mask in the process.
+    This layer copies the input to the output layer with identified padding
+    replaced with 0s and creates an output mask in the process.
 
     At each timestep, if the values all equal `mask_value`,
     then the corresponding mask value for the timestep is 0 (skipped),
@@ -135,6 +135,10 @@ class Masking(MaskedLayer):
     def get_output_mask(self, train=False):
         X = self.get_input(train)
         return T.any(T.ones_like(X) * (1. - T.eq(X, self.mask_value)), axis=-1)
+
+    def get_output(self, train=False):
+        X = self.get_input(train)
+        return X * T.shape_padright(T.any((1. - T.eq(X, self.mask_value)), axis=-1))
 
     def get_config(self):
         return {"name": self.__class__.__name__,

--- a/tests/auto/keras/layers/test_core.py
+++ b/tests/auto/keras/layers/test_core.py
@@ -144,6 +144,19 @@ class TestMasking(unittest.TestCase):
             # This is the expected output mask, one dimension less
             np.array([[1, 1, 1, 0], [1, 1, 1, 1]])))
 
+    def test_non_zero_output(self):
+        """Test output of masking layer with non-zero mask value"""
+        layer = core.Masking(5)
+        func = theano.function([layer.input], layer.get_output())
+        self.assertTrue(np.all(
+            # get output for this input, replace padding with 0
+            func(np.array(
+            [[[1, 1], [2, 1], [3, 1], [5, 5]],
+             [[1, 5], [5, 0], [0, 0], [0, 0]]], dtype=np.int32)) ==
+            # This is the expected output
+            np.array([[[1, 1], [2, 1], [3, 1], [0, 0]],
+             [[1, 5], [5, 0], [0, 0], [0, 0]]])))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The following - rather artificial - example shows a potential flaw in the current masking approach:

```python
X = np.asarray([[[1e+30]]])
y = np.ones((1, 1, 1))

model = Sequential()
model.add(Masking(mask_value=1e+30))
model.add(SimpleRNN(1, 1, init='one', activation='relu', return_sequences=True))
model.compile(loss='mse', optimizer='sgd')

logs = model.fit(X, y, nb_epoch=3)
```

Produces the following output:
```
Epoch 0
1/1 [==============================] - 0s - loss: inf
Epoch 1
1/1 [==============================] - 0s - loss: nan
Epoch 2
1/1 [==============================] - 0s - loss: nan
```

**Explanation:** In all recurrent layers, the input value is multiplied with some matrix (usually `W`) before the time dimension is evaluated (Theano `scan`). The mask is currently only applied within the Theano `scan` loop, whereas the first multiplication is unmasked. This works fine as long as `0` is chosen as a `mask_value`. For other values this however results in unwanted behavior, as shown here for the extreme case of `mask_value=1e+30`.

**Fix:** By replacing all the values which are to be masked with `0` in the output of the `Masking` layer, everything works again as expected.