### PR TITLE
Parameter names

### DIFF
--- a/keras/initializations.py
+++ b/keras/initializations.py
@@ -12,52 +12,53 @@ def get_fans(shape):
     return fan_in, fan_out
 
 
-def uniform(shape, scale=0.05):
-    return sharedX(np.random.uniform(low=-scale, high=scale, size=shape))
+def uniform(shape, scale=0.05, name=None):
+    return sharedX(np.random.uniform(low=-scale, high=scale, size=shape),
+                   name=name)
 
 
-def normal(shape, scale=0.05):
-    return sharedX(np.random.randn(*shape) * scale)
+def normal(shape, scale=0.05, name=None):
+    return sharedX(np.random.randn(*shape) * scale, name=name)
 
 
-def lecun_uniform(shape):
+def lecun_uniform(shape, name=None):
     ''' Reference: LeCun 98, Efficient Backprop
         http://yann.lecun.com/exdb/publis/pdf/lecun-98b.pdf
     '''
     fan_in, fan_out = get_fans(shape)
     scale = np.sqrt(3. / fan_in)
-    return uniform(shape, scale)
+    return uniform(shape, scale, name=name)
 
 
-def glorot_normal(shape):
+def glorot_normal(shape, name=None):
     ''' Reference: Glorot & Bengio, AISTATS 2010
     '''
     fan_in, fan_out = get_fans(shape)
     s = np.sqrt(2. / (fan_in + fan_out))
-    return normal(shape, s)
+    return normal(shape, s, name=name)
 
 
-def glorot_uniform(shape):
+def glorot_uniform(shape, name=None):
     fan_in, fan_out = get_fans(shape)
     s = np.sqrt(6. / (fan_in + fan_out))
-    return uniform(shape, s)
+    return uniform(shape, s, name=name)
 
 
-def he_normal(shape):
+def he_normal(shape, name=None):
     ''' Reference:  He et al., http://arxiv.org/abs/1502.01852
     '''
     fan_in, fan_out = get_fans(shape)
     s = np.sqrt(2. / fan_in)
-    return normal(shape, s)
+    return normal(shape, s, name=name)
 
 
-def he_uniform(shape):
+def he_uniform(shape, name=None):
     fan_in, fan_out = get_fans(shape)
     s = np.sqrt(6. / fan_in)
-    return uniform(shape, s)
+    return uniform(shape, s, name=name)
 
 
-def orthogonal(shape, scale=1.1):
+def orthogonal(shape, scale=1.1, name=None):
     ''' From Lasagne
     '''
     flat_shape = (shape[0], np.prod(shape[1:]))
@@ -66,22 +67,22 @@ def orthogonal(shape, scale=1.1):
     # pick the one with the correct shape
     q = u if u.shape == flat_shape else v
     q = q.reshape(shape)
-    return sharedX(scale * q[:shape[0], :shape[1]])
+    return sharedX(scale * q[:shape[0], :shape[1]], name=name)
 
 
-def identity(shape, scale=1):
+def identity(shape, scale=1, name=None):
     if len(shape) != 2 or shape[0] != shape[1]:
         raise Exception("Identity matrix initialization can only be used for 2D square matrices")
     else:
-        return sharedX(scale * np.identity(shape[0]))
+        return sharedX(scale * np.identity(shape[0]), name=name)
 
 
-def zero(shape):
-    return shared_zeros(shape)
+def zero(shape, name=None):
+    return shared_zeros(shape, name=name)
 
 
-def one(shape):
-    return shared_ones(shape)
+def one(shape, name=None):
+    return shared_ones(shape, name=name)
 
 
 from .utils.generic_utils import get_from_module

--- a/keras/layers/advanced_activations.py
+++ b/keras/layers/advanced_activations.py
@@ -28,7 +28,7 @@ class PReLU(MaskedLayer):
     def __init__(self, input_shape, init='zero', weights=None):
         super(PReLU, self).__init__()
         self.init = initializations.get(init)
-        self.alphas = self.init(input_shape)
+        self.alphas = self.init(input_shape, name="alphas")
         self.params = [self.alphas]
         self.input_shape = input_shape
 
