### PR TITLE
fixed error in reading hdf5 dataset

### DIFF
--- a/keras/models.py
+++ b/keras/models.py
@@ -52,11 +52,16 @@ def standardize_X(X):
 def slice_X(X, start=None, stop=None):
     if type(X) == list:
         if hasattr(start, '__len__'):
+            # hdf5 dataset only support list object as indices
+            if hasattr(start, 'shape'):
+            	start = start.tolist()
             return [x[start] for x in X]
         else:
             return [x[start:stop] for x in X]
     else:
         if hasattr(start, '__len__'):
+            if hasattr(start, 'shape'):
+            	start = start.tolist()
             return X[start]
         else:
             return X[start:stop]


### PR DESCRIPTION
Tested usage:
```python
f = h5py.File('/path/to/data', 'r')
X = f['X'].value
y = f['y'].value

m = keras.models.Sequential()
m.add(keras.layers.recurrent.LSTM(32, input_dim=13, input_length=20, return_sequences=False))
m.add(keras.layers.core.Dense(10, activation='softmax'))
m.compile(keras.optimizers.RMSprop(), keras.objectives.categorical_crossentropy)

# Using hdf5 dataset as input
m.fit(f['X'], f['y'], shuffle='batch', nb_epoch=5)
m.evaluate(f['X'], f['y'])
m.predict(f['X'])

# Same as using numpy array as input
m.fit(X, y, shuffle=True, nb_epoch=5)
m.evaluate(X, y)
m.predict(X)
```