### PR TITLE
General 1D & 2D Pooling layers

### DIFF
--- a/docs/sources/layers/convolutional.md
+++ b/docs/sources/layers/convolutional.md
@@ -100,13 +100,13 @@ Max pooling operation for temporal data.
 
 ---
 
-## MeanPooling1D
+## AveragePooling1D
 
 ```python
-keras.layers.convolutional.MeanPooling1D(pool_length=2, stride=None, border_mode='valid')
+keras.layers.convolutional.AveragePooling1D(pool_length=2, stride=None, border_mode='valid')
 ```
 
-Mean/average pooling operation for temporal data.
+Average pooling operation for temporal data.
 
 - __Input shape__: 3D tensor with shape: `(samples, steps, features)`.
 
@@ -143,13 +143,13 @@ or 4D tensor with shape: `(samples, pooled_rows, pooled_cols, channels)` if dim_
 
 ---
 
-## MeanPooling2D
+## AveragePooling2D
 
 ```python
-keras.layers.convolutional.MeanPooling2D(pool_size=(2, 2), border_mode='valid', dim_ordering='th')
+keras.layers.convolutional.AveragePooling2D(pool_size=(2, 2), border_mode='valid', dim_ordering='th')
 ```
 
-Mean/average pooling operation for spatial data.
+Average pooling operation for spatial data.
 
 - __Input shape__: 4D tensor with shape: `(samples, channels, rows, cols)` if dim_ordering='th'
 or 4D tensor with shape: `(samples, rows, cols, channels)` if dim_ordering='tf'.

--- a/docs/sources/layers/convolutional.md
+++ b/docs/sources/layers/convolutional.md
@@ -100,6 +100,26 @@ Max pooling operation for temporal data.
 
 ---
 
