### PR TITLE
Deep Averaging Networks

### DIFF
--- a/examples/imdb_dan.py
+++ b/examples/imdb_dan.py
@@ -28,7 +28,8 @@ from keras.datasets import imdb
     - Parameters are not optimized in any way -- I just used a fixed number for the embedding
     and hidden dimension
 
-    This model achieves 0.8340 test accuracy after 3 epochs.
+    This model achieves 0.8344 test accuracy after 3 epochs, and takes 4 seconds per epoch
+    on a Titan X GPU.
 '''
 
 max_features = 20000

--- a/examples/imdb_dan.py
+++ b/examples/imdb_dan.py
@@ -21,11 +21,14 @@ from keras.datasets import imdb
     Notes:
 
     - Deep averaging networks are can be thought of as a drop-in for recurrent neural networks
-    - In the paper, dropout was applied at the word level; that's not done here.
+    - In the paper, dropout was applied at the word level; that's not done here. I just added dropout
+    in the fully connected layers. This could be fixed later. 
     - The sequence of characters doesn't matter, so it's pretty surprising that something like
     this does well.
     - Parameters are not optimized in any way -- I just used a fixed number for the embedding
     and hidden dimension
+
+    This model achieves 0.8340 test accuracy after 3 epochs.
 '''
 
 max_features = 20000
@@ -48,9 +51,12 @@ model = Sequential()
 model.add(Embedding(max_features, 300))
 model.add(TimeDistributedMerge(mode='ave'))
 model.add(Dense(300, 300, activation = 'relu'))
+model.add(Dropout(.5))
 model.add(Dense(300, 300, activation = 'relu'))
+model.add(Dropout(.5))
 model.add(Dense(300, 300, activation = 'relu'))
-model.add(Dense(300, 300, activation = 'sigmoid'))
+model.add(Dropout(.5))
+model.add(Dense(300, 1, activation = 'sigmoid'))
 
 # try using different optimizers and different optimizer configs
 model.compile(loss='binary_crossentropy', optimizer='adagrad', class_mode="binary")

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -159,11 +159,41 @@ class Masking(MaskedLayer):
         return {"name": self.__class__.__name__,
                 "mask_value": self.mask_value}
 
+class TimeDistributedMerge(Layer):
+    def __init__(self, mode='sum'):
+        '''
+        Sum/multiply/avearge over a time distributed layer's outputs.
+        mode: {'sum', 'mul', 'ave'}
+        Tensor input dimensions:   (nb_sample, shared_dimension, input_dim)
+        Tensor output dimensions:  (nb_sample, output_dim)
+        '''
+        self.mode = mode
+        self.params = []
+        self.regularizers = []
+        self.constraints = []
+        self.updates = []
+
+    def get_output(self, train=False):
+        X = self.get_input(train)
+        if self.mode == 'sum' or self.mode == 'ave':
+            s = theano.tensor.sum(X, axis=1)
+            if self.mode == 'ave':
+                s /= X.shape[1]
+            return s
+        elif self.mode == 'mul':
+            s = theano.tensor.mul(X, axis=1)
+            return s
+        else:
+            raise Exception('Unknown merge mode')
+
+    def get_config(self):
+        return {"name": self.__class__.__name__,
+                "mode": self.mode}
 
 class Merge(Layer):
     def __init__(self, layers, mode='sum'):
         ''' Merge the output of a list of layers or containers into a single tensor.
-            mode: {'sum', 'mul', 'concat'}
+            mode: {'sum', 'mul', 'concat', 'ave'}
         '''
         if len(layers) < 2:
             raise Exception("Please specify two or more input layers (or containers) to merge")
@@ -191,6 +221,12 @@ class Merge(Layer):
             s = self.layers[0].get_output(train)
             for i in range(1, len(self.layers)):
                 s += self.layers[i].get_output(train)
+            return s
+        elif self.mode == 'ave':
+            s = self.layers[0].get_output(train)
+            for i in range(1, len(self.layers)):
+                s += self.layers[i].get_output(train)
+            s /= len(self.layers)
             return s
         elif self.mode == 'concat':
             inputs = [self.layers[i].get_output(train) for i in range(len(self.layers))]


### PR DESCRIPTION
Added a new layer "TimeDistributedMerge" which is capable of merging time distributed outputs. Previously, the merge layer could only merge named layers, which is problematic if you want to implement something like the "Deep Averaging Network" which is detailed here:

http://cs.umd.edu/~miyyer/pubs/2015_acl_dan.pdf

This implementation of the deep averaging network outperforms the imdb cnn/lstm by a bit, and only takes 4 seconsd to train per epoch on a titan X GPU.

Sorry if there are formatting issues, this is the first time I have made a PR for keras .