### PR TITLE
Make mask accessible to layers in nested models

### DIFF
--- a/keras/layers/containers.py
+++ b/keras/layers/containers.py
@@ -121,6 +121,11 @@ class Sequential(Layer):
     def count_params(self):
         return sum([layer.count_params() for layer in self.layers])
 
+    def get_input_mask(self, train=False):
+        if hasattr(self, 'previous') and self.previous:
+            return self.previous.get_output_mask(train)
+        return None
+
 
 class Graph(Layer):
     '''

--- a/keras/layers/containers.py
+++ b/keras/layers/containers.py
@@ -37,6 +37,7 @@ class Sequential(Layer):
 
     def add(self, layer):
         self.layers.append(layer)
+        setattr(layer, 'parent', self)
         if len(self.layers) > 1:
             self.layers[-1].set_previous(self.layers[-2])
             if not hasattr(self.layers[0], 'input'):

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -208,6 +208,8 @@ class MaskedLayer(Layer):
     def get_input_mask(self, train=False):
         if hasattr(self, 'previous'):
             return self.previous.get_output_mask(train)
+        elif hasattr(self, 'parent'):
+            return self.parent.get_input_mask(train)
         else:
             return None
 


### PR DESCRIPTION
Consider the following model:
```
m1  = Sequential()
m1.add(LSTM(....))

m2 = Sequential()
m2.add(Embedding(...))
m2.add(m1)

m2.compile(...)
m2.fit(x,y)
```

As of now, the mask from the embedding layer will be invisible to the LSTM. This PR is an attempt to address this issue.
