### PR TITLE
support for multiple files in ModelCheckpoint

### DIFF
--- a/docs/sources/callbacks.md
+++ b/docs/sources/callbacks.md
@@ -33,7 +33,10 @@ The `logs` dictionary will contain keys for quantities relevant to the current b
 keras.callbacks.ModelCheckpoint(filepath, verbose=0, save_best_only=False)
 ```
 
-Save the model after every epoch. If `save_best_only=True`, the latest best model according to the validation loss will not be overwritten. 
+Save the model after every epoch. If `save_best_only=True`, the latest best model according to the validation loss will not be overwritten.
+`filepath` can contain named formatting options, which will be filled the value of `epoch` and keys in `logs` (passed in `on_epoch_end`).
+
+For example: if `filepath` is `weights.{epoch:02d}-{val_loss:.2f}.hdf5`, then multiple files will be save with the epoch number and the validation loss.
 
 
 ```python

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -182,6 +182,7 @@ class ModelCheckpoint(Callback):
         self.best = np.Inf
 
     def on_epoch_end(self, epoch, logs={}):
+        filepath = self.filepath.format(epoch=epoch, **logs)
         if self.save_best_only:
             current = logs.get(self.monitor)
             if current is None:
@@ -190,16 +191,16 @@ class ModelCheckpoint(Callback):
                 if current < self.best:
                     if self.verbose > 0:
                         print("Epoch %05d: %s improved from %0.5f to %0.5f, saving model to %s"
-                              % (epoch, self.monitor, self.best, current, self.filepath))
+                              % (epoch, self.monitor, self.best, current, filepath))
                     self.best = current
-                    self.model.save_weights(self.filepath, overwrite=True)
+                    self.model.save_weights(filepath, overwrite=True)
                 else:
                     if self.verbose > 0:
                         print("Epoch %05d: %s did not improve" % (epoch, self.monitor))
         else:
             if self.verbose > 0:
-                print("Epoch %05d: saving model to %s" % (epoch, self.filepath))
-            self.model.save_weights(self.filepath, overwrite=True)
+                print("Epoch %05d: saving model to %s" % (epoch, filepath))
+            self.model.save_weights(filepath, overwrite=True)
 
 
 class EarlyStopping(Callback):

--- a/tests/manual/check_callbacks.py
+++ b/tests/manual/check_callbacks.py
@@ -215,12 +215,22 @@ print("Test model checkpointer without validation data")
 import warnings
 warnings.filterwarnings('error')
 try:
+    passed = False
     # this should issue a warning
     model.fit(X_train, Y_train, batch_size=batch_size, nb_epoch=nb_epoch, show_accuracy=True, verbose=0, callbacks =[checkpointer])
 except:
-    print("Tests passed")
-    import sys
-    sys.exit(0)
+    passed = True
+if not passed:
+    raise Exception("Modelcheckpoint tests did not pass")
 
-raise Exception("Modelcheckpoint tests did not pass")
+print("Test model checkpointer with pattern")
+filename = "model_weights.{epoch:04d}.hdf5"
+f = os.path.join(path, filename)
+nb_epoch = 3
+checkpointer = cbks.ModelCheckpoint(f)
+model.fit(X_train, Y_train, batch_size=batch_size, nb_epoch=nb_epoch, verbose=0, callbacks=[checkpointer])
+for i in range(nb_epoch):
+    if not os.path.isfile(f.format(epoch=i)):
+        raise Exception("Model weights were not saved separately for each epoch")
 
+print("Tests passed")


### PR DESCRIPTION
enable string formatted filenames (e.g. weights.{epoch:02d}.hdf5), so
every epoch will be saved to a different file without overwriting.

Signed-off-by: Amit Beka <amit.beka@gmail.com>