### PR TITLE
Fix weight mask interaction in objectives

### DIFF
--- a/keras/models.py
+++ b/keras/models.py
@@ -82,7 +82,6 @@ def weighted_objective(fn):
             # We assume the time index to be masked is axis=1
             filtered_mask = mask[weights.nonzero()[:-1]]
             wc = filtered_weights * obj_output
-            wc = wc.reshape(filtered_mask.shape)
             # Divide by mask.sum() here not filtered_mask.sum() since otherwise interactions
             # between sample_weight and masks cause issues.
             wc = wc.sum() / mask.sum()

--- a/keras/models.py
+++ b/keras/models.py
@@ -84,8 +84,7 @@ def weighted_objective(fn):
             wc = filtered_weights * obj_output
             # Divide by mask.sum() here not filtered_mask.sum() since otherwise interactions
             # between sample_weight and masks cause issues.
-            wc = wc.sum() / mask.sum()
-            return wc.mean()
+            return (wc * filtered_mask).sum() / (filtered_mask * filtered_weights).sum()
     return weighted
 
 

--- a/keras/models.py
+++ b/keras/models.py
@@ -75,16 +75,13 @@ def weighted_objective(fn):
         filtered_y_pred = y_pred[weights.nonzero()[:-1]]
         filtered_weights = weights[weights.nonzero()]
         obj_output = fn(filtered_y_true, filtered_y_pred)
+        weighted = filtered_weights * obj_output
         if mask is None:
             # Instead of calling mean() here, we divide by the sum of filtered_weights.
-            return (filtered_weights.flatten() * obj_output.flatten()).sum() / filtered_weights.sum()
+            return weighted.sum() / filtered_weights.sum()
         else:
-            # We assume the time index to be masked is axis=1
             filtered_mask = mask[weights.nonzero()[:-1]]
-            wc = filtered_weights * obj_output
-            # Divide by mask.sum() here not filtered_mask.sum() since otherwise interactions
-            # between sample_weight and masks cause issues.
-            return (wc * filtered_mask).sum() / (filtered_mask * filtered_weights).sum()
+            return weighted.sum() / (filtered_mask * filtered_weights).sum()
     return weighted
 
 

--- a/tests/auto/test_loss_masking.py
+++ b/tests/auto/test_loss_masking.py
@@ -1,7 +1,9 @@
 import numpy as np
 import unittest
-from keras.models import Sequential
+from keras.models import Sequential, weighted_objective
 from keras.layers.core import TimeDistributedDense, Masking
+from keras import objectives
+import theano
 
 
 class TestLossMasking(unittest.TestCase):
@@ -16,6 +18,25 @@ class TestLossMasking(unittest.TestCase):
         y = model.predict(X)
         loss = model.fit(X, 4*y, nb_epoch=1, batch_size=2, verbose=1).history['loss'][0]
         assert loss == 282.375
+
+    def test_loss_masking_time(self):
+        theano.config.mode = 'FAST_COMPILE'
+        weighted_loss = weighted_objective(objectives.get('categorical_crossentropy'))
+        shape = (3, 4, 2)
+        X = np.arange(24).reshape(shape)
+        Y = 2*X
+
+        weights = np.ones((3, 4, 1)) # Normally the trailing 1 is added by standardize_weights
+        weights[0,0] = 0
+        mask = np.ones((3, 4))
+        mask[1,0] = 0
+
+        out = weighted_loss(X, Y, weights, mask).eval()
+        weights[0,0] = 1e-9 # so that nonzero() doesn't remove this weight
+        out2 = weighted_loss(X, Y, weights, mask).eval()
+        print(out)
+        print(out2)
+        assert abs(out-out2) < 1e-8
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
We used nonzero() on the weights in order to ensure that if there
happened to be a NaN or an Inf in the output that was going to be masked
about by the weights anyway, it wouldn't propagate (because 0*inf = NaN)
however this was causing interaction issues if you also used a mask,
because that wasn't using nonzero() properly.

This fixes that, and also fixes what I believe was an issue where I was
calling mean() instead of dividing by the sum of the sample weights.

Please think about this carefully: getting the normalization across both forms of weights right is a bit subtle, and I screwed up a number of times before creating this PR. I *think* it's right now though.