### PR TITLE
Add Clockwork RNN

### DIFF
--- a/examples/addition_rnn.py
+++ b/examples/addition_rnn.py
@@ -12,11 +12,6 @@ Input: "535+61"
 Output: "596"
 Padding is handled by using a repeated sentinel character (space)
 
-By default, the JZS1 recurrent neural network is used
-JZS1 was an "evolved" recurrent neural network performing well on arithmetic benchmark in:
-"An Empirical Exploration of Recurrent Network Architectures"
-http://jmlr.org/proceedings/papers/v37/jozefowicz15.pdf
-
 Input may optionally be inverted, shown to increase performance in many tasks in:
 "Learning to Execute"
 http://arxiv.org/abs/1410.4615
@@ -26,16 +21,16 @@ http://papers.nips.cc/paper/5346-sequence-to-sequence-learning-with-neural-netwo
 Theoretically it introduces shorter term dependencies between source and target.
 
 Two digits inverted:
-+ One layer JZS1 (128 HN), 5k training examples = 99% train/test accuracy in 55 epochs
++ One layer LSTM (128 HN), 5k training examples = 99% train/test accuracy in 55 epochs
 
 Three digits inverted:
-+ One layer JZS1 (128 HN), 50k training examples = 99% train/test accuracy in 100 epochs
++ One layer LSTM (128 HN), 50k training examples = 99% train/test accuracy in 100 epochs
 
 Four digits inverted:
-+ One layer JZS1 (128 HN), 400k training examples = 99% train/test accuracy in 20 epochs
++ One layer LSTM (128 HN), 400k training examples = 99% train/test accuracy in 20 epochs
 
 Five digits inverted:
