### PR TITLE
FIxed Tensorboard callback for Python 3

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -513,7 +513,10 @@ class TensorBoard(Callback):
                 summary_str = result[0]
                 self.writer.add_summary(summary_str, epoch)
 
-        for name, value in self.totals.items() + logs.items():
+        all_values = self.totals.copy()
+        all_values.update(logs)
+        
+        for name, value in all_values.items():
             if name in ['batch', 'size']:
                 continue
             summary = tf.Summary()


### PR DESCRIPTION
Adding `dict_items` [does not work](https://stackoverflow.com/questions/13361510/typeerror-unsupported-operand-types-for-dict-items-and-dict-items) in Python 3. Workaround is to create a copy of the dict and `update` it with the other dict.