### PR TITLE
Minor typos in example commands

### DIFF
--- a/examples/imdb_cnn_lstm.py
+++ b/examples/imdb_cnn_lstm.py
@@ -2,7 +2,7 @@
 classification task.
 
 GPU command:
-    THEANO_FLAGS=mode=FAST_RUN,device=gpu,floatX=float32 python imdb_lstm.py
+    THEANO_FLAGS=mode=FAST_RUN,device=gpu,floatX=float32 python imdb_cnn_lstm.py
 
 Get to 0.8498 test accuracy after 2 epochs. 41s/epoch on K520 GPU.
 '''

--- a/examples/mnist_transfer_cnn.py
+++ b/examples/mnist_transfer_cnn.py
@@ -4,7 +4,7 @@
 2- Freeze convolutional layers and fine-tune dense layers
    for the classification of digits [5..9].
 
-Run on GPU: THEANO_FLAGS=mode=FAST_RUN,device=gpu,floatX=float32 python mnist_cnn.py
+Run on GPU: THEANO_FLAGS=mode=FAST_RUN,device=gpu,floatX=float32 python mnist_transfer_cnn.py
 
 Get to 99.8% test accuracy after 5 epochs
 for the first five digits classifier


### PR DESCRIPTION
The example GPU commands did not contain the correct filename