### PR TITLE
Fix evaluated and weighted_objective

### DIFF
--- a/keras/models.py
+++ b/keras/models.py
@@ -73,10 +73,11 @@ def weighted_objective(fn):
         weighted = filtered_weights * obj_output
         if mask is None:
             # Instead of calling mean() here, we divide by the sum of filtered_weights.
-            return weighted.sum() / filtered_weights.sum()
+            weights_sum = filtered_weights.sum()
         else:
             filtered_mask = mask[weights.nonzero()[:-1]]
-            return weighted.sum() / (filtered_mask * filtered_weights).sum()
+            weights_sum = (filtered_mask * filtered_weights).sum()
+        return ifelse(T.eq(weights_sum, 0), 0.0, weighted.sum() / weights_sum)
     return weighted
 
 


### PR DESCRIPTION
Hi all,

first: Keras is awesome :-) !
I am new here, and suggest the following PR to make Keras even better:

1) Fixes weight standardization in `evaluate()` of Graph model
Before, the unnormalized version of output vectors (y) was used to standardize weights, which resulted in a shape mismatch between y and the weight vector when standardize_y changed the shape of y. Now, y is first standardized and used afterwards to standardize weights as also done in other methods like `fit()`.

2) Fixes division by zero in `weighted_objective()`
Before, `weighted_objective()` returned nan due to division by zero if the weight vector contained only zero weights. Now, it returns zero if there are no observations. I found this bug when I trained a multi-task model with sparse output vectors. In some batches, there were no observations for some tasks, which resulted in nan in the objective.

Cheers,
Christof 
