### PR TITLE
Sprint to bring up test coverage

### DIFF
--- a/tests/keras/layers/test_core.py
+++ b/tests/keras/layers/test_core.py
@@ -113,9 +113,10 @@ def test_maxout_dense():
     _runner(layer)
 
 
-@pytest.mark.skipif(K._BACKEND == 'tensorflow', reason="currently not working with TensorFlow")
+@pytest.mark.skipif(K._BACKEND == 'tensorflow',
+                    reason='currently not working with TensorFlow')
 def test_sequences():
-    """Test masking sequences with zeroes as padding"""
+    '''Test masking sequences with zeroes as padding'''
     # integer inputs, one per timestep, like embeddings
     layer = core.Masking()
     func = K.function([layer.input], [layer.get_output_mask()])
@@ -127,12 +128,13 @@ def test_sequences():
 
     # get mask for this input
     output = func([input_data])[0]
-    assert np.all(output == expected), "Output not as expected"
+    assert np.all(output == expected), 'Output not as expected'
 
 
-@pytest.mark.skipif(K._BACKEND == 'tensorflow', reason="currently not working with TensorFlow")
+@pytest.mark.skipif(K._BACKEND == 'tensorflow',
+                    reason='currently not working with TensorFlow')
 def test_non_zero():
-    """Test masking with non-zero mask value"""
+    '''Test masking with non-zero mask value'''
     layer = core.Masking(5)
     func = K.function([layer.input], [layer.get_output_mask()])
     input_data = np.array([[[1, 1], [2, 1], [3, 1], [5, 5]],
@@ -140,12 +142,13 @@ def test_non_zero():
                           dtype=np.int32)
     output = func([input_data])[0]
     expected = np.array([[1, 1, 1, 0], [1, 1, 1, 1]])
-    assert np.all(output == expected), "Output not as expected"
+    assert np.all(output == expected), 'Output not as expected'
 
 
-@pytest.mark.skipif(K._BACKEND == 'tensorflow', reason="currently not working with TensorFlow")
+@pytest.mark.skipif(K._BACKEND == 'tensorflow',
+                    reason='currently not working with TensorFlow')
 def test_non_zero_output():
-    """Test output of masking layer with non-zero mask value"""
+    '''Test output of masking layer with non-zero mask value'''
     layer = core.Masking(5)
     func = K.function([layer.input], [layer.get_output()])
 
@@ -155,7 +158,7 @@ def test_non_zero_output():
     output = func([input_data])[0]
     expected = np.array([[[1, 1], [2, 1], [3, 1], [0, 0]],
                         [[1, 5], [5, 0], [0, 0], [0, 0]]])
-    assert np.all(output == expected), "Output not as expected"
+    assert np.all(output == expected), 'Output not as expected'
 
 
 def _runner(layer):


### PR DESCRIPTION
This is a work in progress. I will be working on this all weekend (I hope). My timezone is CET. If anyone wants to join me, let me know ( @olegsinyavskiy @EderSantana @farizrahman4u ?) and I will give you push access.

# Todos
## Meta 
Things that are not tests as such but that would be nice to have
- [x] Get coveralls to work (now available for my fork on https://coveralls.io/github/phreeza/keras )
- [x] Tag front page with coveralls and travis tags
- [ ] clean up tests directory with a structure that matches the main project
- [x] convert all tests into pytest tests instead of using unittest

## Tests
Tests that need to be written, in approximate order of coverage increase they will bring
- [ ] preprocessing code
- [x] examples ( @olegsinyavskiy started work on this in #1177 )
- [ ] Siamese, Lambda and LambdaMerge layers (just saw @farizrahman4u is working on this in #1171)
- [ ] Changed interface in Graph and Sequential containers
- [x] advanced activations
- [x] sklearn wrapper
- [ ] I/O utils
- [ ] overwrite protection in model saving

I recon if all these are met, we should be pretty close to 90%, which seems like a more presentable number.