### PR TITLE
Add debug_mode for enabling suggested Theano detect_nan implementation.

### DIFF
--- a/keras/backend/__init__.py
+++ b/keras/backend/__init__.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 import os
 import json
-from .common import epsilon, floatx, set_epsilon, set_floatx
+from .common import epsilon, floatx, debug_mode, set_epsilon, set_floatx, set_debug_mode
 
 _keras_dir = os.path.expanduser(os.path.join('~', '.keras'))
 if not os.path.exists(_keras_dir):
@@ -16,16 +16,20 @@ if os.path.exists(_config_path):
     assert _floatx in {'float32', 'float64'}
     _epsilon = _config.get('epsilon', epsilon())
     assert type(_epsilon) == float
+    _debug_mode = _config.get('debug_mode', debug_mode())
+    assert _debug_mode in {'none', 'detect_nan'}
     _backend = _config.get('backend', _BACKEND)
     assert _backend in {'theano', 'tensorflow'}
 
     set_floatx(_floatx)
     set_epsilon(_epsilon)
+    set_debug_mode(_debug_mode)
     _BACKEND = _backend
 else:
     # save config file, for easy edition
     _config = {'floatx': floatx(),
                'epsilon': epsilon(),
+               'debug_mode': debug_mode(),
                'backend': _BACKEND}
     with open(_config_path, 'w') as f:
         # add new line in order for bash 'cat' display the content correctly

--- a/keras/backend/common.py
+++ b/keras/backend/common.py
@@ -3,6 +3,7 @@ import numpy as np
 # the type of float to use throughout the session.
 _FLOATX = 'float32'
 _EPSILON = 10e-8
+_DEBUG_MODE = 'none'
 
 
 def epsilon():
@@ -30,3 +31,14 @@ def cast_to_floatx(x):
     '''Cast a Numpy array to floatx.
     '''
     return np.asarray(x, dtype=_FLOATX)
+
+
+def debug_mode():
+    return _DEBUG_MODE
+
+
+def set_debug_mode(debug_mode):
+    global _DEBUG_MODE
+    if debug_mode not in {'none', 'detect_nan'}:
+        raise Exception('Unknown debug_mode: ' + debug_mode)
+    _DEBUG_MODE = debug_mode

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -3,7 +3,7 @@ from theano import tensor as T
 from theano.sandbox.rng_mrg import MRG_RandomStreams as RandomStreams
 from theano.tensor.signal import downsample
 import numpy as np
-from .common import _FLOATX, _EPSILON
+from .common import _FLOATX, _EPSILON, _DEBUG_MODE
 
 
 # INTERNAL UTILS
@@ -357,8 +357,11 @@ class Function(object):
         return self.function(*inputs)
 
 
-def function(inputs, outputs, updates=[]):
-    return Function(inputs, outputs, updates=updates)
+def function(inputs, outputs, updates=[], debug_nan=False):
+    mode = None
+    if _DEBUG_MODE == 'detect_nan':  # use suggested Theano detect_nan implementation
+        mode = theano.compile.MonitorMode(post_func=theano.compile.monitormode.detect_nan).excluding('local_elemwise_fusion', 'inplace')
+    return Function(inputs, outputs, updates=updates, mode=mode)
 
 
 def gradients(loss, variables):

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -357,10 +357,10 @@ class Function(object):
         return self.function(*inputs)
 
 
-def function(inputs, outputs, updates=[], debug_nan=False):
+def function(inputs, outputs, updates=[]):
     mode = None
     if _DEBUG_MODE == 'detect_nan':  # use suggested Theano detect_nan implementation
-        mode = theano.compile.MonitorMode(post_func=theano.compile.monitormode.detect_nan).excluding('local_elemwise_fusion', 'inplace')
+        mode = 'NanGuardMode'
     return Function(inputs, outputs, updates=updates, mode=mode)
 
 


### PR DESCRIPTION
Added `debug_mode` configuration with values:

- `'none'` is the previous and default behavior.
- `detect_nan` enables suggested Theano `detect_nan` implementation for debugging NaN values (some combinations of optimizer, objective, and activations result are numerically unstable and can cause such problems, eg. adam, mse, PReLu).