### PR TITLE
Import pydot-ng with pydot as fallback when visualizing.

### DIFF
--- a/keras/utils/visualize_util.py
+++ b/keras/utils/visualize_util.py
@@ -1,9 +1,16 @@
-import pydot
-# old pydot will not work with python3, must use one
-# that works with python3 such as pydot2 or pydot
 import itertools
 from keras.layers.containers import Graph, Sequential
 from keras.layers.core import Merge
+
+try:
+    # pydot-ng is a fork of pydot that is better maintained
+    import pydot_ng as pydot
+except ImportError:
+    # fall back on pydot if necessary
+    import pydot
+if not pydot.find_graphviz():
+    raise RuntimeError("Failed to import pydot. You must install pydot"
+                       " and graphviz for `pydotprint` to work.")
 
 
 def layer_typename(layer):


### PR DESCRIPTION
Added support for importing `pydot-ng` with `pydot` as fallback when visualizing, similar to like it is done in `Theano` (eg. https://github.com/Theano/Theano/blob/master/theano/printing.py or in a PR https://github.com/Theano/Theano/pull/3772).