### PR TITLE
Modified examples to explain need for latest theano version

### DIFF
--- a/examples/antirectifier.py
+++ b/examples/antirectifier.py
@@ -21,7 +21,6 @@ following command:
 '''
 
 from __future__ import print_function
-import theano
 import numpy as np
 from keras.models import Sequential
 from keras.layers.core import Dense, Dropout, Layer, Activation

--- a/examples/antirectifier.py
+++ b/examples/antirectifier.py
@@ -8,9 +8,20 @@ Note that the same result can also be achieved via a Lambda layer.
 
 Because our custom layer is written with primitives from the Keras
 backend (`K`), our code can run both on TensorFlow and Theano.
+
+Note
+----
+
+This example requires a Theano version that is greater than what
+is installed by pip. To get the latest version of Theano, run the
+following command:
+
+    pip install git+https://github.com/Theano/Theano
+
 '''
 
 from __future__ import print_function
+import theano
 import numpy as np
 from keras.models import Sequential
 from keras.layers.core import Dense, Dropout, Layer, Activation
@@ -60,6 +71,12 @@ class Antirectifier(Layer):
         pos = K.relu(x)
         neg = K.relu(-x)
         return K.concatenate([pos, neg], axis=1)
+
+
+# Quick check for theano version > 0.7.0
+import theano.tensor.nnet
+if not hasattr(theano.tensor.nnet, 'relu'):
+    raise Exception("This example requires Theano > 0.7.0. Please refer to the docstring for more information.")
 
 # global parameters
 batch_size = 128

--- a/examples/cifar10_cnn.py
+++ b/examples/cifar10_cnn.py
@@ -9,6 +9,16 @@ It gets down to 0.65 test logloss in 25 epochs, and down to 0.55 after 50 epochs
 Note: the data was pickled with Python 2, and some encoding issues might prevent you
 from loading it in Python 3. You might have to load it in Python 2,
 save it in a different format, load it in Python 3 and repickle it.
+
+Note
+----
+
+This example requires a Theano version that is greater than what
+is installed by pip. To get the latest version of Theano, run the
+following command:
+
+    pip install git+https://github.com/Theano/Theano
+
 '''
 
 from __future__ import print_function
@@ -19,6 +29,11 @@ from keras.layers.core import Dense, Dropout, Activation, Flatten
 from keras.layers.convolutional import Convolution2D, MaxPooling2D
 from keras.optimizers import SGD
 from keras.utils import np_utils
+
+# Quick check for theano version > 0.7.0
+import theano.tensor.nnet
+if not hasattr(theano.tensor.nnet, 'relu'):
+    raise Exception("This example requires Theano > 0.7.0. Please refer to the docstring for more information.")
 
 batch_size = 32
 nb_classes = 10

--- a/examples/deep_dream.py
+++ b/examples/deep_dream.py
@@ -13,6 +13,16 @@ It is preferrable to run this script on GPU, for speed.
 If running on CPU, prefer the TensorFlow backend (much faster).
 
 Example results: http://i.imgur.com/FX6ROg9.jpg
+
+Note
+----
+
+This example requires a Theano version that is greater than what
+is installed by pip. To get the latest version of Theano, run the
+following command:
+
+    pip install git+https://github.com/Theano/Theano
+
 '''
 from __future__ import print_function
 from scipy.misc import imread, imresize, imsave
@@ -25,6 +35,11 @@ import h5py
 from keras.models import Sequential
 from keras.layers.convolutional import Convolution2D, ZeroPadding2D, MaxPooling2D
 from keras import backend as K
