### PR TITLE
Tensorboard

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -8,6 +8,7 @@ import warnings
 
 from collections import deque
 from .utils.generic_utils import Progbar
+from .backend import _BACKEND
 from keras import backend as K
 
 
@@ -44,9 +45,11 @@ class CallbackList(object):
             callback.on_batch_begin(batch, logs)
         self._delta_ts_batch_begin.append(time.time() - t_before_callbacks)
         delta_t_median = np.median(self._delta_ts_batch_begin)
-        if self._delta_t_batch > 0. and delta_t_median > 0.95 * self._delta_t_batch and delta_t_median > 0.1:
+        if self._delta_t_batch > 0. and delta_t_median > 0.95 * \
+           self._delta_t_batch and delta_t_median > 0.1:
             warnings.warn('Method on_batch_begin() is slow compared '
-                          'to the batch update (%f). Check your callbacks.' % delta_t_median)
+                          'to the batch update (%f). Check your callbacks.'
+                          % delta_t_median)
         self._t_enter_batch = time.time()
 
     def on_batch_end(self, batch, logs={}):
@@ -58,9 +61,11 @@ class CallbackList(object):
             callback.on_batch_end(batch, logs)
         self._delta_ts_batch_end.append(time.time() - t_before_callbacks)
         delta_t_median = np.median(self._delta_ts_batch_end)
-        if self._delta_t_batch > 0. and delta_t_median > 0.95 * self._delta_t_batch and delta_t_median > 0.1:
+        if self._delta_t_batch > 0. and delta_t_median > 0.95 * \
+           self._delta_t_batch and delta_t_median > 0.1:
             warnings.warn('Method on_batch_end() is slow compared '
-                          'to the batch update (%f). Check your callbacks.' % delta_t_median)
+                          'to the batch update (%f). Check your callbacks.'
+                          % delta_t_median)
 
     def on_train_begin(self, logs={}):
         for callback in self.callbacks:
@@ -252,7 +257,8 @@ class ModelCheckpoint(Callback):
 
         if mode not in ['auto', 'min', 'max']:
             warnings.warn('ModelCheckpoint mode %s is unknown, '
-                          'fallback to auto mode' % (self.mode), RuntimeWarning)
+                          'fallback to auto mode' % (self.mode),
+                          RuntimeWarning)
             mode = 'auto'
 
         if mode == 'min':
@@ -279,7 +285,8 @@ class ModelCheckpoint(Callback):
             else:
                 if self.monitor_op(current, self.best):
                     if self.verbose > 0:
