### PR TITLE
Bidirectional RNNs

### DIFF
--- a/examples/imdb_lstm.py
+++ b/examples/imdb_lstm.py
@@ -1,19 +1,17 @@
 from __future__ import absolute_import
 from __future__ import print_function
 import numpy as np
-np.random.seed(1337)  # for reproducibility
 
 from keras.preprocessing import sequence
-from keras.optimizers import SGD, RMSprop, Adagrad
-from keras.utils import np_utils
+
 from keras.models import Sequential
 from keras.layers.core import Dense, Dropout, Activation
 from keras.layers.embeddings import Embedding
-from keras.layers.recurrent import LSTM, GRU
+from keras.layers.recurrent import LSTM, Bidirectional
 from keras.datasets import imdb
 
 '''
-    Train a LSTM on the IMDB sentiment classification task.
+    Train a bidirectional LSTM on the IMDB sentiment classification task.
 
     The dataset is actually too small for LSTM to be of any advantage
     compared to simpler, much faster methods such as TF-IDF+LogReg.
@@ -30,6 +28,8 @@ from keras.datasets import imdb
     GPU command:
         THEANO_FLAGS=mode=FAST_RUN,device=gpu,floatX=float32 python imdb_lstm.py
 '''
+
+np.random.seed(1337)  # for reproducibility
 
 max_features = 20000
 maxlen = 100  # cut texts after this number of words (among top max_features most common words)
@@ -49,7 +49,7 @@ print('X_test shape:', X_test.shape)
 print('Build model...')
 model = Sequential()
 model.add(Embedding(max_features, 128))
-model.add(LSTM(128, 128))  # try using a GRU instead, for fun
+model.add(Bidirectional(LSTM, 128, 128))
 model.add(Dropout(0.5))
 model.add(Dense(128, 1))
 model.add(Activation('sigmoid'))

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -115,7 +115,6 @@ class MaskedLayer(Layer):
         implementations if, for instance, you are reshaping the input'''
         return self.get_input_mask(train)
 
-
 class Masking(MaskedLayer):
     """Mask an input sequence by using a mask value to identify padding.
 

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -8,7 +8,7 @@ import numpy as np
 from .. import activations, initializations, regularizers, constraints
 from ..utils.theano_utils import shared_zeros, floatX
 from ..utils.generic_utils import make_tuple
-from ..regularizers import ActivityRegularizer, Regularizer
+from ..regularizers import ActivityRegularizer
 
 from theano.sandbox.rng_mrg import MRG_RandomStreams as RandomStreams
 from six.moves import zip
@@ -325,7 +325,7 @@ class RepeatVector(Layer):
 
     def get_output(self, train=False):
         X = self.get_input(train)
-        tensors = [X]*self.n
+        tensors = [X] * self.n
         stacked = theano.tensor.stack(*tensors)
         return stacked.dimshuffle((1, 0, 2))
 

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 import theano
 import theano.tensor as T
 import numpy as np
@@ -848,17 +848,21 @@ class Bidirectional(Recurrent):
             # reverse the output of the backward model along the
             # time dimension so that it's aligned with the forward model's
             # output
-            backward_output = backward_output[:, ::-1]
+            backward_output = backward_output[:, ::-1, :]
         # both forward_output and backward_output have shapes like
         # (n_samples, n_timesteps, output_dim) in the case of self.return_sequences=True
         # or otherwise like (n_samples, output_dim)
         # In either case, concatenate the two outputs to get a final dimension
         # of output_dim * 2
-        return T.concatenate([forward_output, backward_output], axis=-1)
+        return T.concatenate(
+            [forward_output, backward_output],
+            axis=-1)
 
     def get_output_mask(self, train=False):
         if self.return_sequences:
-            return self.get_input_mask(train)
+            mask = self.get_input_mask(train)
+            print(mask, mask.ndim)
+            return mask
         else:
             return None
 

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -5,8 +5,8 @@ import theano.tensor as T
 import numpy as np
 
 from .. import activations, initializations
-from ..utils.theano_utils import shared_scalar, shared_zeros, alloc_zeros_matrix
-from ..layers.core import Layer, MaskedLayer
+from ..utils.theano_utils import shared_zeros, alloc_zeros_matrix
+from ..layers.core import MaskedLayer
 from six.moves import range
 
 
@@ -43,8 +43,9 @@ class SimpleRNN(Recurrent):
         (demonstrates how to use theano.scan to build a basic RNN).
     '''
     def __init__(self, input_dim, output_dim,
-                 init='glorot_uniform', inner_init='orthogonal', activation='sigmoid', weights=None,
-                 truncate_gradient=-1, return_sequences=False):
+                 init='glorot_uniform', inner_init='orthogonal', activation='sigmoid',
+                 weights=None, truncate_gradient=-1, return_sequences=False,
+                 go_backwards=False):
 
         super(SimpleRNN, self).__init__()
         self.init = initializations.get(init)
