### PR TITLE
Clipping values at the right place in order to avoid losses with nan.

### DIFF
--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -475,21 +475,23 @@ def softplus(x):
 
 
 def categorical_crossentropy(output, target, from_logits=False):
+    # avoid numerical instability with _EPSILON clipping
+    output = T.clip(output, _EPSILON, 1.0 - _EPSILON)
+   
     if from_logits:
         output = T.nnet.softmax(output)
     else:
         # scale preds so that the class probas of each sample sum to 1
         output /= output.sum(axis=-1, keepdims=True)
-    # avoid numerical instability with _EPSILON clipping
-    output = T.clip(output, _EPSILON, 1.0 - _EPSILON)
-    return T.nnet.categorical_crossentropy(output, target)
+   return T.nnet.categorical_crossentropy(output, target)
 
 
 def binary_crossentropy(output, target, from_logits=False):
-    if from_logits:
-        output = T.nnet.sigmoid(output)
     # avoid numerical instability with _EPSILON clipping
     output = T.clip(output, _EPSILON, 1.0 - _EPSILON)
+
+    if from_logits:
+        output = T.nnet.sigmoid(output)
     return T.nnet.binary_crossentropy(output, target)
 
 


### PR DESCRIPTION
The clipping was being applied in a wrong place.

On the categorical_crossentropy function at the theano_backend (I don't have the TensorFlow installed, but I suspect the same fix must be applied there...). the code
```
#scale preds so that the class probas of each sample sum to 1
output /= output.sum(axis=-1, keepdims=True)
```
was resulting in nans if there was a sample with all indexes with 0 values (in my problem - EEG Analysis - the zero-vector means 'doing nothing').

So clipping the value before this operation stopped resulting nans on my simulations.