### PR TITLE
Fixed handling of negative dimensions in Reshape layers

### DIFF
--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -685,13 +685,43 @@ class Reshape(Layer):
         super(Reshape, self).__init__(**kwargs)
         self.dims = tuple(dims)
 
+    def _fix_unknown_dimension(self, input_shape, output_shape):
+        """
+        A near direct port of the internal numpy function _fix_unknown_dimension
+        in numpy/core/src/multiarray/shape.c
+        """
+
+        output_shape = list(output_shape)
+
+        msg = 'total size of new array must be unchanged'
+
+        known, unknown = 1, None
+        for index, dim in enumerate(output_shape):
+            if dim < 0:
+                if unknown is None:
+                    unknown = index
+                else:
+                    raise ValueError('can only specify one unknown dimension')
+            else:
+                known *= dim
+
+        original = np.prod(input_shape, dtype=int)
+        if not unknown is None:
+            if known == 0 or original % known != 0:
+                raise ValueError(msg)
+            output_shape[unknown] = original // known
+        elif original != known:
+            raise ValueError(msg)
+
+        return tuple(output_shape)
+
     @property
     def output_shape(self):
-        return (self.input_shape[0],) + self.dims
+        return (self.input_shape[0],) + self._fix_unknown_dimension(self.input_shape[1:], self.dims)
 
     def get_output(self, train=False):
         X = self.get_input(train)
-        return K.reshape(X, (-1,) + self.dims)
+        return K.reshape(X, (-1,) + self.output_shape[1:])
 
     def get_config(self):
         config = {'name': self.__class__.__name__,

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -686,10 +686,26 @@ class Reshape(Layer):
         self.dims = tuple(dims)
 
     def _fix_unknown_dimension(self, input_shape, output_shape):
-        """
+        '''Find and replace a single missing dimension in an output shape
+        given and input shape.
+        
         A near direct port of the internal numpy function _fix_unknown_dimension
         in numpy/core/src/multiarray/shape.c
-        """
+
+        # Arguments
+            input_shape: shape of array being reshaped
+
+            output_shape: desired shaped of the array with at most
+                a single -1 which indicates a dimension that should be
+                derived from the input shape.
+
+        # Returns
+            The new output shape with a -1 replaced with its computed value.
+
+            Raises a ValueError if the total array size of the output_shape is
+            different then the input_shape, or more then one unknown dimension
+            is specified.
+        '''
 
         output_shape = list(output_shape)
 
@@ -706,7 +722,7 @@ class Reshape(Layer):
                 known *= dim
 
         original = np.prod(input_shape, dtype=int)
-        if not unknown is None:
+        if unknown is not None:
             if known == 0 or original % known != 0:
                 raise ValueError(msg)
             output_shape[unknown] = original // known

--- a/tests/test_shape_inference.py
+++ b/tests/test_shape_inference.py
@@ -22,10 +22,19 @@ def check_layer_output_shape(layer, input_data):
 # Core #
 ########
 def test_Reshape():
-    layer = Reshape(dims=(2, 3))
     input_data = np.random.random((2, 6))
+
+    layer = Reshape(dims=(2, 3))
     check_layer_output_shape(layer, input_data)
 
+    layer = Reshape(dims=(-1,))
+    check_layer_output_shape(layer, input_data)
+
+    layer = Reshape(dims=(-1, 2))
+    check_layer_output_shape(layer, input_data)
+
+    layer = Reshape(dims=(2, -1))
+    check_layer_output_shape(layer, input_data)
 
 def test_Permute():
     layer = Permute(dims=(1, 3, 2))


### PR DESCRIPTION
This block of code correctly returns a y with shape `(5, 2)` however model.output_shape incorrectly returns the value of dims `(-1, 2)`

```python
x = np.random.random((6, 10))

model = Sequential()
model.add(Reshape(dims=(-1, 2), input_shape=x.shape[1:]))
model.compile(loss='mean_squared_error', optimizer='sgd')

y = model.predict(x, batch_size=16)

print y.shape
print model.output_shape
```