### PR TITLE
Modifies UpSampling1D/2D to repeat entries instead of tiling arrays.

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -235,6 +235,19 @@ def permute_dimensions(x, pattern):
     '''
     return tf.transpose(x, perm=pattern)
 
+def repeat_elements(x, rep, axis):
+    '''Repeats the elements of a tensor along an axis, like np.repeat
+
+    If x has shape (s1, s2, s3) and axis=1, the output
+    will have shape (s1, s2 * rep, s3)
+    '''
+    x_shape = x.get_shape().as_list()
+    # slices along the repeat axis
+    splits = tf.split(axis, x_shape[axis], x)
+    # repeat each slice the given number of reps
+    x_rep = [s for s in splits for i in xrange(rep)]
+    return tf.concat(axis, x_rep)
+
 
 def repeat(x, n):
     '''Repeat a 2D tensor:

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -245,7 +245,7 @@ def repeat_elements(x, rep, axis):
     # slices along the repeat axis
     splits = tf.split(axis, x_shape[axis], x)
     # repeat each slice the given number of reps
-    x_rep = [s for s in splits for i in xrange(rep)]
+    x_rep = [s for s in splits for i in range(rep)]
     return tf.concat(axis, x_rep)
 
 

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -243,6 +243,14 @@ def permute_dimensions(x, pattern):
     return x.dimshuffle(pattern)
 
 
+def repeat_elements(x, rep, axis):
+    '''Repeats the elements of a tensor along an axis, like np.repeat
+
+    If x has shape (s1, s2, s3) and axis=1, the output
+    will have shape (s1, s2 * rep, s3)
+    '''
+    return T.repeat(x, rep, axis=axis)
+
 def repeat(x, n):
     '''Repeat a 2D tensor:
 

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -609,7 +609,7 @@ class UpSampling1D(Layer):
 
     def get_output(self, train=False):
         X = self.get_input(train)
-        output = K.concatenate([X] * self.length, axis=1)
+        output = K.repeat_elements(X, self.length, axis=1)
         return output
 
     def get_config(self):
@@ -669,11 +669,11 @@ class UpSampling2D(Layer):
     def get_output(self, train=False):
         X = self.get_input(train)
         if self.dim_ordering == 'th':
-            output = K.concatenate([X] * self.size[0], axis=2)
-            output = K.concatenate([output] * self.size[1], axis=3)
+            output = K.repeat_elements(X, self.size[0], axis=2)
+            output = K.repeat_elements(output, self.size[1], axis=3)
         elif self.dim_ordering == 'tf':
-            output = K.concatenate([X] * self.size[0], axis=1)
-            output = K.concatenate([output] * self.size[1], axis=2)
+            output = K.repeat_elements(X, self.size[0], axis=1)
+            output = K.repeat_elements(output, self.size[1], axis=2)
         else:
             raise Exception('Invalid dim_ordering: ' + self.dim_ordering)
         return output

--- a/tests/keras/backend/test_backends.py
+++ b/tests/keras/backend/test_backends.py
@@ -64,6 +64,26 @@ class TestBackend(object):
         check_single_tensor_operation('expand_dims', (4, 3, 2), dim=1)
         check_single_tensor_operation('squeeze', (4, 3, 1), axis=2)
 
+    def test_repeat_elements(self):
+        reps = 3
+        for ndims in [1, 2, 3]:
+            shape = np.arange(2, 2+ndims)
+            arr = np.arange(np.prod(shape)).reshape(shape)
+            arr_th = KTH.variable(arr)
+            arr_tf = KTF.variable(arr)
+
+            for rep_axis in xrange(ndims):
+                np_rep = np.repeat(arr, reps, axis=rep_axis)
+                th_rep = KTH.eval(
+                    KTH.repeat_elements(arr_th, reps, axis=rep_axis))
+                tf_rep = KTF.eval(
+                    KTF.repeat_elements(arr_tf, reps, axis=rep_axis))
+
+                assert th_rep.shape == np_rep.shape
+                assert tf_rep.shape == np_rep.shape
+                assert_allclose(np_rep, th_rep, atol=1e-05)
+                assert_allclose(np_rep, tf_rep, atol=1e-05)
+
     def test_value_manipulation(self):
         val = np.random.random((4, 2))
         xth = KTH.variable(val)

--- a/tests/keras/backend/test_backends.py
+++ b/tests/keras/backend/test_backends.py
@@ -72,7 +72,7 @@ class TestBackend(object):
             arr_th = KTH.variable(arr)
             arr_tf = KTF.variable(arr)
 
-            for rep_axis in xrange(ndims):
+            for rep_axis in range(ndims):
                 np_rep = np.repeat(arr, reps, axis=rep_axis)
                 th_rep = KTH.eval(
                     KTH.repeat_elements(arr_th, reps, axis=rep_axis))


### PR DESCRIPTION
Currently, UpSampling1D/2D does tiling on its input ([0, 1] => [0, 1, 0, 1]).
This modifies those layers to repeat individual entries instead (so [0, 0, 1, 1] => [0, 0, 1, 1]), as discused in #1226 and #1287 and should fix those issues.

This works by adding a new backend operation ``repeat_elements`` which has the same behavior as ``np.repeat``.

The tensorflow implementation uses a `split` and a `concat`. This might not be the most efficient way to do it, but at least it works. I am just starting to learn tensorflow, so if some indexing tricks wizard knows a better way, please let me know :-)