### PR TITLE
Added the name of the model when loading it from config

### DIFF
--- a/keras/models.py
+++ b/keras/models.py
@@ -150,8 +150,10 @@ def model_from_config(config, custom_objects={}):
     model = container_from_config(config, custom_objects=custom_objects)
     if model_name == 'Graph':
         model.__class__ = Graph
+        model.name = model_name
     elif model_name == 'Sequential':
         model.__class__ = Sequential
+        model.name = model_name
 
     if 'optimizer' in config:
         # if it has an optimizer, the model is assumed to be compiled


### PR DESCRIPTION
When loading a model from config, the returned object doesn't have a name.
```python
from keras.models import model_from_json
loaded_model = model_from_json(model_str)
print(loaded_model.name)

---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-73-3f3d9efa33de> in <module>()
----> 1 loaded_model.name

/opt/conda/lib/python2.7/site-packages/Keras-0.3.1-py2.7.egg/keras/layers/core.py in name(self)
     60     @property
     61     def name(self):
---> 62         return self._name
     63 
     64     @name.setter

AttributeError: 'Graph' object has no attribute '_name'
```
This PR add the name of the model along with the `__class__`.