### PR TITLE
Removing magic numbers from MNIST and CIFAR10

### DIFF
--- a/examples/cifar10_cnn.py
+++ b/examples/cifar10_cnn.py
@@ -28,6 +28,17 @@ nb_classes = 10
 nb_epoch = 200
 data_augmentation = True
 
+# shape of the image (SHAPE x SHAPE)
+shapex, shapey = 32, 32
+# number of convolutional filters to use at each layer
+nb_filters = [32, 64]
+# level of pooling to perform at each layer (POOL x POOL)
+nb_pool = [2, 2]
+# level of convolution to perform at each layer (CONV x CONV)
+nb_conv = [3, 3]
+# the CIFAR10 images are RGB
+image_dimensions = 3
+
 # the data, shuffled and split between tran and test sets
 (X_train, y_train), (X_test, y_test) = cifar10.load_data()
 print('X_train shape:', X_train.shape)
@@ -40,22 +51,24 @@ Y_test = np_utils.to_categorical(y_test, nb_classes)
 
 model = Sequential()
 
-model.add(Convolution2D(32, 3, 3, 3, border_mode='full'))
+model.add(Convolution2D(nb_filters[0], image_dimensions, nb_conv[0], nb_conv[0], border_mode='full'))
 model.add(Activation('relu'))
-model.add(Convolution2D(32, 32, 3, 3))
+model.add(Convolution2D(nb_filters[0], nb_filters[0], nb_conv[0], nb_conv[0]))
 model.add(Activation('relu'))
-model.add(MaxPooling2D(poolsize=(2, 2)))
+model.add(MaxPooling2D(poolsize=(nb_pool[0], nb_pool[0])))
 model.add(Dropout(0.25))
 
-model.add(Convolution2D(64, 32, 3, 3, border_mode='full'))
+model.add(Convolution2D(nb_filters[1], nb_filters[0], nb_conv[0], nb_conv[0], border_mode='full'))
 model.add(Activation('relu'))
-model.add(Convolution2D(64, 64, 3, 3))
+model.add(Convolution2D(nb_filters[1], nb_filters[1], nb_conv[1], nb_conv[1]))
 model.add(Activation('relu'))
-model.add(MaxPooling2D(poolsize=(2, 2)))
+model.add(MaxPooling2D(poolsize=(nb_pool[1], nb_pool[1])))
 model.add(Dropout(0.25))
 
 model.add(Flatten())
-model.add(Dense(64*8*8, 512))
+# the image dimensions are the original dimensions divided by any pooling
+# each pixel has a number of filters, determined by the last Convolution2D layer
+model.add(Dense(nb_filters[-1] * (shapex / nb_pool[0] / nb_pool[1]) * (shapey / nb_pool[0] / nb_pool[1]), 512))
 model.add(Activation('relu'))
 model.add(Dropout(0.5))
 

--- a/examples/mnist_cnn.py
+++ b/examples/mnist_cnn.py
@@ -22,11 +22,20 @@ batch_size = 128
 nb_classes = 10
 nb_epoch = 12
 
+# shape of the image (SHAPE x SHAPE)
+shapex, shapey = 28, 28
+# number of convolutional filters to use
+nb_filters = 32
+# level of pooling to perform (POOL x POOL)
+nb_pool = 2
+# level of convolution to perform (CONV x CONV)
+nb_conv = 3
+
 # the data, shuffled and split between tran and test sets
 (X_train, y_train), (X_test, y_test) = mnist.load_data()
 
-X_train = X_train.reshape(X_train.shape[0], 1, 28, 28)
-X_test = X_test.reshape(X_test.shape[0], 1, 28, 28)
+X_train = X_train.reshape(X_train.shape[0], 1, shapex, shapey)
+X_test = X_test.reshape(X_test.shape[0], 1, shapex, shapey)
 X_train = X_train.astype("float32")
 X_test = X_test.astype("float32")
 X_train /= 255
@@ -41,15 +50,18 @@ Y_test = np_utils.to_categorical(y_test, nb_classes)
 
 model = Sequential()
 
-model.add(Convolution2D(32, 1, 3, 3, border_mode='full'))
+model.add(Convolution2D(nb_filters, 1, nb_conv, nb_conv, border_mode='full'))
 model.add(Activation('relu'))
-model.add(Convolution2D(32, 32, 3, 3))
+model.add(Convolution2D(nb_filters, nb_filters, nb_conv, nb_conv))
 model.add(Activation('relu'))
-model.add(MaxPooling2D(poolsize=(2, 2)))
+model.add(MaxPooling2D(poolsize=(nb_pool, nb_pool)))
 model.add(Dropout(0.25))
 
 model.add(Flatten())
-model.add(Dense(32*196, 128))
+# the resulting image after conv and pooling is the original shape
+# divided by the pooling with a number of filters for each "pixel"
+# (the number of filters is determined by the last Conv2D)
+model.add(Dense(nb_filters * (shapex / nb_pool) * (shapey / nb_pool), 128))
 model.add(Activation('relu'))
 model.add(Dropout(0.5))
 


### PR DESCRIPTION
This code is my proposal for closing #469. Magic numbers are removed from both MNIST and CIFAR10. CIFAR10 also features a reasonably intuitive approach to handling multiple layers with various pooling / filter sizes. I've tried following the general convention for variables and comments as set forth by other examples.

Note: It'd be a good idea to add a subsample / stride example in the near future as there are no tests / examples of that within Keras and it's non-trivial but that's likely a separate issue. I've still not gotten subsampling to work in my code for the [Right Whale Recognition](https://www.kaggle.com/c/noaa-right-whale-recognition) Kaggle competition, where the high image resolution almost demands it.