### PR TITLE
Added compatibility for custom loss functions

### DIFF
--- a/keras/models.py
+++ b/keras/models.py
@@ -158,10 +158,13 @@ def model_from_config(config, custom_objects={}):
         loss = config.get('loss')
 
         # if a custom loss function is passed replace it in loss
-        for l in loss:
-            for c in custom_objects:
-                if loss[l] == c:
-                    loss[l] = custom_objects[c]
+        if model_name == 'Graph':
+            for l in loss:
+                for c in custom_objects:
+                    if loss[l] == c:
+                        loss[l] = custom_objects[c]
+        elif model_name == 'Sequential' and loss in custom_objects:
+            loss = custom_objects[loss]
 
         class_mode = config.get('class_mode')
 

--- a/keras/models.py
+++ b/keras/models.py
@@ -156,6 +156,13 @@ def model_from_config(config, custom_objects={}):
     if 'optimizer' in config:
         # if it has an optimizer, the model is assumed to be compiled
         loss = config.get('loss')
+
+        # if a custom loss function is passed replace it in loss
+        for l in loss:
+            for c in custom_objects:
+                if loss[l] == c:
+                    loss[l] = custom_objects[c]
+
         class_mode = config.get('class_mode')
 
         optimizer_params = dict([(k, v) for k, v in config.get('optimizer').items()])


### PR DESCRIPTION
Following #1025, #1119, #911 and #868 custom objectives functions still can't be loaded when loading a saved model with `model_from_json` or `model_from_yaml`. I made a simple change to check if the names of the outputs were not in the `custom_objects` passed so we can feed it to the `.compile` method.
`globals()` seems to be local at the module level and the custom function is not visible inside the `objectives.py` module.

As always, I'm not sure if it's the best way to do it but I tried to minimise the changes in other modules and submodules.

For the tests, should I add a custom objective, compile it and try to serialize it using json and yaml?