@@ -60,8 +60,8 @@ class ParametricSoftplus(MaskedLayer):
         super(ParametricSoftplus, self).__init__()
         self.alpha_init = alpha_init
         self.beta_init = beta_init
-        self.alphas = sharedX(alpha_init * np.ones(input_shape))
-        self.betas = sharedX(beta_init * np.ones(input_shape))
+        self.alphas = sharedX(alpha_init * np.ones(input_shape), name="alphas")
+        self.betas = sharedX(beta_init * np.ones(input_shape), name="betas")
         self.params = [self.alphas, self.betas]
         self.input_shape = input_shape
 

--- a/keras/layers/containers.py
+++ b/keras/layers/containers.py
@@ -19,6 +19,7 @@ class Sequential(Layer):
     '''
 
     def __init__(self, layers=[]):
+        super(Sequential, self).__init__()
         self.layers = []
         self.params = []
         self.regularizers = []
@@ -44,6 +45,10 @@ class Sequential(Layer):
         self.regularizers += regularizers
         self.constraints += constraints
         self.updates += updates
+
+        if layer.name is None or (layer.name == type(layer).__name__):
+            name = 'Layer%d_%s' % (len(self.layers), type(layer).__name__)
+            layer.set_name(name)
 
     def get_output(self, train=False):
         return self.layers[-1].get_output(train)
@@ -98,6 +103,7 @@ class Graph(Layer):
             - set_weights
     '''
     def __init__(self):
+        super(Graph, self).__init__()
         self.namespace = set()  # strings
         self.nodes = {}  # layer-like
         self.inputs = {}  # layer-like

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -14,6 +14,7 @@ class Convolution1D(Layer):
     def __init__(self, input_dim, nb_filter, filter_length,
                  init='uniform', activation='linear', weights=None,
                  border_mode='valid', subsample_length=1,
+                 name=None,
                  W_regularizer=None, b_regularizer=None, activity_regularizer=None,
                  W_constraint=None, b_constraint=None):
 
@@ -32,8 +33,8 @@ class Convolution1D(Layer):
 
         self.input = T.tensor3()
         self.W_shape = (nb_filter, input_dim, filter_length, 1)
-        self.W = self.init(self.W_shape)
-        self.b = shared_zeros((nb_filter,))
+        self.W = self.init(self.W_shape, name="W")
+        self.b = shared_zeros((nb_filter,), name="b")
 
         self.params = [self.W, self.b]
 
@@ -60,6 +61,10 @@ class Convolution1D(Layer):
 
         if weights is not None:
             self.set_weights(weights)
+
+        if name is not None:
+            self.set_name(name)
+
 
     def get_output(self, train):
         X = self.get_input(train)
@@ -98,6 +103,7 @@ class Convolution2D(Layer):
     def __init__(self, nb_filter, stack_size, nb_row, nb_col,
                  init='glorot_uniform', activation='linear', weights=None,
                  border_mode='valid', subsample=(1, 1),
+                 name=None,
                  W_regularizer=None, b_regularizer=None, activity_regularizer=None,
                  W_constraint=None, b_constraint=None):
 
@@ -117,8 +123,8 @@ class Convolution2D(Layer):
 
         self.input = T.tensor4()
         self.W_shape = (nb_filter, stack_size, nb_row, nb_col)
-        self.W = self.init(self.W_shape)
-        self.b = shared_zeros((nb_filter,))
+        self.W = self.init(self.W_shape, name="W")
+        self.b = shared_zeros((nb_filter,), name="b")
 
         self.params = [self.W, self.b]
 
@@ -145,6 +151,9 @@ class Convolution2D(Layer):
 
         if weights is not None:
             self.set_weights(weights)
+
+        if name is not None:
+            self.set_name(name)
 
     def get_output(self, train):
         X = self.get_input(train)

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -62,8 +62,7 @@ class Convolution1D(Layer):
         if weights is not None:
             self.set_weights(weights)
 
-        if name is not None:
-            self.set_name(name)
+        self.set_name(name)
 
 
     def get_output(self, train):
@@ -152,8 +151,8 @@ class Convolution2D(Layer):
         if weights is not None:
             self.set_weights(weights)
 
