### PR TITLE
Speed up random shifts in data augmentation

### DIFF
--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -38,7 +38,7 @@ def random_shift(x, wrg, hrg, fill_mode="nearest", cval=0.):
         crop = random.uniform(0., hrg)
         split = random.uniform(0, 1)
         crop_top_pixels = int(split*crop*x.shape[2])
-    x = ndimage.interpolation.shift(x, (0, crop_left_pixels, crop_top_pixels),
+    x = ndimage.interpolation.shift(x, (0, crop_left_pixels, crop_top_pixels), order=0,
                                     mode=fill_mode, cval=cval)
     return x
 


### PR DESCRIPTION
Currently, polynomial interpolation of 3rd order is done when shifting. However, that is not needed because the images are shifted by integer values (crop_left_pixels, crop_top_pixels), and there is nothing to interpolate.
Setting ```order=0``` will speed up random shifts significantly.