### PR TITLE
Output Format of predict_on_batch in Graph() Model as Dictionary

### DIFF
--- a/keras/models.py
+++ b/keras/models.py
@@ -1097,7 +1097,8 @@ class Graph(Model, containers.Graph):
         '''Generate predictions for a single batch of samples.
         '''
         ins = [data[name] for name in self.input_order]
-        return self._predict(ins)
+        outs = self._predict(ins)
+        return dict(zip(self.output_order, outs))
 
     def save_weights(self, filepath, overwrite=False):
         '''Save weights from all layers to a HDF5 files.


### PR DESCRIPTION
Hi,
for this pull request, I adapted the return value of the predict_on_batch() function such that it is consistent with the predict() method. That means, both function return a dictionary of their predicted outputs instead of an ordered list. Exemplary usage:

```python
predictions = model.predict_on_batch({"input1": X1,"input2": X2,"input3": X3}})
Y1 = predictions["output1"]
Y2 = predictions["output2"]
```

This way, it is more intuitive to retrieve the specific output one is interested in.
I believe this is a small change that many people might profit from.

Any comments?