### PR TITLE
Check keras_dir writing permission and assign temporary directory

### DIFF
--- a/keras/backend/__init__.py
+++ b/keras/backend/__init__.py
@@ -4,9 +4,11 @@ import os
 import json
 from .common import epsilon, floatx, set_epsilon, set_floatx
 
-_keras_dir = os.path.expanduser(os.path.join('~', '.keras'))
-if not os.access(_keras_dir, os.W_OK):
-    _keras_dir = os.path.join('/tmp', '.keras')
+_keras_base_dir = os.path.expanduser('~')
+if not os.access(_keras_base_dir, os.W_OK):
+    _keras_base_dir = '/tmp'
+
+_keras_dir = os.path.join(_keras_base_dir, '.keras')
 if not os.path.exists(_keras_dir):
     os.makedirs(_keras_dir)
 

--- a/keras/backend/__init__.py
+++ b/keras/backend/__init__.py
@@ -5,11 +5,13 @@ import json
 from .common import epsilon, floatx, set_epsilon, set_floatx
 
 _keras_dir = os.path.expanduser(os.path.join('~', '.keras'))
+if not os.access(_keras_dir, os.W_OK):
+    _keras_dir = os.path.join('/tmp', '.keras')
 if not os.path.exists(_keras_dir):
     os.makedirs(_keras_dir)
 
 _BACKEND = 'theano'
-_config_path = os.path.expanduser(os.path.join('~', '.keras', 'keras.json'))
+_config_path = os.path.expanduser(os.path.join(_keras_dir, 'keras.json'))
 if os.path.exists(_config_path):
     _config = json.load(open(_config_path))
     _floatx = _config.get('floatx', floatx())

--- a/keras/datasets/data_utils.py
+++ b/keras/datasets/data_utils.py
@@ -14,9 +14,10 @@ class ParanoidURLopener(FancyURLopener):
 
 
 def get_file(fname, origin, untar=False):
-    datadir = os.path.expanduser(os.path.join('~', '.keras', 'datasets'))
-    if not os.access(datadir, os.W_OK):
-        datadir = os.path.join('/tmp', '.keras', 'datasets')
+    datadir_base = os.path.expanduser(os.path.join('~', '.keras'))
+    if not os.access(datadir_base, os.W_OK):
+        datadir_base = os.path.join('/tmp', '.keras')
+    datadir = os.path.join(datadir_base, 'datasets')
     if not os.path.exists(datadir):
         os.makedirs(datadir)
 

--- a/keras/datasets/data_utils.py
+++ b/keras/datasets/data_utils.py
@@ -15,6 +15,8 @@ class ParanoidURLopener(FancyURLopener):
 
 def get_file(fname, origin, untar=False):
     datadir = os.path.expanduser(os.path.join('~', '.keras', 'datasets'))
+    if not os.access(datadir, os.W_OK):
+        datadir = os.path.join('/tmp', '.keras', 'datasets')
     if not os.path.exists(datadir):
         os.makedirs(datadir)
 


### PR DESCRIPTION
I ran keras on a distributed environment. On worker nodes, it might possibly we don't have writing permission for the `_keras_dir`. In this case, the running will be failed. I think we can check its permission and assign it to temporary directory in this case.
