### PR TITLE
FIx `Exception: Invalid layer: LRN2D`

### DIFF
--- a/keras/utils/layer_utils.py
+++ b/keras/utils/layer_utils.py
@@ -10,7 +10,7 @@ from ..layers.core import ActivityRegularization, TimeDistributedDense, AutoEnco
 from ..layers.convolutional import Convolution1D, Convolution2D, MaxPooling1D, MaxPooling2D, ZeroPadding2D
 from ..layers.embeddings import Embedding, WordContextProduct
 from ..layers.noise import GaussianNoise, GaussianDropout
-from ..layers.normalization import BatchNormalization
+from ..layers.normalization import BatchNormalization, LRN2D
 from ..layers.recurrent import SimpleRNN, SimpleDeepRNN, GRU, LSTM, JZS1, JZS2, JZS3
 from ..layers import containers
 from .. import regularizers


### PR DESCRIPTION
This should fix the problem`Exception: Invalid layer: LRN2D` while loading a model that includes LRN2D layer.

```py
model = Sequential()
model.add(Convolution2D(30, 3, 3, input_shape=(1, 28, 28)))
model.add(LRN2D())

model_def = model.to_yaml()

# this line raises Exception: Invalid layer: LRN2D
model_from_yaml(model_def)
```

The code above could reproduce the problem.