### PR TITLE
Added filter_size option for Convolution2D and tests of this new feature

### DIFF
--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -115,7 +115,7 @@ class MaxPooling1D(Layer):
 class Convolution2D(Layer):
     def __init__(self, nb_filter, stack_size, nb_row, nb_col,
                  init='glorot_uniform', activation='linear', weights=None,
-                 border_mode='valid', subsample=(1, 1),
+                 border_mode='valid', subsample=(1, 1),filter_size=[None,None],
                  W_regularizer=None, b_regularizer=None, activity_regularizer=None,
                  W_constraint=None, b_constraint=None):
 
@@ -132,9 +132,17 @@ class Convolution2D(Layer):
 
         self.nb_row = nb_row
         self.nb_col = nb_col
+        
+        self.filter_size=filter_size
+        if len(self.filter_size) != 2:
+            raise Exception('Invalid filter size:', filter_size)
+        if  self.filter_size[0] is None:
+            self.filter_size[0] = self.nb_row
+        if  self.filter_size[1] is None:
+            self.filter_size[1] = self.nb_col
 
         self.input = T.tensor4()
-        self.W_shape = (nb_filter, stack_size, nb_row, nb_col)
+        self.W_shape = (nb_filter, stack_size, self.filter_size[0], self.filter_size[1])
         self.W = self.init(self.W_shape)
         self.b = shared_zeros((nb_filter,))
 

--- a/tests/auto/keras/layers/test_convolution2d_filter_size.py
+++ b/tests/auto/keras/layers/test_convolution2d_filter_size.py
@@ -1,0 +1,119 @@
+
+# coding: utf-8
+
+# In[1]:
+
+#import sys
+#sys.path.append("./")
+
+
+# In[29]:
+
+from __future__ import absolute_import
+from keras.layers.convolutional import Convolution2D
+from keras.models import Sequential
+import numpy as np
+import unittest
+
+class TestFilterSizeConvolution2D(unittest.TestCase):
+    def test_shape_default_valid(self):
+
+        d = 4
+        depth = 1
+        nfilter = 2
+        model = Sequential()
+        model.add(Convolution2D(nfilter, depth, d, d, border_mode='valid')) 
+        model.compile(loss='mean_squared_error', optimizer="rmsprop")
+        I = np.ones([d,d])
+        I = np.array([[I]])
+        #print I.shape
+        R = model.predict(I)
+        assert(R.shape == (1,2,1,1))
+
+    def test_shape_default_full(self):
+
+        d = 4
+        depth = 1
+        nfilter = 2
+        model = Sequential()
+        model.add(Convolution2D(nfilter, depth, d, d, border_mode='full')) 
+        model.compile(loss='mean_squared_error', optimizer="rmsprop")
+        I = np.ones([d,d])
+        I = np.array([[I]])
+        #print I.shape
+        R = model.predict(I)
+        assert(R.shape == (1,2,2*d-1,2*d-1))
+
+    def test_shape_default_same(self):
+
+        d = 4
+        depth = 1
+        nfilter = 2
+        model = Sequential()
+        model.add(Convolution2D(nfilter, depth, d, d, border_mode='same')) 
+        model.compile(loss='mean_squared_error', optimizer="rmsprop")
+        I = np.ones([d,d])
+        I = np.array([[I]])
+        #print I.shape
+        R = model.predict(I)
+        #print R.shape
+        assert(R.shape == (1,2,d,d))
+
+
+    def test_shape_filter_size_valid(self):
+
+        d = 4
+        depth = 1
+        nfilter = 2
+        model = Sequential()
+        model.add(Convolution2D(nfilter, depth, d, d, border_mode='valid',filter_size=[2,2])) 
+        model.compile(loss='mean_squared_error', optimizer="rmsprop")
+        I = np.ones([d,d])
+        I = np.array([[I]])
+        #print I.shape
+        R = model.predict(I)
+        #print R.shape
+        #print R
+        assert(R.shape == (1,2,3,3))
+
+    def test_shape_filter_size_full(self):
+
+        d = 4
+        depth = 1
+        nfilter = 2
+        sfilter=2
+        model = Sequential()
+        model.add(Convolution2D(nfilter, depth, d, d, border_mode='full',filter_size=[sfilter,sfilter])) 
+        model.compile(loss='mean_squared_error', optimizer="rmsprop")
+        I = np.ones([d,d])
+        I = np.array([[I]])
+        #print I.shape
+        R = model.predict(I)
+        #print R.shape
+        assert(R.shape == (1,2,d+sfilter-1,d+sfilter-1))
+
+    def test_shape_filter_size_same(self):
+
+        d = 4
+        depth = 1
+        nfilter = 2
+        sfilter=2
+        model = Sequential()
+        model.add(Convolution2D(nfilter, depth, d, d, border_mode='same',filter_size=[sfilter,sfilter]))
+        model.compile(loss='mean_squared_error', optimizer="rmsprop")
+        I = np.ones([d,d])
+        I = np.array([[I]])
+        #print I.shape
+        R = model.predict(I)
+        #print R.shape
+        assert(R.shape == (1,2,d,d))
+
+if __name__ == "__main__":
+    print('Test Filter size')
+    unittest.main()
+
+
+# In[ ]:
+
+
+


### PR DESCRIPTION
Added a filter_size option to Convolution2D
By default [None,None] it keeps the filter_size to nb_row,nb_col,
but now you can specify a different filter size.

The filter size option can be understood there:

http://cs231n.github.io/convolutional-networks/