-+ One layer JZS1 (128 HN), 550k training examples = 99% train/test accuracy in 30 epochs
++ One layer LSTM (128 HN), 550k training examples = 99% train/test accuracy in 30 epochs
 
 """
 
@@ -75,8 +70,8 @@ class colors:
 TRAINING_SIZE = 50000
 DIGITS = 3
 INVERT = True
-# Try replacing JZS1 with LSTM, GRU, or SimpleRNN
-RNN = recurrent.JZS1
+# Try replacing GRU, or SimpleRNN
+RNN = recurrent.LSTM
 HIDDEN_SIZE = 128
 BATCH_SIZE = 128
 LAYERS = 1
@@ -123,6 +118,7 @@ indices = np.arange(len(y))
 np.random.shuffle(indices)
 X = X[indices]
 y = y[indices]
+
 # Explicitly set apart 10% for validation data that we never train over
 split_at = len(X) - len(X) / 10
 (X_train, X_val) = (slice_X(X, 0, split_at), slice_X(X, split_at))
@@ -136,7 +132,7 @@ model = Sequential()
 # "Encode" the input sequence using an RNN, producing an output of HIDDEN_SIZE
 # note: in a situation where your input sequences have a variable length,
 # use input_shape=(None, nb_feature).
-model.add(RNN(HIDDEN_SIZE, input_shape=(None, len(chars))))
+model.add(RNN(HIDDEN_SIZE, input_shape=(MAXLEN, len(chars))))
 # For the decoder's input, we repeat the encoded input for each time step
 model.add(RepeatVector(DIGITS + 1))
 # The decoder RNN could be multiple layers stacked or a single layer

--- a/examples/imdb_bidirectional_lstm.py
+++ b/examples/imdb_bidirectional_lstm.py
@@ -41,7 +41,7 @@ y_test = np.array(y_test)
 
 print('Build model...')
 model = Graph()
-model.add_input(name='input', input_shape=(1,), dtype=int)
+model.add_input(name='input', input_shape=(maxlen,), dtype=int)
 model.add_node(Embedding(max_features, 128, input_length=maxlen),
                name='embedding', input='input')
 model.add_node(LSTM(64), name='forward', input='embedding')

--- a/examples/mnist_irnn.py
+++ b/examples/mnist_irnn.py
@@ -23,8 +23,8 @@ from keras.utils import np_utils
     Optimizer is replaced with RMSprop which yields more stable and steady
     improvement.
 
-    Reaches 0.93 train/test accuracy after 900 epochs (which roughly corresponds
-    to 1687500 steps in the original paper.)
+    Reaches 0.93 train/test accuracy after 900 epochs
+    (which roughly corresponds to 1687500 steps in the original paper.)
 '''
 
 batch_size = 32
@@ -34,7 +34,6 @@ hidden_units = 100
 
 learning_rate = 1e-6
 clip_norm = 1.0
-BPTT_truncate = 28*28
 
 # the data, shuffled and split between train and test sets
 (X_train, y_train), (X_test, y_test) = mnist.load_data()
@@ -58,8 +57,7 @@ model = Sequential()
 model.add(SimpleRNN(output_dim=hidden_units,
                     init=lambda shape: normal(shape, scale=0.001),
                     inner_init=lambda shape: identity(shape, scale=1.0),
-                    activation='relu', truncate_gradient=BPTT_truncate,
-                    input_shape=(None, 1)))
+                    activation='relu', input_shape=X_train.shape[1:]))
 model.add(Dense(nb_classes))
 model.add(Activation('softmax'))
 rmsprop = RMSprop(lr=learning_rate)
@@ -74,7 +72,7 @@ print('IRNN test accuracy:', scores[1])
 
 print('Compare to LSTM...')
 model = Sequential()
-model.add(LSTM(hidden_units, input_shape=(None, 1)))
+model.add(LSTM(hidden_units, input_shape=X_train.shape[1:]))
 model.add(Dense(nb_classes))
 model.add(Activation('softmax'))
 rmsprop = RMSprop(lr=learning_rate)

--- a/keras/activations.py
+++ b/keras/activations.py
@@ -3,7 +3,18 @@ from . import backend as K
 
 
 def softmax(x):
-    return K.softmax(x)
+    ndim = K.ndim(x)
+    if ndim == 2:
+        return K.softmax(x)
+    elif ndim == 3:
+        # apply softmax to each timestep
+        def step(x, states):
+            return K.softmax(x), []
+        last_output, outputs, states = K.rnn(step, x, [], masking=False)
+        return outputs
+    else:
+        raise Exception('Cannot apply softmax to a tensor that is not 2D or 3D. ' +
+                        'Here, ndim=' + str(ndim))
 
 
 def softplus(x):

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -381,7 +381,7 @@ def rnn(step_function, inputs, initial_states,
     successive_states = []
     successive_outputs = []
     if go_backwards:
-        input_list = input_list.reverse()
+        input_list.reverse()
     for input in input_list:
         output, new_states = step_function(input, states)
         if masking:

--- a/keras/layers/containers.py
+++ b/keras/layers/containers.py
@@ -224,12 +224,13 @@ class Graph(Layer):
         self.input_order.append(name)
         layer = Layer()  # empty layer
         layer.set_input_shape(input_shape)
-        ndim = len(input_shape) + 1
         if dtype == 'float':
-            layer.input = K.placeholder(ndim=ndim, name=name)
+            layer.input = K.placeholder(shape=layer.input_shape, name=name)
         else:
-            if ndim == 2:
-                layer.input = K.placeholder(ndim=2, dtype='int32', name=name)
+            if len(input_shape) == 1:
+                layer.input = K.placeholder(shape=layer.input_shape,
+                                            dtype='int32',
+                                            name=name)
             else:
                 raise Exception('Type "int" can only be used with ndim==2 (Embedding).')
         self.inputs[name] = layer

--- a/keras/layers/embeddings.py
+++ b/keras/layers/embeddings.py
@@ -17,9 +17,12 @@ class Embedding(Layer):
     '''
     input_ndim = 2
 
-    def __init__(self, input_dim, output_dim, init='uniform', input_length=None,
-                 W_regularizer=None, activity_regularizer=None, W_constraint=None,
-                 mask_zero=False, weights=None, **kwargs):
+    def __init__(self, input_dim, output_dim,
+                 init='uniform', input_length=None,
+                 W_regularizer=None, activity_regularizer=None,
+                 W_constraint=None,
+                 mask_zero=False,
+                 weights=None, **kwargs):
         self.input_dim = input_dim
         self.output_dim = output_dim
         self.init = initializations.get(init)

--- a/tests/keras/backend/test_backends.py
+++ b/tests/keras/backend/test_backends.py
@@ -38,7 +38,7 @@ def check_two_tensor_operation(function_name, x_input_shape,
     assert_allclose(zth, ztf, atol=1e-06)
 
 
-@pytest.mark.skipif(sys.version_info < (2, 7), reason="Requires Python 2.7")
+@pytest.mark.skipif(sys.version_info.major != 2, reason="Requires Python 2.7")
 class TestBackend(unittest.TestCase):
 
     def test_linear_operations(self):

--- a/tests/keras/backend/test_backends.py
+++ b/tests/keras/backend/test_backends.py
@@ -4,8 +4,9 @@ from numpy.testing import assert_allclose
 import numpy as np
 import pytest
 
-from keras.backend import theano_backend as KTH
-from keras.backend import tensorflow_backend as KTF
+if sys.version_info.major == 2:
+    from keras.backend import theano_backend as KTH
+    from keras.backend import tensorflow_backend as KTF
 
 
 def check_single_tensor_operation(function_name, input_shape, **kwargs):


### PR DESCRIPTION
I have a clockwork RNN implementation in layers/recurrent.py:

```python
class CWRNN(Recurrent):
    '''
        Clockwork Recurrent Unit - Koutnik et al. 2014

        Clockwork RNN splits simple RNN neurons into groups of equal sizes.
        Each group is activated every specified period. As a result, fast
        groups capture short-term input features while slow groups capture
        long-term input features.

        References:
            A Clockwork RNN
                http://arxiv.org/abs/1402.3511
    '''
    def __init__(self, output_dim, periods=[1],
                 init='glorot_uniform', inner_init='orthogonal',
                 activation='sigmoid',
                 weights=None, truncate_gradient=-1, return_sequences=False,
                 input_dim=None, input_length=None, **kwargs):
        self.output_dim = output_dim
        assert output_dim % len(periods) == 0
        self.periods = np.asarray(sorted(periods, reverse=True))
        self.init = initializations.get(init)
        self.inner_init = initializations.get(inner_init)

        self.activation = activations.get(activation)
        self.truncate_gradient = truncate_gradient
        self.return_sequences = return_sequences
        self.initial_weights = weights

        self.input_dim = input_dim
        self.input_length = input_length
        if self.input_dim:
            kwargs['input_shape'] = (self.input_length, self.input_dim)
        super(CWRNN, self).__init__(**kwargs)

    def build(self):
        input_dim = self.input_shape[2]
        n = self.output_dim // len(self.periods)
        self.mask = np.zeros((self.output_dim, self.output_dim), theano.config.floatX)
        self.period = np.zeros((self.output_dim,), 'i')
        for i, t in enumerate(self.periods):
            self.mask[i*n:(i+1)*n, i*n:] = 1
            self.period[i*n:(i+1)*n] = t
        self.input = T.tensor3()
        self.W = self.init((input_dim, self.output_dim))
        self.U = self.inner_init((self.output_dim, self.output_dim))
        self.params = [self.W, self.U, self.b]

        if self.initial_weights is not None:
            self.set_weights(self.initial_weights)
            del self.initial_weights

    def _step(self, t, x_t,
              y_tm1,
              u, period):
        y = x_t + T.dot(y_tm1, u)
        y_t = T.switch(T.eq(t % period, 0), self.activation(y), y_tm1)
        return y_t

    def get_output(self, train=False):
        X = self.get_input(train)
        X = X.dimshuffle(1, 0, 2)
        x = T.dot(X, self.W) + self.b
        outputs, updates = theano.scan(
            self._step,
            sequences=[T.arange(x.shape[0]), x],
            outputs_info=T.unbroadcast(alloc_zeros_matrix(X.shape[1], self.output_dim), 1),
            non_sequences=[self.U * self.mask, self.period],
            truncate_gradient=self.truncate_gradient)

        if self.return_sequences:
            return outputs.dimshuffle((1, 0, 2))
        return outputs[-1]

    def get_config(self):
        config = {"name": self.__class__.__name__,
                  "output_dim": self.output_dim,
                  "periods": self.periods,
                  "init": self.init.__name__,
                  "inner_init": self.inner_init.__name__,
                  "activation": self.activation.__name__,
                  "truncate_gradient": self.truncate_gradient,
                  "return_sequences": self.return_sequences,
                  "input_dim": self.input_dim,
                  "input_length": self.input_length}
        base_config = super(CWRNN, self).get_config()
        return dict(list(base_config.items()) + list(config.items()))

```