### PR TITLE
Bugfix/reshape

### DIFF
--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -341,10 +341,12 @@ class Reshape(Layer):
         Can't be used as first layer in a model (no fixed input!)
         First dimension is assumed to be nb_samples.
     '''
-    def __init__(self, *dims):
+    def __init__(self, *dims, **kwargs):
         super(Reshape, self).__init__()
-        if type(dims[0]) in [list, tuple]:
+        if len(dims) > 0 and type(dims[0]) in [list, tuple]:
             dims = dims[0]
+        if len(dims) == 0 and 'dims' in kwargs:
+            dims = kwargs['dims']
         self.dims = tuple(dims)
 
     def get_output(self, train=False):

--- a/keras/models.py
+++ b/keras/models.py
@@ -312,17 +312,17 @@ class Model(object):
             pp.pprint(config)
         return config
 
-    def to_yaml(self):
+    def to_yaml(self, **kwargs):
         # dump model configuration to yaml string
         import yaml
         config = self.get_config()
-        return yaml.dump(config)
+        return yaml.dump(config, **kwargs)
 
-    def to_json(self):
+    def to_json(self, **kwargs):
         # dump model configuration to json string
         import json
         config = self.get_config()
-        return json.dumps(config)
+        return json.dumps(config, **kwargs)
 
 
 class Sequential(Model, containers.Sequential):


### PR DESCRIPTION
There's an issue with loading a model from a YAML/JSON file when the network contains a layer which only has *args such as `Reshape`. 

```py
TypeError: __init__() got an unexpected keyword argument 'dims'
```

This error is due to how the models are loaded in https://github.com/fchollet/keras/blob/master/keras/utils/generic_utils.py#L8.

Layers like `Reshape` that have no keyword arguments simply won't work. This could be fixed by having a `**kwargs` that could catch the provided argument in addition to list arguments (default to list args if `dims` is not empty). However, I'm not sure if there are some unforeseen backwards compatibility issues that I'm not seeing here.

Let me know if you see any issues that I'm missing.