### PR TITLE
Fix Tensorboard callback exception when using fit_generator without validation_data

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -501,7 +501,7 @@ class TensorBoard(Callback):
     def on_epoch_end(self, epoch, logs={}):
         import tensorflow as tf
 
-        if self.model.validation_data and self.histogram_freq:
+        if self.histogram_freq and self.model.validation_data:
             if epoch % self.histogram_freq == 0:
                 if self.params.get('show_accuracy'):
                     test_function = self.model._test_with_acc


### PR DESCRIPTION
As described in #1631 Tensorboard callback does not work when using `fit_generator()`, even if you  are not using `validation_data` and do not want `histogram_freq=0`. Changing the order of conditions prevents the following exception.

```
Epoch 1/10000
29/29 [==============================] - 13s - loss: 2.0924     
Traceback (most recent call last):
  File "./v20/run.py", line 173, in <module>
    model.fit_generator(train_iter, nb_epoch=epochs, samples_per_epoch=len(train_rel_ids), callbacks=callbacks)
  File "/home/gw/Projects/StudentPhD/conll16st-multi-classifier-keras/venv/src/keras/keras/models.py", line 1477, in fit_generator
    callbacks.on_epoch_end(epoch, epoch_logs)
  File "/home/gw/Projects/StudentPhD/conll16st-multi-classifier-keras/venv/src/keras/keras/callbacks.py", line 39, in on_epoch_end
    callback.on_epoch_end(epoch, logs)
  File "/home/gw/Projects/StudentPhD/conll16st-multi-classifier-keras/venv/src/keras/keras/callbacks.py", line 504, in on_epoch_end
    if self.model.validation_data and self.histogram_freq:
AttributeError: 'Graph' object has no attribute 'validation_data'
```