### PR TITLE
fix batch normalization

### DIFF
--- a/keras/layers/normalization.py
+++ b/keras/layers/normalization.py
@@ -27,6 +27,14 @@ class BatchNormalization(Layer):
                 each combination of a channel, row and column
                 will be normalized separately).
             - 1: sample-wise normalization. This mode assumes a 2D input.
+            - 2: standard implementation feature-wise normalization on a per batch basis.
+                The running average is only used to compute the prediction.
+                If the input has multiple feature dimensions,
+                each will be normalized separately
+                (e.g. for an image input with shape
+                `(channels, rows, cols)`,
+                each combination of a channel, row and column
+                will be normalized separately).
         momentum: momentum in the computation of the
             exponential average of the mean and standard deviation
             of the data, for feature-wise normalization.
@@ -37,7 +45,7 @@ class BatchNormalization(Layer):
     # References
         - [Batch Normalization: Accelerating Deep Network Training by Reducing Internal Covariate Shift](http://arxiv.org/pdf/1502.03167v3.pdf)
     '''
-    def __init__(self, epsilon=1e-6, mode=0, momentum=0.9,
+    def __init__(self, epsilon=1e-6, mode=2, momentum=0.1,
                  weights=None, **kwargs):
         self.init = initializations.get("uniform")
         self.epsilon = epsilon
@@ -87,6 +95,20 @@ class BatchNormalization(Layer):
             m = K.mean(X, axis=-1, keepdims=True)
             std = K.std(X, axis=-1, keepdims=True)
             X_normed = (X - m) / (std + self.epsilon)
+        elif self.mode == 2:
+            if train:
+                m = K.mean(X, axis=0)
+                std = K.mean(K.square(X - m) + self.epsilon, axis=0)
+                std = K.sqrt(std)
+                mean_update = self.momentum * self.running_mean + (1-self.momentum) * m
+                std_update = self.momentum * self.running_std + (1-self.momentum) * std
+                self.updates = [(self.running_mean, mean_update),
+                                (self.running_std, std_update)]
+                X_normed = ((X - m) /
+                            (std + self.epsilon))
+            else:
+                X_normed = ((X - self.running_mean) /
+                            (self.running_std + self.epsilon))
         out = self.gamma * X_normed + self.beta
         return out
 

--- a/tests/keras/layers/test_normalization.py
+++ b/tests/keras/layers/test_normalization.py
@@ -17,7 +17,7 @@ input_shapes = [np.ones((10, 10)), np.ones((10, 10, 10))]
 def test_batchnorm_mode_0():
     np.random.seed(1337)
     model = Sequential()
-    norm_m0 = normalization.BatchNormalization(input_shape=(10,))
+    norm_m0 = normalization.BatchNormalization(input_shape=(10,), mode=0, momentum=.9)
     model.add(norm_m0)
     model.compile(loss='mse', optimizer='sgd')
 
@@ -33,7 +33,7 @@ def test_batchnorm_mode_0():
 
 def test_batchnorm_mode_1():
     np.random.seed(1337)
-    norm_m1 = normalization.BatchNormalization(input_shape=(10,), mode=1)
+    norm_m1 = normalization.BatchNormalization(input_shape=(10,), mode=1, momentum=.9)
 
     for inp in [input_1, input_2, input_3]:
         norm_m1.input = K.variable(inp)
@@ -43,6 +43,23 @@ def test_batchnorm_mode_1():
             assert_allclose(K.eval(K.std(out)), 1.0, atol=1e-1)
         else:
             assert_allclose(K.eval(K.std(out)), 0.0, atol=1e-1)
+
+
+def test_batchnorm_mode_2():
+    np.random.seed(1337)
+    model = Sequential()
+    norm_m0 = normalization.BatchNormalization(input_shape=(10,), mode=2)
+    model.add(norm_m0)
+    model.compile(loss='mse', optimizer='sgd')
+
+    # centered on 5.0, variance 10.0
+    X = np.random.normal(loc=5.0, scale=10.0, size=(1000, 10))
+    model.fit(X, X, nb_epoch=5, verbose=0)
+    norm_m0.input = K.variable(X)
+    out = (norm_m0.get_output(train=True) - norm_m0.beta) / norm_m0.gamma
+
+    assert_allclose(K.eval(K.mean(out)), 0.0, atol=1e-1)
+    assert_allclose(K.eval(K.std(out)), 1.0, atol=1e-1)
 
 
 def test_batchnorm_shapes():


### PR DESCRIPTION
The previous implementation of batch norm didn't match the paper or other implementations, i.e. https://github.com/torch/nn/blob/master/BatchNormalization.lua
It didn't even have different behavior for training and test time!
I set the new version to be the default, but left the previous ones for backward compatibility. The running estimates of the mean and std are now only used at test time. I also set the default momentum to 0.1 as in the torch implementation. Hopefully this helps some of the issues people have had with batch norm...