### PR TITLE
Fixed dnn_conv output size

### DIFF
--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -548,12 +548,14 @@ def conv2d(x, kernel, strides=(1, 1), border_mode='valid', dim_ordering='th',
     if _on_gpu() and dnn.dnn_available():
         if border_mode == 'same':
             assert(strides == (1, 1))
-            np_kernel = kernel.eval()
-            pad_x = (np_kernel.shape[2] - strides[0]) // 2
-            pad_y = (np_kernel.shape[3] - strides[1]) // 2
             conv_out = dnn.dnn_conv(img=x,
                                     kerns=kernel,
-                                    border_mode=(pad_x, pad_y))
+                                    border_mode='full')
+            shift_x = (kernel.shape[2] - 1) // 2
+            shift_y = (kernel.shape[3] - 1) // 2
+            conv_out = conv_out[:, :,
+                                shift_x:x.shape[2] + shift_x,
+                                shift_y:x.shape[3] + shift_y]
         else:
             conv_out = dnn.dnn_conv(img=x,
                                     kerns=kernel,


### PR DESCRIPTION
This patch closes #1276.
As I understand the bug, the padding is applied on both sides horizontally and vertically when using custom padding in cuDNN.
To be consistent with the behavior of [T.nnet.conv.conv2d](https://github.com/fchollet/keras/blob/master/keras/backend/theano_backend.py#L577-L581)                     the same trick is applied here.
The convolution is padded according to the `full` mode and then sliced to have the same size as the input.