### PR TITLE
Added version information and docstring to __init__

### DIFF
--- a/keras/__init__.py
+++ b/keras/__init__.py
@@ -1,0 +1,18 @@
+
+"""
+Keras: Theano-based Deep Learning library
+==================================
+Keras is a minimalist, highly modular neural network library in 
+the spirit of Torch, written in Python / Theano so as not to have 
+to deal with the dearth of ecosystem in Lua. It was developed with 
+a focus on enabling fast experimentation. Being able to go from 
+idea to result with the least possible delay is key to doing 
+good research.
+
+See http://keras.io/
+"""
+import sys
+import re
+import warnings
+
+__version__ = '0.2.0'

--- a/keras/__init__.py
+++ b/keras/__init__.py
@@ -11,8 +11,5 @@ good research.
 
 See http://keras.io/
 """
-import sys
-import re
-import warnings
 
 __version__ = '0.2.0'


### PR DESCRIPTION
Learning from other data processing library. It is important that user-code is able to check for version, e.g. http://stackoverflow.com/questions/28501072/how-to-check-which-version-of-nltk-scikit-learn-installed.

 - https://github.com/nltk/nltk/blob/develop/nltk/__init__.py#L26
 - https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/__init__.py#L24

This mini improvement would allow:

```
>>> import keras
>>> keras.__version__
0.2.0
```

And from the command line

```
$ python -c "import keras; print keras.__version__"
0.2.0
```

Note that the current version number is consistent with [PEP0440](https://www.python.org/dev/peps/pep-0440/) =)

Also note, `numpy` and `scipy` has a more complicated `__version__` string but i think it's an overkill for now =):

 - https://github.com/scipy/scipy/blob/master/scipy/__init__.py#L105
 - https://github.com/numpy/numpy/blob/master/numpy/__init__.py