### PR TITLE
Fix categorical crossentropy and Masking

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -154,12 +154,12 @@ def mean(x, axis=None, keepdims=False):
 def any(x, axis=None, keepdims=False):
     '''Bitwise reduction (logical OR).
 
-    Return array of int8 (0s and 1s).
+    Return array of uint8 (0s and 1s).
     '''
     axis = normalize_axis(axis, ndim(x))
     x = tf.cast(x, tf.bool)
     x = tf.reduce_any(x, reduction_indices=axis, keep_dims=keepdims)
-    return tf.cast(x, tf.int8)
+    return tf.cast(x, tf.uint8)
 
 
 def argmax(x, axis=-1):
@@ -438,7 +438,10 @@ def rnn(step_function, inputs, initial_states,
 
     if mask is not None:
         # Transpose not supported by bool tensor types, hence round-trip to uint8.
-        mask = tf.cast(tf.transpose(tf.cast(mask, tf.uint8), axes), tf.bool)
+        mask = tf.cast(mask, tf.uint8)
+        if len(mask.get_shape()) == ndim-1:
+            mask = expand_dims(mask)
+        mask = tf.cast(tf.transpose(mask, axes), tf.bool)
         mask_list = tf.unpack(mask)
 
         for input, mask_t in zip(input_list, mask_list):

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -427,7 +427,7 @@ def rnn(step_function, inputs, initial_states,
         the step function.
     go_backwards: boolean. If True, do the iteration over
         the time dimension in reverse order.
-    mask: binary tensor with shape (samples, time, 1),
+    mask: binary tensor with shape (samples, time),
         with a zero for every element that is masked.
 
     Returns
@@ -447,6 +447,9 @@ def rnn(step_function, inputs, initial_states,
     if mask is None:
         mask = expand_dims(ones_like(T.sum(inputs, axis=-1)))
     else:
+        if mask.ndim == ndim-1:
+            mask = expand_dims(mask)
+        assert mask.ndim == ndim
         mask = mask.dimshuffle(axes)
 
     def _step(input, mask, output_tm1, *states):
@@ -664,6 +667,7 @@ def pool2d(x, pool_size, strides=(1, 1), border_mode='valid',
     if dim_ordering == 'tf':
         pool_out = pool_out.dimshuffle((0, 2, 3, 1))
     return pool_out
+
 
 # RANDOMNESS
 

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -319,17 +319,16 @@ class Masking(MaskedLayer):
     def __init__(self, mask_value=0., **kwargs):
         super(Masking, self).__init__(**kwargs)
         self.mask_value = mask_value
-        self.input = K.placeholder(ndim=3)
+        if (not hasattr(self, 'input')):
+            self.input = K.placeholder(ndim=3)
 
     def get_output_mask(self, train=False):
         X = self.get_input(train)
-        return K.any(K.ones_like(X) * (1. - K.equal(X, self.mask_value)),
-                     axis=-1)
+        return K.any(K.not_equal(X, self.mask_value), axis=-1)
 
     def get_output(self, train=False):
         X = self.get_input(train)
-        return X * K.any((1. - K.equal(X, self.mask_value)),
-                         axis=-1, keepdims=True)
+        return X * K.cast(K.any(K.not_equal(X, self.mask_value), axis=-1, keepdims=True), K.floatx())
 
     def get_config(self):
         config = {'name': self.__class__.__name__,

--- a/keras/layers/embeddings.py
+++ b/keras/layers/embeddings.py
@@ -89,7 +89,7 @@ class Embedding(Layer):
         if not self.mask_zero:
             return None
         else:
-            return K.expand_dims(K.not_equal(X, 0))
+            return K.not_equal(X, 0)
 
     @property
     def output_shape(self):

--- a/keras/objectives.py
+++ b/keras/objectives.py
@@ -37,7 +37,7 @@ def hinge(y_true, y_pred):
 def categorical_crossentropy(y_true, y_pred):
     '''Expects a binary class matrix instead of a vector of scalar classes.
     '''
-    return K.mean(K.categorical_crossentropy(y_pred, y_true), axis=-1)
+    return K.categorical_crossentropy(y_pred, y_true)
 
 
 def binary_crossentropy(y_true, y_pred):
@@ -49,11 +49,9 @@ def poisson(y_true, y_pred):
 
 
 def cosine_proximity(y_true, y_pred):
-    assert K.ndim(y_true) == 2
-    assert K.ndim(y_pred) == 2
-    y_true = K.l2_normalize(y_true, axis=1)
-    y_pred = K.l2_normalize(y_pred, axis=1)
-    return -K.mean(y_true * y_pred, axis=1)
+    y_true = K.l2_normalize(y_true, axis=-1)
+    y_pred = K.l2_normalize(y_pred, axis=-1)
+    return -K.mean(y_true * y_pred, axis=-1)
 
 
 # aliases

--- a/tests/keras/layers/test_core.py
+++ b/tests/keras/layers/test_core.py
@@ -172,13 +172,11 @@ def test_naming():
     model.train_on_batch(np.random.random((2, 2)), np.random.random((2, 2)))
 
 
-@pytest.mark.skipif(K._BACKEND == 'tensorflow',
-                    reason='currently not working with TensorFlow')
 def test_sequences():
     '''Test masking sequences with zeroes as padding'''
     # integer inputs, one per timestep, like embeddings
     layer = core.Masking()
-    func = K.function([layer.input], [layer.get_output_mask()])
+    func = K.function([layer.get_input(True)], [layer.get_output_mask()])
     input_data = np.array([[[1], [2], [3], [0]],
                            [[0], [4], [5], [0]]], dtype=np.int32)
 
@@ -190,8 +188,6 @@ def test_sequences():
     assert np.all(output == expected), 'Output not as expected'
 
 
-@pytest.mark.skipif(K._BACKEND == 'tensorflow',
-                    reason='currently not working with TensorFlow')
 def test_non_zero():
     '''Test masking with non-zero mask value'''
     layer = core.Masking(5)
@@ -204,8 +200,6 @@ def test_non_zero():
     assert np.all(output == expected), 'Output not as expected'
 
 
-@pytest.mark.skipif(K._BACKEND == 'tensorflow',
-                    reason='currently not working with TensorFlow')
 def test_non_zero_output():
     '''Test output of masking layer with non-zero mask value'''
     layer = core.Masking(5)

--- a/tests/keras/layers/test_recurrent.py
+++ b/tests/keras/layers/test_recurrent.py
@@ -3,6 +3,9 @@ import numpy as np
 from numpy.testing import assert_allclose
 
 from keras.layers import recurrent, embeddings
+from keras.models import Sequential
+from keras.layers.core import Masking
+
 from keras import backend as K
 from keras.models import Sequential
 
@@ -98,6 +101,21 @@ def test_GRU():
 
 def test_LSTM():
     _runner(recurrent.LSTM)
+
+
+def test_masking_layer():
+    ''' This test based on a previously failing issue here:
+    https://github.com/fchollet/keras/issues/1567
+
+    '''
+    model = Sequential()
+    model.add(Masking(input_shape=(3, 4)))
+    model.add(recurrent.LSTM(output_dim=5, return_sequences=True))
+    model.compile(loss='categorical_crossentropy', optimizer='adam')
+    I = np.random.random((6, 3, 4))
+    V = np.abs(np.random.random((6, 3, 5)))
+    V /= V.sum(axis=-1, keepdims=True)
+    model.fit(I, V, nb_epoch=1, batch_size=100, verbose=1)
 
 
 if __name__ == '__main__':

--- a/tests/keras/test_objectives.py
+++ b/tests/keras/test_objectives.py
@@ -1,0 +1,25 @@
+import numpy as np
+
+from keras import objectives
+from keras import backend as K
+
+
+allobj = [objectives.mean_squared_error, objectives.root_mean_squared_error,
+          objectives.mean_absolute_error, objectives.mean_absolute_percentage_error,
+          objectives.mean_squared_logarithmic_error, objectives.squared_hinge,
+          objectives.hinge, objectives.categorical_crossentropy, objectives.binary_crossentropy, objectives.poisson,
+          objectives.cosine_proximity]
+
+def test_objective_shapes_3d():
+    y_a = K.variable(np.random.random((5, 6, 7)))
+    y_b = K.variable(np.random.random((5, 6, 7)))
+    for obj in allobj:
+        objective_output = obj(y_a, y_b)
+        assert K.eval(objective_output).shape == (5, 6)
+
+def test_objective_shapes_2d():
+    y_a = K.variable(np.random.random((6, 7)))
+    y_b = K.variable(np.random.random((6, 7)))
+    for obj in allobj:
+        objective_output = obj(y_a, y_b)
+        assert K.eval(objective_output).shape == (6,)

--- a/tests/test_loss_masking.py
+++ b/tests/test_loss_masking.py
@@ -7,15 +7,13 @@ from keras import objectives
 from keras import backend as K
 
 
-@pytest.mark.skipif(K._BACKEND == 'tensorflow',
-                    reason='currently not working with TensorFlow')
 def test_masking():
     np.random.seed(1337)
     X = np.array(
         [[[1, 1], [2, 1], [3, 1], [5, 5]],
          [[1, 5], [5, 0], [0, 0], [0, 0]]], dtype=np.int32)
     model = Sequential()
-    model.add(Masking(mask_value=0, input_shape=(None, 2)))
+    model.add(Masking(mask_value=0, input_shape=(4, 2)))
     model.add(TimeDistributedDense(1, init='one'))
     model.compile(loss='mse', optimizer='sgd')
     y = model.predict(X)


### PR DESCRIPTION
Fixes #1567

- The RNN backend call can now take a mask with or without the same number of dimensions as the input data
- As part of the investigation, I found that categorical_crossentropy was taking an extra mean, the function already removes the final dimension of your input, so you don't need to take a mean as you would with, say, L2 loss. This seems like a pretty severe potential issue so anyone doing sequence to sequence learning should take note.

- Since I was already down that rabbit-hole, I also fixed Masking to work with tensorflow.
