### PR TITLE
Dropout: rescale data at training time (breaks bw compat.)

### DIFF
--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -453,9 +453,7 @@ class Dropout(MaskedLayer):
         if self.p > 0.:
             retain_prob = 1. - self.p
             if train:
-                X *= self.srng.binomial(X.shape, p=retain_prob, dtype=theano.config.floatX)
-            else:
-                X *= retain_prob
+                X *= self.srng.binomial(X.shape, p=retain_prob, dtype=theano.config.floatX) / retain_prob
         return X
 
     def get_config(self):


### PR DESCRIPTION
Following the discussion https://groups.google.com/forum/#!topic/keras-users/PYbBnZXCvO4, here is a simple change to the '''Dropout''' layer that follows the Caffe implementation. 

Data rescaling is done during training instead of testing. This has the advantage of making the layer equal to identity at test time. Therefore, it can be safely removed in a production environment.

However, this will break compatibility with previously saved models.