### PR TITLE
Recent update broke HDF5Matrix

### DIFF
--- a/keras/utils/io_utils.py
+++ b/keras/utils/io_utils.py
@@ -5,8 +5,7 @@ from collections import defaultdict
 
 
 class HDF5Matrix():
-    def __init__(self):
-        self.refs = defaultdict(int)
+    refs = defaultdict(int)
 
     def __init__(self, datapath, dataset, start, end, normalizer=None):
         if datapath not in list(self.refs.keys()):


### PR DESCRIPTION
`refs` is a class attribute, not an instance attribute. If we make `refs` an instance attribute, this will cause `HDF5Matrix` to open the same HDF5 file more than once (which should never happen).