-        if name is not None:
-            self.set_name(name)
+        self.set_name(name)
+
 
     def get_output(self, train):
         X = self.get_input(train)

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -17,6 +17,7 @@ from six.moves import zip
 class Layer(object):
     def __init__(self):
         self.params = []
+        self.name = None
 
     def init_updates(self):
         self.updates = []
@@ -109,11 +110,19 @@ class Layer(object):
     def set_name(self, name=None):
         if name is None:
             name = self.__class__.__name__
-        for i, p in enumerate(self.params):
-            if p is None:
-                p.name = '%s_p%d' % (name, i)
-            else:
-                p.name = '%s_%s' % (name, p.name)
+        if self.name is not None:
+            # if already set, we only need to replace the prefix
+            old_name_len = len(self.name)
+            for p in self.params:
+                p.name = name + p.name[old_name_len:]
+        else: # first time we same the layer name
+            self.name = name
+            # we set all parameter names
+            for i, p in enumerate(self.params):
+                if p is None:
+                    p.name = '%s_p%d' % (name, i)
+                else:
+                    p.name = '%s_%s' % (name, p.name)
         return
 
 class MaskedLayer(Layer):
@@ -409,12 +418,8 @@ class Dense(Layer):
         if weights is not None:
             self.set_weights(weights)
 
-        if name is not None:
-            self.set_name(name)
+        self.set_name(name)
 
-    def set_name(self, name):
-        self.W.name = '%s_W' % name
-        self.b.name = '%s_b' % name
 
     def get_output(self, train=False):
         X = self.get_input(train)

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -179,6 +179,7 @@ class Merge(Layer):
         ''' Merge the output of a list of layers or containers into a single tensor.
             mode: {'sum', 'mul', 'concat'}
         '''
+        super(Merge, self).__init__()
         if len(layers) < 2:
             raise Exception("Please specify two or more input layers (or containers) to merge")
         self.mode = mode

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -106,10 +106,15 @@ class Layer(object):
 
         return self.params, regularizers, consts, updates
 
