### PR TITLE
Fix: Issue #1639. Changed as proposed in issue

### DIFF
--- a/keras/models.py
+++ b/keras/models.py
@@ -1014,7 +1014,7 @@ class Sequential(Model, containers.Sequential):
                 X, y, sample_weight = input_validation(generator_output)
 
                 batch_logs = {}
-                batch_size = len(X[0])
+                batch_size = len(X)
                 batch_logs['batch'] = batch_index
                 batch_logs['size'] = batch_size
                 callbacks.on_batch_begin(batch_index, batch_logs)


### PR DESCRIPTION
Hi maintainers,

I've addressed the issue #1639 by changing just one line of code as described in the issue.

I tried to run the tests `py.test tests/` but I kept getting some weird error as follows:
```
$ py.test tests/
============================= test session starts =============================
platform win32 -- Python 2.7.11, pytest-2.8.7, py-1.4.31, pluggy-0.3.1 -- c:\anaconda2\python.exe
cachedir: .cache
rootdir: C:\Users\jingpingw\Documents\keras, inifile: pytest.ini
plugins: cov-2.2.1, pep8-1.0.6, xdist-1.14
gw0 I / gw1 I
[gw0] win32 Python 2.7.11 cwd: C:\Users\jingpingw\Documents\keras
[gw1] win32 Python 2.7.11 cwd: C:\Users\jingpingw\Documents\keras
[gw1] Python 2.7.11 |Anaconda 2.4.1 (64-bit)| (default, Dec  7 2015, 14:10:42) [MSC v.1500 64 bit (AMD64)]
[gw0] Python 2.7.11 |Anaconda 2.4.1 (64-bit)| (default, Dec  7 2015, 14:10:42) [MSC v.1500 64 bit (AMD64)]

---------------------------------- coverage -----------------------------------
Name                                   Stmts   Miss  Cover   Missing
--------------------------------------------------------------------
keras\__init__.py                          1      1     0%   1
keras\activations.py                      27     27     0%   1-51
keras\backend\__init__.py                 39     39     0%   1-51
keras\backend\common.py                   16     16     0%   1-32
keras\backend\tensorflow_backend.py      326    326     0%   1-687
keras\backend\theano_backend.py          302    302     0%   1-678
keras\callbacks.py                       298    298     0%   1-527
keras\constraints.py                      36     36     0%   1-95
keras\datasets\__init__.py                 0      0   100%
keras\datasets\cifar.py                   17     17     0%   2-22
keras\datasets\cifar10.py                 22     22     0%   1-30
keras\datasets\cifar100.py                20     20     0%   1-28
keras\datasets\data_utils.py              37     37     0%   1-53
keras\datasets\imdb.py                    49     49     0%   1-69
keras\datasets\mnist.py                   14     14     0%   2-22
keras\datasets\reuters.py                 48     48     0%   2-67
keras\initializations.py                  49     49     0%   1-89
keras\layers\__init__.py                   8      8     0%   1-8
keras\layers\advanced_activations.py      92     92     0%   1-224
keras\layers\containers.py               312    312     0%   2-532
keras\layers\convolutional.py            323    323     0%   2-771
keras\layers\core.py                    1043   1043     0%   2-1960
keras\layers\embeddings.py                48     48     0%   1-114
keras\layers\noise.py                     29     29     0%   1-75
keras\layers\normalization.py             56     56     0%   1-109
keras\layers\recurrent.py                212    212     0%   2-459
keras\models.py                          792    792     0%   1-1516
keras\objectives.py                       39     39     0%   1-67
keras\optimizers.py                      170    170     0%   1-342
keras\preprocessing\__init__.py            0      0   100%
keras\preprocessing\image.py             183    183     0%   1-296
keras\preprocessing\sequence.py           66     66     0%   1-151
keras\preprocessing\text.py              115    115     0%   2-205
keras\regularizers.py                     52     52     0%   1-85
keras\utils\__init__.py                    0      0   100%
keras\utils\generic_utils.py              90     90     0%   1-123
keras\utils\io_utils.py                   54     54     0%   1-71
keras\utils\layer_utils.py               117    117     0%   1-157
keras\utils\np_utils.py                   36     36     0%   1-53
keras\utils\test_utils.py                 15     15     0%   1-27
keras\utils\visualize_util.py             72     72     0%   1-154
keras\wrappers\__init__.py                 0      0   100%
keras\wrappers\scikit_learn.py            61     61     0%   1-266
--------------------------------------------------------------------
TOTAL                                   5286   5286     0%
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! KeyboardInterrupt !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
c:\anaconda2\lib\threading.py:359: KeyboardInterrupt
======================== no tests ran in 2.31 seconds =========================
Coverage.py warning: No data was collected.

```

Not sure what the reason for the failure might be, would appreciate your kind enlightening!

This is my first time submitting a pull request so hope you'll be patient with me and guide me if need be! I was learning how to submit a PR from this [site](https://akrabat.com/the-beginners-guide-to-contributing-to-a-github-project/) 