### PR TITLE
Add __call__

### DIFF
--- a/docs/sources/layers/core.md
+++ b/docs/sources/layers/core.md
@@ -12,13 +12,12 @@ __Methods__:
 __call__
 ```
 
-Apply layer transformation defined by its `get_output` method to an input `X`.
+Apply layer transformation an input Tensor `X`.
 
 - __Return__: Tensor.
 
 - __Arguments__:
-    - __X__: Tensor. External input Tensor that will temporally replace
-        __get_input__ value.
+    - __X__: Tensor. Input Tensor.
     - __train__: bool. Specifies whether output is computed in training mode or in testing mode, which can change the logic, for instance in there are any `Dropout` layers in the network.
 
 

--- a/docs/sources/layers/core.md
+++ b/docs/sources/layers/core.md
@@ -1,10 +1,25 @@
 ## Base class
 
+Note: Where ever we refer to a "Tensor" bear in mind that its the type depends on the backend you are using.
+
 ```python
 keras.layers.core.Layer()
 ```
 
 __Methods__:
+
+```python
+__call__
+```
+
+Apply Layer to an external input tensor.
+
+- __Return__: Tensor.
+
+- __Arguments__:
+    - __X__: Tensor. External input Tensor that will temporally replace
+        __get_input__ value.
+
 
 ```python
 set_previous(previous_layer)
@@ -14,7 +29,7 @@ Connect the input of the current layer to the output of the argument layer.
 
 - __Return__: None.
 
-- __Arguments__: 
+- __Arguments__:
     - __previous_layer__: Layer object.
 
 
@@ -25,10 +40,10 @@ get_output(train)
 
 Get the output of the layer.
 
-- __Return__: Theano tensor.
+- __Return__: Tensor.
 
-- __Arguments__: 
-    - __train__: Boolean. Specifies whether output is computed in training mode or in testing mode, which can change the logic, for instance in there are any `Dropout` layers in the network. 
+- __Arguments__:
+    - __train__: Boolean. Specifies whether output is computed in training mode or in testing mode, which can change the logic, for instance in there are any `Dropout` layers in the network.
 
 
 
@@ -38,10 +53,10 @@ get_input(train)
 
 Get the input of the layer.
 
-- __Return__: Theano tensor.
+- __Return__: Tensor.
 
-- __Arguments__: 
-    - __train__: Boolean. Specifies whether output is computed in training mode or in testing mode, which can change the logic, for instance in there are any `Dropout` layers in the network. 
+- __Arguments__:
+    - __train__: Boolean. Specifies whether output is computed in training mode or in testing mode, which can change the logic, for instance in there are any `Dropout` layers in the network.
 
 
 
@@ -51,7 +66,7 @@ get_weights()
 
 Get the weights of the parameters of the layer.
 
-- __Return__: List of numpy arrays (one per layer parameter). 
+- __Return__: List of numpy arrays (one per layer parameter).
 
 
 
@@ -61,7 +76,7 @@ set_weights(weights)
 
 Set the weights of the parameters of the layer.
 
-- __Arguments__: 
+- __Arguments__:
     - __weights__: List of numpy arrays (one per layer parameter). Should be in the same order as what `get_weights(self)` returns.
 
 
