### PR TITLE
fixed python3 compatibility issue introduced in #1512

### DIFF
--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -441,7 +441,7 @@ def rnn(step_function, inputs, initial_states,
     '''
     ndim = inputs.ndim
     assert ndim >= 3, "Input should be at least 3D."
-    axes = [1, 0] + range(2, ndim)
+    axes = [1, 0] + list(range(2, ndim))
     inputs = inputs.dimshuffle(axes)
     if mask is None:
         mask = expand_dims(ones_like(T.sum(inputs, axis=-1)))
@@ -479,7 +479,7 @@ def rnn(step_function, inputs, initial_states,
     outputs = T.squeeze(outputs)
     last_output = outputs[-1]
 
-    axes = [1, 0] + range(2, outputs.ndim)
+    axes = [1, 0] + list(range(2, outputs.ndim))
     outputs = outputs.dimshuffle(axes)
     states = [T.squeeze(state[-1]) for state in states]
     return last_output, outputs, states


### PR DESCRIPTION
in py3 `range` returns an iterator, and this crashes:
`TypeError: can only concatenate list (not "range") to list`. 

I'm curious about why this didn't get picked up by tests. Are they only being run in python 2?