@@ -54,6 +55,8 @@ class SimpleRNN(Recurrent):
         self.truncate_gradient = truncate_gradient
         self.activation = activations.get(activation)
         self.return_sequences = return_sequences
+        self.go_backwards = go_backwards
+
         self.input = T.tensor3()
 
         self.W = self.init((self.input_dim, self.output_dim))
@@ -74,7 +77,8 @@ class SimpleRNN(Recurrent):
 
     def get_output(self, train=False):
         X = self.get_input(train)  # shape: (nb_samples, time (padded with zeros), input_dim)
-        # new shape: (time, nb_samples, input_dim) -> because theano.scan iterates over main dimension
+        # new shape: (time, nb_samples, input_dim)
+        # because theano.scan iterates over main dimension
         padded_mask = self.get_padded_shuffled_mask(train, X, pad=1)
         X = X.dimshuffle((1, 0, 2))
         x = T.dot(X, self.W) + self.b
@@ -88,21 +92,25 @@ class SimpleRNN(Recurrent):
             # initialization of the output. Input to _step with default tap=-1.
             outputs_info=T.unbroadcast(alloc_zeros_matrix(X.shape[1], self.output_dim), 1),
             non_sequences=self.U,  # static inputs to _step
-            truncate_gradient=self.truncate_gradient)
+            truncate_gradient=self.truncate_gradient,
+            go_backwards=self.go_backwards)
 
         if self.return_sequences:
             return outputs.dimshuffle((1, 0, 2))
         return outputs[-1]
 
     def get_config(self):
-        return {"name": self.__class__.__name__,
-                "input_dim": self.input_dim,
-                "output_dim": self.output_dim,
-                "init": self.init.__name__,
-                "inner_init": self.inner_init.__name__,
-                "activation": self.activation.__name__,
-                "truncate_gradient": self.truncate_gradient,
-                "return_sequences": self.return_sequences}
+        return {
+            "name": self.__class__.__name__,
+            "input_dim": self.input_dim,
+            "output_dim": self.output_dim,
+            "init": self.init.__name__,
+            "inner_init": self.inner_init.__name__,
+            "activation": self.activation.__name__,
+            "truncate_gradient": self.truncate_gradient,
+            "return_sequences": self.return_sequences,
+            "go_backwards": self.go_backwards
+        }
 
 
 class SimpleDeepRNN(Recurrent):
@@ -118,7 +126,8 @@ class SimpleDeepRNN(Recurrent):
     def __init__(self, input_dim, output_dim, depth=3,
                  init='glorot_uniform', inner_init='orthogonal',
                  activation='sigmoid', inner_activation='hard_sigmoid',
-                 weights=None, truncate_gradient=-1, return_sequences=False):
+                 weights=None, truncate_gradient=-1, return_sequences=False,
+                 go_backwards=False):
 
         super(SimpleDeepRNN, self).__init__()
         self.init = initializations.get(init)
@@ -130,10 +139,15 @@ class SimpleDeepRNN(Recurrent):
         self.inner_activation = activations.get(inner_activation)
         self.depth = depth
         self.return_sequences = return_sequences
+        self.go_backwards = go_backwards
+
         self.input = T.tensor3()
 
         self.W = self.init((self.input_dim, self.output_dim))
-        self.Us = [self.inner_init((self.output_dim, self.output_dim)) for _ in range(self.depth)]
+        self.Us = [
+            self.inner_init((self.output_dim, self.output_dim))
+            for _ in range(self.depth)
+        ]
         self.b = shared_zeros((self.output_dim))
         self.params = [self.W] + self.Us + [self.b]
 
@@ -145,8 +159,8 @@ class SimpleDeepRNN(Recurrent):
         for i in range(self.depth):
             mask_tmi = args[i]
             h_tmi = args[i + self.depth]
-            U_tmi = args[i + 2*self.depth]
-            o += mask_tmi*self.inner_activation(T.dot(h_tmi, U_tmi))
+            U_tmi = args[i + 2 * self.depth]
+            o += mask_tmi * self.inner_activation(T.dot(h_tmi, U_tmi))
         return self.activation(o)
 
     def get_output(self, train=False):
@@ -159,7 +173,9 @@ class SimpleDeepRNN(Recurrent):
         if self.depth == 1:
             initial = T.unbroadcast(alloc_zeros_matrix(X.shape[1], self.output_dim), 1)
         else:
