### PR TITLE
data_utils: add error handling on url fetches

### DIFF
--- a/keras/datasets/data_utils.py
+++ b/keras/datasets/data_utils.py
@@ -2,10 +2,13 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import tarfile, inspect, os
-from six.moves.urllib.request import urlretrieve
+from six.moves.urllib.request import FancyURLopener
 
 from ..utils.generic_utils import Progbar
 
+class ParanoidURLopener(FancyURLopener):
+  def http_error_default(self, url, fp, errcode, errmsg, headers):
+    raise Exception('URL fetch failure on {}: {} -- {}'.format(url, errcode, errmsg))
 
 def get_file(fname, origin, untar=False):
     datadir = os.path.expanduser(os.path.join('~', '.keras', 'datasets'))
@@ -33,7 +36,7 @@ def get_file(fname, origin, untar=False):
             else:
                 progbar.update(count*block_size)
 
-        urlretrieve(origin, fpath, dl_progress)
+        ParanoidURLopener().retrieve(origin, fpath, dl_progress)
         progbar = None
 
     if untar:


### PR DESCRIPTION
urlretrieve will blindly swallow any 4xx and 5xx responses
and then save the html error response in the local file. This
is probably exactly what we don't want, because not only will
the program crash if there is a network hiccup when the error
file cannot be opened, but it will continue to do so when rerun
until the corrupt cached file is found and manually removed.

Luckily, urlretrieve is just a thin wrapper around
FancyURLopener, so we can make our own thin wrapper
that throws an exception instead of caching the
wrong file.

Tested to be working as before when running cached and
uncached datasets, and also verified to fail loudly
when asked to fetch http://httpstat.us/500