### PR TITLE
Add .output_shape attribute in all layers (+tests)

### DIFF
--- a/keras/layers/containers.py
+++ b/keras/layers/containers.py
@@ -45,6 +45,10 @@ class Sequential(Layer):
         self.constraints += constraints
         self.updates += updates
 
+    @property
+    def output_shape(self):
+        return self.layers[-1].output_shape
+
     def get_output(self, train=False):
         return self.layers[-1].get_output(train)
 
@@ -82,6 +86,7 @@ class Sequential(Layer):
 
     def count_params(self):
         return sum([layer.count_params() for layer in self.layers])
+
 
 class Graph(Layer):
     '''
@@ -146,6 +151,15 @@ class Graph(Layer):
     @property
     def input(self):
         return self.get_input()
+
+    @property
+    def output_shape(self):
+        if self.nb_output == 1:
+            # return tuple
+            return self.outputs[self.output_order[0]].output_shape
+        else:
+            # return dictionary mapping output names to shape tuples
+            return dict([(k, v.output_shape) for k, v in self.outputs.items()])
 
     def get_output(self, train=False):
         if len(self.inputs) == len(self.outputs) == 1:

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -220,9 +220,9 @@ class Convolution2D(Layer):
                                           border_mode=border_mode,
                                           subsample=self.subsample)
             if self.border_mode == 'same':
-                    shift_x = (self.nb_row - 1) // 2
-                    shift_y = (self.nb_col - 1) // 2
-                    conv_out = conv_out[:, :, shift_x:X.shape[2] + shift_x, shift_y:X.shape[3] + shift_y]
+                shift_x = (self.nb_row - 1) // 2
+                shift_y = (self.nb_col - 1) // 2
+                conv_out = conv_out[:, :, shift_x:X.shape[2] + shift_x, shift_y:X.shape[3] + shift_y]
 
         return self.activation(conv_out + self.b.dimshuffle('x', 0, 'x', 'x'))
 

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -13,6 +13,37 @@ if on_gpu():
     from theano.sandbox.cuda import dnn
 
 
+def conv_output_length(input_length, filter_size, border_mode, stride):
+    assert border_mode in {'same', 'full', 'valid'}
+    if border_mode == 'same':
+        output_length = input_length
+    elif border_mode == 'full':
+        output_length = input_length + filter_size - 1
+    elif border_mode == 'valid':
+        output_length = input_length - filter_size + 1
+    return (output_length + stride - 1) // stride
+
+
+def pool_output_length(input_length, pool_size, ignore_border, stride):
+    if ignore_border:
+        output_length = input_length - pool_size + 1
+        output_length = (output_length + stride - 1) // stride
+    else:
+        if pool_size == input_length:
+            output_length = min(input_length, stride - stride % 2)
+            if output_length <= 0:
+                output_length = 1
+        elif stride >= pool_size:
+            output_length = (input_length + stride - 1) // stride
+        else:
+            output_length = (input_length - pool_size + stride - 1) // stride
+            if output_length <= 0:
+                output_length = 1
+            else:
+                output_length += 1
+    return output_length
+
+
 class Convolution1D(Layer):
     def __init__(self, input_dim, nb_filter, filter_length,
                  init='uniform', activation='linear', weights=None,
@@ -30,7 +61,7 @@ class Convolution1D(Layer):
         self.subsample_length = subsample_length
         self.init = initializations.get(init)
         self.activation = activations.get(activation)
-        self.subsample = (1, subsample_length)
+        self.subsample = (subsample_length, 1)
         self.border_mode = border_mode
 
         self.input = T.tensor3()
@@ -64,13 +95,19 @@ class Convolution1D(Layer):
         if weights is not None:
             self.set_weights(weights)
 
-    def get_output(self, train):
+    @property
+    def output_shape(self):
+        length = conv_output_length(self.input_shape[1], self.filter_length, self.border_mode, self.subsample[0])
+        return (self.input_shape[0], length, self.nb_filter)
+
+    def get_output(self, train=False):
         X = self.get_input(train)
         X = T.reshape(X, (X.shape[0], X.shape[1], X.shape[2], 1)).dimshuffle(0, 2, 1, 3)
 
         border_mode = self.border_mode
         if border_mode == 'same':
             border_mode = 'full'
+            assert self.subsample == (1, 1)
 
         conv_out = T.nnet.conv.conv2d(X, self.W, border_mode=border_mode, subsample=self.subsample)
         if self.border_mode == 'same':
@@ -149,7 +186,16 @@ class Convolution2D(Layer):
         if weights is not None:
             self.set_weights(weights)
 
-    def get_output(self, train):
+    @property
+    def output_shape(self):
+        input_shape = self.input_shape
+        rows = input_shape[2]
+        cols = input_shape[3]
+        rows = conv_output_length(rows, self.nb_row, self.border_mode, self.subsample[0])
+        cols = conv_output_length(cols, self.nb_col, self.border_mode, self.subsample[1])
+        return (input_shape[0], self.nb_filter, rows, cols)
+
+    def get_output(self, train=False):
         X = self.get_input(train)
         border_mode = self.border_mode
         if on_gpu() and dnn.dnn_available():
@@ -168,14 +214,15 @@ class Convolution2D(Layer):
         else:
             if border_mode == 'same':
                 border_mode = 'full'
+                assert(self.subsample == (1, 1))
 
             conv_out = T.nnet.conv.conv2d(X, self.W,
                                           border_mode=border_mode,
                                           subsample=self.subsample)
             if self.border_mode == 'same':
-                shift_x = (self.nb_row - 1) // 2
-                shift_y = (self.nb_col - 1) // 2
-                conv_out = conv_out[:, :, shift_x:X.shape[2] + shift_x, shift_y:X.shape[3] + shift_y]
+                    shift_x = (self.nb_row - 1) // 2
+                    shift_y = (self.nb_col - 1) // 2
+                    conv_out = conv_out[:, :, shift_x:X.shape[2] + shift_x, shift_y:X.shape[3] + shift_y]
 
         return self.activation(conv_out + self.b.dimshuffle('x', 0, 'x', 'x'))
 
@@ -197,20 +244,25 @@ class Convolution2D(Layer):
 
 
 class MaxPooling1D(Layer):
-    def __init__(self, pool_length=2, stride=None, ignore_border=True):
+    def __init__(self, pool_length=2, stride=1, ignore_border=True):
         super(MaxPooling1D, self).__init__()
+        if type(stride) is not int or not stride:
+            raise Exception('"stride" argument in MaxPooling1D should be an int > 0.')
         self.pool_length = pool_length
         self.stride = stride
-        if self.stride:
-            self.st = (self.stride, 1)
-        else:
-            self.st = None
+        self.st = (self.stride, 1)
 
         self.input = T.tensor3()
         self.poolsize = (pool_length, 1)
         self.ignore_border = ignore_border
 
-    def get_output(self, train):
+    @property
+    def output_shape(self):
+        input_shape = self.input_shape
+        length = pool_output_length(input_shape[1], self.pool_length, self.ignore_border, self.stride)
+        return (input_shape[0], length, input_shape[2])
+
+    def get_output(self, train=False):
         X = self.get_input(train)
         X = T.reshape(X, (X.shape[0], X.shape[1], X.shape[2], 1)).dimshuffle(0, 2, 1, 3)
         output = downsample.max_pool_2d(X, ds=self.poolsize, st=self.st, ignore_border=self.ignore_border)
@@ -225,14 +277,21 @@ class MaxPooling1D(Layer):
 
 
 class MaxPooling2D(Layer):
-    def __init__(self, poolsize=(2, 2), stride=None, ignore_border=True):
+    def __init__(self, poolsize=(2, 2), stride=(1, 1), ignore_border=True):
         super(MaxPooling2D, self).__init__()
         self.input = T.tensor4()
         self.poolsize = tuple(poolsize)
-        self.stride = stride
+        self.stride = tuple(stride)
         self.ignore_border = ignore_border
 
-    def get_output(self, train):
+    @property
+    def output_shape(self):
+        input_shape = self.input_shape
+        rows = pool_output_length(input_shape[2], self.poolsize[0], self.ignore_border, self.stride[0])
+        cols = pool_output_length(input_shape[3], self.poolsize[1], self.ignore_border, self.stride[1])
+        return (input_shape[0], input_shape[1], rows, cols)
+
+    def get_output(self, train=False):
         X = self.get_input(train)
         output = downsample.max_pool_2d(X, ds=self.poolsize, st=self.stride, ignore_border=self.ignore_border)
         return output
@@ -250,7 +309,12 @@ class UpSample1D(Layer):
         self.length = length
         self.input = T.tensor3()
 
-    def get_output(self, train):
+    @property
+    def output_shape(self):
+        input_shape = self.input_shape
+        return (input_shape[0], self.length * input_shape[1], input_shape[2])
+
+    def get_output(self, train=False):
         X = self.get_input(train)
         output = theano.tensor.extra_ops.repeat(X, self.length, axis=1)
         return output
@@ -266,7 +330,12 @@ class UpSample2D(Layer):
         self.input = T.tensor4()
         self.size = tuple(size)
 
-    def get_output(self, train):
+    @property
+    def output_shape(self):
+        input_shape = self.input_shape
+        return (input_shape[0], input_shape[1], self.size[0] * input_shape[2], self.size[1] * input_shape[3])
+
+    def get_output(self, train=False):
         X = self.get_input(train)
         Y = theano.tensor.extra_ops.repeat(X, self.size[0], axis=2)
         output = theano.tensor.extra_ops.repeat(Y, self.size[1], axis=3)
@@ -283,7 +352,12 @@ class ZeroPadding2D(Layer):
         self.pad = tuple(pad)
         self.input = T.tensor4()
 
-    def get_output(self, train):
+    @property
+    def output_shape(self):
+        input_shape = self.input_shape
+        return (input_shape[0], input_shape[1], input_shape[2] + 2 * self.pad[0], input_shape[3] + 2 * self.pad[1])
+
+    def get_output(self, train=False):
         X = self.get_input(train)
         pad = self.pad
         in_shape = X.shape

--- a/keras/layers/embeddings.py
+++ b/keras/layers/embeddings.py
@@ -57,6 +57,10 @@ class Embedding(Layer):
         else:
             return T.ones_like(X) * (1 - T.eq(X, 0))
 
+    @property
+    def output_shape(self):
+        return (self.input_shape[0], None, self.output_dim)
+
     def get_output(self, train=False):
         X = self.get_input(train)
         out = self.W[X]
@@ -115,6 +119,10 @@ class WordContextProduct(Layer):
 
         if weights is not None:
             self.set_weights(weights)
+
+    @property
+    def output_shape(self):
+        return (self.input_shape[0], 1)
 
     def get_output(self, train=False):
         X = self.get_input(train)

--- a/keras/layers/normalization.py
+++ b/keras/layers/normalization.py
@@ -19,18 +19,18 @@ class BatchNormalization(Layer):
     def __init__(self, input_shape, epsilon=1e-6, mode=0, momentum=0.9, weights=None):
         super(BatchNormalization, self).__init__()
         self.init = initializations.get("uniform")
-        self.input_shape = input_shape
+        self._input_shape = input_shape
         self.epsilon = epsilon
         self.mode = mode
         self.momentum = momentum
-        self.input = ndim_tensor(len(self.input_shape) + 1)
+        self.input = ndim_tensor(len(input_shape) + 1)
 
-        self.gamma = self.init((self.input_shape))
-        self.beta = shared_zeros(self.input_shape)
+        self.gamma = self.init((input_shape))
+        self.beta = shared_zeros(input_shape)
 
         self.params = [self.gamma, self.beta]
-        self.running_mean = shared_zeros(self.input_shape)
-        self.running_std = shared_ones((self.input_shape))
+        self.running_mean = shared_zeros(input_shape)
+        self.running_std = shared_ones((input_shape))
         if weights is not None:
             self.set_weights(weights)
 
@@ -66,7 +66,7 @@ class BatchNormalization(Layer):
 
     def get_config(self):
         return {"name": self.__class__.__name__,
-                "input_shape": self.input_shape,
+                "input_shape": self._input_shape,
                 "epsilon": self.epsilon,
                 "mode": self.mode}
 

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -34,6 +34,14 @@ class Recurrent(MaskedLayer):
             mask = T.concatenate([padding, mask], axis=0)
         return mask.astype('int8')
 
+    @property
+    def output_shape(self):
+        input_shape = self.input_shape
+        if self.return_sequences:
+            return (input_shape[0], input_shape[1], self.output_dim)
+        else:
+            return (input_shape[0], self.output_dim)
+
 
 class SimpleRNN(Recurrent):
     '''

