### PR TITLE
[Important]  Remove `output_dim` argument from RNN API

### DIFF
--- a/keras/activations.py
+++ b/keras/activations.py
@@ -10,7 +10,7 @@ def softmax(x):
         # apply softmax to each timestep
         def step(x, states):
             return K.softmax(x), []
-        last_output, outputs, states = K.rnn(step, x, [], masking=False)
+        last_output, outputs, states = K.rnn(step, x, [], mask=None)
         return outputs
     else:
         raise Exception('Cannot apply softmax to a tensor that is not 2D or 3D. ' +

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -388,7 +388,7 @@ def gradients(loss, variables):
 
 # CONTROL FLOW
 
-def rnn(step_function, inputs, output_dim, initial_states,
+def rnn(step_function, inputs, initial_states,
         go_backwards=False, mask=None):
     '''Iterates over the time dimension of a tensor.
 
@@ -406,9 +406,6 @@ def rnn(step_function, inputs, output_dim, initial_states,
             output: tensor with shape (samples, ...) (no time dimension),
             new_states: list of tensors, same length and shapes
                 as 'states'.
-    output_dim:
-        Number of output dimensions (for tensorflow back-end can safely be set
-        to None, it will be inferred automatically)
     initial_states: tensor with shape (samples, ...) (no time dimension),
         containing the initial values for the states used in
         the step function.

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -454,9 +454,8 @@ def rnn(step_function, inputs, initial_states,
             return_states.append(T.switch(mask, new_state, state))
         return [output] + return_states
 
-    initial_output = step_function(inputs[0], initial_states)[0] * 0
     # build an all-zero tensor of shape (samples, output_dim)
-    #initial_output = T.zeros((inputs.shape[1], output_dim))
+    initial_output = step_function(inputs[0], initial_states)[0] * 0
     # Theano gets confused by broadcasting patterns in the scan op
     initial_output = T.unbroadcast(initial_output, 0, 1)
 

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -403,7 +403,7 @@ def gradients(loss, variables):
 
 # CONTROL FLOW
 
-def rnn(step_function, inputs, output_dim, initial_states,
+def rnn(step_function, inputs, initial_states,
         go_backwards=False, mask=None):
     '''Iterates over the time dimension of a tensor.
 
@@ -456,8 +456,9 @@ def rnn(step_function, inputs, output_dim, initial_states,
             return_states.append(T.switch(mask, new_state, state))
         return [output] + return_states
 
+    initial_output = step(inputs[0], initial_states) * 0
     # build an all-zero tensor of shape (samples, output_dim)
-    initial_output = T.zeros((inputs.shape[1], output_dim))
+    #initial_output = T.zeros((inputs.shape[1], output_dim))
     # Theano gets confused by broadcasting patterns in the scan op
     initial_output = T.unbroadcast(initial_output, 0, 1)
 

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -421,8 +421,6 @@ def rnn(step_function, inputs, initial_states,
             output: tensor with shape (samples, ...) (no time dimension),
             new_states: list of tensors, same length and shapes
                 as 'states'.
-    output_dim:
-        Number of output dimensions
     initial_states: tensor with shape (samples, ...) (no time dimension),
         containing the initial values for the states used in
         the step function.

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -456,7 +456,7 @@ def rnn(step_function, inputs, initial_states,
             return_states.append(T.switch(mask, new_state, state))
         return [output] + return_states
 
-    initial_output = step(inputs[0], initial_states) * 0
+    initial_output = step_function(inputs[0], initial_states) * 0
     # build an all-zero tensor of shape (samples, output_dim)
     #initial_output = T.zeros((inputs.shape[1], output_dim))
     # Theano gets confused by broadcasting patterns in the scan op

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -454,7 +454,7 @@ def rnn(step_function, inputs, initial_states,
             return_states.append(T.switch(mask, new_state, state))
         return [output] + return_states
 
-    initial_output = step_function(inputs[0], initial_states) * 0
+    initial_output = step_function(inputs[0], initial_states)[0] * 0
     # build an all-zero tensor of shape (samples, output_dim)
     #initial_output = T.zeros((inputs.shape[1], output_dim))
     # Theano gets confused by broadcasting patterns in the scan op

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -1118,7 +1118,6 @@ class TimeDistributedDense(MaskedLayer):
             return output, []
 
         last_output, outputs, states = K.rnn(step, X,
-                                             output_dim=self.output_dim,
                                              initial_states=[],
                                              mask=None)
         outputs = self.activation(outputs)

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -140,7 +140,7 @@ class Recurrent(MaskedLayer):
         else:
             initial_states = self.get_initial_states(X)
 
-        last_output, outputs, states = K.rnn(self.step, X, self.output_dim,
+        last_output, outputs, states = K.rnn(self.step, X,
                                              initial_states,
                                              go_backwards=self.go_backwards,
                                              mask=mask)

--- a/tests/keras/backend/test_backends.py
+++ b/tests/keras/backend/test_backends.py
@@ -225,7 +225,6 @@ class TestBackend(object):
         inputs = KTH.variable(input_val)
         initial_states = [KTH.variable(init_state_val)]
         last_output, outputs, new_states = KTH.rnn(th_rnn_step_fn, inputs,
-                                                   output_dim,
                                                    initial_states,
                                                    go_backwards=False,
                                                    mask=None)
@@ -238,7 +237,6 @@ class TestBackend(object):
         inputs = KTF.variable(input_val)
         initial_states = [KTF.variable(init_state_val)]
         last_output, outputs, new_states = KTF.rnn(tf_rnn_step_fn, inputs,
-                                                   output_dim,
                                                    initial_states,
                                                    go_backwards=False,
                                                    mask=None)


### PR DESCRIPTION
Get rid of the annoying `output_dim` argument in rnn api.