### PR TITLE
Add sqrt for proper noise sigma calculation

### DIFF
--- a/keras/layers/noise.py
+++ b/keras/layers/noise.py
@@ -65,7 +65,7 @@ class GaussianDropout(MaskedLayer):
             # self.p refers to drop probability rather than
             # retain probability (as in paper), for consistency
             X *= K.random_normal(shape=K.shape(X), mean=1.0,
-                                 std=self.p / (1.0 - self.p))
+                                 std=K.sqrt(self.p / (1.0 - self.p)))
         return X
 
     def get_config(self):


### PR DESCRIPTION
Just a small fix to add back a missing square root to match the original paper (and the documentation).