### PR TITLE
Make docs compile on the mac

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,9 +1,9 @@
 site_name: Keras Documentation
-#theme: readthedocs
+theme: readthedocs
 docs_dir: sources
 repo_url: http://github.com/fchollet/keras
 site_url: http://keras.io/
-theme_dir: theme
+#theme_dir: theme
 site_description: Documentation for fast and lightweight Keras Deep Learning library.
 
 dev_addr: '0.0.0.0:8000'


### PR DESCRIPTION
So on my mac when I try to build the docs with "mkdocs" I get the following error

    ERROR   -  Config value: 'theme_dir'. Error: The path theme doesn't exist 

This fixes it for me. Is there a reason that it was the way it was? Does mkdocs work differently on Linux or something? I'm running mkdocs 0.14.0.