### PR TITLE
correct image_shape and filter_shape parameters in Convolution2D

### DIFF
--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -249,9 +249,7 @@ class Convolution2D(Layer):
                 conv_out = dnn.dnn_conv(img=X,
                                         kerns=self.W,
                                         border_mode=border_mode,
-                                        subsample=self.subsample,
-                                        image_shape=self.input_shape,
-                                        filter_shape=self.W_shape)
+                                        subsample=self.subsample)
         else:
             if border_mode == 'same':
                 border_mode = 'full'
@@ -259,7 +257,9 @@ class Convolution2D(Layer):
 
             conv_out = T.nnet.conv.conv2d(X, self.W,
                                           border_mode=border_mode,
-                                          subsample=self.subsample)
+                                          subsample=self.subsample,
+                                          image_shape=self.input_shape,
+                                          filter_shape=self.W_shape)
             if self.border_mode == 'same':
                 shift_x = (self.nb_row - 1) // 2
                 shift_y = (self.nb_col - 1) // 2


### PR DESCRIPTION
In commit cb77f7d, `image_shape` and `filter_shape` were added - correctly on `T.nnet.conv.conv2d` in `Convolution1D`, but mistakenly on `dnn.dnn_conv` in `Convolution2D`. This causes the following error when using dnn: `TypeError: dnn_conv() got an unexpected keyword argument 'image_shape'`. 

refs:
http://deeplearning.net/software/theano/library/sandbox/cuda/dnn.html#functions
http://deeplearning.net/software/theano/library/tensor/signal/conv.html