### PR TITLE
Fix TimeDistributedMerge

### DIFF
--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -257,10 +257,11 @@ class TimeDistributedMerge(Layer):
 
     def get_output(self, train=False):
         X = self.get_input(train)
-        if self.mode == 'sum' or self.mode == 'ave':
+        if self.mode == 'ave':
+            s = theano.tensor.mean(X, axis=1)
+            return s
+        if self.mode == 'sum':
             s = theano.tensor.sum(X, axis=1)
-            if self.mode == 'ave':
-                s /= X.shape[1]
             return s
         elif self.mode == 'mul':
             s = theano.tensor.mul(X, axis=1)


### PR DESCRIPTION
When mode='ave', and the dtype of the input is float32, dividing the sum
by shape[1], which is of dtype int64, results in an output of dtype
float64, which is wrong.

fixed to use theano.tensor.mean instead.