### PR TITLE
Support >3d mask matrices.

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -440,7 +440,7 @@ def rnn(step_function, inputs, initial_states,
         mask = tf.cast(mask, tf.bool)
     else:
         # Transpose not supported by bool tensor types, hence round-trip to uint8.
-        mask = tf.cast(tf.transpose(tf.cast(mask, tf.uint8), (1, 0, 2)), tf.bool)
+        mask = tf.cast(tf.transpose(tf.cast(mask, tf.uint8), axes), tf.bool)
 
     mask_list = tf.unpack(mask)
 

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -447,7 +447,7 @@ def rnn(step_function, inputs, initial_states,
     if mask is None:
         mask = expand_dims(ones_like(T.sum(inputs, axis=-1)))
     else:
-        mask = mask.dimshuffle((1, 0, 2))
+        mask = mask.dimshuffle(axes)
 
     def _step(input, mask, output_tm1, *states):
         output, new_states = step_function(input, states)


### PR DESCRIPTION
The change to the dimshuffle/transpose call to support >3d inputs was
correct for the inputs array but did not apply to the mask array. This
fixes that.