--- a/tests/auto/keras/layers/test_convolutional.py
+++ b/tests/auto/keras/layers/test_convolutional.py
@@ -23,6 +23,8 @@ class TestConvolutions(unittest.TestCase):
         for weight in [None, weights_in]:
             for border_mode in ['valid', 'full', 'same']:
                 for subsample_length in [1, 3]:
+                    if border_mode == 'same' and subsample_length != 1:
+                        continue
                     for W_regularizer in [None, 'l2']:
                         for b_regularizer in [None, 'l2']:
                             for act_regularizer in [None, 'l2']:
@@ -49,7 +51,7 @@ class TestConvolutions(unittest.TestCase):
 
         input = np.ones((nb_samples, nb_steps, input_dim))
         for ignore_border in [True, False]:
-            for stride in [None, 2]:
+            for stride in [1, 2]:
                 layer = convolutional.MaxPooling1D(stride=stride, ignore_border=ignore_border)
                 layer.input = theano.shared(value=input)
                 for train in [True, False]:
@@ -77,6 +79,8 @@ class TestConvolutions(unittest.TestCase):
         for weight in [None, weights_in]:
             for border_mode in ['valid', 'full', 'same']:
                 for subsample in [(1, 1), (2, 3)]:
+                    if border_mode == 'same' and subsample != (1, 1):
+                        continue
                     for W_regularizer in [None, 'l2']:
                         for b_regularizer in [None, 'l2']:
                             for act_regularizer in [None, 'l2']:
