### PR TITLE
Allows choosing the backend by setting the KERAS_BACKEND environment …

### DIFF
--- a/docs/templates/backend.md
+++ b/docs/templates/backend.md
@@ -23,6 +23,15 @@ It probably looks like this:
 
 Simply change the field `backend` to either `"theano"` or `"tensorflow"`, and Keras will use the new configuration next time you run any Keras code.
 
+You can also define the environment variable ``KERAS_BACKEND`` and this will
+override what is defined in your config file :
+
+```bash
+KERAS_BACKEND=tensorflow python -c "from keras import backend; print backend._BACKEND"
+Using TensorFlow backend.
+tensorflow
+```
+
 ## Using the abstract Keras backend to write new code
 
 If you want the Keras modules you write to be compatible with both Theano and TensorFlow, you have to write them via the abstract Keras backend API. Here's an intro.

--- a/keras/backend/__init__.py
+++ b/keras/backend/__init__.py
@@ -31,6 +31,11 @@ else:
         # add new line in order for bash 'cat' display the content correctly
         f.write(json.dumps(_config) + '\n')
 
+if 'KERAS_BACKEND' in os.environ:
+    _backend = os.environ['KERAS_BACKEND']
+    assert _backend in {'theano', 'tensorflow'}
+    _BACKEND = _backend
+
 if _BACKEND == 'theano':
     print('Using Theano backend.')
     from .theano_backend import *


### PR DESCRIPTION
This allows one to define the `KERAS_BACKEND` environment variable to change the backend to be used. This overrides the config. When switching between theano and tensorflow for testing, this is easier than modified the config file.