### PR TITLE
Fix merge concat mode

### DIFF
--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -307,7 +307,12 @@ class Merge(Layer):
                     if shape1[dot_axes[0][i]] != shape2[dot_axes[1][i]]:
                         raise Exception(" Dot incompatible layers can not be merged using dot mode")
         elif mode == 'concat':
-            input_shapes = set([list(l.output_shape).pop(concat_axis) for l in layers])
+            input_shapes = set()
+            for l in layers:
+                oshape = list(l.output_shape)
+                oshape.pop(concat_axis)
+                oshape = tuple(oshape)
+                input_shapes.add(oshape)
             if len(input_shapes) > 1:
                 raise Exception("'concat' mode can only merge layers with matching output shapes except for the concat axis")
 


### PR DESCRIPTION
The assertion checked the opposite of what was desired. That is, it checked that inputs aligned along the concat axis, rather than on every axis _except_ the concat axis.