### PR TITLE
added caltech101 dataset and example

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,23 @@
-The MIT License (MIT)
+COPYRIGHT
 
-Copyright (c) 2015 
+All contributions by François Chollet:
+Copyright (c) 2015, François Chollet.
+All rights reserved.
+
+All contributions by Google:
+Copyright (c) 2015, Google, Inc.
+All rights reserved.
+
+All other contributions:
+Copyright (c) 2015, the respective contributors.
+All rights reserved.
+
+Each contributor holds copyright over their respective contributions.
+The project versioning (Git) records all such contribution source information.
+
+LICENSE
+
+The MIT License (MIT)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -218,6 +218,11 @@ Keras uses the following dependencies:
 - HDF5 and h5py (optional, required if you use model saving/loading functions)
 - Optional but recommended if you use CNNs: cuDNN.
 
+**Note**: You should use the latest version of Theano, not the PyPI version. Install it with:
+```
+sudo pip install git+git://github.com/Theano/Theano.git
+```
+
 To install, `cd` to the Keras folder and run the install command:
 ```
 sudo python setup.py install

--- a/docs/sources/index.md
+++ b/docs/sources/index.md
@@ -99,6 +99,11 @@ Keras uses the following dependencies:
 - __HDF5__ and __h5py__ (optional, required if you use model saving/loading functions)
 - Optional but recommended if you use CNNs: __cuDNN__.
 
+**Note**: You should use the latest version of Theano, not the PyPI version. Install it with:
+```
+sudo pip install git+git://github.com/Theano/Theano.git
+```
+
 Once you have the dependencies installed, clone the repo:
 ```bash
 git clone https://github.com/fchollet/keras.git

--- a/docs/sources/layers/recurrent.md
+++ b/docs/sources/layers/recurrent.md
@@ -2,7 +2,7 @@
 ## SimpleRNN
 
 ```python
-keras.layers.recurrent.SimpleRNN(output_dim, 
+keras.layers.recurrent.SimpleRNN(output_dim,
         init='glorot_uniform', inner_init='orthogonal', activation='sigmoid', weights=None,
         truncate_gradient=-1, return_sequences=False, input_dim=None, input_length=None)
 ```
@@ -56,7 +56,6 @@ Not a particularly useful model, included for demonstration purposes.
 
 
 - __Arguments__:
-    - __input_dim__: dimension of the input.
     - __output_dim__: dimension of the internal projections and the final output.
     - __depth__: int >= 1. Lookback depth (eg. depth=1 is equivalent to SimpleRNN).
     - __init__: weight initialization function for the output cell. Can be the name of an existing function (str), or a Theano function (see: [initializations](../initializations.md)).
@@ -75,7 +74,7 @@ Not a particularly useful model, included for demonstration purposes.
 ## GRU
 
 ```python
-keras.layers.recurrent.GRU(input_dim, output_dim=128, 
+keras.layers.recurrent.GRU(output_dim,
         init='glorot_uniform', inner_init='orthogonal',
         activation='sigmoid', inner_activation='hard_sigmoid',
         weights=None, truncate_gradient=-1, return_sequences=False,
@@ -93,7 +92,6 @@ Gated Recurrent Unit - Cho et al. 2014.
 - __Masking__: This layer supports masking for input data with a variable number of timesteps To introduce masks to your data, use an [Embedding](embeddings.md) layer with the `mask_zero` parameter set to true.
 
 - __Arguments__:
-    - __input_dim__: dimension of the input.
     - __output_dim__: dimension of the internal projections and the final output.
     - __init__: weight initialization function for the output cell. Can be the name of an existing function (str), or a Theano function (see: [initializations](../initializations.md)).
     - __inner_init__: weight initialization function for the inner cells.
@@ -114,7 +112,7 @@ Gated Recurrent Unit - Cho et al. 2014.
 ## LSTM
 
 ```python
