### PR TITLE
Raise error if both class_weight and sample_weight given

### DIFF
--- a/keras/models.py
+++ b/keras/models.py
@@ -74,6 +74,8 @@ def weighted_objective(fn):
 
 
 def standardize_weights(y, sample_weight=None, class_weight=None):
+    if sample_weight is not None and class_weight is not None:
+        raise Exception("Can't specify both a sample_weight and a class_weight, pick one")
     if sample_weight is not None:
         return standardize_y(sample_weight)
     elif isinstance(class_weight, dict):


### PR DESCRIPTION
The behaviour previously was to silently ignore class_weight, at least
now you get an error.

An alternative: since class_weight is always given as a dictionary, and sample_weight is always given as a matrix, we could overload the single parameter: if you pass it a dictionary it behaves as class weighting, if you pass it an ndarray it behaves as sample weighting. What do you think of this?