-            initial = T.unbroadcast(T.unbroadcast(alloc_zeros_matrix(self.depth, X.shape[1], self.output_dim), 0), 2)
+            initial = T.unbroadcast(
+                T.unbroadcast(
+                    alloc_zeros_matrix(self.depth, X.shape[1], self.output_dim), 0), 2)
 
         outputs, updates = theano.scan(
             self._step,
@@ -169,10 +185,11 @@ class SimpleDeepRNN(Recurrent):
             )],
             outputs_info=[dict(
                 initial=initial,
-                taps=[(-i-1) for i in range(self.depth)]
+                taps=[(-i - 1) for i in range(self.depth)]
             )],
             non_sequences=self.Us,
-            truncate_gradient=self.truncate_gradient
+            truncate_gradient=self.truncate_gradient,
+            go_backwards=self.go_backwards
         )
 
         if self.return_sequences:
@@ -180,16 +197,19 @@ class SimpleDeepRNN(Recurrent):
         return outputs[-1]
 
     def get_config(self):
-        return {"name": self.__class__.__name__,
-                "input_dim": self.input_dim,
-                "output_dim": self.output_dim,
-                "depth": self.depth,
-                "init": self.init.__name__,
-                "inner_init": self.inner_init.__name__,
-                "activation": self.activation.__name__,
-                "inner_activation": self.inner_activation.__name__,
-                "truncate_gradient": self.truncate_gradient,
-                "return_sequences": self.return_sequences}
+        return {
+            "name": self.__class__.__name__,
+            "input_dim": self.input_dim,
+            "output_dim": self.output_dim,
+            "depth": self.depth,
+            "init": self.init.__name__,
+            "inner_init": self.inner_init.__name__,
+            "activation": self.activation.__name__,
+            "inner_activation": self.inner_activation.__name__,
+            "truncate_gradient": self.truncate_gradient,
+            "return_sequences": self.return_sequences,
+            "go_backwards": self.go_backwards,
+        }
 
 
 class GRU(Recurrent):
@@ -217,18 +237,21 @@ class GRU(Recurrent):
     def __init__(self, input_dim, output_dim=128,
                  init='glorot_uniform', inner_init='orthogonal',
                  activation='sigmoid', inner_activation='hard_sigmoid',
-                 weights=None, truncate_gradient=-1, return_sequences=False):
+                 weights=None, truncate_gradient=-1, return_sequences=False,
+                 go_backwards=False):
 
         super(GRU, self).__init__()
         self.input_dim = input_dim
         self.output_dim = output_dim
         self.truncate_gradient = truncate_gradient
         self.return_sequences = return_sequences
+        self.go_backwards = go_backwards
 
         self.init = initializations.get(init)
         self.inner_init = initializations.get(inner_init)
         self.activation = activations.get(activation)
         self.inner_activation = activations.get(inner_activation)
+
         self.input = T.tensor3()
 
         self.W_z = self.init((self.input_dim, self.output_dim))
@@ -276,22 +299,26 @@ class GRU(Recurrent):
             sequences=[x_z, x_r, x_h, padded_mask],
             outputs_info=T.unbroadcast(alloc_zeros_matrix(X.shape[1], self.output_dim), 1),
             non_sequences=[self.U_z, self.U_r, self.U_h],
-            truncate_gradient=self.truncate_gradient)
+            truncate_gradient=self.truncate_gradient,
+            go_backwards=self.go_backwards)
 
         if self.return_sequences:
             return outputs.dimshuffle((1, 0, 2))
         return outputs[-1]
 
     def get_config(self):
-        return {"name": self.__class__.__name__,
-                "input_dim": self.input_dim,
-                "output_dim": self.output_dim,
-                "init": self.init.__name__,
-                "inner_init": self.inner_init.__name__,
-                "activation": self.activation.__name__,
-                "inner_activation": self.inner_activation.__name__,
-                "truncate_gradient": self.truncate_gradient,
-                "return_sequences": self.return_sequences}
+        return {
+            "name": self.__class__.__name__,
+            "input_dim": self.input_dim,
+            "output_dim": self.output_dim,
+            "init": self.init.__name__,
+            "inner_init": self.inner_init.__name__,
+            "activation": self.activation.__name__,
+            "inner_activation": self.inner_activation.__name__,
+            "truncate_gradient": self.truncate_gradient,
+            "return_sequences": self.return_sequences,
+            "go_backwards": self.go_backwards,
+        }
 
 
 class LSTM(Recurrent):
