### PR TITLE
First crack at threading `custom_layers` through.

### DIFF
--- a/keras/models.py
+++ b/keras/models.py
@@ -100,29 +100,29 @@ def standardize_weights(y, sample_weight=None, class_weight=None):
         return np.ones(y.shape[:-1] + (1,))
 
 
-def model_from_yaml(yaml_string):
+def model_from_yaml(yaml_string, custom_layers={}):
     '''
         Returns a model generated from a local yaml file,
         which is either created by hand or from to_yaml method of Sequential or Graph
     '''
     import yaml
     config = yaml.load(yaml_string)
-    return model_from_config(config)
+    return model_from_config(config, custom_layers=custom_layers)
 
 
-def model_from_json(json_string):
+def model_from_json(json_string, custom_layers={}):
     import json
     config = json.loads(json_string)
-    return model_from_config(config)
+    return model_from_config(config, custom_layers=custom_layers)
 
 
-def model_from_config(config):
+def model_from_config(config, custom_layers={}):
     model_name = config.get('name')
     if model_name not in {'Graph', 'Sequential'}:
         raise Exception('Unrecognized model:', model_name)
 
     # Create a container then set class to appropriate model
-    model = container_from_config(config)
+    model = container_from_config(config, custom_layers=custom_layers)
     if model_name == 'Graph':
         model.__class__ = Graph
     elif model_name == 'Sequential':

--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -5,9 +5,9 @@ import sys
 import six
 
 
-def get_from_module(identifier, module_params, module_name, instantiate=False, kwargs=None):
+def get_from_module(identifier, module_params, module_name, instantiate=False, kwargs=None, custom_layers={}):
     if isinstance(identifier, six.string_types):
-        res = module_params.get(identifier)
+        res = module_params.get(identifier, custom_layers.get(identifier))
         if not res:
             raise Exception('Invalid ' + str(module_name) + ': ' + str(identifier))
         if instantiate and not kwargs:

--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -5,9 +5,9 @@ import sys
 import six
 
 
-def get_from_module(identifier, module_params, module_name, instantiate=False, kwargs=None, custom_layers={}):
+def get_from_module(identifier, module_params, module_name, instantiate=False, kwargs=None):
     if isinstance(identifier, six.string_types):
-        res = module_params.get(identifier, custom_layers.get(identifier))
+        res = module_params.get(identifier)
         if not res:
             raise Exception('Invalid ' + str(module_name) + ': ' + str(identifier))
         if instantiate and not kwargs:
@@ -111,7 +111,7 @@ class Progbar(object):
                     info += ' - %s: %.4f' % (k, self.sum_values[k][0] / max(1, self.sum_values[k][1]))
                 else:
                     info += ' - %s: %s' % (k, self.sum_values[k])
-                
+
             self.total_width += len(info)
             if prev_total_width > self.total_width:
                 info += ((prev_total_width-self.total_width) * " ")

--- a/keras/utils/layer_utils.py
+++ b/keras/utils/layer_utils.py
@@ -125,4 +125,7 @@ def print_layer_shapes(model, input_shapes):
 
 from .generic_utils import get_from_module
 def get_layer(identifier, kwargs=None, custom_layers={}):
-    return get_from_module(identifier, globals(), 'layer', instantiate=True, kwargs=kwargs, custom_layers=custom_layers)
+    # Insert custom layers into globals so they can be accessed by `get_from_module`.
+    for cls_key in custom_layers:
+        globals()[cls_key] = custom_layers[cls_key]
+    return get_from_module(identifier, globals(), 'layer', instantiate=True, kwargs=kwargs)

--- a/keras/utils/layer_utils.py
+++ b/keras/utils/layer_utils.py
@@ -17,7 +17,7 @@ from .. import regularizers
 from .. import constraints
 
 
-def container_from_config(original_layer_dict):
+def container_from_config(original_layer_dict, custom_layers={}):
     layer_dict = copy.deepcopy(original_layer_dict)
     name = layer_dict.get('name')
 