-                        print('Epoch %05d: %s improved from %0.5f to %0.5f, saving model to %s'
+                        print('Epoch %05d: %s improved from %0.5f to %0.5f,'
+                              ' saving model to %s'
                               % (epoch, self.monitor, self.best,
                                  current, filepath))
                     self.best = current
@@ -404,5 +411,88 @@ class LearningRateScheduler(Callback):
         self.schedule = schedule
 
     def on_epoch_begin(self, epoch, logs={}):
-        assert hasattr(self.model.optimizer, 'lr'), 'Optimizer must have a "lr" attribute.'
+        assert hasattr(self.model.optimizer, 'lr'), \
+            'Optimizer must have a "lr" attribute.'
         K.set_value(self.model.optimizer.lr, self.schedule(epoch))
+
+
+class TensorBoard(Callback):
+    ''' Tensorboard basic visualizations.
+
+    This callback writes a log usable with TensorBoard.
+    TensorBoard is a visualization tools provided with TensorFlow.
+
+    If you have installed TensorFlow with pip, you should be able
+    to launch TensorBoard from the command line:
+    ```
+    tensorboard --logdir=/full_path_to_your_logs
+    ```
+    You could find more information at:
+    https://www.tensorflow.org/versions/master/how_tos/summaries_and_tensorboard/index.html
+
+    # Arguments
+        model: a keras model linked to a tensorflow session
+        feed: a dictionnary mapping tensors (inputs, outputs, weigths)
+            from the model._test keras function i.e. model._test.inputs
+            to the corresponding arrays.
+        freq: the frequency at which the callback will output
+            parameters and metrics to the log
+        log_dir: the path of the directory where to save the log
+            files to be parsed by tensorboard
+    '''
+    def __init__(self, model, feed, freq=2, log_dir='./logs',
+                 show_accuracy=False):
+        super(Callback, self).__init__()
+        assert _BACKEND == 'tensorflow', \
+            'TensorBoard callback only works with the tensorflow backend'
+        import tensorflow as tf
+        import keras.backend.tensorflow_backend as KTF
+
+        self.model = model
+        self.freq = freq
+        self.log_dir = log_dir
+        self.sess = KTF._get_session()
+        self.feed = feed
+        mod_type = self.model.get_config()['name']
+        if mod_type == 'Sequential':
+            layers = {l.get_config()['name']: l for l in self.model.layers}
+        elif mod_type == 'Graph':
+            layers = self.model.nodes
+        else:
+            raise Exception('Unrecognized model:',
+                            self.model.get_config()['name'])
+        for l in layers:
+            cur_layer = layers[l]
+            if hasattr(cur_layer, 'W'):
+                tf.histogram_summary('{}_W'.format(l), cur_layer.W)
+            if hasattr(cur_layer, 'b'):
+                tf.histogram_summary('{}_b'.format(l), cur_layer.b)
+            if hasattr(cur_layer, 'get_output'):
+                tf.histogram_summary('{}_out'.format(l),
+                                     cur_layer.get_output())
+        f_output = self.model._test
+        if mod_type == 'Sequential':
+            if show_accuracy is True:
+                f_output = self.model._test_with_acc
+                tf.scalar_summary('Accuracy',
+                                  f_output.outputs[1])
+            tf.scalar_summary('Loss',
+                              f_output.outputs[0])
+        else:
+            losses = [self.model.loss[loss] for loss in self.model.loss]
+            if len(losses) > 1:
+                l_name = " + ".join(losses)
+            else:
+                l_name = losses[0]
+            tf.scalar_summary(l_name,
+                              f_output.outputs[0])
+        self.merged = tf.merge_all_summaries()
+        self.writer = tf.train.SummaryWriter(self.log_dir,
+                                             self.sess.graph_def)
+
+    def on_epoch_end(self, epoch, logs={}):
+        if epoch % self.freq == 0:
+            result = self.sess.run([self.merged],
+                                   feed_dict=self.feed)
+            summary_str = result[0]
+            self.writer.add_summary(summary_str, epoch)

--- a/tests/keras/test_callbacks.py
+++ b/tests/keras/test_callbacks.py
@@ -9,6 +9,7 @@ from keras.layers.core import Dense
 from keras.utils.test_utils import get_test_data
 from keras import backend as K
 from keras.utils import np_utils
+from keras.callbacks import _BACKEND
 
 input_dim = 2
 nb_hidden = 4
@@ -119,6 +120,87 @@ def test_LearningRateScheduler():
               validation_data=(X_test, y_test), callbacks=cbks, nb_epoch=5)
     assert (float(K.get_value(model.optimizer.lr)) - 0.2) < K.epsilon()
 
