### PR TITLE
Fixed error go_backward and return sequences.

### DIFF
--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -112,7 +112,9 @@ class SimpleRNN(Recurrent):
             truncate_gradient=self.truncate_gradient,
             go_backwards=self.go_backwards)
 
-        if self.return_sequences:
+        if self.return_sequences and self.go_backwards:
+            return outputs[::-1].dimshuffle((1, 0, 2))
+        elif self.return_sequences:
             return outputs.dimshuffle((1, 0, 2))
         return outputs[-1]
 
@@ -210,7 +212,9 @@ class SimpleDeepRNN(Recurrent):
             truncate_gradient=self.truncate_gradient,
             go_backwards=self.go_backwards)
 
-        if self.return_sequences:
+        if self.return_sequences and self.go_backwards:
+            return outputs[::-1].dimshuffle((1, 0, 2))
+        elif self.return_sequences:
             return outputs.dimshuffle((1, 0, 2))
         return outputs[-1]
 
@@ -327,7 +331,9 @@ class GRU(Recurrent):
             truncate_gradient=self.truncate_gradient,
             go_backwards=self.go_backwards)
 
-        if self.return_sequences:
+        if self.return_sequences and self.go_backwards:
+            return outputs[::-1].dimshuffle((1, 0, 2))
+        elif self.return_sequences:
             return outputs.dimshuffle((1, 0, 2))
         return outputs[-1]
 
@@ -460,7 +466,9 @@ class LSTM(Recurrent):
             truncate_gradient=self.truncate_gradient,
             go_backwards=self.go_backwards)
 
-        if self.return_sequences:
+        if self.return_sequences and self.go_backwards:
+            return outputs[::-1].dimshuffle((1, 0, 2))
+        elif self.return_sequences:
             return outputs.dimshuffle((1, 0, 2))
         return outputs[-1]
 
@@ -581,7 +589,9 @@ class JZS1(Recurrent):
             non_sequences=[self.U_r, self.U_h],
             truncate_gradient=self.truncate_gradient,
             go_backwards=self.go_backwards)
-        if self.return_sequences:
+        if self.return_sequences and self.go_backwards:
+            return outputs[::-1].dimshuffle((1, 0, 2))
+        elif self.return_sequences:
             return outputs.dimshuffle((1, 0, 2))
         return outputs[-1]
 
@@ -703,7 +713,9 @@ class JZS2(Recurrent):
             truncate_gradient=self.truncate_gradient,
             go_backwards=self.go_backwards)
 
-        if self.return_sequences:
+        if self.return_sequences and self.go_backwards:
+            return outputs[::-1].dimshuffle((1, 0, 2))
+        elif self.return_sequences:
             return outputs.dimshuffle((1, 0, 2))
         return outputs[-1]
 
@@ -817,7 +829,9 @@ class JZS3(Recurrent):
             truncate_gradient=self.truncate_gradient,
             go_backwards=self.go_backwards)
         
-        if self.return_sequences:
+        if self.return_sequences and self.go_backwards:
+            return outputs[::-1].dimshuffle((1, 0, 2))
+        elif self.return_sequences:
             return outputs.dimshuffle((1, 0, 2))
         return outputs[-1]
 


### PR DESCRIPTION
I double checked my bidirectional RNN code and looked closely to the theano scan implementation and i found an error where the return sequences flag is active. (it actually return the reversed sequences that may cause failure in particular where stacking Bidirectional Layers.

Here is the fix.