### PR TITLE
Run non-optimization updates on predict for stateful RNN's

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ keras/datasets/temp/*
 docs/site/*
 docs/theme/*
 tags
+Keras.egg-info
 
 # test-related
 .coverage

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -407,15 +407,12 @@ def rnn(step_function, inputs, initial_states,
     '''
     inputs = inputs.dimshuffle((1, 0, 2))
 
-    def _step(*args):
-        global single_result
-        input = args[0]
-        states = args[1:]
-        output, new_states = step_function(input, states)
+    def _step(ins, *states):
+        output, new_states = step_function(ins, states)
         if masking:
             # if all-zero input timestep, return
             # all-zero output and unchanged states
-            switch = T.any(input)
+            switch = T.any(ins)
             output = T.switch(switch, output, 0. * output)
             return_states = []
             for state, new_state in zip(states, new_states):

--- a/keras/layers/containers.py
+++ b/keras/layers/containers.py
@@ -75,6 +75,14 @@ class Sequential(Layer):
         return updates
 
     @property
+    def state_updates(self):
+        state_updates = []
+        for l in self.layers:
+            if l.trainable and getattr(l, 'stateful', False):
+                state_updates += l.get_params()[3]
+        return state_updates
+
+    @property
     def output_shape(self):
         return self.layers[-1].output_shape
 
@@ -191,6 +199,14 @@ class Graph(Layer):
             if l.trainable:
                 updates += l.get_params()[3]
         return updates
+
+    @property
+    def state_updates(self):
+        state_updates = []
+        for l in self.nodes.values():
+            if l.trainable and getattr(l, 'stateful', False):
+                state_updates += l.get_params()[3]
+        return state_updates
 
     def set_previous(self, layer, connection_map={}):
         if self.nb_input != layer.nb_output:

--- a/keras/layers/containers.py
+++ b/keras/layers/containers.py
@@ -76,9 +76,15 @@ class Sequential(Layer):
 
     @property
     def state_updates(self):
+        """
+        Returns the `updates` from all layers in the sequence that are
+        stateful.  This is useful for separating _training_ updates and
+        _prediction_ updates for when we need to update a layers internal state
+        during a stateful prediction.
+        """
         state_updates = []
         for l in self.layers:
-            if l.trainable and getattr(l, 'stateful', False):
+            if getattr(l, 'stateful', False):
                 state_updates += l.get_params()[3]
         return state_updates
 
@@ -202,9 +208,15 @@ class Graph(Layer):
 
     @property
     def state_updates(self):
+        """
+        Returns the `updates` from all nodes in that graph for nodes that are
+        stateful.  This is useful for separating _training_ updates and
+        _prediction_ updates for when we need to update a layers internal state
+        during a stateful prediction.
+        """
         state_updates = []
         for l in self.nodes.values():
-            if l.trainable and getattr(l, 'stateful', False):
+            if getattr(l, 'stateful', False):
                 state_updates += l.get_params()[3]
         return state_updates
 

--- a/keras/layers/containers.py
+++ b/keras/layers/containers.py
@@ -82,6 +82,11 @@ class Sequential(Layer):
                 state_updates += l.get_params()[3]
         return state_updates
 
+    def reset_states(self):
+        for l in self.layers:
+            if hasattr(l, 'reset_states') and getattr(l, 'stateful', False):
+                l.reset_states()
+
     @property
     def output_shape(self):
         return self.layers[-1].output_shape
@@ -120,11 +125,6 @@ class Sequential(Layer):
             nb_param = len(self.layers[i].params)
             self.layers[i].set_weights(weights[:nb_param])
             weights = weights[nb_param:]
-
-    def reset_states(self):
-        for layer in self.layers:
-            if hasattr(layer, 'reset_states') and getattr(layer, 'stateful', False):
-                layer.reset_states()
 
     def get_config(self):
         return {"name": self.__class__.__name__,
@@ -207,6 +207,11 @@ class Graph(Layer):
             if l.trainable and getattr(l, 'stateful', False):
                 state_updates += l.get_params()[3]
         return state_updates
+
+    def reset_states(self):
+        for l in self.nodes.values():
+            if hasattr(l, 'reset_states') and getattr(l, 'stateful', False):
+                l.reset_states()
 
     def set_previous(self, layer, connection_map={}):
         if self.nb_input != layer.nb_output:

--- a/keras/layers/containers.py
+++ b/keras/layers/containers.py
@@ -113,6 +113,11 @@ class Sequential(Layer):
             self.layers[i].set_weights(weights[:nb_param])
             weights = weights[nb_param:]
 
+    def reset_states(self):
+        for layer in self.layers:
+            if hasattr(layer, 'reset_states') and getattr(layer, 'stateful', False):
+                layer.reset_states()
+
     def get_config(self):
         return {"name": self.__class__.__name__,
                 "layers": [layer.get_config() for layer in self.layers]}

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -79,9 +79,9 @@ class Recurrent(MaskedLayer):
                                              go_backwards=self.go_backwards,
                                              masking=masking)
         if self.stateful:
-            self.updates = []
+            self.state_updates = []
             for i in range(len(states)):
-                self.updates.append((self.states[i], states[i]))
+                self.state_updates.append((self.states[i], states[i]))
 
         if self.return_sequences:
             return outputs

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -79,9 +79,9 @@ class Recurrent(MaskedLayer):
                                              go_backwards=self.go_backwards,
                                              masking=masking)
         if self.stateful:
-            self.state_updates = []
+            self.updates = []
             for i in range(len(states)):
-                self.state_updates.append((self.states[i], states[i]))
+                self.updates.append((self.states[i], states[i]))
 
         if self.return_sequences:
             return outputs

--- a/keras/models.py
+++ b/keras/models.py
@@ -406,7 +406,6 @@ class Sequential(Model, containers.Sequential):
                                              self.constraints,
                                              train_loss)
         updates += self.updates
-        state_updates = self.state_updates()
 
         if type(self.X_train) == list:
             train_ins = self.X_train + [self.y, self.weights]
@@ -420,7 +419,7 @@ class Sequential(Model, containers.Sequential):
 
         self._train = K.function(train_ins, [train_loss], updates=updates)
         self._train_with_acc = K.function(train_ins, [train_loss, train_accuracy], updates=updates)
-        self._predict = K.function(predict_ins, [self.y_test], updates=state_updates)
+        self._predict = K.function(predict_ins, [self.y_test], updates=self.state_updates)
         self._test = K.function(test_ins, [test_loss])
         self._test_with_acc = K.function(test_ins, [test_loss, test_accuracy])
 
@@ -627,13 +626,12 @@ class Graph(Model, containers.Graph):
         self.optimizer = optimizers.get(optimizer)
         updates = self.optimizer.get_updates(self.params, self.constraints, train_loss)
         updates += self.updates
-        state_updates = self.state_updates()
         self.theano_mode = theano_mode
         self.loss = loss
 
         self._train = K.function(train_ins, [train_loss], updates=updates)
         self._test = K.function(test_ins, [test_loss])
-        self._predict = K.function(inputs=ins, outputs=ys_test, updates=state_updates)
+        self._predict = K.function(inputs=ins, outputs=ys_test, updates=self.state_updates)
 
     def train_on_batch(self, data, class_weight={}, sample_weight={}):
         # data is a dictionary mapping output and input names to arrays

--- a/keras/models.py
+++ b/keras/models.py
@@ -406,6 +406,7 @@ class Sequential(Model, containers.Sequential):
                                              self.constraints,
                                              train_loss)
         updates += self.updates
+        state_updates = self.state_updates()
 
         if type(self.X_train) == list:
             train_ins = self.X_train + [self.y, self.weights]
@@ -419,7 +420,7 @@ class Sequential(Model, containers.Sequential):
 
         self._train = K.function(train_ins, [train_loss], updates=updates)
         self._train_with_acc = K.function(train_ins, [train_loss, train_accuracy], updates=updates)
-        self._predict = K.function(predict_ins, [self.y_test], updates=self.updates)
+        self._predict = K.function(predict_ins, [self.y_test], updates=state_updates)
         self._test = K.function(test_ins, [test_loss])
         self._test_with_acc = K.function(test_ins, [test_loss, test_accuracy])
 
@@ -626,12 +627,13 @@ class Graph(Model, containers.Graph):
         self.optimizer = optimizers.get(optimizer)
         updates = self.optimizer.get_updates(self.params, self.constraints, train_loss)
         updates += self.updates
+        state_updates = self.state_updates()
         self.theano_mode = theano_mode
         self.loss = loss
 
         self._train = K.function(train_ins, [train_loss], updates=updates)
         self._test = K.function(test_ins, [test_loss])
-        self._predict = K.function(inputs=ins, outputs=ys_test)
+        self._predict = K.function(inputs=ins, outputs=ys_test, updates=state_updates)
 
     def train_on_batch(self, data, class_weight={}, sample_weight={}):
         # data is a dictionary mapping output and input names to arrays

--- a/keras/models.py
+++ b/keras/models.py
@@ -419,7 +419,7 @@ class Sequential(Model, containers.Sequential):
 
         self._train = K.function(train_ins, [train_loss], updates=updates)
         self._train_with_acc = K.function(train_ins, [train_loss, train_accuracy], updates=updates)
-        self._predict = K.function(predict_ins, [self.y_test])
+        self._predict = K.function(predict_ins, [self.y_test], updates=self.updates)
         self._test = K.function(test_ins, [test_loss])
         self._test_with_acc = K.function(test_ins, [test_loss, test_accuracy])
 

--- a/tests/keras/layers/test_recurrent.py
+++ b/tests/keras/layers/test_recurrent.py
@@ -55,6 +55,16 @@ def _runner(layer_class):
     out3 = model.predict(np.ones((nb_samples, timesteps, input_dim)))
     assert(out2.max() != out3.max())
 
+    # check that we stay stateful during predictions
+    out4 = model.predict(np.ones((nb_samples, timesteps, input_dim)))
+    assert(out3.max() != out4.max())
+
+    # check that container-level reset_states() works
+    model.reset_states()
+    out5 = model.predict(np.ones((nb_samples, timesteps, input_dim)))
+    assert(out4.max() != out5.max())
+
+
 
 class TestRNNS(unittest.TestCase):
     """


### PR DESCRIPTION
Ideally, I could set my RNN's to stateful and use them to predict sequences in a stateful way.  Right now, the `_predict` function generated in the model does not run the updates necessary to set the RNN state.

~~The one problem I see is that we have collision with other layers that also set updates, namely the `BatchNormalization` layer.  A solution to this is to have the RNN state updates go to another variable, `state_updates` and leave `updates` for things that should only happen on training.  This seems like the right way of doing things, but the `get_param` function is thrown around a lot with tuple expansion and it seems like a mess to dig into that (maybe a good place for a `NamedTuple`).~~

EDIT: 56fa445 adds new property, `state_updates` to the `model` object that returns only the updates defined on layers set as stateful.  This allows us to update states on prediction only for layers that require this functionality to remain stateful.