### PR TITLE
Fix AutoEncoder

### DIFF
--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -512,11 +512,9 @@ class AutoEncoder(Layer):
         self.constraints = []
         for layer in [self.encoder, self.decoder]:
             params, regularizers, constraints = layer.get_params()
+            self.params += params
+            self.regularizers += regularizers
             self.constraints += constraints
-            for p, r in zip(params, regularizers):
-                if p not in self.params:
-                    self.params.append(p)
-                    self.regularizers.append(r)
 
         if weights is not None:
             self.set_weights(weights)


### PR DESCRIPTION
Looks like AutoEncoder got out-of-synch with other changes.

AutoEncoder __init()__ assumed both encoder and decode have same number
of parameters and regularizers; this is not the case when using default
Dense encoder/decoder in current revision of Keras for instance.