@@ -85,7 +100,7 @@ keras.layers.core.Dense(output_dim,
                         input_dim=None)
 ```
 
-Standard 1D fully-connect layer. 
+Standard 1D fully-connect layer.
 
 - __Input shape__: 2D tensor with shape: `(nb_samples, input_dim)`.
 
@@ -93,7 +108,7 @@ Standard 1D fully-connect layer.
 
 - __Arguments__:
 
-    - __output_dim__: int >= 0. 
+    - __output_dim__: int >= 0.
     - __init__: name of initialization function for the weights of the layer (see: [initializations](../initializations.md)), or alternatively, Theano function to use for weights initialization. This parameter is only relevant if you don't pass a `weights` argument.
     - __activation__: name of activation function to use (see: [activations](../activations.md)), or alternatively, elementwise Theano function. If you don't specify anything, no activation is applied (ie. "linear" activation: a(x) = x).
     - __weights__: list of numpy arrays to set as initial weights. The list should have 1 element, of shape `(input_dim, output_dim)`.
@@ -102,7 +117,7 @@ Standard 1D fully-connect layer.
     - __activity_regularizer__: instance of [ActivityRegularizer](../regularizers.md), applied to the network output.
     - __W_constraint__: instance of the [constraints](../constraints.md) module (eg. maxnorm, nonneg), applied to the main weights matrix.
     - __b_constraint__: instance of the [constraints](../constraints.md) module, applied to the bias.
-    - __input_dim__: dimensionality of the input (integer). This argument (or alternatively, the keyword argument `input_shape`) is required when using this layer as the first layer in a model. 
+    - __input_dim__: dimensionality of the input (integer). This argument (or alternatively, the keyword argument `input_shape`) is required when using this layer as the first layer in a model.
 
 ---
 
@@ -122,7 +137,7 @@ Fully-connected layer distributed over the time dimension. Useful after a recurr
 - __Input shape__: 3D tensor with shape: `(nb_samples, timesteps, input_dim)`.
 
 - __Arguments__:
-    - __output_dim__: int >= 0. 
+    - __output_dim__: int >= 0.
     - __init__: name of initialization function for the weights of the layer (see: [initializations](../initializations.md)), or alternatively, Theano function to use for weights initialization. This parameter is only relevant if you don't pass a `weights` argument.
     - __activation__: name of activation function to use (see: [activations](../activations.md)), or alternatively, elementwise Theano function. If you don't specify anything, no activation is applied (ie. "linear" activation: a(x) = x).
     - __weights__: list of numpy arrays to set as initial weights. The list should have 1 element, of shape `(input_dim, output_dim)`.
@@ -161,9 +176,9 @@ A customizable autoencoder model. If `output_reconstruction = True` then dim(inp
     - __encoder__: A [layer](./) or [layer container](./containers.md).
 
     - __decoder__: A [layer](./) or [layer container](./containers.md).
-    
+
     - __output_reconstruction__: If this is False, then when .predict() is called, the output is the deepest hidden layer's activation. Otherwise, the output of the final decoder layer is presented. Be sure your validation data conforms to this logic if you decide to use any.
-    
+
     - __weights__: list of numpy arrays to set as initial weights. The list should have 1 element, of shape `(input_dim, output_dim)`.
 
 - __Example__:
@@ -185,7 +200,7 @@ autoencoder.add(AutoEncoder(encoder=encoder, decoder=decoder, output_reconstruct
 ```python
 keras.layers.core.Activation(activation)
 ```
-Apply an activation function to the input. 
+Apply an activation function to the input.
 
 
 - __Input shape__: Arbitrary. Use the keyword argument `input_shape` (tuple of integers, does not include the samples axis) when using this layer as the first layer in a model. To specify the number of samples per batch, you can use the keyword argument `batch_input_shape` (tuple of integers, including the samples axis).
@@ -212,7 +227,7 @@ Apply dropout to the input. Dropout consists in randomly setting a fraction `p` 
 
 - __Arguments__:
 
-    - __p__: float (0 <= p < 1). Fraction of the input that gets dropped out at training time. 
+    - __p__: float (0 <= p < 1). Fraction of the input that gets dropped out at training time.
 
 ---
 
@@ -222,7 +237,7 @@ Apply dropout to the input. Dropout consists in randomly setting a fraction `p` 
 keras.layers.core.Reshape(dims)
 ```
 
-Reshape the input to a new shape containing the same number of units. 
+Reshape the input to a new shape containing the same number of units.
 
 
 - __Input shape__: Arbitrary. Use the keyword argument `input_shape` (tuple of integers, does not include the samples axis) when using this layer as the first layer in a model. To specify the number of samples per batch, you can use the keyword argument `batch_input_shape` (tuple of integers, including the samples axis).
