### PR TITLE
[WIP] partial output objective function

### DIFF
--- a/keras/objectives.py
+++ b/keras/objectives.py
@@ -55,6 +55,11 @@ def cosine_proximity(y_true, y_pred):
     y_pred = K.l2_normalize(y_pred, axis=1)
     return -K.mean(y_true * y_pred, axis=1)
 
+# This allows some of the outputs to be undefined (by setting to 0) without affecting the objective function.
+def non_zero_mean_squared_error(y_true, y_pred):
+    total = theano.tensor.sum(theano.tensor.square(abs(theano.tensor.sgn(y_true))*(y_pred - y_true)), axis=-1)
+    count = theano.tensor.sum(abs(theano.tensor.sgn(y_true)))
+    return total/count
 
 # aliases
 mse = MSE = mean_squared_error


### PR DESCRIPTION
I don't know enough about keras/theano to make this an official pull request with confidence, but the idea is that one can pass 0's for unknown outputs without affecting the loss function.  This is especially important for deep q learning where an agent only takes one of the outputted actions, and thus the other actions' error is undefined.  By setting a non-zero error for the action taken and zeroes for the other actions, this loss function should ignore the zeroes and optimize for the non-zero values.