### PR TITLE
Fix shapes should be tuples.

### DIFF
--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -1018,7 +1018,7 @@ class TimeDistributedDense(MaskedLayer):
         input_dim = self.input_shape[2]
 
         self.W = self.init((input_dim, self.output_dim))
-        self.b = K.zeros((self.output_dim))
+        self.b = K.zeros((self.output_dim,))
 
         self.params = [self.W, self.b]
         self.regularizers = []

--- a/keras/layers/normalization.py
+++ b/keras/layers/normalization.py
@@ -50,12 +50,12 @@ class BatchNormalization(Layer):
         input_shape = self.input_shape  # starts with samples axis
         input_shape = input_shape[1:]
 
-        self.gamma = self.init((input_shape))
+        self.gamma = self.init(input_shape)
         self.beta = K.zeros(input_shape)
 
         self.params = [self.gamma, self.beta]
         self.running_mean = K.zeros(input_shape)
-        self.running_std = K.ones((input_shape))
+        self.running_std = K.ones(input_shape)
 
         # initialize self.updates: batch mean/std computation
         X = self.get_input(train=True)

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -205,7 +205,7 @@ class SimpleRNN(Recurrent):
 
         self.W = self.init((input_dim, self.output_dim))
         self.U = self.inner_init((self.output_dim, self.output_dim))
-        self.b = K.zeros((self.output_dim))
+        self.b = K.zeros((self.output_dim,))
         self.params = [self.W, self.U, self.b]
 
         if self.initial_weights is not None:
@@ -391,19 +391,19 @@ class LSTM(Recurrent):
 
         self.W_i = self.init((input_dim, self.output_dim))
         self.U_i = self.inner_init((self.output_dim, self.output_dim))
-        self.b_i = K.zeros((self.output_dim))
+        self.b_i = K.zeros((self.output_dim,))
 
         self.W_f = self.init((input_dim, self.output_dim))
         self.U_f = self.inner_init((self.output_dim, self.output_dim))
-        self.b_f = self.forget_bias_init((self.output_dim))
+        self.b_f = self.forget_bias_init((self.output_dim,))
 
         self.W_c = self.init((input_dim, self.output_dim))
         self.U_c = self.inner_init((self.output_dim, self.output_dim))
-        self.b_c = K.zeros((self.output_dim))
+        self.b_c = K.zeros((self.output_dim,))
 
         self.W_o = self.init((input_dim, self.output_dim))
         self.U_o = self.inner_init((self.output_dim, self.output_dim))
-        self.b_o = K.zeros((self.output_dim))
+        self.b_o = K.zeros((self.output_dim,))
 
         self.params = [self.W_i, self.U_i, self.b_i,
                        self.W_c, self.U_c, self.b_c,


### PR DESCRIPTION
It seems that refactoring for multiple backends introduced some typos and some input or output shapes (especially one-dimensional) were not tuples anymore. In some circumstances, like using a LSTM layer with `forget_bias_init='he_normal'`, Keras crashed:

```
    model.add_node(LSTM(embedding_dim, return_sequences=True, forget_bias_init='he_normal'), name='lstm', input='shared_1')
  File "/home/xxx/venv/src/keras/keras/layers/containers.py", line 262, in add_node
    layer.set_previous(self.nodes[input])
  File "/home/xxx/venv/src/keras/keras/layers/core.py", line 53, in set_previous
    self.build()
  File "/home/xxx/venv/src/keras/keras/layers/recurrent.py", line 328, in build
    self.b_f = self.forget_bias_init((self.output_dim))
  File "/home/xxx/venv/src/keras/keras/initializations.py", line 46, in he_normal
    fan_in, fan_out = get_fans(shape)
  File "/home/xxx/venv/src/keras/keras/initializations.py", line 7, in get_fans
    fan_in = shape[0] if len(shape) == 2 else np.prod(shape[1:])
TypeError: object of type 'int' has no len()
```