@@ -247,7 +262,7 @@ model.add(Reshape(dims=(10, 10)))  # output shape: (nb_samples, 10, 10)
 keras.layers.core.Flatten()
 ```
 
-Convert a nD input to 1D. 
+Convert a nD input to 1D.
 
 - __Input shape__: Arbitrary. Use the keyword argument `input_shape` (tuple of integers, does not include the samples axis) when using this layer as the first layer in a model. To specify the number of samples per batch, you can use the keyword argument `batch_input_shape` (tuple of integers, including the samples axis).
 
@@ -259,7 +274,6 @@ Convert a nD input to 1D.
 ```python
 keras.layers.core.RepeatVector(n)
 ```
-
 Repeat the 1D input n times. Dimensions of input are assumed to be `(nb_samples, dim)`. Output will have the shape `(nb_samples, n, dim)`.
 
 Note that the output is still a single tensor; `RepeatVector` does not split the data flow.
@@ -269,7 +283,7 @@ Note that the output is still a single tensor; `RepeatVector` does not split the
 - __Output shape__: `(nb_samples, n, input_dims)`.
 
 - __Arguments__:
-    - __n__: int. 
+    - __n__: int.
 
 ---
 
@@ -324,8 +338,8 @@ A dense maxout layer. A `MaxoutDense` layer takes the element-wise maximum of `n
 
 - __Arguments__:
 
-    - __output_dim__: int >= 0. 
-    - __nb_feature__: int >= 0. the number of features to create for the maxout. This is equivalent to the number of piecewise elements to be allowed for the activation function. 
+    - __output_dim__: int >= 0.
+    - __nb_feature__: int >= 0. the number of features to create for the maxout. This is equivalent to the number of piecewise elements to be allowed for the activation function.
     - __init__: name of initialization function for the weights of the layer (see: [initializations](../initializations.md)), or alternatively, Theano function to use for weights initialization. This parameter is only relevant if you don't pass a `weights` argument.
     - __weights__: list of numpy arrays to set as initial weights. The list should have 1 element, of shape `(input_dim, output_dim)`.
     - __W_regularizer__: instance of [WeightRegularizer](../regularizers.md) (eg. L1 or L2 regularization), applied to the main weights matrix.

--- a/docs/sources/layers/core.md
+++ b/docs/sources/layers/core.md
@@ -1,6 +1,6 @@
 ## Base class
 
-Note: Where ever we refer to a "Tensor" bear in mind that its the type depends on the backend you are using.
+Note: Where ever we refer to a "Tensor" bear in mind that its type depends on the backend you are using.
 
 ```python
 keras.layers.core.Layer()
@@ -12,13 +12,14 @@ __Methods__:
 __call__
 ```
 
-Apply Layer to an external input tensor.
+Apply layer transformation defined by its `get_output` method to an input `X`.
 
 - __Return__: Tensor.
 
 - __Arguments__:
     - __X__: Tensor. External input Tensor that will temporally replace
         __get_input__ value.