@@ -104,7 +108,7 @@ class TestConvolutions(unittest.TestCase):
 
         input = np.ones((nb_samples, stack_size, input_nb_row, input_nb_col))
         for ignore_border in [True, False]:
-            for stride in [None, (2, 2)]:
+            for stride in [(1, 1), (2, 2)]:
                 layer = convolutional.MaxPooling2D(stride=stride, ignore_border=ignore_border, poolsize=poolsize)
                 layer.input = theano.shared(value=input)
                 for train in [True, False]:

--- a/tests/auto/keras/layers/test_core.py
+++ b/tests/auto/keras/layers/test_core.py
@@ -12,11 +12,6 @@ class TestLayerBase(unittest.TestCase):
         input_dim = 5
         layer = core.Layer()
 
-        # As long as there is no input, an error should be raised.
-        for train in [True, False]:
-            self.assertRaises(AttributeError, layer.get_input, train)
-            self.assertRaises(AttributeError, layer.get_output, train)
-
         # Once an input is provided, it should be reachable through the
         # appropriate getters
         input = np.ones((nb_samples, input_dim))
@@ -33,10 +28,6 @@ class TestLayerBase(unittest.TestCase):
 
         input = np.ones((nb_samples, input_dim))
         layer1.input = theano.shared(value=input)
