### PR TITLE
Save weights fwrite buffer issue in Windows

### DIFF
--- a/keras/models.py
+++ b/keras/models.py
@@ -7,7 +7,6 @@ import warnings, time, copy, pprint
 from six.moves import range
 import six
 
-
 from . import optimizers
 from . import objectives
 from . import regularizers

--- a/keras/models.py
+++ b/keras/models.py
@@ -7,6 +7,7 @@ import warnings, time, copy, pprint
 from six.moves import range
 import six
 
+
 from . import optimizers
 from . import objectives
 from . import regularizers
@@ -531,6 +532,7 @@ class Sequential(Model, containers.Sequential):
         # Save weights from all layers to HDF5
         import h5py
         import os.path
+        import os
         # if file exists and should not be overwritten
         if not overwrite and os.path.isfile(filepath):
             import sys
@@ -543,8 +545,10 @@ class Sequential(Model, containers.Sequential):
             if overwrite == 'n':
                 return
             print('[TIP] Next time specify overwrite=True in save_weights!')
-
-        f = h5py.File(filepath, 'w')
+        if os.name == 'nt':
+            f = h5py.File(filepath, 'wb')
+        else:
+            f = h5py.File(filepath, 'w')
         f.attrs['nb_layers'] = len(self.layers)
         for k, l in enumerate(self.layers):
             g = f.create_group('layer_{}'.format(k))
@@ -701,6 +705,7 @@ class Graph(Model, containers.Graph):
         # Save weights from all layers to HDF5
         import h5py
         import os.path
+        import os
         # if file exists and should not be overwritten
         if not overwrite and os.path.isfile(filepath):
             import sys
@@ -714,7 +719,10 @@ class Graph(Model, containers.Graph):
                 return
             print('[TIP] Next time specify overwrite=True in save_weights!')
 
-        f = h5py.File(filepath, 'w')
+        if os.name == 'nt':
+            f = h5py.File(filepath, 'wb')
+        else:
+            f = h5py.File(filepath, 'w')
         g = f.create_group('graph')
         weights = self.get_weights()
         g.attrs['nb_params'] = len(weights)


### PR DESCRIPTION
I encountered an issue saving weights upon epoch completion in Windows. I found this [bug workaround](http://webcache.googleusercontent.com/search?q=cache:rrgvnf2-0LIJ:https:%2F%2Fsupport.microsoft.com%2Fen-us%2Fkb%2F899149%20&cd=1&hl=en&ct=clnk&gl=us) which suggested using 'wb' mode when opening the file to write. I edited the mode for both Sequential and Graph mode if using Windows. It seems to have solved the issue for me.