### PR TITLE
Update optimizers.py

### DIFF
--- a/keras/optimizers.py
+++ b/keras/optimizers.py
@@ -82,7 +82,7 @@ class SGD(Optimizer):
         return {"name": self.__class__.__name__,
                 "lr": float(self.lr.get_value()),
                 "momentum": float(self.momentum.get_value()),
-                "decay": float(self.decay),
+                "decay": float(self.decay.get_value()),
                 "nesterov": self.nesterov}
 
 


### PR DESCRIPTION
Bug:
float() argument must be a string or a number, not 'TensorSharedVariable'
fixed!