### PR TITLE
models: when dumping config to json, parse unhandled types correctly

### DIFF
--- a/keras/models.py
+++ b/keras/models.py
@@ -370,8 +370,21 @@ class Model(object):
         `keras.models.from_json(json_string, custom_objects={})`.
         '''
         import json
+
+        def get_json_type(obj):
+
+            # if obj is any numpy type
+            if type(obj).__module__ == np.__name__:
+                return obj.item();
+
+            # if obj is a python 'type'
+            if type(obj).__name__ == type.__name__:
+                return obj.__name__
+
+            raise TypeError('Not JSON Serializable')
+
         config = self.get_config()
-        return json.dumps(config, **kwargs)
+        return json.dumps(config, default=get_json_type, **kwargs)
 
     def summary(self):
         '''Print out a summary of the model architecture,


### PR DESCRIPTION
In model.to_json, some unhandled types are manually converted to JSON type:

- if the object is any numpy type, convert using obj.item()
- for python objects of the type 'type', return the name as a string

This avoids an error being thrown when these types appear in the model config. Fixes https://github.com/fchollet/keras/issues/1355