### PR TITLE
Fixed the progbar in the cifar10 example

### DIFF
--- a/examples/cifar10_cnn.py
+++ b/examples/cifar10_cnn.py
@@ -111,11 +111,11 @@ else:
         progbar = generic_utils.Progbar(X_train.shape[0])
         for X_batch, Y_batch in datagen.flow(X_train, Y_train):
             loss = model.train_on_batch(X_batch, Y_batch)
-            progbar.add(X_batch.shape[0], values=[("train loss", loss)])
+            progbar.add(X_batch.shape[0], values=[("train loss", loss[0])])
 
         print("Testing...")
         # test time!
         progbar = generic_utils.Progbar(X_test.shape[0])
         for X_batch, Y_batch in datagen.flow(X_test, Y_test):
             score = model.test_on_batch(X_batch, Y_batch)
-            progbar.add(X_batch.shape[0], values=[("test loss", score)])
+            progbar.add(X_batch.shape[0], values=[("test loss", score[0])])


### PR DESCRIPTION
The progbar in the cifar10 example didn't work, because due to the back end changes train_on_batch now returns the loss as a 1x1 matrix.