### PR TITLE
Add K.resize_images backend op.

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -236,6 +236,24 @@ def permute_dimensions(x, pattern):
     return tf.transpose(x, perm=pattern)
 
 
+def resize_images(X, height, width, height_factor, width_factor, dim_ordering):
+    '''Resize the images contained in a 4D tensor of shape
+    - [batch, channels, height, width] (for 'th' dim_ordering)
+    - [batch, height, width, channels] (for 'tf' dim_ordering)
+    by a factor of (height_factor, width_factor)
+    '''
+    new_height = height * height_factor
+    new_width = width * width_factor
+    if dim_ordering == 'th':
+        X = permute_dimensions(X, [0, 2, 3, 1])
+        X = tf.image.resize_nearest_neighbor(X, (new_height, new_width))
+        return permute_dimensions(X, [0, 3, 1, 2])
+    elif dim_ordering == 'tf':
+        return tf.image.resize_nearest_neighbor(X, (new_height, new_width))
+    else:
+        raise Exception('Invalid dim_ordering: ' + dim_ordering)
+
+
 def repeat_elements(x, rep, axis):
     '''Repeats the elements of a tensor along an axis, like np.repeat
 

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -236,19 +236,22 @@ def permute_dimensions(x, pattern):
     return tf.transpose(x, perm=pattern)
 
 
-def resize_images(X, height, width, height_factor, width_factor, dim_ordering):
+def resize_images(X, height_factor, width_factor, dim_ordering):
     '''Resize the images contained in a 4D tensor of shape
     - [batch, channels, height, width] (for 'th' dim_ordering)
     - [batch, height, width, channels] (for 'tf' dim_ordering)
-    by a factor of (height_factor, width_factor)
+    by a factor of (height_factor, width_factor). Both factors should be
+    positive integers.
     '''
-    new_height = height * height_factor
-    new_width = width * width_factor
     if dim_ordering == 'th':
+        new_height = shape(X)[2].value * height_factor
+        new_width = shape(X)[3].value * width_factor
         X = permute_dimensions(X, [0, 2, 3, 1])
         X = tf.image.resize_nearest_neighbor(X, (new_height, new_width))
         return permute_dimensions(X, [0, 3, 1, 2])
     elif dim_ordering == 'tf':
+        new_height = shape(X)[1].value * height_factor
+        new_width = shape(X)[2].value * width_factor
         return tf.image.resize_nearest_neighbor(X, (new_height, new_width))
     else:
         raise Exception('Invalid dim_ordering: ' + dim_ordering)

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -252,11 +252,12 @@ def repeat_elements(x, rep, axis):
     return T.repeat(x, rep, axis=axis)
 
 
-def resize_images(X, height, width, height_factor, width_factor, dim_ordering):
+def resize_images(X, height_factor, width_factor, dim_ordering):
     '''Resize the images contained in a 4D tensor of shape
     - [batch, channels, height, width] (for 'th' dim_ordering)
     - [batch, height, width, channels] (for 'tf' dim_ordering)
-    by a factor of (height_factor, width_factor)
+    by a factor of (height_factor, width_factor). Both factors should be
+    positive integers.
     '''
     if dim_ordering == 'th':
         output = repeat_elements(X, height_factor, axis=2)

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -251,6 +251,23 @@ def repeat_elements(x, rep, axis):
     '''
     return T.repeat(x, rep, axis=axis)
 
+
+def resize_images(X, height, width, height_factor, width_factor, dim_ordering):
+    '''Resize the images contained in a 4D tensor of shape
+    - [batch, channels, height, width] (for 'th' dim_ordering)
+    - [batch, height, width, channels] (for 'tf' dim_ordering)
+    by a factor of (height_factor, width_factor)
+    '''
+    if self.dim_ordering == 'th':
+        output = K.repeat_elements(X, height_factor, axis=2)
+        output = K.repeat_elements(output, width_factor, axis=3)
+    elif self.dim_ordering == 'tf':
+        output = K.repeat_elements(X, height_factor, axis=1)
+        output = K.repeat_elements(output, width_factor, axis=2)
+    else:
+        raise Exception('Invalid dim_ordering: ' + dim_ordering)
+
+
 def repeat(x, n):
     '''Repeat a 2D tensor.
 

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -258,12 +258,14 @@ def resize_images(X, height, width, height_factor, width_factor, dim_ordering):
     - [batch, height, width, channels] (for 'tf' dim_ordering)
     by a factor of (height_factor, width_factor)
     '''
