### PR TITLE
fix iteration shadowed in loop

### DIFF
--- a/examples/lstm_text_generation.py
+++ b/examples/lstm_text_generation.py
@@ -85,7 +85,7 @@ for iteration in range(1, 60):
         print('----- Generating with seed: "' + sentence + '"')
         sys.stdout.write(generated)
 
-        for iteration in range(400):
+        for i in range(400):
             x = np.zeros((1, maxlen, len(chars)))
             for t, char in enumerate(sentence):
                 x[0, t, char_indices[char]] = 1.


### PR DESCRIPTION
The variable `iteration` is shadowed between the second loop and the third loop. So if I want to print `iteration` there, I always get `399`.

This is not a bug for now but since this is an example and many people may write more code from here. It's better to fix it.