### PR TITLE
Lambda layer enhancements

### DIFF
--- a/docs/sources/layers/core.md
+++ b/docs/sources/layers/core.md
@@ -382,7 +382,7 @@ keras.layers.core.Lambda(function, output_shape=None)
 
 Used for evaluating an arbitrary Theano expression on the output of the previous layer.
 
-- __Input shape__: Output shape of the previous layer.
+- __Input shape__: Arbitrary. Use the keyword argument input_shape (tuple of integers, does not include the samples axis) when using this layer as the first layer in a model.
 
 - __Output shape__: Specified by the `output_shape` argument.
 

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -986,8 +986,8 @@ class Lambda(Layer):
     output_shape - Expected output shape from function. Could be a tuple or a function of the shape of the input
     """
 
-    def __init__(self, function, output_shape=None):
-        super(Lambda, self).__init__()
+    def __init__(self, function, output_shape=None, **kwargs):
+        super(Lambda, self).__init__(**kwargs)
         py3 = sys.version_info[0] == 3
         if py3:
             self.function = marshal.dumps(function.__code__)

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -1005,7 +1005,7 @@ class Lambda(Layer):
 
     @property
     def output_shape(self):
-        if self._ouput_shape is None:
+        if self._output_shape is None:
             return self.input_shape
         elif type(self._output_shape) == tuple:
             return (self.input_shape[0], ) + self._output_shape


### PR DESCRIPTION
Fixed a typo in `Lambda` layer. Also allowed it to pass kwargs through to the `Layer` constructor. This lets you pass an `input_shape` kwarg so that you can use `Lambda` as the first layer. I also updated the docs to reflect the change.

For example, this is what I wanted to do, which wasn't possible before:

```{python}
def img_norm(X):
	return X / 255

model = Sequential()
model.add(Lambda(img_norm, input_shape=(3, img_size, img_size)))
model.add(Convolution2D(32, 10, 10))
```