-
-        # As long as there is no previous layer, an error should be raised.
-        for train in [True, False]:
-            self.assertRaises(AttributeError, layer2.get_input, train)
 
         # After connecting, input of layer1 should be passed through
         layer2.set_previous(layer1)

--- a/tests/auto/test_shape_inference.py
+++ b/tests/auto/test_shape_inference.py
@@ -1,0 +1,132 @@
+import unittest
+import numpy as np
+import theano
+from keras.utils.theano_utils import ndim_tensor
+from keras.layers.core import *
+from keras.layers.convolutional import *
+from keras.layers.recurrent import SimpleRNN
+
+
+def check_layer_output_shape(layer, input_data):
+    ndim = len(input_data.shape)
+    layer.input = ndim_tensor(ndim)
+    layer._input_shape = input_data.shape
+    expected_output_shape = layer.output_shape
+
+    function = theano.function([layer.input], [layer.get_output()])
+    output = function(input_data)[0]
+    print output.shape, '(exact) vs.', expected_output_shape, '(predicted)'
+
+    assert output.shape == expected_output_shape
+
+
+class TestShapeInference(unittest.TestCase):
+    # ########
+    # # Core #
+    # ########
+    def test_Reshape(self):
+        layer = Reshape(2, 3)
+        input_data = np.random.random((2, 6))
+        check_layer_output_shape(layer, input_data)
+
+    def test_Permute(self):
+        layer = Permute(dims=(1, 3, 2))
+        input_data = np.random.random((2, 2, 4, 3))
+        check_layer_output_shape(layer, input_data)
+
+    def test_Flatten(self):
+        layer = Flatten()
+        input_data = np.random.random((2, 2, 3))
+        check_layer_output_shape(layer, input_data)
+
+    def test_RepeatVector(self):
+        layer = RepeatVector(2)
+        input_data = np.random.random((2, 2))
+        check_layer_output_shape(layer, input_data)
+
+    def test_Dense(self):
+        layer = Dense(2, 3)
+        input_data = np.random.random((2, 2))
+        check_layer_output_shape(layer, input_data)
+
+    def test_TimeDistributedDense(self):
+        layer = TimeDistributedDense(3, 2)
+        input_data = np.random.random((2, 2, 3))
+        check_layer_output_shape(layer, input_data)
+
+    #################
+    # Convolutional #
+    #################
+    def test_Convolution1D(self):
+        for border_mode in ['same', 'full', 'valid']:
+            for filter_length in [2, 3]:
+                for subsample_length in [1, 2]:
+                    if subsample_length > 1 and border_mode == 'same':
+                        continue
+                    for input_data_shape in [(2, 3, 2), (2, 4, 2)]:
+                        layer = Convolution1D(input_dim=2, nb_filter=1, filter_length=filter_length,
+                                              border_mode=border_mode, subsample_length=subsample_length)
+                        input_data = np.random.random(input_data_shape)
+                        check_layer_output_shape(layer, input_data)
+
+    def test_Convolution2D(self):
+        for border_mode in ['same', 'full', 'valid']:
+            for nb_row, nb_col in [(2, 1), (3, 2)]:
+                for subsample in [(1, 1), (2, 2)]:
+                    if (subsample[0] > 1 or subsample[1] > 1) and border_mode == 'same':
+                        continue
+                    for input_data_shape in [(2, 1, 3, 3), (2, 1, 4, 4)]:
+                        print 'border_mode:', border_mode
+                        print 'subsample:', subsample
+                        print 'input_data_shape:', input_data_shape
+                        layer = Convolution2D(nb_filter=1, stack_size=1, nb_row=nb_row, nb_col=nb_row,
+                                              border_mode=border_mode, subsample=subsample)
+                        input_data = np.random.random(input_data_shape)
+                        check_layer_output_shape(layer, input_data)
+
+    def test_MaxPooling1D(self):
+        for ignore_border in [True, False]:
+            for stride in [1, 2]:
+                for pool_length in [1, 2]:
+                    for input_data_shape in [(2, 1, 3), (2, 1, 4)]:
+                        layer = MaxPooling1D(pool_length=pool_length, stride=stride, ignore_border=ignore_border)
+                        input_data = np.random.random(input_data_shape)
+                        check_layer_output_shape(layer, input_data)
+
+    def test_MaxPooling2D(self):
+        for ignore_border in [True, False]:
+            for stride in [(1, 1), (2, 2)]:
+                for poolsize in [(2, 2), (3, 3), (4, 4)]:
+                    for input_data_shape in [(2, 1, 3, 3), (2, 1, 4, 4), (2, 1, 5, 5), (2, 1, 6, 6)]:
+                        layer = MaxPooling2D(poolsize=poolsize, stride=stride, ignore_border=ignore_border)
+                        input_data = np.random.random(input_data_shape)
+                        check_layer_output_shape(layer, input_data)
+
+    def test_UpSample1D(self):
+        layer = UpSample1D(length=2)
+        input_data = np.random.random((2, 2, 3))
+        check_layer_output_shape(layer, input_data)
+
+    def test_UpSample2D(self):
+        layer = UpSample2D(size=(2, 2))
+        input_data = np.random.random((2, 1, 2, 3))
+        check_layer_output_shape(layer, input_data)
+
+    def test_ZeroPadding2D(self):
+        layer = ZeroPadding2D((1, 2))
+        input_data = np.random.random((2, 1, 2, 3))
+        check_layer_output_shape(layer, input_data)
+
+    # #############
+    # # Recurrent #
+    # #############
+    def test_SimpleRNN(self):
+        # all recurrent layers inherit output_shape
+        # from the same base recurrent layer
+        layer = SimpleRNN(3, 2)
+        input_data = np.random.random((2, 2, 3))
+        check_layer_output_shape(layer, input_data)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/auto/test_shape_inference.py
+++ b/tests/auto/test_shape_inference.py
@@ -76,9 +76,6 @@ class TestShapeInference(unittest.TestCase):
                     if (subsample[0] > 1 or subsample[1] > 1) and border_mode == 'same':
                         continue
                     for input_data_shape in [(2, 1, 3, 3), (2, 1, 4, 4)]:
-                        print 'border_mode:', border_mode
-                        print 'subsample:', subsample
-                        print 'input_data_shape:', input_data_shape
                         layer = Convolution2D(nb_filter=1, stack_size=1, nb_row=nb_row, nb_col=nb_row,
                                               border_mode=border_mode, subsample=subsample)
                         input_data = np.random.random(input_data_shape)

--- a/tests/auto/test_shape_inference.py
+++ b/tests/auto/test_shape_inference.py
@@ -15,8 +15,6 @@ def check_layer_output_shape(layer, input_data):
 
     function = theano.function([layer.input], [layer.get_output()])
     output = function(input_data)[0]
-    print output.shape, '(exact) vs.', expected_output_shape, '(predicted)'
-
     assert output.shape == expected_output_shape
 
 


### PR DESCRIPTION
Note: this PR does NOT modify the model construction API at all, since that is apparently still under debate. Instead, this PR just introduces the logic needed to add automatic shape inference to Keras.

All layers now have an attribute `output_shape` that returns a shape tuple (or a dictionary mapping output names to shapes in the case of the `Graph` container).

The input shape of connected layers is inferred from the output shape of the previous layer. For a layer that is not connected (like the first layer in a network), you can set input shape manually by setting the layer attribute `_input_shape` to a tuple. This allows to skip `Input` layers entirely.

```python
input_layer = Dense(...)
input_layer._input_shape = (None, 10)
```

`None` dimensions in shape tuples are variable dimensions (such as sample number).

I also introduce minor changes in the handling of `stride` for `MaxPooling` layers.