+
+# Quick check for theano version > 0.7.0
+import theano.tensor.nnet
+if not hasattr(theano.tensor.nnet, 'relu'):
+    raise Exception("This example requires Theano > 0.7.0. Please refer to the docstring for more information.")
 
 parser = argparse.ArgumentParser(description='Deep Dreams with Keras.')
 parser.add_argument('base_image_path', metavar='base', type=str,

--- a/examples/imdb_cnn.py
+++ b/examples/imdb_cnn.py
@@ -3,6 +3,16 @@
 Run on GPU: THEANO_FLAGS=mode=FAST_RUN,device=gpu,floatX=float32 python imdb_cnn.py
 
 Get to 0.835 test accuracy after 2 epochs. 100s/epoch on K520 GPU.
+
+Note
+----
+
+This example requires a Theano version that is greater than what
+is installed by pip. To get the latest version of Theano, run the
+following command:
+
+    pip install git+https://github.com/Theano/Theano
+
 '''
 
 from __future__ import print_function
@@ -16,6 +26,10 @@ from keras.layers.embeddings import Embedding
 from keras.layers.convolutional import Convolution1D, MaxPooling1D
 from keras.datasets import imdb
 
+# Quick check for theano version > 0.7.0
+import theano.tensor.nnet
+if not hasattr(theano.tensor.nnet, 'relu'):
+    raise Exception("This example requires Theano > 0.7.0. Please refer to the docstring for more information.")
 
 # set parameters:
 max_features = 5000

--- a/examples/imdb_cnn_lstm.py
+++ b/examples/imdb_cnn_lstm.py
@@ -5,6 +5,16 @@ GPU command:
     THEANO_FLAGS=mode=FAST_RUN,device=gpu,floatX=float32 python imdb_lstm.py
 
 Get to 0.8498 test accuracy after 2 epochs. 41s/epoch on K520 GPU.
+
+Note
+----
+
+This example requires a Theano version that is greater than what
+is installed by pip. To get the latest version of Theano, run the
+following command:
+
+    pip install git+https://github.com/Theano/Theano
+
 '''
 
 from __future__ import print_function
@@ -19,6 +29,10 @@ from keras.layers.recurrent import LSTM, GRU, SimpleRNN
 from keras.layers.convolutional import Convolution1D, MaxPooling1D
 from keras.datasets import imdb
 
+# Quick check for theano version > 0.7.0
+import theano.tensor.nnet
+if not hasattr(theano.tensor.nnet, 'relu'):
+    raise Exception("This example requires Theano > 0.7.0. Please refer to the docstring for more information.")
 
 # Embedding
 max_features = 20000

--- a/examples/kaggle_otto_nn.py
+++ b/examples/kaggle_otto_nn.py
@@ -18,6 +18,16 @@ Try it at home:
 
 Get the data from Kaggle:
 https://www.kaggle.com/c/otto-group-product-classification-challenge/data
+
+Note
+----
+
+This example requires a Theano version that is greater than what
+is installed by pip. To get the latest version of Theano, run the
+following command:
+
+    pip install git+https://github.com/Theano/Theano
+
 '''
 
 from __future__ import print_function
@@ -33,7 +43,6 @@ from keras.utils import np_utils, generic_utils
 
 from sklearn.preprocessing import LabelEncoder
 from sklearn.preprocessing import StandardScaler
-
 
 def load_data(path, train=True):
     df = pd.read_csv(path)
@@ -75,6 +84,11 @@ def make_submission(y_prob, ids, encoder, fname):
             f.write(probas)
             f.write('\n')
     print('Wrote submission to file {}.'.format(fname))
+
+# Quick check for theano version > 0.7.0
+import theano.tensor.nnet
+if not hasattr(theano.tensor.nnet, 'relu'):
+    raise Exception("This example requires Theano > 0.7.0. Please refer to the docstring for more information.")
 
 print('Loading data...')
 X, labels = load_data('train.csv', train=True)

--- a/examples/mnist_cnn.py
+++ b/examples/mnist_cnn.py
@@ -4,6 +4,16 @@ Run on GPU: THEANO_FLAGS=mode=FAST_RUN,device=gpu,floatX=float32 python mnist_cn
 
 Get to 99.25% test accuracy after 12 epochs (there is still a lot of margin for parameter tuning).
 16 seconds per epoch on a GRID K520 GPU.
+
+Note
+----
+
+This example requires a Theano version that is greater than what
+is installed by pip. To get the latest version of Theano, run the
+following command:
+
+    pip install git+https://github.com/Theano/Theano
+
 '''
 
 from __future__ import print_function
@@ -15,6 +25,11 @@ from keras.models import Sequential
 from keras.layers.core import Dense, Dropout, Activation, Flatten
 from keras.layers.convolutional import Convolution2D, MaxPooling2D
 from keras.utils import np_utils
+
+# Quick check for theano version > 0.7.0
+import theano.tensor.nnet
+if not hasattr(theano.tensor.nnet, 'relu'):
+    raise Exception("This example requires Theano > 0.7.0. Please refer to the docstring for more information.")
 
 batch_size = 128
 nb_classes = 10

--- a/examples/mnist_irnn.py
+++ b/examples/mnist_irnn.py
@@ -11,6 +11,16 @@ improvement.
 
 Reaches 0.93 train/test accuracy after 900 epochs
 (which roughly corresponds to 1687500 steps in the original paper.)
+
+Note
+----
+
+This example requires a Theano version that is greater than what
+is installed by pip. To get the latest version of Theano, run the
+following command:
+
+    pip install git+https://github.com/Theano/Theano
+
 '''
 
 from __future__ import print_function
@@ -25,6 +35,10 @@ from keras.layers.recurrent import SimpleRNN, LSTM
 from keras.optimizers import RMSprop
 from keras.utils import np_utils
 
+# Quick check for theano version > 0.7.0
+import theano.tensor.nnet
+if not hasattr(theano.tensor.nnet, 'relu'):
+    raise Exception("This example requires Theano > 0.7.0. Please refer to the docstring for more information.")
 
 batch_size = 32
 nb_classes = 10

--- a/examples/mnist_mlp.py
+++ b/examples/mnist_mlp.py
@@ -3,6 +3,16 @@
 Get to 98.40% test accuracy after 20 epochs
 (there is *a lot* of margin for parameter tuning).
 2 seconds per epoch on a K520 GPU.
+
+Note
+----
+
+This example requires a Theano version that is greater than what
+is installed by pip. To get the latest version of Theano, run the
+following command:
+
+    pip install git+https://github.com/Theano/Theano
+
 '''
 
 from __future__ import print_function
@@ -14,6 +24,11 @@ from keras.models import Sequential
 from keras.layers.core import Dense, Dropout, Activation
 from keras.optimizers import SGD, Adam, RMSprop
 from keras.utils import np_utils
+
+# Quick check for theano version > 0.7.0
+import theano.tensor.nnet
+if not hasattr(theano.tensor.nnet, 'relu'):
+    raise Exception("This example requires Theano > 0.7.0. Please refer to the docstring for more information.")
 
 
 batch_size = 128

--- a/examples/mnist_transfer_cnn.py
+++ b/examples/mnist_transfer_cnn.py
@@ -9,6 +9,16 @@ Run on GPU: THEANO_FLAGS=mode=FAST_RUN,device=gpu,floatX=float32 python mnist_cn
 Get to 99.8% test accuracy after 5 epochs
 for the first five digits classifier
 and 99.2% for the last five digits after transfer + fine-tuning.
+
+Note
+----
+
+This example requires a Theano version that is greater than what
+is installed by pip. To get the latest version of Theano, run the
+following command:
+
+    pip install git+https://github.com/Theano/Theano
+
 '''
 
 from __future__ import print_function
@@ -23,6 +33,10 @@ from keras.layers.core import Dense, Dropout, Activation, Flatten
 from keras.layers.convolutional import Convolution2D, MaxPooling2D
 from keras.utils import np_utils
 
+# Quick check for theano version > 0.7.0
+import theano.tensor.nnet
+if not hasattr(theano.tensor.nnet, 'relu'):
+    raise Exception("This example requires Theano > 0.7.0. Please refer to the docstring for more information.")
 
 now = datetime.datetime.now
 

--- a/examples/neural_style_transfer.py
+++ b/examples/neural_style_transfer.py
@@ -46,6 +46,16 @@ keeping the generated image close enough to the original one.
 
 # References
     - [A Neural Algorithm of Artistic Style](http://arxiv.org/abs/1508.06576)
+
+Note
+----
+
+This example requires a Theano version that is greater than what
+is installed by pip. To get the latest version of Theano, run the
+following command:
+
+    pip install git+https://github.com/Theano/Theano
+    
 '''
 
 from __future__ import print_function
@@ -60,6 +70,11 @@ import h5py
 from keras.models import Sequential
 from keras.layers.convolutional import Convolution2D, ZeroPadding2D, MaxPooling2D
 from keras import backend as K
+
+# Quick check for theano version > 0.7.0
+import theano.tensor.nnet
+if not hasattr(theano.tensor.nnet, 'relu'):
+    raise Exception("This example requires Theano > 0.7.0. Please refer to the docstring for more information.")
 
 parser = argparse.ArgumentParser(description='Neural style transfer with Keras.')
 parser.add_argument('base_image_path', metavar='base', type=str,

--- a/examples/reuters_mlp.py
+++ b/examples/reuters_mlp.py
@@ -3,6 +3,16 @@ GPU run command:
     THEANO_FLAGS=mode=FAST_RUN,device=gpu,floatX=float32 python examples/reuters_mlp.py
 CPU run command:
     python examples/reuters_mlp.py
+
+Note
+----
+
+This example requires a Theano version that is greater than what
+is installed by pip. To get the latest version of Theano, run the
+following command:
+
+    pip install git+https://github.com/Theano/Theano
+
 '''
 
 from __future__ import print_function
@@ -15,6 +25,11 @@ from keras.layers.core import Dense, Dropout, Activation
 from keras.layers.normalization import BatchNormalization
 from keras.utils import np_utils
 from keras.preprocessing.text import Tokenizer
+
+# Quick check for theano version > 0.7.0
+import theano.tensor.nnet
+if not hasattr(theano.tensor.nnet, 'relu'):
+    raise Exception("This example requires Theano > 0.7.0. Please refer to the docstring for more information.")
 
 max_words = 1000
 batch_size = 32


### PR DESCRIPTION
I've seen a lot of questions in the issues and on the mailing list about missing functions (like ```relu```, which was introduced in Theano 0.7.1a1). Unfortunately, the release of Theano in PyPI is still way behind the latest release. This was a non-intrusive way of informing the user that they needed Theano > 0.7.0 to run specific examples.