-    if self.dim_ordering == 'th':
-        output = K.repeat_elements(X, height_factor, axis=2)
-        output = K.repeat_elements(output, width_factor, axis=3)
-    elif self.dim_ordering == 'tf':
-        output = K.repeat_elements(X, height_factor, axis=1)
-        output = K.repeat_elements(output, width_factor, axis=2)
+    if dim_ordering == 'th':
+        output = repeat_elements(X, height_factor, axis=2)
+        output = repeat_elements(output, width_factor, axis=3)
+        return output
+    elif dim_ordering == 'tf':
+        output = repeat_elements(X, height_factor, axis=1)
+        output = repeat_elements(output, width_factor, axis=2)
+        return output
     else:
         raise Exception('Invalid dim_ordering: ' + dim_ordering)
 

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -668,15 +668,13 @@ class UpSampling2D(Layer):
 
     def get_output(self, train=False):
         X = self.get_input(train)
+        input_shape = self.input_shape
         if self.dim_ordering == 'th':
-            output = K.repeat_elements(X, self.size[0], axis=2)
-            output = K.repeat_elements(output, self.size[1], axis=3)
+            height, width = input_shape[2], input_shape[3]
         elif self.dim_ordering == 'tf':
-            output = K.repeat_elements(X, self.size[0], axis=1)
-            output = K.repeat_elements(output, self.size[1], axis=2)
-        else:
-            raise Exception('Invalid dim_ordering: ' + self.dim_ordering)
-        return output
+            height, width = input_shape[1], input_shape[2]
+        return K.resize_images(X, height, width, self.size[0], self.size[1],
+                               self.dim_ordering)
 
     def get_config(self):
         config = {'name': self.__class__.__name__,

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -668,12 +668,7 @@ class UpSampling2D(Layer):
 
     def get_output(self, train=False):
         X = self.get_input(train)
-        input_shape = self.input_shape
-        if self.dim_ordering == 'th':
-            height, width = input_shape[2], input_shape[3]
-        elif self.dim_ordering == 'tf':
-            height, width = input_shape[1], input_shape[2]
-        return K.resize_images(X, height, width, self.size[0], self.size[1],
+        return K.resize_images(X, self.size[0], self.size[1],
                                self.dim_ordering)
 
     def get_config(self):

--- a/tests/keras/layers/test_convolutional.py
+++ b/tests/keras/layers/test_convolutional.py
@@ -188,17 +188,44 @@ def test_upsampling_2d():
     input_nb_row = 11
     input_nb_col = 12
 
-    input = np.ones((nb_samples, stack_size, input_nb_row, input_nb_col))
 
-    for length_row in [2, 3, 9]:
-        for length_col in [2, 3, 9]:
-            layer = convolutional.UpSampling2D(size=(length_row, length_col))
-            layer.input = K.variable(input)
-            for train in [True, False]:
-                out = K.eval(layer.get_output(train))
-                assert out.shape[2] == length_row * input_nb_row
-                assert out.shape[3] == length_col * input_nb_col
-        layer.get_config()
+    for dim_ordering in ['th', 'tf']:
+        if dim_ordering == 'th':
+            input = np.random.rand(nb_samples, stack_size, input_nb_row,
+                                   input_nb_col)
+        else:  # tf
+            input = np.random.rand(nb_samples, input_nb_row, input_nb_col,
+                                   stack_size)
+
+        for length_row in [2, 3, 9]:
+            for length_col in [2, 3, 9]:
+                    layer = convolutional.UpSampling2D(
+                        size=(length_row, length_col),
+                        input_shape=input.shape[1:],
+                        dim_ordering=dim_ordering)
+                    layer.input = K.variable(input)
+                    for train in [True, False]:
+                        out = K.eval(layer.get_output(train))
+                        if dim_ordering == 'th':
+                            assert out.shape[2] == length_row * input_nb_row
+                            assert out.shape[3] == length_col * input_nb_col
+                        else:  # tf
+                            assert out.shape[1] == length_row * input_nb_row
+                            assert out.shape[2] == length_col * input_nb_col
+
+                        # compare with numpy
+                        if dim_ordering == 'th':
+                            expected_out = np.repeat(input, length_row, axis=2)
+                            expected_out = np.repeat(expected_out, length_col,
+                                                     axis=3)
+                        else:  # tf
+                            expected_out = np.repeat(input, length_row, axis=1)
+                            expected_out = np.repeat(expected_out, length_col,
+                                                     axis=2)
+
+                        assert_allclose(out, expected_out)
+
+                    layer.get_config()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This allows to take advantage of tensorflow’s resize_images operator in UpSampling2D. This was discussed in #1293 .

This also modifies `test_upsampling_2d` to test with different dim_ordering.