### PR TITLE
Fix set_input_shape function in Layer

### DIFF
--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -84,7 +84,7 @@ class Layer(object):
     def set_input_shape(self, input_shape):
         if type(input_shape) not in [tuple, list]:
             raise Exception('Invalid input shape - input_shape should be a tuple of int.')
-        input_shape = (None,) + tuple(input_shape)
+        input_shape = tuple(input_shape)
         if hasattr(self, 'input_ndim') and self.input_ndim:
             if self.input_ndim != len(input_shape):
                 raise Exception('Invalid input shape - Layer expects input ndim=' +


### PR DESCRIPTION
This PR is to fix the following problem when trying to set the input shape of a layer:

```python
X = np.zeros((1,1))
model = Sequential()
model.add(Dense(1, input_shape=X.shape))
```
Output:
```
Exception: Invalid input shape - Layer expects input ndim=2, was provided with input shape (None, 1, 1)
```