@@ -322,19 +349,22 @@ class LSTM(Recurrent):
     def __init__(self, input_dim, output_dim=128,
                  init='glorot_uniform', inner_init='orthogonal', forget_bias_init='one',
                  activation='tanh', inner_activation='hard_sigmoid',
-                 weights=None, truncate_gradient=-1, return_sequences=False):
+                 weights=None, truncate_gradient=-1, return_sequences=False,
+                 go_backwards=False):
 
         super(LSTM, self).__init__()
         self.input_dim = input_dim
         self.output_dim = output_dim
         self.truncate_gradient = truncate_gradient
         self.return_sequences = return_sequences
+        self.go_backwards = go_backwards
 
         self.init = initializations.get(init)
         self.inner_init = initializations.get(inner_init)
         self.forget_bias_init = initializations.get(forget_bias_init)
         self.activation = activations.get(activation)
         self.inner_activation = activations.get(inner_activation)
+
         self.input = T.tensor3()
 
         self.W_i = self.init((self.input_dim, self.output_dim))
@@ -395,23 +425,27 @@ class LSTM(Recurrent):
                 T.unbroadcast(alloc_zeros_matrix(X.shape[1], self.output_dim), 1)
             ],
             non_sequences=[self.U_i, self.U_f, self.U_o, self.U_c],
-            truncate_gradient=self.truncate_gradient)
+            truncate_gradient=self.truncate_gradient,
+            go_backwards=self.go_backwards)
 
         if self.return_sequences:
             return outputs.dimshuffle((1, 0, 2))
         return outputs[-1]
 
     def get_config(self):
-        return {"name": self.__class__.__name__,
-                "input_dim": self.input_dim,
-                "output_dim": self.output_dim,
-                "init": self.init.__name__,
-                "inner_init": self.inner_init.__name__,
-                "forget_bias_init": self.forget_bias_init.__name__,
-                "activation": self.activation.__name__,
-                "inner_activation": self.inner_activation.__name__,
-                "truncate_gradient": self.truncate_gradient,
-                "return_sequences": self.return_sequences}
+        return {
+            "name": self.__class__.__name__,
+            "input_dim": self.input_dim,
+            "output_dim": self.output_dim,
+            "init": self.init.__name__,
+            "inner_init": self.inner_init.__name__,
+            "forget_bias_init": self.forget_bias_init.__name__,
+            "activation": self.activation.__name__,
+            "inner_activation": self.inner_activation.__name__,
+            "truncate_gradient": self.truncate_gradient,
+            "return_sequences": self.return_sequences,
+            "go_backwards": self.go_backwards
+        }
 
 
 class JZS1(Recurrent):
@@ -437,18 +471,21 @@ class JZS1(Recurrent):
     def __init__(self, input_dim, output_dim=128,
                  init='glorot_uniform', inner_init='orthogonal',
                  activation='tanh', inner_activation='sigmoid',
-                 weights=None, truncate_gradient=-1, return_sequences=False):
+                 weights=None, truncate_gradient=-1, return_sequences=False,
+                 go_backwards=False):
 
         super(JZS1, self).__init__()
         self.input_dim = input_dim
         self.output_dim = output_dim
         self.truncate_gradient = truncate_gradient
         self.return_sequences = return_sequences
+        self.go_backwards = go_backwards
 
         self.init = initializations.get(init)
         self.inner_init = initializations.get(inner_init)
         self.activation = activations.get(activation)
         self.inner_activation = activations.get(inner_activation)
+
         self.input = T.tensor3()
 
         self.W_z = self.init((self.input_dim, self.output_dim))
@@ -465,7 +502,8 @@ class JZS1(Recurrent):
         if self.input_dim == self.output_dim:
             self.Pmat = theano.shared(np.identity(self.output_dim, dtype=theano.config.floatX), name=None)
         else:
-            P = np.random.binomial(1, 0.5, size=(self.input_dim, self.output_dim)).astype(theano.config.floatX) * 2 - 1
+            P_shape = (self.input_dim, self.output_dim)
+            P = np.random.binomial(1, 0.5, size=P_shape).astype(theano.config.floatX) * 2 - 1
             P = 1 / np.sqrt(self.input_dim) * P
             self.Pmat = theano.shared(P, name=None)
 
@@ -502,21 +540,25 @@ class JZS1(Recurrent):
             sequences=[x_z, x_r, x_h, padded_mask],
             outputs_info=T.unbroadcast(alloc_zeros_matrix(X.shape[1], self.output_dim), 1),
             non_sequences=[self.U_r, self.U_h],