+## MeanPooling1D
+
+```python
+keras.layers.convolutional.MeanPooling1D(pool_length=2, stride=None, border_mode='valid')
+```
+
+Mean/average pooling operation for temporal data.
+
+- __Input shape__: 3D tensor with shape: `(samples, steps, features)`.
+
+- __Output shape__: 3D tensor with shape: `(samples, downsampled_steps, features)`.
+
+- __Arguments__:
+
+    - __pool_length__: factor by which to downscale. 2 will halve the input.
+    - __stride__: integer or None. Stride value.
+    - __border_mode__: 'valid' or 'same'. **Note:** 'same' will only work with TensorFlow for the time being.
+
+---
+
 ## MaxPooling2D
 
 ```python
@@ -121,6 +141,28 @@ or 4D tensor with shape: `(samples, pooled_rows, pooled_cols, channels)` if dim_
     - __border_mode__: 'valid' or 'same'. **Note:** 'same' will only work with TensorFlow for the time being.
     - __dim_ordering__: 'th' or 'tf'. In 'th' mode, the channels dimension (the depth) is at index 1, in 'tf' mode is it at index 3.
 
+---
+
+## MeanPooling2D
+
+```python
+keras.layers.convolutional.MeanPooling2D(pool_size=(2, 2), border_mode='valid', dim_ordering='th')
+```
+
+Mean/average pooling operation for spatial data.
+
+- __Input shape__: 4D tensor with shape: `(samples, channels, rows, cols)` if dim_ordering='th'
+or 4D tensor with shape: `(samples, rows, cols, channels)` if dim_ordering='tf'.
+
+- __Output shape__: 4D tensor with shape: `(nb_samples, channels, pooled_rows, pooled_cols)` if dim_ordering='th'
+or 4D tensor with shape: `(samples, pooled_rows, pooled_cols, channels)` if dim_ordering='tf'.
+
+- __Arguments__:
+
+    - __pool_size__: tuple of 2 integers, factors by which to downscale (vertical, horizontal). (2, 2) will halve the image in each dimension.
+    - __strides__: tuple of 2 integers, or None. Strides values.
+    - __border_mode__: 'valid' or 'same'. **Note:** 'same' will only work with TensorFlow for the time being.
+    - __dim_ordering__: 'th' or 'tf'. In 'th' mode, the channels dimension (the depth) is at index 1, in 'tf' mode is it at index 3.
 
 ---
 

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -546,7 +546,7 @@ def conv2d(x, kernel, strides=(1, 1), border_mode='valid', dim_ordering='th',
 
 
 def pool2d(x, pool_size, strides=(1, 1),
-              border_mode='valid', dim_ordering='th', pool_mode='max'):
+           border_mode='valid', dim_ordering='th', pool_mode='max'):
     '''
     pool_size: tuple of 2 integers.
     strides: tuple of 2 integers.
@@ -567,28 +567,23 @@ def pool2d(x, pool_size, strides=(1, 1),
         # tf max_pool only supports float32
         x = tf.cast(x, 'float32')
 
-    if dim_ordering == 'th':
-        # TF uses the last dimension as channel dimension,
-        # instead of the 2nd one.
-        # TH input shape: (samples, input_depth, rows, cols)
-        # TF input shape: (samples, rows, cols, input_depth)
-        # TH kernel shape: (depth, input_depth, rows, cols)
-        # TF kernel shape: (rows, cols, input_depth, depth)
-        x = tf.transpose(x, (0, 2, 3, 1))
-        if pool_mode=='max':
+    if dim_ordering in {'tf', 'th'}:
+        if dim_ordering == 'th':
+            # TF uses the last dimension as channel dimension,
+            # instead of the 2nd one.
+            # TH input shape: (samples, input_depth, rows, cols)
+            # TF input shape: (samples, rows, cols, input_depth)
+            # TH kernel shape: (depth, input_depth, rows, cols)
+            # TF kernel shape: (rows, cols, input_depth, depth)
+            x = tf.transpose(x, (0, 2, 3, 1))
+        if pool_mode == 'max':
             x = tf.nn.max_pool(x, pool_size, strides, padding=padding)
-        elif pool_mode=='mean':
+        elif pool_mode == 'avg':
             x = tf.nn.avg_pool(x, pool_size, strides, padding=padding)
         else:
             raise Exception('Invalid pooling mode: ' + str(pool_mode))
-        x = tf.transpose(x, (0, 3, 1, 2))
-    elif dim_ordering == 'tf':
-        if pool_mode=='max':
-            x = tf.nn.max_pool(x, pool_size, strides, padding=padding)
-        elif pool_mode=='mean':
-            x = tf.nn.avg_pool(x, pool_size, strides, padding=padding)
-        else:
-            raise Exception('Invalid pooling mode: ' + str(pool_mode))
+        if dim_ordering == 'th':
+            x = tf.transpose(x, (0, 3, 1, 2))
     else:
         raise Exception('Unknown dim_ordering: ' + str(dim_ordering))
 

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -580,7 +580,7 @@ def pool2d(x, pool_size, strides=(1, 1),
         elif pool_mode=='mean':
             x = tf.nn.avg_pool(x, pool_size, strides, padding=padding)
         else:
-            raise Exception('Invalid pooling mode: ' + str(pool_mode)
+            raise Exception('Invalid pooling mode: ' + str(pool_mode))
         x = tf.transpose(x, (0, 3, 1, 2))
     elif dim_ordering == 'tf':
         if pool_mode=='max':
@@ -588,7 +588,7 @@ def pool2d(x, pool_size, strides=(1, 1),
         elif pool_mode=='mean':
             x = tf.nn.avg_pool(x, pool_size, strides, padding=padding)
         else:
-            raise Exception('Invalid pooling mode: ' + str(pool_mode)
+            raise Exception('Invalid pooling mode: ' + str(pool_mode))
     else:
         raise Exception('Unknown dim_ordering: ' + str(dim_ordering))
 

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -545,8 +545,8 @@ def conv2d(x, kernel, strides=(1, 1), border_mode='valid', dim_ordering='th',
     return x
 
 
-def maxpool2d(x, pool_size, strides=(1, 1),
-              border_mode='valid', dim_ordering='th'):
+def pool2d(x, pool_size, strides=(1, 1),
+              border_mode='valid', dim_ordering='th', pool_mode='max'):
     '''
     pool_size: tuple of 2 integers.
     strides: tuple of 2 integers.
@@ -575,10 +575,20 @@ def maxpool2d(x, pool_size, strides=(1, 1),
         # TH kernel shape: (depth, input_depth, rows, cols)
         # TF kernel shape: (rows, cols, input_depth, depth)
         x = tf.transpose(x, (0, 2, 3, 1))
-        x = tf.nn.max_pool(x, pool_size, strides, padding=padding)
+        if pool_mode=='max':
+            x = tf.nn.max_pool(x, pool_size, strides, padding=padding)
+        elif pool_mode=='mean':
+            x = tf.nn.avg_pool(x, pool_size, strides, padding=padding)
+        else:
+            raise Exception('Invalid pooling mode: ' + str(pool_mode)
         x = tf.transpose(x, (0, 3, 1, 2))
     elif dim_ordering == 'tf':
-        x = tf.nn.max_pool(x, pool_size, strides, padding=padding)
+        if pool_mode=='max':
+            x = tf.nn.max_pool(x, pool_size, strides, padding=padding)
+        elif pool_mode=='mean':
+            x = tf.nn.avg_pool(x, pool_size, strides, padding=padding)
+        else:
+            raise Exception('Invalid pooling mode: ' + str(pool_mode)
     else:
         raise Exception('Unknown dim_ordering: ' + str(dim_ordering))
 

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -601,17 +601,11 @@ def pool2d(x, pool_size, strides=(1, 1), border_mode='valid',
                                           ignore_border=ignore_border,
                                           padding=padding,
                                           mode='max')
-    elif pool_mode == 'mean':
-        # Only seems to work with mode='ignore_borders' right now
+    elif pool_mode == 'avg':
         pool_out = downsample.max_pool_2d(x, ds=pool_size, st=strides,
                                           ignore_border=ignore_border,
                                           padding=padding,
                                           mode='average_exc_pad')
-    elif pool_mode == 'sum':
-        pool_out = downsample.max_pool_2d(x, ds=pool_size, st=strides,
-                                          ignore_border=ignore_border,
-                                          padding=padding,
-                                          mode='sum')
     else:
         raise Exception('Invalid pooling mode: ' + str(pool_mode))
 

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -602,8 +602,10 @@ def pool2d(x, pool_size, strides=(1, 1), border_mode='valid',
     elif pool_mode == 'mean':
         # Only seems to work with mode='ignore_borders' right now
         pool_out = images2neibs(x,neib_shape=pool_size,neib_step=strides, mode='ignore_borders').mean(axis=-1)
-    #elif pool_mode == 'sum':
-    #    pool_out = images2neibs(x,neib_shape=pool_size,neib_step=strides, mode='ignore_borders').sum(axis=-1)
+        pool_out = reshape(pool_out, (x.shape[0], x.shape[1], (x.shape[2]-pool_size[0])/strides[0]+1, (x.shape[3]-pool_size[1])/strides[1]+1))
+    elif pool_mode == 'sum':
+        pool_out = images2neibs(x,neib_shape=pool_size,neib_step=strides, mode='ignore_borders').sum(axis=-1)
+        pool_out = reshape(pool_out, (x.shape[0], x.shape[1], (x.shape[2]-pool_size[0])/strides[0]+1, (x.shape[3]-pool_size[1])/strides[1]+1))
     else:
         raise Exception('Invalid pooling mode: ' + str(pool_mode))
 

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -366,64 +366,6 @@ class MaxPooling2D(Pooling2D):
                              dim_ordering=self.dim_ordering)
         return output
 
-class MaxPooling2D(Layer):
-    input_ndim = 4
-
-    def __init__(self, pool_size=(2, 2), strides=None, border_mode='valid',
-                 dim_ordering='th', **kwargs):
-        super(MaxPooling2D, self).__init__(**kwargs)
-        self.input = K.placeholder(ndim=4)
-        self.pool_size = tuple(pool_size)
-        if strides is None:
-            strides = self.pool_size
-        self.strides = tuple(strides)
-        assert border_mode in {'valid', 'same'}, 'border_mode must be in {valid, same}'
-        self.border_mode = border_mode
-        assert dim_ordering in {'tf', 'th'}, 'dim_ordering must be in {tf, th}'
-        self.dim_ordering = dim_ordering
-
-    @property
-    def output_shape(self):
-        input_shape = self.input_shape
-        if self.dim_ordering == 'th':
-            rows = input_shape[2]
-            cols = input_shape[3]
-        elif self.dim_ordering == 'tf':
-            rows = input_shape[1]
-            cols = input_shape[2]
-        else:
-            raise Exception('Invalid dim_ordering: ' + self.dim_ordering)
-
-        rows = conv_output_length(rows, self.pool_size[0],
-                                  self.border_mode, self.strides[0])
-        cols = conv_output_length(cols, self.pool_size[1],
-                                  self.border_mode, self.strides[1])
-
-        if self.dim_ordering == 'th':
-            return (input_shape[0], input_shape[1], rows, cols)
-        elif self.dim_ordering == 'tf':
-            return (input_shape[0], rows, cols, input_shape[3])
-        else:
-            raise Exception('Invalid dim_ordering: ' + self.dim_ordering)
-
-    def get_output(self, train=False):
-        X = self.get_input(train)
-        output = K.maxpool2d(X, pool_size=self.pool_size,
-                             strides=self.strides,
-                             border_mode=self.border_mode,
-                             dim_ordering=self.dim_ordering)
-        return output
-
-    def get_config(self):
-        config = {"name": self.__class__.__name__,
-                  "pool_size": self.pool_size,
-                  "border_mode": self.border_mode,
-                  "strides": self.strides,
-                  "dim_ordering": self.dim_ordering}
-        base_config = super(MaxPooling2D, self).get_config()
-        return dict(list(base_config.items()) + list(config.items()))
-
-
 
 class UpSampling1D(Layer):
     input_ndim = 3

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -591,29 +591,3 @@ class ZeroPadding2D(Layer):
                   "padding": self.padding}
         base_config = super(ZeroPadding2D, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
-
-
-
-class GlobalPooling2D(Layer):
-    """
-    By @entron
-    Borrowed and modified from here: https://github.com/fchollet/keras/pull/522
-    """
-    def __init__(self, pooling_function='average'):
-        super(GlobalPooling2D, self).__init__()
-        if pooling_function not in {'average', 'max'}:
-            raise Exception('Invalid pooling function for GlobalPooling2D:', pooling_function)
-        if pooling_function == 'average':
-            self.pooling_function = K.mean
-        else:
-            self.pooling_function = K.max
-        self.input = K.placeholder(ndim=4)
-
-    def get_output(self, train):
-        X = self.get_input(train)
-        return self.pooling_function(self.pooling_function(X, axis=-1), axis=-1)
-
-    def get_config(self):
-        return {"name": self.__class__.__name__,
-                "pooling_function": self.pooling_function.__name__}
-

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -281,7 +281,7 @@ class Pooling1D(Layer):
                   "stride": self.stride,
                   "pool_length": self.pool_length,
                   "border_mode": self.border_mode}
-        base_config = super(MaxPooling1D, self).get_config()
+        base_config = super(Pooling1D, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
 
 
@@ -353,7 +353,7 @@ class Pooling2D(Layer):
                   "border_mode": self.border_mode,
                   "strides": self.strides,
                   "dim_ordering": self.dim_ordering}
-        base_config = super(MaxPooling2D, self).get_config()
+        base_config = super(Pooling2D, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
 
 

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -295,13 +295,13 @@ class MaxPooling1D(Pooling1D):
         return output
 
 
-class MeanPooling1D(Pooling1D):
+class AveragePooling1D(Pooling1D):
     def __init__(self, **kwargs):
-        super(MeanPooling1D, self).__init__(**kwargs)
+        super(AveragePooling1D, self).__init__(**kwargs)
 
     def pooling_function(self, back_end, inputs, pool_size, strides, border_mode, dim_ordering):
         output = back_end.pool2d(inputs, pool_size, strides,
-                                 border_mode, dim_ordering, pool_mode='mean')
+                                 border_mode, dim_ordering, pool_mode='avg')
         return output
 
 
@@ -376,13 +376,13 @@ class MaxPooling2D(Pooling2D):
         return output
 
 
-class MeanPooling2D(Pooling2D):
+class AveragePooling2D(Pooling2D):
     def __init__(self, **kwargs):
-        super(MeanPooling2D, self).__init__(**kwargs)
+        super(AveragePooling2D, self).__init__(**kwargs)
 
     def pooling_function(self, back_end, inputs, pool_size, strides, border_mode, dim_ordering):
         output = back_end.pool2d(inputs, pool_size, strides,
-                                 border_mode, dim_ordering, pool_mode='mean')
+                                 border_mode, dim_ordering, pool_mode='avg')
         return output
 
 

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -342,7 +342,7 @@ class Pooling2D(Layer):
     def get_output(self, train=False):
         X = self.get_input(train)
         output = self.pooling_function(back_end=K, inputs=X, pool_size=self.pool_size,
-                strides=self.st,
+                strides=self.strides,
                 border_mode=self.border_mode,
                 dim_ordering='th')
         return output
@@ -360,7 +360,9 @@ class Pooling2D(Layer):
 class MaxPooling2D(Pooling2D):
     def __init__(self, **kwargs):
         super(MaxPooling2D, self).__init__(**kwargs)
-        output = K.maxpool2d(X, pool_size=self.pool_size,
+
+    def pooling_function(self, back_end, inputs, pool_size, strides, border_mode, dim_ordering):
+        output = back_end.maxpool2d(inputs, pool_size=self.pool_size,
                              strides=self.strides,
                              border_mode=self.border_mode,
                              dim_ordering=self.dim_ordering)

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -290,8 +290,8 @@ class MaxPooling1D(Pooling1D):
         super(MaxPooling1D, self).__init__(**kwargs)
 
     def pooling_function(self, back_end, inputs, pool_size, strides, border_mode, dim_ordering):
-        output = back_end.pool2d(inputs, pool_size=self.pool_size, strides=self.st,
-                border_mode=self.border_mode, dim_ordering='th', pool_mode='max')
+        output = back_end.pool2d(inputs, pool_size, strides,
+                border_mode, dim_ordering, pool_mode='max')
         return output
 
 class MeanPooling1D(Pooling1D):
@@ -299,8 +299,8 @@ class MeanPooling1D(Pooling1D):
         super(MeanPooling1D, self).__init__(**kwargs)
 
     def pooling_function(self, back_end, inputs, pool_size, strides, border_mode, dim_ordering):
-        output = back_end.pool2d(inputs, pool_size=self.pool_size, strides=self.st,
-                border_mode=self.border_mode, dim_ordering='th', pool_mode='mean')
+        output = back_end.pool2d(inputs, pool_size, strides,
+                border_mode, dim_ordering, pool_mode='mean')
         return output
 
 
@@ -370,10 +370,8 @@ class MaxPooling2D(Pooling2D):
         super(MaxPooling2D, self).__init__(**kwargs)
 
     def pooling_function(self, back_end, inputs, pool_size, strides, border_mode, dim_ordering):
-        output = back_end.pool2d(inputs, pool_size=self.pool_size,
-                             strides=self.strides,
-                             border_mode=self.border_mode,
-                             dim_ordering=self.dim_ordering, pool_mode='max')
+        output = back_end.pool2d(inputs, pool_size, strides,
+                             border_mode, dim_ordering, pool_mode='max')
         return output
 
 class MeanPooling2D(Pooling2D):
@@ -381,10 +379,8 @@ class MeanPooling2D(Pooling2D):
         super(MeanPooling2D, self).__init__(**kwargs)
 
     def pooling_function(self, back_end, inputs, pool_size, strides, border_mode, dim_ordering):
-        output = back_end.pool2d(inputs, pool_size=self.pool_size,
-                             strides=self.strides,
-                             border_mode=self.border_mode,
-                             dim_ordering=self.dim_ordering, pool_mode='mean')
+        output = back_end.pool2d(inputs, pool_size, strides,
+                             border_mode, dim_ordering, pool_mode='max')
         return output
 
 

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -270,9 +270,9 @@ class Pooling1D(Layer):
         X = K.expand_dims(X, -1)   # add dummy last dimension
         X = K.permute_dimensions(X, (0, 2, 1, 3))
         output = self.pooling_function(back_end=K, inputs=X, pool_size=self.pool_size,
-                             strides=self.st,
-                             border_mode=self.border_mode,
-                             dim_ordering='th')
+                                       strides=self.st,
+                                       border_mode=self.border_mode,
+                                       dim_ordering='th')
         output = K.permute_dimensions(output, (0, 2, 1, 3))
         return K.squeeze(output, 3)  # remove dummy last dimension
 
@@ -291,8 +291,9 @@ class MaxPooling1D(Pooling1D):
 
     def pooling_function(self, back_end, inputs, pool_size, strides, border_mode, dim_ordering):
         output = back_end.pool2d(inputs, pool_size, strides,
-                border_mode, dim_ordering, pool_mode='max')
+                                 border_mode, dim_ordering, pool_mode='max')
         return output
+
 
 class MeanPooling1D(Pooling1D):
     def __init__(self, **kwargs):
@@ -300,7 +301,7 @@ class MeanPooling1D(Pooling1D):
 
     def pooling_function(self, back_end, inputs, pool_size, strides, border_mode, dim_ordering):
         output = back_end.pool2d(inputs, pool_size, strides,
-                border_mode, dim_ordering, pool_mode='mean')
+                                 border_mode, dim_ordering, pool_mode='mean')
         return output
 
 
@@ -350,9 +351,9 @@ class Pooling2D(Layer):
     def get_output(self, train=False):
         X = self.get_input(train)
         output = self.pooling_function(back_end=K, inputs=X, pool_size=self.pool_size,
-                strides=self.strides,
-                border_mode=self.border_mode,
-                dim_ordering='th')
+                                       strides=self.strides,
+                                       border_mode=self.border_mode,
+                                       dim_ordering=self.dim_ordering)
         return output
 
     def get_config(self):
@@ -371,8 +372,9 @@ class MaxPooling2D(Pooling2D):
 
     def pooling_function(self, back_end, inputs, pool_size, strides, border_mode, dim_ordering):
         output = back_end.pool2d(inputs, pool_size, strides,
-                             border_mode, dim_ordering, pool_mode='max')
+                                 border_mode, dim_ordering, pool_mode='max')
         return output
+
 
 class MeanPooling2D(Pooling2D):
     def __init__(self, **kwargs):
@@ -380,7 +382,7 @@ class MeanPooling2D(Pooling2D):
 
     def pooling_function(self, back_end, inputs, pool_size, strides, border_mode, dim_ordering):
         output = back_end.pool2d(inputs, pool_size, strides,
-                             border_mode, dim_ordering, pool_mode='max')
+                                 border_mode, dim_ordering, pool_mode='mean')
         return output
 
 

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -290,9 +290,17 @@ class MaxPooling1D(Pooling1D):
         super(MaxPooling1D, self).__init__(**kwargs)
 
     def pooling_function(self, back_end, inputs, pool_size, strides, border_mode, dim_ordering):
-        output = back_end.maxpool2d(inputs, pool_size=self.pool_size, strides=self.st,
-                border_mode=self.border_mode,
-                dim_ordering='th')
+        output = back_end.pool2d(inputs, pool_size=self.pool_size, strides=self.st,
+                border_mode=self.border_mode, dim_ordering='th', pool_mode='max')
+        return output
+
+class MeanPooling1D(Pooling1D):
+    def __init__(self, **kwargs):
+        super(MeanPooling1D, self).__init__(**kwargs)
+
+    def pooling_function(self, back_end, inputs, pool_size, strides, border_mode, dim_ordering):
+        output = back_end.pool2d(inputs, pool_size=self.pool_size, strides=self.st,
+                border_mode=self.border_mode, dim_ordering='th', pool_mode='mean')
         return output
 
 
@@ -362,10 +370,21 @@ class MaxPooling2D(Pooling2D):
         super(MaxPooling2D, self).__init__(**kwargs)
 
     def pooling_function(self, back_end, inputs, pool_size, strides, border_mode, dim_ordering):
-        output = back_end.maxpool2d(inputs, pool_size=self.pool_size,
+        output = back_end.pool2d(inputs, pool_size=self.pool_size,
                              strides=self.strides,
                              border_mode=self.border_mode,
-                             dim_ordering=self.dim_ordering)
+                             dim_ordering=self.dim_ordering, pool_mode='max')
+        return output
+
+class MeanPooling2D(Pooling2D):
+    def __init__(self, **kwargs):
+        super(MeanPooling2D, self).__init__(**kwargs)
+
+    def pooling_function(self, back_end, inputs, pool_size, strides, border_mode, dim_ordering):
+        output = back_end.pool2d(inputs, pool_size=self.pool_size,
+                             strides=self.strides,
+                             border_mode=self.border_mode,
+                             dim_ordering=self.dim_ordering, pool_mode='mean')
         return output
 
 

--- a/tests/keras/backend/test_backends.py
+++ b/tests/keras/backend/test_backends.py
@@ -291,17 +291,17 @@ class TestBackend(unittest.TestCase):
     #     check_two_tensor_operation('conv2d', (5, 3, 10, 12), (4, 3, 3, 3),
     #                                strides=(2, 2), border_mode='valid')
 
-    # def test_maxpool2d(self):
-    #     '''maxpool2d works "properly" with Theano and TF but outputs different
+    # def test_pool2d(self):
+    #     '''pool2d works "properly" with Theano and TF but outputs different
     #     values in each case. Cause unclear (input shape format?)
     #     '''
-    #     check_single_tensor_operation('maxpool2d', (5, 3, 10, 12), pool_size=(2, 2),
+    #     check_single_tensor_operation('pool2d', (5, 3, 10, 12), pool_size=(2, 2),
     #                                   strides=(1, 1), border_mode='valid')
 
-    #     check_single_tensor_operation('maxpool2d', (5, 3, 9, 11), pool_size=(2, 2),
+    #     check_single_tensor_operation('pool2d', (5, 3, 9, 11), pool_size=(2, 2),
     #                                   strides=(1, 1), border_mode='valid')
 
-    #     check_single_tensor_operation('maxpool2d', (5, 3, 9, 11), pool_size=(2, 3),
+    #     check_single_tensor_operation('pool2d', (5, 3, 9, 11), pool_size=(2, 3),
     #                                   strides=(1, 1), border_mode='valid')
 
     def test_random_normal(self):

--- a/tests/keras/layers/test_convolutional.py
+++ b/tests/keras/layers/test_convolutional.py
@@ -58,15 +58,15 @@ class TestConvolutions(unittest.TestCase):
                 K.eval(layer.get_output(train))
             layer.get_config()
 
-    def test_meanpooling_1d(self):
+    def test_averagepooling_1d(self):
         nb_samples = 9
         nb_steps = 7
         input_dim = 10
 
         input = np.ones((nb_samples, nb_steps, input_dim))
         for stride in [1, 2]:
-            layer = convolutional.MeanPooling1D(stride=stride,
-                                               border_mode='valid')
+            layer = convolutional.AveragePooling1D(stride=stride,
+                                                   border_mode='valid')
             layer.input = K.variable(input)
             for train in [True, False]:
                 K.eval(layer.get_output(train))
@@ -127,7 +127,7 @@ class TestConvolutions(unittest.TestCase):
                 K.eval(layer.get_output(train))
             layer.get_config()
 
-    def test_meanpooling_2d(self):
+    def test_averagepooling_2d(self):
         nb_samples = 9
         stack_size = 7
         input_nb_row = 11
@@ -136,9 +136,9 @@ class TestConvolutions(unittest.TestCase):
 
         input = np.ones((nb_samples, stack_size, input_nb_row, input_nb_col))
         for strides in [(1, 1), (2, 2)]:
-            layer = convolutional.MeanPooling2D(strides=strides,
-                                               border_mode='valid',
-                                               pool_size=pool_size)
+            layer = convolutional.AveragePooling2D(strides=strides,
+                                                   border_mode='valid',
+                                                   pool_size=pool_size)
             layer.input = K.variable(input)
             for train in [True, False]:
                 K.eval(layer.get_output(train))

--- a/tests/keras/layers/test_convolutional.py
+++ b/tests/keras/layers/test_convolutional.py
@@ -58,6 +58,20 @@ class TestConvolutions(unittest.TestCase):
                 K.eval(layer.get_output(train))
             layer.get_config()
 
+    def test_meanpooling_1d(self):
+        nb_samples = 9
+        nb_steps = 7
+        input_dim = 10
+
+        input = np.ones((nb_samples, nb_steps, input_dim))
+        for stride in [1, 2]:
+            layer = convolutional.MeanPooling1D(stride=stride,
+                                               border_mode='valid')
+            layer.input = K.variable(input)
+            for train in [True, False]:
+                K.eval(layer.get_output(train))
+            layer.get_config()
+
     def test_convolution_2d(self):
         nb_samples = 8
         nb_filter = 9
@@ -106,6 +120,23 @@ class TestConvolutions(unittest.TestCase):
         input = np.ones((nb_samples, stack_size, input_nb_row, input_nb_col))
         for strides in [(1, 1), (2, 2)]:
             layer = convolutional.MaxPooling2D(strides=strides,
+                                               border_mode='valid',
+                                               pool_size=pool_size)
+            layer.input = K.variable(input)
+            for train in [True, False]:
+                K.eval(layer.get_output(train))
+            layer.get_config()
+
+    def test_meanpooling_2d(self):
+        nb_samples = 9
+        stack_size = 7
+        input_nb_row = 11
+        input_nb_col = 12
+        pool_size = (3, 3)
+
+        input = np.ones((nb_samples, stack_size, input_nb_row, input_nb_col))
+        for strides in [(1, 1), (2, 2)]:
+            layer = convolutional.MeanPooling2D(strides=strides,
                                                border_mode='valid',
                                                pool_size=pool_size)
             layer.input = K.variable(input)

--- a/tests/test_shape_inference.py
+++ b/tests/test_shape_inference.py
@@ -104,6 +104,18 @@ class TestShapeInference(unittest.TestCase):
                         input_data = np.random.random(input_data_shape)
                         check_layer_output_shape(layer, input_data)
 
+    def test_MeanPooling1D(self):
+        for ignore_border in [True, False]:
+            for pool_length in [1,2]:
+                for stride in [1]:
+                    for input_data_shape in [(2, 3, 4), (2, 4, 4)]:
+                        layer = MeanPooling1D(pool_length=pool_length,
+                                             stride=stride,
+                                             border_mode='valid')
+                        input_data = np.random.random(input_data_shape)
+                        check_layer_output_shape(layer, input_data)
+
+
     def test_MaxPooling2D(self):
         for ignore_border in [True, False]:
             for strides in [(1, 1), (2, 2)]:
@@ -123,6 +135,27 @@ class TestShapeInference(unittest.TestCase):
                                              dim_ordering='tf')
                         input_data = np.random.random(input_data_shape)
                         check_layer_output_shape(layer, input_data)
+
+    def test_MeanPooling2D(self):
+        for ignore_border in [True, False]:
+            for strides in [(1, 1), (2, 2)]:
+                for pool_size in [(2, 2), (3, 3), (4, 4)]:
+                    for input_data_shape in [(2, 1, 4, 4), (2, 1, 5, 5), (2, 1, 6, 6)]:
+                        layer = MeanPooling2D(pool_size=pool_size,
+                                             strides=strides,
+                                             border_mode='valid',
+                                             dim_ordering='th')
+                        input_data = np.random.random(input_data_shape)
+                        check_layer_output_shape(layer, input_data)
+
+                    for input_data_shape in [(2, 4, 4, 1)]:
+                        layer = MeanPooling2D(pool_size=pool_size,
+                                             strides=strides,
+                                             border_mode='valid',
+                                             dim_ordering='tf')
+                        input_data = np.random.random(input_data_shape)
+                        check_layer_output_shape(layer, input_data)
+
 
     def test_UpSampling1D(self):
         layer = UpSampling1D(length=2)

--- a/tests/test_shape_inference.py
+++ b/tests/test_shape_inference.py
@@ -112,14 +112,14 @@ def test_MaxPooling1D():
                     check_layer_output_shape(layer, input_data)
 
 
-def test_MeanPooling1D(self):
+def test_AveragePooling1D(self):
     for ignore_border in [True, False]:
         for pool_length in [1, 2]:
             for stride in [1]:
                 for input_data_shape in [(2, 3, 4), (2, 4, 4)]:
-                    layer = MeanPooling1D(pool_length=pool_length,
-                                          stride=stride,
-                                          border_mode='valid')
+                    layer = AveragePooling1D(pool_length=pool_length,
+                                             stride=stride,
+                                             border_mode='valid')
                     input_data = np.random.random(input_data_shape)
                     check_layer_output_shape(layer, input_data)
 
@@ -145,23 +145,23 @@ def test_MaxPooling2D():
                     check_layer_output_shape(layer, input_data)
 
 
-def test_MeanPooling2D(self):
+def test_AveragePooling2D(self):
     for ignore_border in [True, False]:
         for strides in [(1, 1), (2, 2)]:
             for pool_size in [(2, 2), (3, 3), (4, 4)]:
                 for input_data_shape in [(2, 1, 4, 4), (2, 1, 5, 5), (2, 1, 6, 6)]:
-                    layer = MeanPooling2D(pool_size=pool_size,
-                                          strides=strides,
-                                          border_mode='valid',
-                                          dim_ordering='th')
+                    layer = AveragePooling2D(pool_size=pool_size,
+                                             strides=strides,
+                                             border_mode='valid',
+                                             dim_ordering='th')
                     input_data = np.random.random(input_data_shape)
                     check_layer_output_shape(layer, input_data)
 
                 for input_data_shape in [(2, 4, 4, 1)]:
-                    layer = MeanPooling2D(pool_size=pool_size,
-                                          strides=strides,
-                                          border_mode='valid',
-                                          dim_ordering='tf')
+                    layer = AveragePooling2D(pool_size=pool_size,
+                                             strides=strides,
+                                             border_mode='valid',
+                                             dim_ordering='tf')
                     input_data = np.random.random(input_data_shape)
                     check_layer_output_shape(layer, input_data)
 

--- a/tests/test_shape_inference.py
+++ b/tests/test_shape_inference.py
@@ -112,7 +112,7 @@ def test_MaxPooling1D():
                     check_layer_output_shape(layer, input_data)
 
 
-def test_AveragePooling1D(self):
+def test_AveragePooling1D():
     for ignore_border in [True, False]:
         for pool_length in [1, 2]:
             for stride in [1]:
@@ -145,7 +145,7 @@ def test_MaxPooling2D():
                     check_layer_output_shape(layer, input_data)
 
 
-def test_AveragePooling2D(self):
+def test_AveragePooling2D():
     for ignore_border in [True, False]:
         for strides in [(1, 1), (2, 2)]:
             for pool_size in [(2, 2), (3, 3), (4, 4)]:


### PR DESCRIPTION
We address  #522,  #230, #768, #786 and propose a solution that should cover most of those tickets. PR includes

- Added Pooling1D and Pooling2D classes in convolutional
- MaxPooling1D/2D and MeanPooling1D/2D as derived classes implemented (instead of "pool_mode" flags)
- In particular, all existing examples change untouched (same API as before)
- Extended tests and docs

Note: I didn't include SumPooling, bc there seems to be no implementation in TF (that I know of), but I included a suggestion for Theano in comments. If wanted, we can pretty quickly implement other pooling modes later on.