@@ -26,7 +26,7 @@ def container_from_config(original_layer_dict):
         layers = layer_dict.get('layers')
         layer_list = []
         for layer in layers:
-            init_layer = container_from_config(layer)
+            init_layer = container_from_config(layer, custom_layers=custom_layers)
             layer_list.append(init_layer)
         merge_layer = Merge(layer_list, mode)
         return merge_layer
@@ -35,7 +35,7 @@ def container_from_config(original_layer_dict):
         layers = layer_dict.get('layers')
         layer_list = []
         for layer in layers:
-            init_layer = container_from_config(layer)
+            init_layer = container_from_config(layer, custom_layers=custom_layers)
             layer_list.append(init_layer)
         seq_layer = containers.Sequential(layer_list)
         return seq_layer
@@ -49,7 +49,8 @@ def container_from_config(original_layer_dict):
 
         nodes = layer_dict.get('node_config')
         for node in nodes:
-            layer = container_from_config(layer_dict['nodes'].get(node['name']))
+            layer = container_from_config(layer_dict['nodes'].get(node['name']),
+                                          custom_layers=custom_layers)
             node['layer'] = layer
             graph_layer.add_node(**node)
 
@@ -59,8 +60,10 @@ def container_from_config(original_layer_dict):
         return graph_layer
 
     elif name == 'AutoEncoder':
-        kwargs = {'encoder': container_from_config(layer_dict.get('encoder_config')),
-                  'decoder': container_from_config(layer_dict.get('decoder_config'))}
+        kwargs = {'encoder': container_from_config(layer_dict.get('encoder_config'),
+                                                   custom_layers=custom_layers),
+                  'decoder': container_from_config(layer_dict.get('decoder_config'),
+                                                   custom_layers=custom_layers)}
         for kwarg in ['output_reconstruction', 'weights']:
             if kwarg in layer_dict:
                 kwargs[kwarg] = layer_dict[kwarg]
@@ -79,7 +82,7 @@ def container_from_config(original_layer_dict):
                 if vname in [x for x, y in inspect.getmembers(regularizers, predicate=inspect.isclass)]:
                     layer_dict[k] = regularizers.get(vname, v)
 
-        base_layer = get_layer(name, layer_dict)
+        base_layer = get_layer(name, layer_dict, custom_layers=custom_layers)
         return base_layer
 
 
@@ -121,5 +124,5 @@ def print_layer_shapes(model, input_shapes):
 
 
 from .generic_utils import get_from_module
-def get_layer(identifier, kwargs=None):
-    return get_from_module(identifier, globals(), 'layer', instantiate=True, kwargs=kwargs)
+def get_layer(identifier, kwargs=None, custom_layers={}):
+    return get_from_module(identifier, globals(), 'layer', instantiate=True, kwargs=kwargs, custom_layers=custom_layers)


### PR DESCRIPTION
Keras currently uses globals() to access layers. (This doesn't work
across modules.) Hacky solution was to pass a dict mapping name -> class.
I called this dict `custom_layers`. I have a few questions before we merge this in:

1. What would be a better name for this kwarg? `user_layers`? `layers`?
2. Is there a better way of doing this that I'm not seeing?
3. Are there any other places I missed that where should add the `custom_layers` argument?

Currently serialziation with custom layers works fine. The problem that this fixes is trying to call `model_from_*` with a configuration file that has a custom layer name that isn't inside of Keras' `globals()`. This solution allows us to serialize / deserialize models with custom layers. For example:

```py
from keras.models import model_from_yaml
import keras.layers.core

class FooLayer(keras.layers.core.Layer):
    pass

my_layers = {
    'FooLayer': FooLayer
}

with open('foo-network.yaml', 'r') as cfg:
    model = model_from_yaml(cfg.read(), custom_layers=my_layers)
```