-            truncate_gradient=self.truncate_gradient)
+            truncate_gradient=self.truncate_gradient,
+            go_backwards=self.go_backwards)
         if self.return_sequences:
             return outputs.dimshuffle((1, 0, 2))
         return outputs[-1]
 
     def get_config(self):
-        return {"name": self.__class__.__name__,
-                "input_dim": self.input_dim,
-                "output_dim": self.output_dim,
-                "init": self.init.__name__,
-                "inner_init": self.inner_init.__name__,
-                "activation": self.activation.__name__,
-                "inner_activation": self.inner_activation.__name__,
-                "truncate_gradient": self.truncate_gradient,
-                "return_sequences": self.return_sequences}
+        return {
+            "name": self.__class__.__name__,
+            "input_dim": self.input_dim,
+            "output_dim": self.output_dim,
+            "init": self.init.__name__,
+            "inner_init": self.inner_init.__name__,
+            "activation": self.activation.__name__,
+            "inner_activation": self.inner_activation.__name__,
+            "truncate_gradient": self.truncate_gradient,
+            "return_sequences": self.return_sequences,
+            "go_backwards": self.go_backwards
+        }
 
 
 class JZS2(Recurrent):
@@ -542,18 +584,21 @@ class JZS2(Recurrent):
     def __init__(self, input_dim, output_dim=128,
                  init='glorot_uniform', inner_init='orthogonal',
                  activation='tanh', inner_activation='sigmoid',
-                 weights=None, truncate_gradient=-1, return_sequences=False):
+                 weights=None, truncate_gradient=-1, return_sequences=False,
+                 go_backwards=False):
 
         super(JZS2, self).__init__()
         self.input_dim = input_dim
         self.output_dim = output_dim
         self.truncate_gradient = truncate_gradient
         self.return_sequences = return_sequences
+        self.go_backwards = go_backwards
 
         self.init = initializations.get(init)
         self.inner_init = initializations.get(inner_init)
         self.activation = activations.get(activation)
         self.inner_activation = activations.get(inner_activation)
+
         self.input = T.tensor3()
 
         self.W_z = self.init((self.input_dim, self.output_dim))
@@ -608,21 +653,25 @@ class JZS2(Recurrent):
             sequences=[x_z, x_r, x_h, padded_mask],
             outputs_info=T.unbroadcast(alloc_zeros_matrix(X.shape[1], self.output_dim), 1),
             non_sequences=[self.U_z, self.U_r, self.U_h],
-            truncate_gradient=self.truncate_gradient)
+            truncate_gradient=self.truncate_gradient,
+            go_backwards=self.go_backwards)
         if self.return_sequences:
             return outputs.dimshuffle((1, 0, 2))
         return outputs[-1]
 
     def get_config(self):
-        return {"name": self.__class__.__name__,
-                "input_dim": self.input_dim,
-                "output_dim": self.output_dim,
-                "init": self.init.__name__,
-                "inner_init": self.inner_init.__name__,
-                "activation": self.activation.__name__,
-                "inner_activation": self.inner_activation.__name__,
-                "truncate_gradient": self.truncate_gradient,
-                "return_sequences": self.return_sequences}
+        return {
+            "name": self.__class__.__name__,
+            "input_dim": self.input_dim,
+            "output_dim": self.output_dim,
+            "init": self.init.__name__,
+            "inner_init": self.inner_init.__name__,
+            "activation": self.activation.__name__,
+            "inner_activation": self.inner_activation.__name__,
+            "truncate_gradient": self.truncate_gradient,
+            "return_sequences": self.return_sequences,
+            "go_backwards": self.go_backwards
+        }
 
 
 class JZS3(Recurrent):
@@ -648,18 +697,21 @@ class JZS3(Recurrent):
     def __init__(self, input_dim, output_dim=128,
                  init='glorot_uniform', inner_init='orthogonal',
                  activation='tanh', inner_activation='sigmoid',
-                 weights=None, truncate_gradient=-1, return_sequences=False):
+                 weights=None, truncate_gradient=-1, return_sequences=False,
+                 go_backwards=False):
 
         super(JZS3, self).__init__()
         self.input_dim = input_dim
         self.output_dim = output_dim
         self.truncate_gradient = truncate_gradient
         self.return_sequences = return_sequences
+        self.go_backwards = go_backwards
 
         self.init = initializations.get(init)
         self.inner_init = initializations.get(inner_init)
         self.activation = activations.get(activation)
         self.inner_activation = activations.get(inner_activation)
+
         self.input = T.tensor3()
 
         self.W_z = self.init((self.input_dim, self.output_dim))
