### PR TITLE
Update norm constraints to take axis arguments.

### DIFF
--- a/keras/constraints.py
+++ b/keras/constraints.py
@@ -21,11 +21,11 @@ class MaxNorm(Constraint):
             In a `MaxoutDense` layer the weight tensor has shape (nb_feature, input_dim, output_dim),
             set `axis` to `1` to constrain each weight vector of length (input_dim),
             i.e. constrain the filters incident to the `max` operation.
-            In a `Convolution2D` layer with the Theano backend, the weight tensor 
-            has shape (nb_filter, stack_size, nb_row, nb_col), set `axis` to `[1,2,3]` 
+            In a `Convolution2D` layer with the Theano backend, the weight tensor
+            has shape (nb_filter, stack_size, nb_row, nb_col), set `axis` to `[1,2,3]`
             to constrain the weights of each filter tensor of size (stack_size, nb_row, nb_col).
-            In a `Convolution2D` layer with the TensorFlow backend, the weight tensor 
-            has shape (nb_row, nb_col, stack_size, nb_filter), set `axis` to `[0,1,2]` 
+            In a `Convolution2D` layer with the TensorFlow backend, the weight tensor
+            has shape (nb_row, nb_col, stack_size, nb_filter), set `axis` to `[0,1,2]`
             to constrain the weights of each filter tensor of size (nb_row, nb_col, stack_size).
 
     # References
@@ -43,8 +43,8 @@ class MaxNorm(Constraint):
 
     def get_config(self):
         return {"name": self.__class__.__name__,
-        "m": self.m,
-        "axis": self.axis}
+                "m": self.m,
+                "axis": self.axis}
 
 
 class NonNeg(Constraint):
@@ -65,11 +65,11 @@ class UnitNorm(Constraint):
             In a `MaxoutDense` layer the weight tensor has shape (nb_feature, input_dim, output_dim),
             set `axis` to `1` to constrain each weight vector of length (input_dim),
             i.e. constrain the filters incident to the `max` operation.
-            In a `Convolution2D` layer with the Theano backend, the weight tensor 
-            has shape (nb_filter, stack_size, nb_row, nb_col), set `axis` to `[1,2,3]` 
+            In a `Convolution2D` layer with the Theano backend, the weight tensor
+            has shape (nb_filter, stack_size, nb_row, nb_col), set `axis` to `[1,2,3]`
             to constrain the weights of each filter tensor of size (stack_size, nb_row, nb_col).
