### PR TITLE
Fix serialization of BatchNormalization layer

### DIFF
--- a/keras/layers/containers.py
+++ b/keras/layers/containers.py
@@ -155,7 +155,7 @@ class Sequential(Layer):
 
     def set_weights(self, weights):
         for i in range(len(self.layers)):
-            nb_param = len(self.layers[i].params)
+            nb_param = len(self.layers[i].params) + len(self.layers[i].additional_params)
             self.layers[i].set_weights(weights[:nb_param])
             weights = weights[nb_param:]
 

--- a/keras/layers/containers.py
+++ b/keras/layers/containers.py
@@ -155,7 +155,7 @@ class Sequential(Layer):
 
     def set_weights(self, weights):
         for i in range(len(self.layers)):
-            nb_param = len(self.layers[i].params) + len(self.layers[i].additional_params)
+            nb_param = len(self.layers[i].params) + len(self.layers[i].non_trainable_weights)
             self.layers[i].set_weights(weights[:nb_param])
             weights = weights[nb_param:]
 

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -53,8 +53,8 @@ class Layer(object):
             self.name = kwargs['name']
         if not hasattr(self, 'params'):
             self.params = []
-        if not hasattr(self, 'additional_params'):
-            self.additional_params = []
+        if not hasattr(self, 'non_trainable_weights'):
+            self.non_trainable_weights = []
         self.cache_enabled = True
         if 'cache_enabled' in kwargs:
             self.cache_enabled = kwargs['cache_enabled']
@@ -224,7 +224,7 @@ class Layer(object):
             of the layer (i.e. it should match the
             output of `get_weights`).
         '''
-        params = self.params + self.additional_params
+        params = self.params + self.non_trainable_weights
         assert len(params) == len(weights), ('Provided weight array does not match layer weights (' +
                                              str(len(params)) + ' layer params vs. ' +
                                              str(len(weights)) + ' provided weights)')
@@ -237,7 +237,7 @@ class Layer(object):
         '''Return the weights of the layer,
         as a list of numpy arrays.
         '''
-        params = self.params + self.additional_params
+        params = self.params + self.non_trainable_weights
         weights = []
         for p in params:
             weights.append(K.get_value(p))

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -53,6 +53,8 @@ class Layer(object):
             self.name = kwargs['name']
         if not hasattr(self, 'params'):
             self.params = []
+        if not hasattr(self, 'additional_params'):
+            self.additional_params = []
         self.cache_enabled = True
         if 'cache_enabled' in kwargs:
             self.cache_enabled = kwargs['cache_enabled']
@@ -222,10 +224,11 @@ class Layer(object):
             of the layer (i.e. it should match the
             output of `get_weights`).
         '''
-        assert len(self.params) == len(weights), ('Provided weight array does not match layer weights (' +
-                                                  str(len(self.params)) + ' layer params vs. ' +
-                                                  str(len(weights)) + ' provided weights)')
-        for p, w in zip(self.params, weights):
+        params = self.params + self.additional_params
+        assert len(params) == len(weights), ('Provided weight array does not match layer weights (' +
+                                             str(len(params)) + ' layer params vs. ' +
+                                             str(len(weights)) + ' provided weights)')
+        for p, w in zip(params, weights):
             if K.get_value(p).shape != w.shape:
                 raise Exception('Layer shape %s not compatible with weight shape %s.' % (K.get_value(p).shape, w.shape))
             K.set_value(p, w)
@@ -234,8 +237,9 @@ class Layer(object):
         '''Return the weights of the layer,
         as a list of numpy arrays.
         '''
+        params = self.params + self.additional_params
         weights = []