@@ -707,19 +759,77 @@ class JZS3(Recurrent):
             sequences=[x_z, x_r, x_h, padded_mask],
             outputs_info=T.unbroadcast(alloc_zeros_matrix(X.shape[1], self.output_dim), 1),
             non_sequences=[self.U_z, self.U_r, self.U_h],
-            truncate_gradient=self.truncate_gradient
+            truncate_gradient=self.truncate_gradient,
+            go_backwards=self.go_backwards,
         )
         if self.return_sequences:
             return outputs.dimshuffle((1, 0, 2))
         return outputs[-1]
 
     def get_config(self):
-        return {"name": self.__class__.__name__,
-                "input_dim": self.input_dim,
-                "output_dim": self.output_dim,
-                "init": self.init.__name__,
-                "inner_init": self.inner_init.__name__,
-                "activation": self.activation.__name__,
-                "inner_activation": self.inner_activation.__name__,
-                "truncate_gradient": self.truncate_gradient,
-                "return_sequences": self.return_sequences}
+        return {
+            "name": self.__class__.__name__,
+            "input_dim": self.input_dim,
+            "output_dim": self.output_dim,
+            "init": self.init.__name__,
+            "inner_init": self.inner_init.__name__,
+            "activation": self.activation.__name__,
+            "inner_activation": self.inner_activation.__name__,
+            "truncate_gradient": self.truncate_gradient,
+            "return_sequences": self.return_sequences,
+            "go_backwards": self.go_backwards
+        }
+
+
+class Bidirectional(Recurrent):
+    """
+    Construct a bidirectional RNN out of an underlying RNN class. Traverses
+    the input sequence both forwards and backwards and then concatenates RNN
+    outputs from both directions.
+    """
+
+    def __init__(self, rnn_class, **kwargs):
+        """
+        All extra arguments are passed to the `rnn_class` constructor.
+        """
+        super(Bidirectional, self).__init__()
+        self.rnn_class = rnn_class
+        self.kwargs = kwargs
+        self.return_sequences = kwargs.get("return_sequences", False)
+
+        kwargs["go_backwards"] = False
+        self.forward_model = rnn_class(**kwargs)
+        kwargs["go_backwards"] = True
+        self.backward_model = rnn_class(**kwargs)
+        self.params = self.forward_model.params + self.backward_model.params
+        self.regularizers = []
+        self.constraints = []
+
+    def get_output(self, train=False):
+        forward_output = self.forward_model.get_output(train)
+        backward_output = self.forward_model.get_output(train)
+        if self.return_sequences:
+            # reverse the output of the backward model along the
+            # time dimension so that it's aligned with the forward model's
+            # output
+
+            reverse_backward_output = backward_output[:, ::-1]
+        # both forward_output and backward_output have shapes like
+        # (n_samples, n_timesteps, output_dim) in the case of self.return_sequences=True
+        # or otherwise like (n_samples, output_dim)
+        # In either case, concatenate the two outputs to get a final dimension
+        # of output_dim * 2
+        return T.concatenate([forward_output, reverse_backward_output], axis=-1)
+
+    def get_output_mask(self, train=False):
+        if self.return_sequences:
+            return self.get_input_mask(train)
+        else:
+            return None
+
+    def get_config(self):
+        config_dict = {
+            "rnn_class": self.rnn_class.__name__,
+        }
+        config_dict.update(self.kwargs)
+        return config_dict

--- a/tests/auto/test_bidirectional_rnn.py
+++ b/tests/auto/test_bidirectional_rnn.py
@@ -8,22 +8,28 @@ from keras.layers.recurrent import LSTM, GRU, JZS1, Bidirectional
 
 class TestBidirectionalRNN(unittest.TestCase):
     def setUp(self):
