### PR TITLE
Evaluate the kernel of base Theano conv2d with the same border mode

### DIFF
--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -601,8 +601,9 @@ def conv2d(x, kernel, strides=(1, 1), border_mode='valid', dim_ordering='th',
                                       image_shape=image_shape,
                                       filter_shape=filter_shape)
         if border_mode == 'same':
-            shift_x = (kernel.shape[2] - 1) // 2
-            shift_y = (kernel.shape[3] - 1) // 2
+            np_kernel = kernel.eval()
+            shift_x = (np_kernel.shape[2] - 1) // 2
+            shift_y = (np_kernel.shape[3] - 1) // 2
             conv_out = conv_out[:, :,
                                 shift_x:x.shape[2] + shift_x,
                                 shift_y:x.shape[3] + shift_y]


### PR DESCRIPTION
A simple copy paste of the [fix](https://github.com/fchollet/keras/commit/13379da81bff3d72d7ade8b662640545f4c1b559) following this [discussion](https://groups.google.com/forum/?hl=fr#!topic/keras-users/zLMpqJTSZJ8) for the conv2d using base Theano.
This way we should have the same behavior when using one or the other.

*The last [fix](https://github.com/fchollet/keras/commit/13379da81bff3d72d7ade8b662640545f4c1b559) has been tested on both cuDNN v3 and cuDNN v4.