-        for p in self.params:
+        for p in params:
             weights.append(K.get_value(p))
         return weights
 

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -33,6 +33,11 @@ class Layer(object):
             (e.g. `(32, 100)` for a batch of 32 100-dimensional inputs).
     '''
     def __init__(self, **kwargs):
+        if not hasattr(self, 'params'):
+            self.params = []
+        if not hasattr(self, 'non_trainable_weights'):
+            self.non_trainable_weights = []
+            
         allowed_kwargs = {'input_shape',
                           'trainable',
                           'batch_input_shape',
@@ -40,7 +45,6 @@ class Layer(object):
                           'name'}
         for kwarg in kwargs:
             assert kwarg in allowed_kwargs, 'Keyword argument not understood: ' + kwarg
-
         if 'batch_input_shape' in kwargs:
             self.set_input_shape(tuple(kwargs['batch_input_shape']))
         elif 'input_shape' in kwargs:
@@ -51,10 +55,6 @@ class Layer(object):
         self.name = self.__class__.__name__.lower()
         if 'name' in kwargs:
             self.name = kwargs['name']
-        if not hasattr(self, 'params'):
-            self.params = []
-        if not hasattr(self, 'non_trainable_weights'):
-            self.non_trainable_weights = []
         self.cache_enabled = True
         if 'cache_enabled' in kwargs:
             self.cache_enabled = kwargs['cache_enabled']

--- a/keras/layers/normalization.py
+++ b/keras/layers/normalization.py
@@ -61,7 +61,7 @@ class BatchNormalization(Layer):
         
         self.running_mean = K.zeros(shape)
         self.running_std = K.ones(shape)
-        self.additional_params = [self.running_mean, self.running_std]
+        self.non_trainable_weights = [self.running_mean, self.running_std]
         
         if self.initial_weights is not None:
             self.set_weights(self.initial_weights)

--- a/keras/layers/normalization.py
+++ b/keras/layers/normalization.py
@@ -42,15 +42,13 @@ class BatchNormalization(Layer):
         - [Batch Normalization: Accelerating Deep Network Training by Reducing Internal Covariate Shift](http://arxiv.org/pdf/1502.03167v3.pdf)
     '''
     def __init__(self, epsilon=1e-6, mode=0, axis=-1, momentum=0.9,
-                 weights=None, running_mean=None, running_std=None, **kwargs):
+                 weights=None, **kwargs):
         self.init = initializations.get("uniform")
         self.epsilon = epsilon
         self.mode = mode
         self.axis = axis
         self.momentum = momentum
         self.initial_weights = weights
-        self.initial_running_mean = running_mean
-        self.initial_running_std = running_std
         super(BatchNormalization, self).__init__(**kwargs)
 
     def build(self):
@@ -62,13 +60,8 @@ class BatchNormalization(Layer):
         self.params = [self.gamma, self.beta]
         
         self.running_mean = K.zeros(shape)
-        if self.initial_running_mean is not None:
-            K.set_value(self.running_mean, self.initial_running_mean)
-            del self.initial_running_mean
         self.running_std = K.ones(shape)
-        if self.initial_running_std is not None:
-            K.set_value(self.running_std, self.initial_running_std)
-            del self.initial_running_std
+        self.additional_params = [self.running_mean, self.running_std]
         
         if self.initial_weights is not None:
             self.set_weights(self.initial_weights)


### PR DESCRIPTION
The serialization of the `BatchNormalization` layer is currently broken. This can be easily tested with the following code:

```
from keras.models import Sequential
from keras.layers.core import Dense, Activation
from keras.layers.normalization import BatchNormalization
from keras.models import model_from_config


def build_model():
	model = Sequential()
	
	model.add(Dense(20, input_shape=(10,)))
	model.add(Activation('relu'))
	model.add(BatchNormalization())
	
	model.add(Dense(10))
	model.add(Activation('linear'))
	
	model.compile(loss='mse', optimizer='sgd')
	return model


def clone_model(model):
	config = model.get_config()
	clone = model_from_config(config)
	clone.compile(loss='mse', optimizer='sgd')
	clone.set_weights(model.get_weights())
	return clone


model = build_model()
clone = clone_model(model)
```

The same problem would occur if a network with `BatchNormalization` would be written to disk and re-loaded later.

The root of the problem lies in the way the hacky way the layer handles `running_mean` and `running_std`: These are *not* part of the params array since they are not optimized during training. However, they are still part of the weights list obtained by `get_weights()` (see removed implementation). This causes problems since the layer reportedly only has two params (`gamma` and `beta`) but the weights list contains for elements. When de-serializing, this triggers an exception. Additionally, since the layer reports that it only uses two weight tensors, the serialization process only ever passes a list of two elements to `set_weights()`. This is very much problematic since the following layers would then (had the assertion not been there) receive the `running_mean` and `running_std` as weight vectors, corrupting the entire de-serialization process.

My solution moves the `running_mean` and `running_std` from the weights to the configuration. I do realize that this is not optimal since this means that we encode a potentially high-dimensional vector into the configuration. However, it was the easiest solution to fix the problem now.

Any feedback is highly welcome, maybe someone has a better idea than somewhat misusing the config like that.