### PR TITLE
Add merge_mode join

### DIFF
--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -5,6 +5,8 @@ import theano
 import theano.tensor as T
 import numpy as np
 
+from collections import OrderedDict
+
 from .. import activations, initializations, regularizers, constraints
 from ..utils.theano_utils import shared_zeros, floatX
 from ..utils.generic_utils import make_tuple
@@ -197,7 +199,9 @@ class Merge(Layer):
             inputs = [self.layers[i].get_output(train) for i in range(len(self.layers))]
             return T.concatenate(inputs, axis=self.concat_axis)
         elif self.mode == 'join':
-            inputs = [self.layers[i].get_output(train) for i in range(len(self.layers))]
+            inputs = OrderedDict()
+            for i in range(len(self.layers)):
+                inputs[self.layers[i].get_output(train).name] = self.layers[i].get_output(train)
             return inputs
         elif self.mode == 'mul':
             s = self.layers[0].get_output(train)

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -203,10 +203,11 @@ class Merge(Layer):
         elif self.mode == 'join':
             inputs = OrderedDict()
             for i in range(len(self.layers)):
+                X = self.layers[i].get_output(train)
                 if X.name is None:
-                    raise ValueError('merge_mode=`join` only works with named inputs')
+                    raise ValueError("merge_mode='join' only works with named inputs")
                 else:
-                    inputs[self.layers[i].get_output(train).name] = self.layers[i].get_output(train)
+                    inputs[X.name] = self.layers[i].get_output(train)
             return inputs
         elif self.mode == 'mul':
             s = self.layers[0].get_output(train)

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -196,6 +196,9 @@ class Merge(Layer):
         elif self.mode == 'concat':
             inputs = [self.layers[i].get_output(train) for i in range(len(self.layers))]
             return T.concatenate(inputs, axis=self.concat_axis)
+        elif self.mode == 'join':
+            inputs = [self.layers[i].get_output(train) for i in range(len(self.layers))]
+            return inputs
         elif self.mode == 'mul':
             s = self.layers[0].get_output(train)
             for i in range(1, len(self.layers)):

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -203,7 +203,10 @@ class Merge(Layer):
         elif self.mode == 'join':
             inputs = OrderedDict()
             for i in range(len(self.layers)):
-                inputs[self.layers[i].get_output(train).name] = self.layers[i].get_output(train)
+                if X.name is None:
+                    raise ValueError('merge_mode=`join` only works with named inputs')
+                else:
+                    inputs[self.layers[i].get_output(train).name] = self.layers[i].get_output(train)
             return inputs
         elif self.mode == 'mul':
             s = self.layers[0].get_output(train)


### PR DESCRIPTION
Some advanced models are made easier with this simple addition. It does not break anything, just add an extra option to Merge layers. This option allows it to work with layers that get several inputs separately.
For example, I'm writing a DRAW model using Keras and I believe this is the only non-standard thing that the model would require to run with Keras out of the box.