### PR TITLE
Handle an empty document

### DIFF
--- a/keras/preprocessing/sequence.py
+++ b/keras/preprocessing/sequence.py
@@ -24,6 +24,8 @@ def pad_sequences(sequences, maxlen=None, dtype='int32', padding='pre', truncati
 
     x = (np.ones((nb_samples, maxlen)) * value).astype(dtype)
     for idx, s in enumerate(sequences):
+        if len(s) == 0:
+            continue # empty list was found
         if truncating == 'pre':
             trunc = s[-maxlen:]
         elif truncating == 'post':


### PR DESCRIPTION
In case of an empty sequence (as a result of clearing stop words for example), don't raise an error but continue to the next sequence.