### PR TITLE
Optionally mask cost function for sequence to sequence learning

### DIFF
--- a/keras/models.py
+++ b/keras/models.py
@@ -72,7 +72,11 @@ def weighted_objective(fn):
         if mask is None:
             return (masked_weights.flatten() * obj_output.flatten()).mean()
         else:
-            return (masked_weights.flatten() * obj_output.flatten()).sum() / mask.sum()
+            # We assume the time index to be masked is axis=1
+            wc = masked_weights * obj_output
+            wc = wc.reshape(mask.shape)
+            wc = wc.sum(axis=1) / mask.sum(axis=1)
+            return wc.mean()
     return weighted
 
 

--- a/tests/auto/test_loss_masking.py
+++ b/tests/auto/test_loss_masking.py
@@ -22,4 +22,4 @@ def test_cost_masking():
     model.add(TimeDistributedDense(2, 1, init='one'))
     model.compile(loss='mse', optimizer='sgd', mask_cost=True)
     loss = model.fit(X, 4*y, nb_epoch=1, batch_size=2, verbose=1).history['loss'][0]
-    assert loss == 285.0
+    assert loss == 282.375

--- a/tests/auto/test_loss_masking.py
+++ b/tests/auto/test_loss_masking.py
@@ -1,0 +1,25 @@
+import numpy as np
+from keras.models import Sequential
+from keras.layers.core import TimeDistributedDense, Masking
+
+
+def test_cost_masking():
+    X = np.array(
+        [[[1, 1], [2, 1], [3, 1], [5, 5]],
+         [[1, 5], [5, 0], [0, 0], [0, 0]]], dtype=np.int32)
+
+    model = Sequential()
+    model.add(Masking(mask_value=0))
+    model.add(TimeDistributedDense(2, 1, init='one'))
+    model.compile(loss='mse', optimizer='sgd')
+    y = model.predict(X)
+
+    loss = model.fit(X, 4*y, nb_epoch=1, batch_size=2, verbose=1).history['loss'][0]
+    assert loss == 213.75
+
+    model = Sequential()
+    model.add(Masking(mask_value=0))
+    model.add(TimeDistributedDense(2, 1, init='one'))
+    model.compile(loss='mse', optimizer='sgd', mask_cost=True)
+    loss = model.fit(X, 4*y, nb_epoch=1, batch_size=2, verbose=1).history['loss'][0]
+    assert loss == 285.0


### PR DESCRIPTION
Fixes #395
This is a natural continuation of PR #446 

This allows masking of the cost function for sequence to sequence learning with different lengths. It does so with an optional flag `mask_cost` at `model.compile`.