### PR TITLE
Fix for join mode.

### DIFF
--- a/docs/sources/layers/core.md
+++ b/docs/sources/layers/core.md
@@ -3,6 +3,8 @@
 ```python
 keras.layers.core.Layer()
 ```
+- __Arguments__:
+    -__name__: assign a name to the layer. That's is needed when using merge_mode=`join` in `keras.layers.core.Merge()
 
 __Methods__:
 
@@ -339,7 +341,7 @@ Merge the output of a list of layers (or containers) into a single tensor, follo
 
 - __Arguments__:
     - __layers__: List of layers or [containers](/layers/containers/).
-    - __mode__: String, one of `{'sum', 'mul', 'concat'}`. `sum` and `mul` will simply sum/multiply the outputs of the layers (therefore all layers should have an output with the same shape). `concat` will concatenate the outputs along the last dimension (therefore all layers should have an output that only differ along the last dimension). 
+    - __mode__: String, one of `{'sum', 'mul', 'concat', 'dot', 'cos', 'join'}`. `sum` and `mul` will simply sum/multiply the outputs of the layers (therefore all layers should have an output with the same shape). `concat` will concatenate the outputs along the last dimension (therefore all layers should have an output that only differ along the last dimension). `dot` and `cos` computes the dot product/cosine similarity between two input vectors. `join` allows to forward the output of the layers to the upper layer (usefull in graph based model when using custom layers accepting more inputs e.g. Bilinear Layer W dot x + W dot z + b).
 
 - __Example__:
 

--- a/keras/layers/containers.py
+++ b/keras/layers/containers.py
@@ -129,7 +129,7 @@ class Graph(Layer):
             - get_weights
             - set_weights
     '''
-    def __init__(self):
+    def __init__(self, **kwargs):
         self.namespace = set()  # strings
         self.nodes = OrderedDict()  # layer-like
         self.inputs = {}  # layer-like

--- a/keras/layers/containers.py
+++ b/keras/layers/containers.py
@@ -19,10 +19,11 @@ class Sequential(Layer):
         - supports_masked_input
     '''
 
-    def __init__(self, layers=[]):
+    def __init__(self, layers=[], **kwargs):
         self.layers = []
         for layer in layers:
             self.add(layer)
+        super(Sequential, self).__init__(**kwargs)
 
     def set_previous(self, layer):
         self.layers[0].previous = layer
@@ -138,6 +139,7 @@ class Graph(Layer):
         self.input_config = []  # dicts
         self.output_config = []  # dicts
         self.node_config = []  # dicts
+        super(Graph, self).__init__(**kwargs)
 
     @property
     def nb_input(self):

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -24,7 +24,7 @@ import sys
 class Layer(object):
     def __init__(self, **kwargs):
         for kwarg in kwargs:
-            assert kwarg in {'input_shape', 'trainable'}, "Keyword argument not understood: " + kwarg
+            assert kwarg in {'input_shape', 'trainable', 'name'}, "Keyword argument not understood: " + kwarg
         if 'input_shape' in kwargs:
             self.set_input_shape(kwargs['input_shape'])
         if 'trainable' in kwargs:

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -31,6 +31,7 @@ class Layer(object):
             self._trainable = kwargs['trainable']
         if not hasattr(self, 'params'):
             self.params = []
+        self.name = None
 
     def set_previous(self, layer, connection_map={}):
         assert self.nb_input == layer.nb_output == 1, "Cannot connect layers: input count and output count should be 1."
@@ -180,6 +181,7 @@ class Layer(object):
         return self.params, regularizers, consts, updates
 
     def set_name(self, name):
+        self.name = name
         for i in range(len(self.params)):
             self.params[i].name = '%s_p%d' % (name, i)
 
@@ -397,10 +399,10 @@ class Merge(Layer):
             inputs = OrderedDict()
             for i in range(len(self.layers)):
                 X = self.layers[i].get_output(train)
-                if X.name is None:
+                if self.layers[i].name is None:
                     raise ValueError("merge_mode='join' only works with named inputs")
                 else:
-                    inputs[X.name] = X
+                    inputs[self.layers[i].name] = X
             return inputs
         elif self.mode == 'mul':
             s = self.layers[0].get_output(train)

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -31,7 +31,11 @@ class Layer(object):
             self._trainable = kwargs['trainable']
         if not hasattr(self, 'params'):
             self.params = []
-        self.name = None
+        if 'name' in kwargs:
+            self.name = kwargs['name']
+        else:
+            self.name = None
+        
 
     def set_previous(self, layer, connection_map={}):
         assert self.nb_input == layer.nb_output == 1, "Cannot connect layers: input count and output count should be 1."


### PR DESCRIPTION
I need to introduce a bit the problem first.
The `join` mode for the merge layer is the layer designed to pass the inputs of a graph node to the layer without any transformation. That was the pull request with the relative discussion.

https://github.com/fchollet/keras/pull/690

The problem with the previous implementation of the code was that It always produce the exception `raise ValueError("merge_mode='join' only works with named inputs")`
since there are no named output tensors in keras. 

```python
 for i in range(len(self.layers)):
     X = self.layers[i].get_output(train)
    if X.name is None:
       raise ValueError("merge_mode='join' only works with named inputs")
    else:
       inputs[X.name] = X
 return inputs
```



The first and simple solution that came to my mind was obviously to name any output tensors in the code. But i think that for the moment is dispendious and useless.

So i decided to add a parameter `name` to the layer itself that is set with the set_name function.

Tell me what you ( @fchollet  ) and @EderSantana (the original creator of the join mode) think and in particular if any further modification is needed.