+    - __train__: bool. Specifies whether output is computed in training mode or in testing mode, which can change the logic, for instance in there are any `Dropout` layers in the network.
 
 
 ```python

--- a/keras/layers/containers.py
+++ b/keras/layers/containers.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 
 from collections import OrderedDict
 from .. import backend as K
-from ..layers.core import Layer, Merge, Siamese, SiameseHead, Pass
+from ..layers.core import Layer, Merge, Siamese, SiameseHead
 from six.moves import range
 
 
@@ -23,22 +23,13 @@ class Sequential(Layer):
         for layer in layers:
             self.add(layer)
 
-    def __call__(self, X):
-        if hasattr(self.layers[0], 'previous'):
-            tmp = self.layers[0].previous
-            self.previous = Pass(X)
-            Y = self.get_output()
-            self.layers[0].previous = tmp
-        else:
-            if hasattr(self.layers[0], 'input'):
-                tmp = self.layers[0].input
-                flag = True
-            else:
-                flag = False
-            self.layers[0].input = X
-            Y = self.get_output()
-            if flag:
-                self.layers[0].input = tmp
+    def __call__(self, X, train=False):
+        # temporally substitute input of first layer
+        tmp = self.layers[0].get_input
+        self.layers[0].get_input = lambda _: X
+        Y = self.get_output(train=train)
+        # return input to first layer to what it was
+        self.layers[0].get_input = tmp
         return Y
 
     def set_previous(self, layer):

--- a/keras/layers/containers.py
+++ b/keras/layers/containers.py
@@ -24,7 +24,7 @@ class Sequential(Layer):
             self.add(layer)
 
     def __call__(self, X, train=False):
-        # temporally substitute input of first layer
+        # set temporary input to first layer
         tmp = self.layers[0].get_input
         self.layers[0].get_input = lambda _: X
         Y = self.get_output(train=train)

--- a/keras/layers/containers.py
+++ b/keras/layers/containers.py
@@ -24,20 +24,21 @@ class Sequential(Layer):
             self.add(layer)
 
     def __call__(self, X):
-        # temporally substitute layer input
-        tmp1 = self.layers[0].input
         if hasattr(self.layers[0], 'previous'):
-            tmp2 = self.layers[0].previous
-            flag = True
-        self.layers[0].input = X
-        # define X as the new input
-        self.layers[0].previous = Pass(X)
-        # Calculate output given X
-        Y = self.get_output()
-        # Reset original inputs
-        self.layers[0].input = tmp1
-        if flag:
-            self.layers[0].previous = tmp2
+            tmp = self.layers[0].previous
+            self.previous = Pass(X)
+            Y = self.get_output()
+            self.layers[0].previous = tmp
+        else:
+            if hasattr(self.layers[0], 'input'):
+                tmp = self.layers[0].input
+                flag = True
+            else:
+                flag = False
+            self.layers[0].input = X
+            Y = self.get_output()
+            if flag:
+                self.layers[0].input = tmp
         return Y
 
     def set_previous(self, layer):
@@ -321,7 +322,7 @@ class Graph(Layer):
                 raise Exception('Duplicate node identifier: ' + o)
         if merge_mode:
             if merge_mode not in {'sum', 'ave', 'mul', 'dot', 'cos', 'concat', 'join'}:
-                raise Eception("Invalid merge mode")
+                raise Exception("Invalid merge mode")
         layers = []
         for i in range(len(inputs)):
             input = inputs[i]

--- a/keras/layers/containers.py
+++ b/keras/layers/containers.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 
 from collections import OrderedDict
 from .. import backend as K
-from ..layers.core import Layer, Merge, Siamese, SiameseHead
+from ..layers.core import Layer, Merge, Siamese, SiameseHead, Pass
 from six.moves import range
 
 
@@ -22,6 +22,23 @@ class Sequential(Layer):
         self.layers = []
         for layer in layers:
             self.add(layer)
+
+    def __call__(self, X):
+        # temporally substitute layer input
+        tmp1 = self.layers[0].input
+        if hasattr(self.layers[0], 'previous'):
+            tmp2 = self.layers[0].previous
+            flag = True
+        self.layers[0].input = X
+        # define X as the new input
+        self.layers[0].previous = Pass(X)
+        # Calculate output given X
+        Y = self.get_output()
+        # Reset original inputs
+        self.layers[0].input = tmp1
+        if flag:
+            self.layers[0].previous = tmp2
+        return Y
 
     def set_previous(self, layer):
         self.layers[0].previous = layer

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -34,7 +34,7 @@ class Layer(object):
             self.params = []
 
     def __call__(self, X, train=False):
-        # temporally substitute input
+        # set temporary input
         tmp = self.get_input
         self.get_input = lambda _: X
         Y = self.get_output(train=train)

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -17,6 +17,19 @@ import types
 import sys
 
 
+class Pass:
+    ''' Dummy class. Passes placeholder ahead'''
+    def __init__(self, X, output_shape=None):
+        self.X = X
+
+    def get_output(self, train=False):
+        return self.X
+
+    @property
+    def output_shape(self):
+        return self.output_shape
+
+
 class Layer(object):
     def __init__(self, **kwargs):
         allowed_kwargs = {'input_shape',
@@ -32,6 +45,25 @@ class Layer(object):
             self._trainable = kwargs['trainable']
         if not hasattr(self, 'params'):
             self.params = []
+
+    def __call__(self, X):
+        # temporally substitute layer input
+        if hasattr(self, 'previous'):
+            tmp = self.previous
+            self.previous = Pass(X)
+            Y = self.get_output()
+            self.previous = tmp
+        else:
+            if hasattr(self, 'input'):
+                tmp = self.input
+                flag = True
+            else:
+                flag = False
+            self.input = X
+            Y = self.get_output()
+            if flag:
+                self.input = tmp
+        return Y
 
     def set_previous(self, layer, connection_map={}):
         assert self.nb_input == layer.nb_output == 1, "Cannot connect layers: input count and output count should be 1."

--- a/tests/keras/layers/test_call.py
+++ b/tests/keras/layers/test_call.py
@@ -19,7 +19,7 @@ class TestCall(unittest.TestCase):
     """Test __call__ methods"""
 
     def test_layer_call(self):
-        """Test keras.layers.Layer.__call__"""
+        """Test keras.layers.core.Layer.__call__"""
         nb_samples, input_dim = 3, 10
         layer = Layer()
         X = K.placeholder(ndim=2)
@@ -31,7 +31,7 @@ class TestCall(unittest.TestCase):
         assert_allclose(x, y)
 
     def test_sequential_call(self):
-        """Test keras.layers.Layer.__call__"""
+        """Test keras.models.Sequential.__call__"""
         nb_samples, input_dim, output_dim = 3, 10, 5
         model = Sequential()
         model.add(Dense(output_dim=output_dim, input_dim=input_dim))
@@ -44,6 +44,7 @@ class TestCall(unittest.TestCase):
         x = np.random.randn(nb_samples, input_dim).astype(floatX)
         y1 = F(x)
         y2 = model.predict(x)
+        # results of __call__ should match model.predict
         assert_allclose(y1, y2)
 
 

--- a/tests/keras/layers/test_call.py
+++ b/tests/keras/layers/test_call.py
@@ -24,10 +24,10 @@ class TestCall(unittest.TestCase):
         layer = Layer()
         X = K.placeholder(ndim=2)
         Y = layer(X)
-        F = theano.function([X], Y)
+        F = K.function([X], Y)
 
         x = np.random.randn(nb_samples, input_dim).astype(floatX)
-        y = F(x)
+        y = F([x, ])
         assert_allclose(x, y)
 
     def test_sequential_call(self):
@@ -39,10 +39,10 @@ class TestCall(unittest.TestCase):
 
         X = K.placeholder(ndim=2)
         Y = model(X)
-        F = theano.function([X], Y)
+        F = K.function([X], Y)
 
         x = np.random.randn(nb_samples, input_dim).astype(floatX)
-        y1 = F(x)
+        y1 = F([x, ])
         y2 = model.predict(x)
         # results of __call__ should match model.predict
         assert_allclose(y1, y2)

--- a/tests/keras/layers/test_call.py
+++ b/tests/keras/layers/test_call.py
@@ -26,7 +26,7 @@ class TestCall(unittest.TestCase):
         F = K.function([X], [Y])
 
         x = np.random.randn(nb_samples, input_dim).astype(K.floatx())
-        y = F([x])[0]
+        y = F([x])[0].astype(K.floatx())
         assert_allclose(np.dot(x, W), y)
 
     def test_sequential_call(self):
@@ -41,7 +41,7 @@ class TestCall(unittest.TestCase):
         F = K.function([X], [Y])
 
         x = np.random.randn(nb_samples, input_dim).astype(K.floatx())
-        y1 = F([x])[0]
+        y1 = F([x])[0].astype(K.floatx())
         y2 = model.predict(x)
         # results of __call__ should match model.predict
         assert_allclose(y1, y2)

--- a/tests/keras/layers/test_call.py
+++ b/tests/keras/layers/test_call.py
@@ -1,5 +1,5 @@
 # encoding: utf-8
-"""Test seya.layers.recurrent module"""
+"""Test keras.layers.core.Layer.__call__"""
 
 from __future__ import print_function
 
@@ -11,7 +11,6 @@ from numpy.testing import assert_allclose
 from keras import backend as K
 from keras.layers.core import Dense
 from keras.models import Sequential
-floatX = K.common._FLOATX
 
 
 class TestCall(unittest.TestCase):
@@ -26,7 +25,7 @@ class TestCall(unittest.TestCase):
         Y = layer(X)
         F = K.function([X], [Y])
 
-        x = np.random.randn(nb_samples, input_dim).astype(floatX)
+        x = np.random.randn(nb_samples, input_dim).astype(K.floatx())
         y = F([x])[0]
         assert_allclose(np.dot(x, W), y)
 
@@ -41,7 +40,7 @@ class TestCall(unittest.TestCase):
         Y = model(X)
         F = K.function([X], [Y])
 
-        x = np.random.randn(nb_samples, input_dim).astype(floatX)
+        x = np.random.randn(nb_samples, input_dim).astype(K.floatx())
         y1 = F([x])[0]
         y2 = model.predict(x)
         # results of __call__ should match model.predict

--- a/tests/keras/layers/test_call.py
+++ b/tests/keras/layers/test_call.py
@@ -1,0 +1,52 @@
+# encoding: utf-8
+"""Test seya.layers.recurrent module"""
+
+from __future__ import print_function
+
+import unittest
+import numpy as np
+import theano
+
+from numpy.testing import assert_allclose
+
+from keras import backend as K
+from keras.layers.core import Layer, Dense
+from keras.models import Sequential
+floatX = K.common._FLOATX
+
+
+class TestCall(unittest.TestCase):
+    """Test __call__ methods"""
+
+    def test_layer_call(self):
+        """Test keras.layers.Layer.__call__"""
+        nb_samples, input_dim = 3, 10
+        layer = Layer()
+        X = K.placeholder(ndim=2)
+        Y = layer(X)
+        F = theano.function([X], Y)
+
+        x = np.random.randn(nb_samples, input_dim).astype(floatX)
+        y = F(x)
+        assert_allclose(x, y)
+
+    def test_sequential_call(self):
+        """Test keras.layers.Layer.__call__"""
+        nb_samples, input_dim, output_dim = 3, 10, 5
+        model = Sequential()
+        model.add(Dense(output_dim=output_dim, input_dim=input_dim))
+        model.compile('sgd', 'mse')
+
+        X = K.placeholder(ndim=2)
+        Y = model(X)
+        F = theano.function([X], Y)
+
+        x = np.random.randn(nb_samples, input_dim).astype(floatX)
+        y1 = F(x)
+        y2 = model.predict(x)
+        assert_allclose(y1, y2)
+
+
+if __name__ == '__main__':
+    theano.config.exception_verbosity = 'high'
+    unittest.main(verbosity=2)

--- a/tests/keras/layers/test_call.py
+++ b/tests/keras/layers/test_call.py
@@ -5,12 +5,11 @@ from __future__ import print_function
 
 import unittest
 import numpy as np
-import theano
 
 from numpy.testing import assert_allclose
 
 from keras import backend as K
-from keras.layers.core import Layer, Dense
+from keras.layers.core import Dense
 from keras.models import Sequential
 floatX = K.common._FLOATX
 
@@ -20,15 +19,16 @@ class TestCall(unittest.TestCase):
 
     def test_layer_call(self):
         """Test keras.layers.core.Layer.__call__"""
-        nb_samples, input_dim = 3, 10
-        layer = Layer()
+        nb_samples, input_dim, output_dim = 3, 10, 5
+        layer = Dense(output_dim, input_dim=input_dim)
+        W = np.asarray(K.eval(layer.W))
         X = K.placeholder(ndim=2)
         Y = layer(X)
-        F = K.function([X], Y)
+        F = K.function([X], [Y])
 
         x = np.random.randn(nb_samples, input_dim).astype(floatX)
-        y = F([x, ])
-        assert_allclose(x, y)
+        y = F([x])[0]
+        assert_allclose(np.dot(x, W), y)
 
     def test_sequential_call(self):
         """Test keras.models.Sequential.__call__"""
@@ -39,15 +39,14 @@ class TestCall(unittest.TestCase):
 
         X = K.placeholder(ndim=2)
         Y = model(X)
-        F = K.function([X], Y)
+        F = K.function([X], [Y])
 
         x = np.random.randn(nb_samples, input_dim).astype(floatX)
-        y1 = F([x, ])
+        y1 = F([x])[0]
         y2 = model.predict(x)
         # results of __call__ should match model.predict
         assert_allclose(y1, y2)
 
 
 if __name__ == '__main__':
-    theano.config.exception_verbosity = 'high'
     unittest.main(verbosity=2)


### PR DESCRIPTION
Add a `__call__` method to Layer and Sequential. We can do the following:
```python
X = K.placeholder(ndim=2)
Y = model(X)
```

One interesting application is where a model is used as an upper layer of another model. In that case, we don't have access to its `get_input`:
```python
encoder = Sequential()
decoder = Sequential()

model.add(encoder)
model.add(decoder)

X = K.placeholder(ndim=2)
Y = decoder(X)
```

This code temporally change the value of a specific element of the graph by `X` and call `get_output`. Regardless of the fact that the specific element is a `previous` or `input`. For example, the following code would crash:

```python
X = decoder.get_input()  # this is not a placeholder Tensor, it is a graph
Y = decoder.get_output()
F = function([X], Y)
```

I also updated some docs. Let me know what you think.