+
+@pytest.mark.skipif(_BACKEND != 'tensorflow',
+                    reason="Requires tensorflow backend")
+def test_TensorBoard():
+    import shutil
+    import tensorflow as tf
+    import keras.backend.tensorflow_backend as KTF
+    old_session = KTF._get_session()
+    filepath = './logs'
+    (X_train, y_train), (X_test, y_test) = get_test_data(nb_train=train_samples,
+                                                         nb_test=test_samples,
+                                                         input_shape=(input_dim,),
+                                                         classification=True,
+                                                         nb_class=nb_class)
+    y_test = np_utils.to_categorical(y_test)
+    y_train = np_utils.to_categorical(y_train)
+    # case 1 Sequential wo accuracy
+    with tf.Graph().as_default():
+        session = tf.Session('')
+        KTF._set_session(session)
+        model = Sequential()
+        model.add(Dense(nb_hidden, input_dim=input_dim, activation='relu'))
+        model.add(Dense(nb_class, activation='softmax'))
+        model.compile(loss='categorical_crossentropy', optimizer='sgd')
+
+        feed = {model._test.inputs[0]: X_train, model._test.inputs[1]: y_train,
+                model._test.inputs[2]: np.ones(train_samples)}
+        tsb = callbacks.TensorBoard(model=model, feed=feed, log_dir=filepath,
+                                    show_accuracy=False)
+        cbks = [tsb]
+        model.fit(X_train, y_train, batch_size=batch_size, show_accuracy=True,
+                  validation_data=(X_test, y_test), callbacks=cbks, nb_epoch=5)
+        assert os.path.exists(filepath)
+        shutil.rmtree(filepath)
+
+    # case 2 Sequential w accuracy
+    with tf.Graph().as_default():
+        session = tf.Session('')
+        KTF._set_session(session)
+        model = Sequential()
+        model.add(Dense(nb_hidden, input_dim=input_dim, activation='relu'))
+        model.add(Dense(nb_class, activation='softmax'))
+        model.compile(loss='categorical_crossentropy', optimizer='sgd')
+
+        feed = {model._test.inputs[0]: X_train, model._test.inputs[1]: y_train,
+                model._test.inputs[2]: np.ones(train_samples)}
+        tsb = callbacks.TensorBoard(model=model, feed=feed, log_dir=filepath,
+                                    show_accuracy=False)
+        cbks = [tsb]
+        model.fit(X_train, y_train, batch_size=batch_size, show_accuracy=True,
+                  validation_data=(X_test, y_test), callbacks=cbks, nb_epoch=5)
+        assert os.path.exists(filepath)
+        shutil.rmtree(filepath)
+
+    # case 3 Graph
+    with tf.Graph().as_default():
+        session = tf.Session('')
+        KTF._set_session(session)
+        model = Graph()
+        model.add_input(name='X_vars', input_shape=(input_dim, ))
+
+        model.add_node(Dense(nb_hidden, activation="sigmoid"),
+                       name='Dense1', input='X_vars')
+        model.add_node(Dense(nb_class, activation="softmax"),
+                       name='last_dense',
+                       input='Dense1')
+        model.add_output(name='output', input='last_dense')
+        model.compile(optimizer='sgd', loss={'output': 'mse'})
+
+        feed = {model._test.inputs[0]: X_train, model._test.inputs[1]: y_train,
+                model._test.inputs[2]: np.ones(train_samples)}
+        tsb = callbacks.TensorBoard(model=model, feed=feed, log_dir=filepath,
+                                    show_accuracy=False)
+        cbks = [tsb]
+        model.fit({'X_vars': X_train, 'output': y_train}, batch_size=batch_size,
+                  validation_data={'X_vars': X_test, 'output': y_test},
+                  callbacks=cbks, nb_epoch=5)
+        assert os.path.exists(filepath)
+        shutil.rmtree(filepath)
+
+        KTF._set_session(old_session)
 
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
Following the discussion in #1142 I have worked on a cleaner callback.

## Features
* works with a `Graph` or a `Sequential` model
* add weights and biases to the log
* add the data flow graph to the log
* add the loss to the log
* if asked, add the accuracy to the log

What could be added easily:
* image summaries
* sparsity measures if the activation is a ReLU

## Notes
We could improve how we pass data to the callbacks but it depends on how Keras will evolve in the future regarding the scopes and the naming of contexts/ops.

For now, the user has to feed the callback with a dictionnary `{tensor: value}` but he has to get it from the `model._test` Keras function. I didn't found a clean way to do this with the same names provided in the `Graph` model or using positions for the `Sequential` model (if there is something obvious I missed le me know :) ).

## Tests
I'm not sure about how to write tests for this feature (and other callbacks), if anyone is willing to guide me on this you're welcome.

Example:

```python
from keras.models import Sequential
from keras.layers.core import Dense, Activation
from keras.callbacks import TensorBoard
import numpy as np
from keras.utils.test_utils import get_test_data
from keras.utils import np_utils

input_dim = 32
nb_hidden = 16
nb_class = 4
batch_size = 32
nb_epoch = 10


def _get_test_data():
    np.random.seed(1234)

    train_samples = 2000
    test_samples = 500

    (X_train, y_train), (X_test, y_test) = get_test_data(nb_train=train_samples,
                                                         nb_test=test_samples,
                                                         input_shape=(input_dim,),
                                                         classification=True,
                                                         nb_class=4)

    y_test = np_utils.to_categorical(y_test)
    y_train = np_utils.to_categorical(y_train)
    return (X_train, y_train), (X_test, y_test)

(X_train, y_train), (X_test, y_test) = _get_test_data()


def test_seq_acc():
    model = Sequential()
    model.add(Dense(nb_hidden, input_shape=(input_dim,)))
    model.add(Activation('relu'))
    model.add(Dense(nb_class))
    model.add(Activation('softmax'))
    model.compile(loss='categorical_crossentropy', optimizer='rmsprop')
    model.summary()

    feed = {model._test.inputs[0]: X_train, model._test.inputs[1]: y_train,
            model._test.inputs[2]: np.ones(len(X_train))}
    tsb = TensorBoard(model=model, feed=feed, log_dir='./logs',
                      show_accuracy=True)

    model.fit(X_train, y_train, batch_size=batch_size,
              nb_epoch=nb_epoch, show_accuracy=True,
              verbose=1, validation_data=(X_test, y_test),
              callbacks=[tsb])

if __name__ == '__main__':
    test_seq_acc()
```

(closes #1142 )