### PR TITLE
Remove h5py requirement and made it optional.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,5 +10,8 @@ setup(name='Keras',
       url='https://github.com/fchollet/keras',
       download_url='https://github.com/fchollet/keras/tarball/0.1.2',
       license='MIT',
-      install_requires=['theano', 'pyyaml', 'h5py'],
+      install_requires=['theano', 'pyyaml'],
+      extras_require = {
+          'h5py': ['h5py'],
+      },
       packages=find_packages())


### PR DESCRIPTION
Keras documentation says `h5py` is optional, but a recent commit 1ebec1e515bac4c4c4564a410c2de3ee33bb8a1e made it a requirement. Because there are problems installing `h5py` inside a virtualenv, I would suggest that it remains optional.

This fix uses the extras option to specify optional dependencies. Usage:

```bash
pip install 'package[h5py]'
```