-keras.layers.recurrent.LSTM(input_dim, output_dim=128, 
+keras.layers.recurrent.LSTM(output_dim,
         init='glorot_uniform', inner_init='orthogonal', forget_bias_init='one',
         activation='tanh', inner_activation='hard_sigmoid',
         weights=None, truncate_gradient=-1, return_sequences=False,
@@ -132,7 +130,6 @@ Long-Short Term Memory unit - Hochreiter 1997.
 - __Masking__: This layer supports masking for input data with a variable number of timesteps To introduce masks to your data, use an [Embedding](embeddings.md) layer with the `mask_zero` parameter set to true.
 
 - __Arguments__:
-    - __input_dim__: dimension of the input.
     - __output_dim__: dimension of the internal projections and the final output.
     - __init__: weight initialization function for the output cell. Can be the name of an existing function (str), or a Theano function (see: [initializations](../initializations.md)).
     - __inner_init__: weight initialization function for the inner cells.
@@ -155,7 +152,7 @@ Long-Short Term Memory unit - Hochreiter 1997.
 ## JZS1, JZS2, JZS3
 
 ```python
-keras.layers.recurrent.JZS1(input_dim, output_dim=128, 
+keras.layers.recurrent.JZS1(output_dim,
         init='glorot_uniform', inner_init='orthogonal', 
         activation='tanh', inner_activation='sigmoid',
         weights=None, truncate_gradient=-1, return_sequences=False,
@@ -173,7 +170,6 @@ Top 3 RNN architectures evolved from the evaluation of thousands of models. Serv
 - __Masking__: This layer supports masking for input data with a variable number of timesteps To introduce masks to your data, use an [Embedding](embeddings.md) layer with the `mask_zero` parameter set to true.
 
 - __Arguments__:
-    - __input_dim__: dimension of the input.
     - __output_dim__: dimension of the internal projections and the final output.
     - __init__: weight initialization function for the output cell. Can be the name of an existing function (str), or a Theano function (see: [initializations](../initializations.md)).
     - __inner_init__: weight initialization function for the inner cells.

--- a/examples/caltech101_cnn.py
+++ b/examples/caltech101_cnn.py
@@ -1,0 +1,194 @@
+from __future__ import absolute_import
+from __future__ import print_function
+import numpy as np
+
+from keras.datasets import caltech101
+from keras.preprocessing.image import ImageDataGenerator
+from keras.models import Sequential
+from keras.layers.core import Dense, Dropout, Activation, Flatten
+from keras.layers.normalization import LRN2D
+from keras.layers.convolutional import Convolution2D, MaxPooling2D, ZeroPadding2D
+from keras.optimizers import SGD
+from keras.utils import np_utils, generic_utils
+from six.moves import range
+
+import shutil
+import os
+from PIL import Image
+from resizeimage import resizeimage
+
+'''
+    Train a (fairly simple) deep CNN on the Caltech101 images dataset.
+    GPU run command:
+        THEANO_FLAGS=mode=FAST_RUN,device=gpu,floatX=float32 python caltech101_cnn.py
+'''
+
+
+def resize_imgs(fpaths, shapex, shapey, mode='contain', quality=90, verbose=0):
+    resized_fpaths = np.array([])
+
+    tmpdir = os.path.expanduser(os.path.join('~', '.keras', 'datasets', 'tmp'))
+    if os.path.exists(tmpdir):
+        shutil.rmtree(tmpdir)
+
+    os.makedirs(tmpdir)
+
+    try:
+        for i, f in enumerate(fpaths):
+            img = Image.open(f)
+            if mode is 'contain':
+                img = resizeimage.resize_contain(img, [shapex, shapey])
+            elif mode is 'crop':
+                img = resizeimage.resize_crop(img, [shapex, shapey])
+            elif mode is 'cover':
+                img = resizeimage.resize_crop(img, [shapex, shapey])
+            elif mode is 'thumbnail':
+                img = resizeimage.resize_thumbnail(img, [shapex, shapey])
+            elif mode is 'height':
+                img = resizeimage.resize_height(img, shapey)
+
+            _, extension = os.path.splitext(f)
+            out_file = os.path.join(tmpdir, 'resized_img_%05d%s' % (i, extension))
+            resized_fpaths = np.append(resized_fpaths, out_file)
+            img.save(out_file, img.format, quality=quality)
+            if verbose > 0:
+                print("Resizing file : %s" % (f))
+            img.close()
+    except Exception, e:
+        print("Error resize file : %s" % (f))
+
+    return resized_fpaths
+
+
+def load_data(X_path, resize=True, shapex=240, shapey=180, mode='contain', quality=90, verbose=0):
+    if resize:
+        X_path = resize_imgs(X_path, shapex, shapey, mode=mode, quality=quality, verbose=verbose)
+
+    data = np.zeros((X_path.shape[0], 3, shapey, shapex), dtype="uint8")
+
+    for i, f in enumerate(X_path):
+        img = Image.open(f)
+        r, g, b = img.split()
+        data[i, 0, :, :] = np.array(r)
+        data[i, 1, :, :] = np.array(g)
+        data[i, 2, :, :] = np.array(b)
+        img.close()
+
+    return data
+
+# parameters
+batch_size = 4
+nb_classes = 102
+nb_epoch = 10
+data_augmentation = False
+
+shuffle_data = True
+
+# shape of the image (SHAPE x SHAPE)
+shapex, shapey = 240, 180
+
+# the caltech101 images are RGB
+image_dimensions = 3
+
+# load the data, shuffled and split between train and test sets
+print("Loading data...")
+(X_train_path, y_train), (X_test_path, y_test) = caltech101.load_paths(train_imgs_per_category=15,
+                                                                       test_imgs_per_category=3,
+                                                                       shuffle=shuffle_data)
+X_train = load_data(X_train_path, shapex=shapex, shapey=shapey, mode='contain', verbose=1)
+X_test = load_data(X_test_path, shapex=shapex, shapey=shapey, mode='contain', verbose=1)
+print(X_train.shape[0], 'train samples')
+print(X_test.shape[0], 'test samples')
+
+# convert class vectors to binary class matrices
+Y_train = np_utils.to_categorical(y_train, nb_classes)
+Y_test = np_utils.to_categorical(y_test, nb_classes)
+
+# cnn architecture from the CNN-S of http://arxiv.org/abs/1405.3531
+model = Sequential()
+model.add(Convolution2D(96, image_dimensions, 7, 7, subsample=(2, 2)))
+model.add(Activation('relu'))
+model.add(LRN2D(alpha=0.0005, beta=0.75, k=2, n=5))
+model.add(MaxPooling2D(poolsize=(2, 2), stride=(2, 2)))
+
+model.add(Convolution2D(256, 96, 5, 5))
+model.add(Activation('relu'))
+model.add(MaxPooling2D(poolsize=(2, 2), stride=(2, 2)))
+
+model.add(ZeroPadding2D(pad=(1, 1)))
+model.add(Convolution2D(512, 256, 3, 3))
+model.add(Activation('relu'))
+
+model.add(ZeroPadding2D(pad=(1, 1)))
+model.add(Convolution2D(512, 512, 3, 3))
+model.add(Activation('relu'))
+
+model.add(ZeroPadding2D(pad=(1, 1)))
+model.add(Convolution2D(512, 512, 3, 3))
+model.add(Activation('relu'))
+model.add(MaxPooling2D(poolsize=(2, 2), stride=(2, 2)))
+
+model.add(Flatten())
+# the image dimensions are the original dimensions divided by any pooling
+# each pixel has a number of filters, determined by the last Convolution2D layer
+model.add(Dense(59904, 512))
+model.add(Activation('relu'))
+model.add(Dropout(0.5))
+
+model.add(Dense(512, nb_classes))
+model.add(Activation('softmax'))
+
+print('Compiling model...')
+sgd = SGD(lr=0.01, decay=1e-6, momentum=0.9, nesterov=True)
+model.compile(loss='categorical_crossentropy', optimizer=sgd)
+
+if not data_augmentation:
+    print("Not using data augmentation or normalization")
+
+    X_train = X_train.astype("float32")
+    X_test = X_test.astype("float32")
+    X_train /= 255
+    X_test /= 255
+
+    model.fit(X_train, Y_train, batch_size=batch_size, nb_epoch=nb_epoch, show_accuracy=True)
+
+    score = model.evaluate(X_test, Y_test, batch_size=batch_size, show_accuracy=True)
+    print('Test score:', score)
+
+else:
+    print("Using real time data augmentation")
+
+    # this will do preprocessing and realtime data augmentation
+    datagen = ImageDataGenerator(
+        featurewise_center=True,  # set input mean to 0 over the dataset
+        samplewise_center=False,  # set each sample mean to 0
+        featurewise_std_normalization=True,  # divide inputs by std of the dataset
+        samplewise_std_normalization=False,  # divide each input by its std
+        zca_whitening=False,  # apply ZCA whitening
+        rotation_range=20,  # randomly rotate images in the range (degrees, 0 to 180)
+        width_shift_range=0.2,  # randomly shift images horizontally (fraction of total width)
+        height_shift_range=0.2,  # randomly shift images vertically (fraction of total height)
+        horizontal_flip=True,  # randomly flip images
+        vertical_flip=False)  # randomly flip images
+
+    # compute quantities required for featurewise normalization
+    # (std, mean, and principal components if ZCA whitening is applied)
+    datagen.fit(X_train)
+
+    for e in range(nb_epoch):
+        print('-'*40)
+        print('Epoch', e)
+        print('-'*40)
+        print("Training...")
+        # batch train with realtime data augmentation
+        progbar = generic_utils.Progbar(X_train.shape[0])
+        for X_batch, Y_batch in datagen.flow(X_train, Y_train):
+            loss = model.train_on_batch(X_batch, Y_batch)
+            progbar.add(X_batch.shape[0], values=[("train loss", loss)])
+
+        print("Testing...")
+        # test time!
+        progbar = generic_utils.Progbar(X_test.shape[0])
+        for X_batch, Y_batch in datagen.flow(X_test, Y_test):
+            score = model.test_on_batch(X_batch, Y_batch)
+            progbar.add(X_batch.shape[0], values=[("test loss", score)])

--- a/examples/caltech101_cnn.py
+++ b/examples/caltech101_cnn.py
@@ -106,52 +106,50 @@ Y_test = np_utils.to_categorical(y_test, nb_classes)
 
 # cnn architecture from the CNN-S of http://arxiv.org/abs/1405.3531
 model = Sequential()
-model.add(Convolution2D(96, image_dimensions, 7, 7, subsample=(2, 2)))
+model.add(Convolution2D(96, 7, 7, subsample=(2, 2), input_shape=(image_dimensions, shapex, shapey)))
 model.add(Activation('relu'))
 model.add(LRN2D(alpha=0.0005, beta=0.75, k=2, n=5))
-model.add(MaxPooling2D(poolsize=(2, 2), stride=(2, 2)))
+model.add(MaxPooling2D(pool_size=(2, 2), stride=(2, 2)))
 
-model.add(Convolution2D(256, 96, 5, 5))
+model.add(Convolution2D(256, 5, 5))
 model.add(Activation('relu'))
-model.add(MaxPooling2D(poolsize=(2, 2), stride=(2, 2)))
+model.add(MaxPooling2D(pool_size=(2, 2), stride=(2, 2)))
 
-model.add(ZeroPadding2D(pad=(1, 1)))
-model.add(Convolution2D(512, 256, 3, 3))
-model.add(Activation('relu'))
-
-model.add(ZeroPadding2D(pad=(1, 1)))
-model.add(Convolution2D(512, 512, 3, 3))
+model.add(ZeroPadding2D(padding=(1, 1)))
+model.add(Convolution2D(512, 3, 3))
 model.add(Activation('relu'))
 
-model.add(ZeroPadding2D(pad=(1, 1)))
-model.add(Convolution2D(512, 512, 3, 3))
+model.add(ZeroPadding2D(padding=(1, 1)))
+model.add(Convolution2D(512, 3, 3))
 model.add(Activation('relu'))
-model.add(MaxPooling2D(poolsize=(2, 2), stride=(2, 2)))
+
+model.add(ZeroPadding2D(padding=(1, 1)))
+model.add(Convolution2D(512, 3, 3))
+model.add(Activation('relu'))
+model.add(MaxPooling2D(pool_size=(2, 2), stride=(2, 2)))
 
 model.add(Flatten())
 # the image dimensions are the original dimensions divided by any pooling
 # each pixel has a number of filters, determined by the last Convolution2D layer
-model.add(Dense(59904, 512))
+model.add(Dense(512))
 model.add(Activation('relu'))
 model.add(Dropout(0.5))
 
-model.add(Dense(512, nb_classes))
+model.add(Dense(nb_classes))
 model.add(Activation('softmax'))
 
 print('Compiling model...')
 sgd = SGD(lr=0.01, decay=1e-6, momentum=0.9, nesterov=True)
 model.compile(loss='categorical_crossentropy', optimizer=sgd)
 
+X_train = X_train.astype("float32")
+X_test = X_test.astype("float32")
+X_train /= 255
+X_test /= 255
+
 if not data_augmentation:
     print("Not using data augmentation or normalization")
-
-    X_train = X_train.astype("float32")
-    X_test = X_test.astype("float32")
-    X_train /= 255
-    X_test /= 255
-
     model.fit(X_train, Y_train, batch_size=batch_size, nb_epoch=nb_epoch, show_accuracy=True)
-
     score = model.evaluate(X_test, Y_test, batch_size=batch_size, show_accuracy=True)
     print('Test score:', score)
 

--- a/keras/datasets/caltech101.py
+++ b/keras/datasets/caltech101.py
@@ -1,0 +1,50 @@
+from __future__ import absolute_import
+from .data_utils import get_file
+import numpy as np
+import os
+
+
+def load_paths(train_imgs_per_category=15, test_imgs_per_category=15, shuffle=True):
+    dirname = "101_ObjectCategories"
+    origin = "http://www.vision.caltech.edu/Image_Datasets/Caltech101/101_ObjectCategories.tar.gz"
+    path = get_file(dirname, origin=origin, untar=True)
+
+    X_train = np.array([])
+    y_train = np.array([])
+
+    X_test = np.array([])
+    y_test = np.array([])
+
+    # directories are the labels
+    labels = sorted([d for d in os.listdir(path)])
+
+    # loop over all subdirs
+    for i, label in enumerate(labels):
+        label_dir = os.path.join(path, label)
+        fpaths = np.array([os.path.join(label_dir, img_fname) for img_fname in os.listdir(label_dir)])
+
+        np.random.shuffle(fpaths)
+        if train_imgs_per_category + test_imgs_per_category > len(fpaths):
+            print("not enough samples for label " + label)
+
+        X_train = np.append(X_train, fpaths[:train_imgs_per_category])
+        y_train = np.append(y_train, [i for x in range(train_imgs_per_category)])
+
+        X_test = np.append(X_test, fpaths[train_imgs_per_category:train_imgs_per_category+test_imgs_per_category])
+        y_test = np.append(y_test, [i for x in range(test_imgs_per_category)])
+
+    # shuffle/permutation
+    if shuffle:
+        # shuffle training data
+        shuffle_index_training = np.arange(X_train.shape[0])
+        np.random.shuffle(shuffle_index_training)
+        X_train = X_train[shuffle_index_training]
+        y_train = y_train[shuffle_index_training]
+
+        # shuffle test data
+        shuffle_index_test = np.arange(X_test.shape[0])
+        np.random.shuffle(shuffle_index_test)
+        X_test = X_test[shuffle_index_test]
+        y_test = y_test[shuffle_index_test]
+
+    return (X_train, y_train), (X_test, y_test)


### PR DESCRIPTION
keras.datasets.caltech101.load_paths() downloads and extracts the Caltech101 dataset, splits it into train / test set and returns the paths to the images in the train / tests as well as the according labels. Clients have to crop / scale the images themselves; an implementation in examples/caltech101_cnn.py is provided.