-            In a `Convolution2D` layer with the TensorFlow backend, the weight tensor 
-            has shape (nb_row, nb_col, stack_size, nb_filter), set `axis` to `[0,1,2]` 
+            In a `Convolution2D` layer with the TensorFlow backend, the weight tensor
+            has shape (nb_row, nb_col, stack_size, nb_filter), set `axis` to `[0,1,2]`
             to constrain the weights of each filter tensor of size (nb_row, nb_col, stack_size).
     '''
     def __init__(self, axis=0):
@@ -80,7 +80,7 @@ class UnitNorm(Constraint):
 
     def get_config(self):
         return {"name": self.__class__.__name__,
-        "axis": self.axis}
+                "axis": self.axis}
 
 
 identity = Constraint
@@ -89,5 +89,7 @@ nonneg = NonNeg
 unitnorm = UnitNorm
 
 from .utils.generic_utils import get_from_module
+
+
 def get(identifier, kwargs=None):
     return get_from_module(identifier, globals(), 'constraint', instantiate=True, kwargs=kwargs)

--- a/keras/constraints.py
+++ b/keras/constraints.py
@@ -21,9 +21,12 @@ class MaxNorm(Constraint):
             In a `MaxoutDense` layer the weight tensor has shape (nb_feature, input_dim, output_dim),
             set `axis` to `1` to constrain each weight vector of length (input_dim),
             i.e. constrain the filters incident to the `max` operation.
-            In a `Convolution2D` layer the weight tensor has shape (nb_filter, stack_size, nb_row, nb_col),
-            set `axis` to `[1,2,3]` to constrain the weights of each filter tensor
-            of size (stack_size, nb_row, nb_col).
+            In a `Convolution2D` layer with the Theano backend, the weight tensor 
+            has shape (nb_filter, stack_size, nb_row, nb_col), set `axis` to `[1,2,3]` 
+            to constrain the weights of each filter tensor of size (stack_size, nb_row, nb_col).
+            In a `Convolution2D` layer with the TensorFlow backend, the weight tensor 
+            has shape (nb_row, nb_col, stack_size, nb_filter), set `axis` to `[0,1,2]` 
+            to constrain the weights of each filter tensor of size (nb_row, nb_col, stack_size).
 
     # References
         - [Dropout: A Simple Way to Prevent Neural Networks from Overfitting Srivastava, Hinton, et al. 2014](http://www.cs.toronto.edu/~rsalakhu/papers/srivastava14a.pdf)

--- a/keras/constraints.py
+++ b/keras/constraints.py
@@ -11,29 +11,62 @@ class Constraint(object):
 
 
 class MaxNorm(Constraint):
-    def __init__(self, m=2):
+    '''Constrain the weights incident to each hidden unit to have a norm less than or equal to a desired value.
+
+    # Arguments
+        m: the maximum norm for the incoming weights.
+        axis: integer, axis along which to calculate weight norms. For instance,
+            in a `Dense` layer the weight matrix has shape (input_dim, output_dim),
+            set `axis` to `0` to constrain each weight vector of length (input_dim).
+            In a `MaxoutDense` layer the weight tensor has shape (nb_feature, input_dim, output_dim),
+            set `axis` to `1` to constrain each weight vector of length (input_dim),
+            i.e. constrain the filters incident to the `max` operation.
+            In a `Convolution2D` layer the weight tensor has shape (nb_filter, stack_size, nb_row, nb_col),
+            set `axis` to `[1,2,3]` to constrain the weights of each filter tensor
+            of size (stack_size, nb_row, nb_col).
+
+    # References
+        - [Dropout: A Simple Way to Prevent Neural Networks from Overfitting Srivastava, Hinton, et al. 2014](http://www.cs.toronto.edu/~rsalakhu/papers/srivastava14a.pdf)
+    '''
+    def __init__(self, m=2, axis=0):
         self.m = m
+        self.axis = axis
 
     def __call__(self, p):
-        norms = K.sqrt(K.sum(K.square(p), axis=0))
+        norms = K.sqrt(K.sum(K.square(p), axis=self.axis, keepdims=True))
         desired = K.clip(norms, 0, self.m)
         p = p * (desired / (1e-7 + norms))
         return p
 
-    def get_config(self):
-        return {"name": self.__class__.__name__,
-                "m": self.m}
-
 
 class NonNeg(Constraint):
+    '''Constrain the weights to be non-negative.
+    '''
     def __call__(self, p):
         p *= K.cast(p >= 0., K.floatx())
         return p
 
 
 class UnitNorm(Constraint):
+    '''Constrain the weights incident to each hidden unit to have unit norm.
+
+    # Arguments
+        axis: integer, axis along which to calculate weight norms. For instance,
+            in a `Dense` layer the weight matrix has shape (input_dim, output_dim),
+            set `axis` to `0` to constrain each weight vector of length (input_dim).
+            In a `MaxoutDense` layer the weight tensor has shape (nb_feature, input_dim, output_dim),
+            set `axis` to `1` to constrain each weight vector of length (input_dim),
+            i.e. constrain the filters incident to the `max` operation.
+            In a `Convolution2D` layer the weight tensor has shape (nb_filter, stack_size, nb_row, nb_col),
+            set `axis` to `[1,2,3]` to constrain the weights of each filter tensor
+            of size (stack_size, nb_row, nb_col).
+    '''
+    def __init__(self, axis=0):
+        self.axis = axis
+
     def __call__(self, p):
-        return p / K.sqrt(K.sum(K.square(p), axis=-1, keepdims=True))
+        return p / K.sqrt(K.sum(K.square(p), axis=self.axis, keepdims=True))
+
 
 identity = Constraint
 maxnorm = MaxNorm

--- a/tests/keras/layers/test_embeddings.py
+++ b/tests/keras/layers/test_embeddings.py
@@ -15,7 +15,7 @@ W1 = np.array([[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]], dtype='float32')
 def test_unitnorm_constraint():
     lookup = Sequential()
     lookup.add(Embedding(3, 2, weights=[W1],
-                         W_constraint=unitnorm(axis=1),
+                         W_constraint=unitnorm(),
                          input_length=1))
     lookup.add(Flatten())
     lookup.add(Dense(1))
@@ -23,7 +23,7 @@ def test_unitnorm_constraint():
     lookup.compile(loss='binary_crossentropy', optimizer='sgd',
                    class_mode='binary')
     lookup.train_on_batch(X1, np.array([[1], [0]], dtype='int32'))
-    norm = np.linalg.norm(K.get_value(lookup.params[0]), axis=1)
+    norm = np.linalg.norm(K.get_value(lookup.params[0]), axis=0)
     assert_allclose(norm, np.ones_like(norm).astype('float32'), rtol=1e-05)
 
 

--- a/tests/keras/layers/test_embeddings.py
+++ b/tests/keras/layers/test_embeddings.py
@@ -15,7 +15,7 @@ W1 = np.array([[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]], dtype='float32')
 def test_unitnorm_constraint():
     lookup = Sequential()
     lookup.add(Embedding(3, 2, weights=[W1],
-                         W_constraint=unitnorm(),
+                         W_constraint=unitnorm(axis=1),
                          input_length=1))
     lookup.add(Flatten())
     lookup.add(Dense(1))

--- a/tests/keras/test_constraints.py
+++ b/tests/keras/test_constraints.py
@@ -54,7 +54,7 @@ def test_identity_oddballs():
 def test_unitnorm():
     unitnorm_instance = constraints.unitnorm()
     normalized = unitnorm_instance(K.variable(example_array))
-    norm_of_normalized = np.sqrt(np.sum(K.eval(normalized)**2, axis=1))
+    norm_of_normalized = np.sqrt(np.sum(K.eval(normalized)**2, axis=0))
     # in the unit norm constraint, it should be equal to 1.
     difference = norm_of_normalized - 1.
     largest_difference = np.max(np.abs(difference))


### PR DESCRIPTION
Updated constraint functions to address: https://github.com/fchollet/keras/issues/474
Proper use does require knowledge of the structure of the weight tensor. While making it automatic would be nice, that would require adding something to the definition of each layer. This way seemed cleaner to me, but what do you think?