### PR TITLE
Check gpu status correctly when using theano's cuda.use to choose gpu

### DIFF
--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -14,7 +14,7 @@ def _on_gpu():
     '''Return whether the session is set to
     run on GPU or not (i.e. on CPU).
     '''
-    return theano.config.device[:3] == 'gpu'
+    return theano.config.device[:3] == 'gpu' or theano.sandbox.cuda.cuda_enabled
 
 
 if _on_gpu():


### PR DESCRIPTION
As with the theano backend, when using multiple GPUs, one may set gpu by theano.sandbox.cuda.use instead of via config. In this case, the theano's dnn module cann't be imported properly, make CNN training very slow