-        more_ones = np.array([
-            [1, 0, 1, 1],
-            [0, 1, 1, 1]
+        # positive sequences contain the symbol '2'
+        positive_sequences = np.array([
+            [1, 0, 2, 1],
+            [0, 2, 1, 1],
+            [2, 0, 0, 0],
+            [1, 1, 1, 2],
         ])
-        more_zeros = np.array([
+        # negative sequence examples don't contain the symbol '2'
+        negative_sequences = np.array([
             [0, 0, 1, 0],
-            [0, 1, 0, 0]
+            [0, 1, 1, 1],
+            [0, 0, 0, 0],
+            [1, 1, 1, 1]
         ])
-        self.X = np.concatenate([more_ones, more_zeros])
-        self.Y = np.array([1, 1, 0, 0])
+        self.X = np.concatenate([positive_sequences, negative_sequences])
+        self.Y = np.array([1] * len(positive_sequences) + [0] * len(negative_sequences))
 
     def _make_bidirectional_model(self, rnn_class):
         model = Sequential()
-        model.add(Embedding(2, 2))
-        model.add(Bidirectional(rnn_class, input_dim=2, output_dim=5))
-        model.add(Dense(5, 1))
+        model.add(Embedding(3, 3))
+        model.add(Bidirectional(rnn_class, input_dim=3, output_dim=5))
+        model.add(Dense(10, 1))
         model.add(Activation("sigmoid"))
         model.compile("rmsprop", loss="mse")
         return model
@@ -31,17 +37,21 @@ class TestBidirectionalRNN(unittest.TestCase):
     def test_bidirectional_lstm(self):
         model = self._make_bidirectional_model(LSTM)
         model.fit(self.X, self.Y)
-        self.assertTrue(((model.predict(self.X) > 0.5) == self.Y).all())
+        for pred, y in zip(model.predict(self.X), self.Y):
+            self.assertEqual(pred > 0.5, y)
 
     def test_bidirectional_gru(self):
         model = self._make_bidirectional_model(GRU)
-        model.fit(self.X, self.Y)
-        self.assertTrue(((model.predict(self.X) > 0.5) == self.Y).all())
+        model.fit(self.X, self.Y, verbose=0)
+        for pred, y in zip(model.predict(self.X), self.Y):
+            self.assertEqual(pred > 0.5, y)
 
     def test_bidrectional_jzs1(self):
         model = self._make_bidirectional_model(JZS1)
-        model.fit(self.X, self.Y)
-        self.assertTrue(((model.predict(self.X) > 0.5) == self.Y).all())
+        model.fit(self.X, self.Y, verbose=0)
+        for pred, y in zip(model.predict(self.X), self.Y):
+            self.assertEqual(pred > 0.5, y)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/auto/test_bidirectional_rnn.py
+++ b/tests/auto/test_bidirectional_rnn.py
@@ -1,0 +1,47 @@
+import unittest
+import numpy as np
+from keras.models import Sequential
+from keras.layers.core import Dense, Activation
+from keras.layers.embeddings import Embedding
+from keras.layers.recurrent import LSTM, GRU, JZS1, Bidirectional
+
+
+class TestBidirectionalRNN(unittest.TestCase):
+    def setUp(self):
+        more_ones = np.array([
+            [1, 0, 1, 1],
+            [0, 1, 1, 1]
+        ])
+        more_zeros = np.array([
+            [0, 0, 1, 0],
+            [0, 1, 0, 0]
+        ])
+        self.X = np.concatenate([more_ones, more_zeros])
+        self.Y = np.array([1, 1, 0, 0])
+
+    def _make_bidirectional_model(self, rnn_class):
+        model = Sequential()
+        model.add(Embedding(2, 2))
+        model.add(Bidirectional(rnn_class, input_dim=2, output_dim=5))
+        model.add(Dense(5, 1))
+        model.add(Activation("sigmoid"))
+        model.compile("rmsprop", loss="mse")
+        return model
+
+    def test_bidirectional_lstm(self):
+        model = self._make_bidirectional_model(LSTM)
+        model.fit(self.X, self.Y)
+        self.assertTrue(((model.predict(self.X) > 0.5) == self.Y).all())
+
+    def test_bidirectional_gru(self):
+        model = self._make_bidirectional_model(GRU)
+        model.fit(self.X, self.Y)
+        self.assertTrue(((model.predict(self.X) > 0.5) == self.Y).all())
+
+    def test_bidrectional_jzs1(self):
+        model = self._make_bidirectional_model(JZS1)
+        model.fit(self.X, self.Y)
+        self.assertTrue(((model.predict(self.X) > 0.5) == self.Y).all())
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/auto/test_bidirectional_rnn.py
+++ b/tests/auto/test_bidirectional_rnn.py
@@ -3,7 +3,7 @@ import numpy as np
 from keras.models import Sequential
 from keras.layers.core import Dense, Activation
 from keras.layers.embeddings import Embedding
-from keras.layers.recurrent import LSTM, GRU, JZS1, Bidirectional
+from keras.layers.recurrent import LSTM, Bidirectional
 
 
 class TestBidirectionalRNN(unittest.TestCase):
@@ -28,7 +28,7 @@ class TestBidirectionalRNN(unittest.TestCase):
     def _make_bidirectional_model(self, rnn_class):
         model = Sequential()
         model.add(Embedding(3, 3))
-        model.add(Bidirectional(rnn_class, input_dim=3, output_dim=5))
+        model.add(Bidirectional(rnn_class, input_dim=3, output_dim=10))
         model.add(Dense(10, 1))
         model.add(Activation("sigmoid"))
         model.compile("rmsprop", loss="mse")
@@ -36,22 +36,9 @@ class TestBidirectionalRNN(unittest.TestCase):
 
     def test_bidirectional_lstm(self):
         model = self._make_bidirectional_model(LSTM)
-        model.fit(self.X, self.Y)
-        for pred, y in zip(model.predict(self.X), self.Y):
-            self.assertEqual(pred > 0.5, y)
-
-    def test_bidirectional_gru(self):
-        model = self._make_bidirectional_model(GRU)
         model.fit(self.X, self.Y, verbose=0)
         for pred, y in zip(model.predict(self.X), self.Y):
             self.assertEqual(pred > 0.5, y)
-
-    def test_bidrectional_jzs1(self):
-        model = self._make_bidirectional_model(JZS1)
-        model.fit(self.X, self.Y, verbose=0)
-        for pred, y in zip(model.predict(self.X), self.Y):
-            self.assertEqual(pred > 0.5, y)
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/auto/test_bidirectional_rnn.py
+++ b/tests/auto/test_bidirectional_rnn.py
@@ -5,7 +5,6 @@ from keras.layers.core import Dense, Activation
 from keras.layers.embeddings import Embedding
 from keras.layers.recurrent import LSTM, Bidirectional
 
-
 class TestBidirectionalRNN(unittest.TestCase):
     def setUp(self):
         # positive sequences contain the symbol '2'
@@ -14,31 +13,41 @@ class TestBidirectionalRNN(unittest.TestCase):
             [0, 2, 1, 1],
             [2, 0, 0, 0],
             [1, 1, 1, 2],
+            [2, 2, 2, 2],
+            [2, 2, 1, 1],
+            [1, 1, 2, 1],
+            [1, 2, 2, 0],
+            [2, 0, 2, 0]
         ])
         # negative sequence examples don't contain the symbol '2'
         negative_sequences = np.array([
             [0, 0, 1, 0],
             [0, 1, 1, 1],
             [0, 0, 0, 0],
-            [1, 1, 1, 1]
+            [1, 1, 1, 1],
+            [0, 1, 0, 1],
+            [0, 0, 0, 1],
         ])
-        self.X = np.concatenate([positive_sequences, negative_sequences])
-        self.Y = np.array([1] * len(positive_sequences) + [0] * len(negative_sequences))
+        self.X = np.concatenate([negative_sequences, positive_sequences])
+        self.Y = np.array([0] * len(negative_sequences) + [1] * len(positive_sequences))
 
     def _make_bidirectional_model(self, rnn_class):
         model = Sequential()
-        model.add(Embedding(3, 3))
-        model.add(Bidirectional(rnn_class, input_dim=3, output_dim=10))
-        model.add(Dense(10, 1))
+        model.add(Embedding(3, 2))
+        model.add(Bidirectional(rnn_class, input_dim=2, output_dim=4))
+        model.add(Dense(4, 1))
         model.add(Activation("sigmoid"))
-        model.compile("rmsprop", loss="mse")
+        model.compile("rmsprop", loss="binary_crossentropy")
         return model
 
     def test_bidirectional_lstm(self):
         model = self._make_bidirectional_model(LSTM)
-        model.fit(self.X, self.Y, verbose=0)
+        model.fit(self.X, self.Y, verbose=1, nb_epoch=1000)
         for pred, y in zip(model.predict(self.X), self.Y):
-            self.assertEqual(pred > 0.5, y)
+            self.assertEqual(pred > 0.5, y,
+                "Wrong prediction by Bidirectional(LSTM), expected %s0.5 but got %s" % (
+                    ">" if y else "<=",
+                    pred))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This is an implementation of bidirectional RNNs using the `go_backwards` suggestion from https://github.com/fchollet/keras/issues/418. 

* Added a `go_backwards` parameter to every RNN class, which is then passed to `theano.scan`

* Added a layer called `recurrent.Bidirectional`, which is parameterized by an RNN class as well arguments to pass to that RNN class when creating forward and backward instances of it. One choice I'm not sure was the best: the `output_dim` of a `Bidirectional` layer is the sum of the output dims of the forward and backward models (and thus each model gets a hidden state of size `output_dim // 2`). 

* Added a unit test which trains a bidrectional LSTM on a trivial task (detecting whether a character is present or absent in a small set of sequences). 

* Changed the IMDB LSTM example to use a bidirectional LSTM

This is my first attempt at a contribution to Keras and I'm not sure if I implemented enough (or too many) of the methods needed to make a fully functioning Layer, any and all tips & feedback very welcome. 