### PR TITLE
Fix: Specify parameter names for dense layer constructor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ keras/datasets/temp/*
 docs/site/*
 docs/theme/*
 tags
+Keras.egg-info

--- a/tests/manual/check_save_weights.py
+++ b/tests/manual/check_save_weights.py
@@ -9,15 +9,15 @@ import pickle, numpy
 
 def create_model():
     model = Sequential()
-    model.add(Dense(256, 2048, init='uniform', activation='relu'))
+    model.add(Dense(input_dim=256, output_dim=2048, init='uniform', activation='relu'))
     model.add(Dropout(0.5))
-    model.add(Dense(2048, 2048, init='uniform', activation='relu'))
+    model.add(Dense(input_dim=2048, output_dim=2048, init='uniform', activation='relu'))
     model.add(Dropout(0.5))
-    model.add(Dense(2048, 2048, init='uniform', activation='relu'))
+    model.add(Dense(input_dim=2048, output_dim=2048, init='uniform', activation='relu'))
     model.add(Dropout(0.5))
-    model.add(Dense(2048, 2048, init='uniform', activation='relu'))
+    model.add(Dense(input_dim=2048, output_dim=2048, init='uniform', activation='relu'))
     model.add(Dropout(0.5))
-    model.add(Dense(2048, 256, init='uniform', activation='linear'))
+    model.add(Dense(input_dim=2048, output_dim=256, init='uniform', activation='linear'))
     return model
 
 model = create_model()
@@ -36,5 +36,3 @@ for k in range(len(model.layers)):
     for x, y in zip(weights_orig, weights_loaded):
         if numpy.any(x != y):
             raise ValueError('Loaded weights are different from pickled weights!')
-
-


### PR DESCRIPTION
`python tests/manual/check_save_weights.py`

causes this error:

```
Traceback (most recent call last):
  File "tests/manual/check_save_weights.py", line 23, in <module>
    model = create_model()
  File "tests/manual/check_save_weights.py", line 12, in create_model
    model.add(Dense(256, 2048, init='uniform', activation='relu'))
TypeError: __init__() got multiple values for argument 'init'
```

I've explicitly specified the parameter names for the Dense layer.