### PR TITLE
Fix conv layers loading for model_from_config

### DIFF
--- a/keras/utils/layer_utils.py
+++ b/keras/utils/layer_utils.py
@@ -7,6 +7,7 @@ import copy
 from ..layers.advanced_activations import LeakyReLU, PReLU
 from ..layers.core import Dense, Merge, Dropout, Activation, Reshape, Flatten, RepeatVector, Layer
 from ..layers.core import ActivityRegularization, TimeDistributedDense, AutoEncoder, MaxoutDense
+from ..layers.convolutional import Convolution1D, Convolution2D, MaxPooling1D, MaxPooling2D, ZeroPadding2D
 from ..layers.embeddings import Embedding, WordContextProduct
 from ..layers.noise import GaussianNoise, GaussianDropout
 from ..layers.normalization import BatchNormalization


### PR DESCRIPTION
Recently, I tried to save my model using model.to_yaml() and then load it via keras.models.model_from_yaml(). However, I got an "Invalid layer: Convolution2D" Exception.
I found this is due to the global namespace of keras.utils.layer_utils misses all the layer classes in keras.layers.convolutional. Thus, saving and loading any model with layers from keras.layers.convolutional will trigger the "Invalid layer" exception.
The line in this PR fixed this problem.