### PR TITLE
Added Poisson Loss as an objective

### DIFF
--- a/keras/objectives.py
+++ b/keras/objectives.py
@@ -49,6 +49,9 @@ def binary_crossentropy(y_true, y_pred):
     bce = T.nnet.binary_crossentropy(y_pred, y_true).mean(axis=-1)
     return bce
 
+def poisson_loss(y_true, y_pred):
+    return T.mean(y_pred - y_true * T.log(y_pred), axis=-1)
+
 # aliases
 mse = MSE = mean_squared_error
 mae = MAE = mean_absolute_error


### PR DESCRIPTION
I added Poisson loss as an objective. The Poisson loss is the negative log likelihood of data y_true given predictions y_pred, according to a Poisson model (assumes that y_pred > 0). Thus, the loss function is given by y_pred - y_true * log(y_pred).

This loss is typically used in computational neuroscience, when predicting the probability that a neuron will fire. Should be used after a softplus activation, to ensure that y_pred > 0. Often more useful in computational models of cells than the usual cross entropy loss as Poisson loss more heavily penalizes the model for predicting a spike during long periods of cell inactivity, than cross entropy would.

This complements PR https://github.com/fchollet/keras/pull/422.