### PR TITLE
Add visualize_util.to_graph and docs

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -24,6 +24,7 @@ pages:
 - Constraints: constraints.md
 - Callbacks: callbacks.md
 - Datasets: datasets.md
+- Visualization: visualization.md
 - Layers:
   - Core Layers: layers/core.md
   - Convolutional Layers: layers/convolutional.md

--- a/docs/sources/visualization.md
+++ b/docs/sources/visualization.md
@@ -1,0 +1,20 @@
+
+## Model visualization
+
+The `keras.utils.visualize_util` module provides utility functions to plot
+a Keras model (using graphviz).
+
+This will plot a graph of the model and save it to a file:
+```python
+from keras.utils.visualize_util import plot
+plot(model, to_file='model.png')
+```
+
+You can also directly obtain the `pydot.Graph` object and render it yourself,
+for example to show it in an ipython notebook :
+```python
+from IPython.display import SVG
+from keras.utils.visualize_util import to_graph
+
+SVG(to_graph(model).create(prog='dot', format='svg'))
+```

--- a/keras/utils/visualize_util.py
+++ b/keras/utils/visualize_util.py
@@ -3,8 +3,7 @@ import pydot
 # that works with python3 such as pydot2 or pydot
 from keras.models import Sequential, Graph
 
-def plot(model, to_file='model.png'):
-
+def to_graph(model):
     graph = pydot.Dot(graph_type='digraph')
     if type(model) == Sequential:
         previous_node = None
@@ -20,8 +19,6 @@ def plot(model, to_file='model.png'):
             if previous_node:
                 graph.add_edge(pydot.Edge(previous_node, current_node))
             previous_node = current_node
-        graph.write_png(to_file)
-
     elif type(model) == Graph:
         # don't need to append number for names since all nodes labeled
         for input_node in model.input_config:
@@ -37,5 +34,8 @@ def plot(model, to_file='model.png'):
                         graph.add_edge(pydot.Edge(e, node['name']))
                 else:
                     graph.add_edge(pydot.Edge(node['input'], node['name']))
+    return graph
 
-        graph.write_png(to_file)
+def plot(model, to_file='model.png'):
+    graph = to_graph(model)
+    graph.write_png(to_file)


### PR DESCRIPTION
This adds a new to_graph function in visualize_util that allow to get the pydot.Graph object directly, without necessarily rendering to a file. This allow to render the graph inline in a ipython notebook.

This also adds a 'visualization' doc section with examples of visualize_util usage.