### PR TITLE
Fix #821

### DIFF
--- a/keras/optimizers.py
+++ b/keras/optimizers.py
@@ -82,7 +82,7 @@ class SGD(Optimizer):
         return {"name": self.__class__.__name__,
                 "lr": float(self.lr.get_value()),
                 "momentum": float(self.momentum.get_value()),
-                "decay": float(self.decay.get_value()),
+                "decay": float(self.decay),
                 "nesterov": self.nesterov}
 
 


### PR DESCRIPTION
`decay` in `SGD` is not a Theano shared value, so it does not have a `get_value` method.