-    def set_name(self, name):
-        for i in range(len(self.params)):
-            self.params[i].name = '%s_p%d' % (name, i)
-
+    def set_name(self, name=None):
+        if name is None:
+            name = self.__class__.__name__
+        for i, p in enumerate(self.params):
+            if p is None:
+                p.name = '%s_p%d' % (name, i)
+            else:
+                p.name = '%s_%s' % (name, p.name)
+        return
 
 class MaskedLayer(Layer):
     '''
@@ -371,8 +376,8 @@ class Dense(Layer):
         self.output_dim = output_dim
 
         self.input = T.matrix()
-        self.W = self.init((self.input_dim, self.output_dim))
-        self.b = shared_zeros((self.output_dim))
+        self.W = self.init((self.input_dim, self.output_dim), name="W")
+        self.b = shared_zeros((self.output_dim), name="b")
 
         self.params = [self.W, self.b]
 
@@ -466,8 +471,8 @@ class TimeDistributedDense(MaskedLayer):
         self.output_dim = output_dim
 
         self.input = T.tensor3()
-        self.W = self.init((self.input_dim, self.output_dim))
-        self.b = shared_zeros((self.output_dim))
+        self.W = self.init((self.input_dim, self.output_dim), name="W")
+        self.b = shared_zeros((self.output_dim), name="b")
 
         self.params = [self.W, self.b]
 
@@ -598,8 +603,8 @@ class MaxoutDense(Layer):
         self.nb_feature = nb_feature
 
         self.input = T.matrix()
-        self.W = self.init((self.nb_feature, self.input_dim, self.output_dim))
-        self.b = shared_zeros((self.nb_feature, self.output_dim))
+        self.W = self.init((self.nb_feature, self.input_dim, self.output_dim), name="W")
+        self.b = shared_zeros((self.nb_feature, self.output_dim), name="b")
 
         self.params = [self.W, self.b]
 

--- a/keras/layers/embeddings.py
+++ b/keras/layers/embeddings.py
@@ -27,7 +27,7 @@ class Embedding(Layer):
         self.output_dim = output_dim
 
         self.input = T.imatrix()
-        self.W = self.init((self.input_dim, self.output_dim))
+        self.W = self.init((self.input_dim, self.output_dim), name="W")
         self.mask_zero = mask_zero
 
         self.params = [self.W]
@@ -108,8 +108,8 @@ class WordContextProduct(Layer):
         self.input = T.imatrix()
         # two different embeddings for pivot word and its context
         # because p(w|c) != p(c|w)
-        self.W_w = self.init((input_dim, proj_dim))
-        self.W_c = self.init((input_dim, proj_dim))
+        self.W_w = self.init((input_dim, proj_dim), name="W_w")
+        self.W_c = self.init((input_dim, proj_dim), name="W_c")
 
         self.params = [self.W_w, self.W_c]
 

--- a/keras/layers/normalization.py
+++ b/keras/layers/normalization.py
@@ -25,8 +25,8 @@ class BatchNormalization(Layer):
         self.momentum = momentum
         self.input = ndim_tensor(len(self.input_shape) + 1)
 
-        self.gamma = self.init((self.input_shape))
-        self.beta = shared_zeros(self.input_shape)
+        self.gamma = self.init((self.input_shape), name="gamma")
+        self.beta = shared_zeros(self.input_shape, name="beta")
 
         self.params = [self.gamma, self.beta]
         if weights is not None:

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -56,9 +56,9 @@ class SimpleRNN(Recurrent):
         self.return_sequences = return_sequences
         self.input = T.tensor3()
 
-        self.W = self.init((self.input_dim, self.output_dim))
-        self.U = self.inner_init((self.output_dim, self.output_dim))
-        self.b = shared_zeros((self.output_dim))
+        self.W = self.init((self.input_dim, self.output_dim), name="W")
+        self.U = self.inner_init((self.output_dim, self.output_dim), name="U")
+        self.b = shared_zeros((self.output_dim), name="b")
         self.params = [self.W, self.U, self.b]
 
         if weights is not None:
@@ -132,9 +132,11 @@ class SimpleDeepRNN(Recurrent):
         self.return_sequences = return_sequences
         self.input = T.tensor3()
 
-        self.W = self.init((self.input_dim, self.output_dim))
-        self.Us = [self.inner_init((self.output_dim, self.output_dim)) for _ in range(self.depth)]
-        self.b = shared_zeros((self.output_dim))
+        self.W = self.init((self.input_dim, self.output_dim), name="W")
+        self.Us = [self.inner_init((self.output_dim, self.output_dim),
+                                   name="Us%i" % d)
+                   for d in range(self.depth)]
+        self.b = shared_zeros((self.output_dim), name="b")
         self.params = [self.W] + self.Us + [self.b]
 
         if weights is not None:
@@ -231,17 +233,17 @@ class GRU(Recurrent):
         self.inner_activation = activations.get(inner_activation)
         self.input = T.tensor3()
 
-        self.W_z = self.init((self.input_dim, self.output_dim))
-        self.U_z = self.inner_init((self.output_dim, self.output_dim))
-        self.b_z = shared_zeros((self.output_dim))
+        self.W_z = self.init((self.input_dim, self.output_dim), name="W_z")
+        self.U_z = self.inner_init((self.output_dim, self.output_dim), name="U_z")
+        self.b_z = shared_zeros((self.output_dim), name="b_z")
 
-        self.W_r = self.init((self.input_dim, self.output_dim))
-        self.U_r = self.inner_init((self.output_dim, self.output_dim))
-        self.b_r = shared_zeros((self.output_dim))
+        self.W_r = self.init((self.input_dim, self.output_dim), name="W_r")
+        self.U_r = self.inner_init((self.output_dim, self.output_dim), name="U_r")
+        self.b_r = shared_zeros((self.output_dim), name="b_r")
 
-        self.W_h = self.init((self.input_dim, self.output_dim))
-        self.U_h = self.inner_init((self.output_dim, self.output_dim))
-        self.b_h = shared_zeros((self.output_dim))
+        self.W_h = self.init((self.input_dim, self.output_dim), name="W_h")
+        self.U_h = self.inner_init((self.output_dim, self.output_dim), name="U_h")
+        self.b_h = shared_zeros((self.output_dim), name="b_h")
 
         self.params = [
             self.W_z, self.U_z, self.b_z,
@@ -337,21 +339,21 @@ class LSTM(Recurrent):
         self.inner_activation = activations.get(inner_activation)
         self.input = T.tensor3()
 
-        self.W_i = self.init((self.input_dim, self.output_dim))
-        self.U_i = self.inner_init((self.output_dim, self.output_dim))
-        self.b_i = shared_zeros((self.output_dim))
+        self.W_i = self.init((self.input_dim, self.output_dim), name="W_i")
+        self.U_i = self.inner_init((self.output_dim, self.output_dim), name="U_i")
+        self.b_i = shared_zeros((self.output_dim), name="b_i")
 
-        self.W_f = self.init((self.input_dim, self.output_dim))
-        self.U_f = self.inner_init((self.output_dim, self.output_dim))
-        self.b_f = self.forget_bias_init((self.output_dim))
+        self.W_f = self.init((self.input_dim, self.output_dim), name="W_f")
+        self.U_f = self.inner_init((self.output_dim, self.output_dim), name="U_f")
+        self.b_f = self.forget_bias_init((self.output_dim), name="b_f")
 
-        self.W_c = self.init((self.input_dim, self.output_dim))
-        self.U_c = self.inner_init((self.output_dim, self.output_dim))
-        self.b_c = shared_zeros((self.output_dim))
+        self.W_c = self.init((self.input_dim, self.output_dim), name="W_c")
+        self.U_c = self.inner_init((self.output_dim, self.output_dim), name="U_c")
+        self.b_c = shared_zeros((self.output_dim), name="b_c")
 
-        self.W_o = self.init((self.input_dim, self.output_dim))
-        self.U_o = self.inner_init((self.output_dim, self.output_dim))
-        self.b_o = shared_zeros((self.output_dim))
+        self.W_o = self.init((self.input_dim, self.output_dim), name="W_o")
+        self.U_o = self.inner_init((self.output_dim, self.output_dim), name="U_o")
+        self.b_o = shared_zeros((self.output_dim), name="b_o")
 
         self.params = [
             self.W_i, self.U_i, self.b_i,
@@ -451,15 +453,15 @@ class JZS1(Recurrent):
         self.inner_activation = activations.get(inner_activation)
         self.input = T.tensor3()
 
-        self.W_z = self.init((self.input_dim, self.output_dim))
-        self.b_z = shared_zeros((self.output_dim))
+        self.W_z = self.init((self.input_dim, self.output_dim), name="W_z")
+        self.b_z = shared_zeros((self.output_dim), name="b_z")
 
-        self.W_r = self.init((self.input_dim, self.output_dim))
-        self.U_r = self.inner_init((self.output_dim, self.output_dim))
-        self.b_r = shared_zeros((self.output_dim))
+        self.W_r = self.init((self.input_dim, self.output_dim), name="W_r")
+        self.U_r = self.inner_init((self.output_dim, self.output_dim), name="U_r")
+        self.b_r = shared_zeros((self.output_dim), name="b_r")
 
-        self.U_h = self.inner_init((self.output_dim, self.output_dim))
-        self.b_h = shared_zeros((self.output_dim))
+        self.U_h = self.inner_init((self.output_dim, self.output_dim), name="U_h")
+        self.b_h = shared_zeros((self.output_dim), name="b_h")
 
         # P_h used to project X onto different dimension, using sparse random projections
         if self.input_dim == self.output_dim:
@@ -556,16 +558,16 @@ class JZS2(Recurrent):
         self.inner_activation = activations.get(inner_activation)
         self.input = T.tensor3()
 
-        self.W_z = self.init((self.input_dim, self.output_dim))
-        self.U_z = self.inner_init((self.output_dim, self.output_dim))
-        self.b_z = shared_zeros((self.output_dim))
+        self.W_z = self.init((self.input_dim, self.output_dim), name="W_z")
+        self.U_z = self.inner_init((self.output_dim, self.output_dim), name="U_z")
+        self.b_z = shared_zeros((self.output_dim), name="b_z")
 
-        self.U_r = self.inner_init((self.output_dim, self.output_dim))
-        self.b_r = shared_zeros((self.output_dim))
+        self.U_r = self.inner_init((self.output_dim, self.output_dim), name="U_r")
+        self.b_r = shared_zeros((self.output_dim), name="b_r")
 
-        self.W_h = self.init((self.input_dim, self.output_dim))
-        self.U_h = self.inner_init((self.output_dim, self.output_dim))
-        self.b_h = shared_zeros((self.output_dim))
+        self.W_h = self.init((self.input_dim, self.output_dim), name="W_h")
+        self.U_h = self.inner_init((self.output_dim, self.output_dim), name="U_h")
+        self.b_h = shared_zeros((self.output_dim), name="b_h")
 
         # P_h used to project X onto different dimension, using sparse random projections
         if self.input_dim == self.output_dim:
@@ -662,17 +664,17 @@ class JZS3(Recurrent):
         self.inner_activation = activations.get(inner_activation)
         self.input = T.tensor3()
 
-        self.W_z = self.init((self.input_dim, self.output_dim))
-        self.U_z = self.inner_init((self.output_dim, self.output_dim))
-        self.b_z = shared_zeros((self.output_dim))
+        self.W_z = self.init((self.input_dim, self.output_dim), name="W_z")
+        self.U_z = self.inner_init((self.output_dim, self.output_dim), name="U_z")
+        self.b_z = shared_zeros((self.output_dim), name="b_z")
 
-        self.W_r = self.init((self.input_dim, self.output_dim))
-        self.U_r = self.inner_init((self.output_dim, self.output_dim))
-        self.b_r = shared_zeros((self.output_dim))
+        self.W_r = self.init((self.input_dim, self.output_dim), name="W_r")
+        self.U_r = self.inner_init((self.output_dim, self.output_dim), name="U_r")
+        self.b_r = shared_zeros((self.output_dim), name="b_r")
 
-        self.W_h = self.init((self.input_dim, self.output_dim))
-        self.U_h = self.inner_init((self.output_dim, self.output_dim))
-        self.b_h = shared_zeros((self.output_dim))
+        self.W_h = self.init((self.input_dim, self.output_dim), name="W_h")
+        self.U_h = self.inner_init((self.output_dim, self.output_dim), name="U_h")
+        self.b_h = shared_zeros((self.output_dim), name="b_h")
 
         self.params = [
             self.W_z, self.U_z, self.b_z,

--- a/tests/manual/check_parameter_names.py
+++ b/tests/manual/check_parameter_names.py
@@ -49,6 +49,8 @@ class TestParameterNames(unittest.TestCase):
         model = Sequential()
         model.add(Dense(10, 512))
         model.add(Activation('relu'))
+        model.add(Convolution2D(32, 32, 32, 32))
+        model.add(Activation('relu'))
         model.add(Dense(512, 2))
         model.add(Activation('softmax'))
 

--- a/tests/manual/check_parameter_names.py
+++ b/tests/manual/check_parameter_names.py
@@ -43,8 +43,8 @@ class TestParameterNames(unittest.TestCase):
         print_model_parameter_names(seq)
         return
 
-    def test_defaults(self):
-        print("\nTesting default parameter names")
+    def test_sequential_defaults(self):
+        print("\nTesting default parameter names (for sequential model)")
 
         model = Sequential()
         model.add(Dense(10, 512))
@@ -56,6 +56,20 @@ class TestParameterNames(unittest.TestCase):
 
         print_model_parameter_names(model)
         return
+
+    def test_graph_defaults(self):
+        print("\nTesting default parameter names (for graph model)")
+
+        graph = Graph()
+        graph.add_input(name='input1', ndim=2)
+        graph.add_node(Dense(32, 16), name='dense1', input='input1')
+        graph.add_node(Dense(32, 4), name='dense2', input='input1')
+        graph.add_node(Dense(16, 4), name='dense3', input='dense1')
+        graph.add_output(name='output1', inputs=['dense2', 'dense3'], merge_mode='sum')
+
+        print_model_parameter_names(graph)
+        return
+
 
     def test_mix(self):
         print("\nTesting when some nodes have names, and others do not")
@@ -79,6 +93,7 @@ class TestParameterNames(unittest.TestCase):
 
 if __name__ == "__main__":
     t = TestParameterNames()
-    t.test_defaults()
+    t.test_sequential_defaults()
+    t.test_graph_defaults()
     t.test_named_nodes()
     t.test_mix()

--- a/tests/manual/check_parameter_names.py
+++ b/tests/manual/check_parameter_names.py
@@ -1,0 +1,82 @@
+
+
+from __future__ import print_function
+import unittest
+import numpy as np
+np.random.seed(1337)
+
+from keras.models import Graph, Sequential
+from keras.layers import containers
+from keras.layers.core import Dense, Activation
+from keras.layers.convolutional import Convolution1D, Convolution2D
+
+
+def print_model_parameter_names(model):
+
+    assert type(model) in [Graph, Sequential]
+
+    for p in model.params:
+        print(p.name)
+        # all parameters should be named
+        assert p.name is not None and p.name != ""
+
+    return
+
+
+class TestParameterNames(unittest.TestCase):
+
+
+    def test_named_nodes(self):
+        print("\nTesting when all nodes are named")
+        graph = containers.Graph()
+        graph.add_input(name='input1', ndim=2)
+        graph.add_node(Dense(32, 16), name='dense1', input='input1')
+        graph.add_node(Dense(32, 4), name='dense2', input='input1')
+        graph.add_node(Dense(16, 4), name='dense3', input='dense1')
+        graph.add_output(name='output1', inputs=['dense2', 'dense3'], merge_mode='sum')
+
+        seq = Sequential()
+        seq.add(Dense(32, 32, name='first_seq_dense'))
+        seq.add(graph)
+        seq.add(Dense(4, 4, name='last_seq_dense'))
+
+        print_model_parameter_names(seq)
+        return
+
+    def test_defaults(self):
+        print("\nTesting default parameter names")
+
+        model = Sequential()
+        model.add(Dense(10, 512))
+        model.add(Activation('relu'))
+        model.add(Dense(512, 2))
+        model.add(Activation('softmax'))
+
+        print_model_parameter_names(model)
+        return
+
+    def test_mix(self):
+        print("\nTesting when some nodes have names, and others do not")
+        graph = containers.Graph()
+        graph.add_input(name='input1', ndim=2)
+        graph.add_node(Dense(32, 16), name='dense1', input='input1')
+        graph.add_node(Dense(32, 4), name='dense2', input='input1')
+        graph.add_node(Dense(16, 4), name='dense3', input='dense1')
+        graph.add_output(name='output1', inputs=['dense2', 'dense3'], merge_mode='sum')
+
+        seq = Sequential()
+        seq.add(Dense(32, 32, name='first_seq_sense'))
+        seq.add(Dense(32, 32, name=None))
+        seq.add(Convolution2D(32, 32, 32, 32, name=None))
+        seq.add(graph)
+        seq.add(Dense(4, 4, name='last_seq_dense'))
+
+        print_model_parameter_names(seq)
+        return
+
+
+if __name__ == "__main__":
+    t = TestParameterNames()
+    t.test_defaults()
+    t.test_named_nodes()
+    t.test_mix()


### PR DESCRIPTION
Address issue #635, now each layer can have a name, or a default one will be assigned.

```
python3.4 check_parameter_names.py 

Testing default parameter names (for sequential model)
Layer1_Dense_W
Layer1_Dense_b
Layer3_Convolution2D_W
Layer3_Convolution2D_b
Layer5_Dense_W
Layer5_Dense_b

Testing default parameter names (for graph model)
dense1_W
dense1_b
dense2_W
dense2_b
dense3_W
dense3_b

Testing when all nodes are named
first_seq_dense_W
first_seq_dense_b
Layer2_Graph_dense1_W
Layer2_Graph_dense1_b
Layer2_Graph_dense2_W
Layer2_Graph_dense2_b
Layer2_Graph_dense3_W
Layer2_Graph_dense3_b
last_seq_dense_W
last_seq_dense_b

Testing when some nodes have names, and others do not
first_seq_sense_W
first_seq_sense_b
Layer2_Dense_W
Layer2_Dense_b
Layer3_Convolution2D_W
Layer3_Convolution2D_b
Layer4_Graph_dense1_W
Layer4_Graph_dense1_b
Layer4_Graph_dense2_W
Layer4_Graph_dense2_b
Layer4_Graph_dense3_W
Layer4_Graph_dense3_b
last_seq_dense_W
last_seq_dense_b
```

up to code review, this pull request seems good to merge on my side.