### PR TITLE
Fix compatibility with old MaxPooling interface

### DIFF
--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -261,7 +261,9 @@ class Convolution2D(Layer):
 class MaxPooling1D(Layer):
     def __init__(self, pool_length=2, stride=1, ignore_border=True):
         super(MaxPooling1D, self).__init__()
-        if type(stride) is not int or not stride:
+        if stride is None:
+            stride = pool_length
+        if type(stride) not stride:
             raise Exception('"stride" argument in MaxPooling1D should be an int > 0.')
         self.pool_length = pool_length
         self.stride = stride
@@ -292,10 +294,12 @@ class MaxPooling1D(Layer):
 
 
 class MaxPooling2D(Layer):
-    def __init__(self, poolsize=(2, 2), stride=(1, 1), ignore_border=True):
+    def __init__(self, poolsize=(2, 2), stride=(2, 2), ignore_border=True):
         super(MaxPooling2D, self).__init__()
         self.input = T.tensor4()
         self.poolsize = tuple(poolsize)
+        if stride is None:
+            stride = self.poolsize
         self.stride = tuple(stride)
         self.ignore_border = ignore_border
 

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -263,8 +263,6 @@ class MaxPooling1D(Layer):
         super(MaxPooling1D, self).__init__()
         if stride is None:
             stride = pool_length
-        if type(stride) not stride:
-            raise Exception('"stride" argument in MaxPooling1D should be an int > 0.')
         self.pool_length = pool_length
         self.stride = stride
         self.st = (self.stride, 1)

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -259,7 +259,7 @@ class Convolution2D(Layer):
 
 
 class MaxPooling1D(Layer):
-    def __init__(self, pool_length=2, stride=1, ignore_border=True):
+    def __init__(self, pool_length=2, stride=None, ignore_border=True):
         super(MaxPooling1D, self).__init__()
         if stride is None:
             stride = pool_length
@@ -294,7 +294,7 @@ class MaxPooling1D(Layer):
 
 
 class MaxPooling2D(Layer):
-    def __init__(self, poolsize=(2, 2), stride=(2, 2), ignore_border=True):
+    def __init__(self, poolsize=(2, 2), stride=None, ignore_border=True):
         super(MaxPooling2D, self).__init__()
         self.input = T.tensor4()
         self.poolsize = tuple(poolsize)


### PR DESCRIPTION
In my previous PR I removed the default of `None` for the stride in MaxPooling, which was ambiguous and defaulted to a stride equal to the pool size. This broke the Keras CNN examples which were using this default.

I reverted the change to restore backwards compatibility.