### PR TITLE
Fix new rnn() mask keyword argument in softmax()

### DIFF
--- a/keras/activations.py
+++ b/keras/activations.py
@@ -10,7 +10,7 @@ def softmax(x):
         # apply softmax to each timestep
         def step(x, states):
             return K.softmax(x), []
-        last_output, outputs, states = K.rnn(step, x, [], masking=False)
+        last_output, outputs, states = K.rnn(step, x, [], mask=None)
         return outputs
     else:
         raise Exception('Cannot apply softmax to a tensor that is not 2D or 3D. ' +


### PR DESCRIPTION
In `activations.py`, the changes introduced in commit ac773ed243154c5408937122bb67f5ec754b29d5 (renaming "mask" to "masking" were not aligned in `keras/activations.py:softmax()` ), causing an error when using softmax activation.