### PR TITLE
Fix program termination when threads are used in fit_generator().

### DIFF
--- a/keras/models.py
+++ b/keras/models.py
@@ -995,6 +995,7 @@ class Sequential(Model, containers.Sequential):
 
         generator_threads = [threading.Thread(target=generator_task) for _ in range(nb_worker)]
         for thread in generator_threads:
+            thread.daemon = True
             thread.start()
 
         self.stop_training = False
@@ -1452,6 +1453,7 @@ class Graph(Model, containers.Graph):
 
         generator_threads = [threading.Thread(target=generator_task) for _ in range(nb_worker)]
         for thread in generator_threads:
+            thread.daemon = True
             thread.start()
 
         self.stop_training = False


### PR DESCRIPTION
Pressing *Ctrl+C* or terminating the main program with any other exception does not close it in case you are using `fit_generator()`, because threads are not initialized in daemon mode.