### PR TITLE
reverse the output sequence in backwards RNN

### DIFF
--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -153,6 +153,9 @@ class Recurrent(MaskedLayer):
                 self.updates.append((self.states[i], states[i]))
 
         if self.return_sequences:
+	    if self.go_backwards:
+		#if we have reversed the inputs, we have to put the output sequence back to original direction
+		outputs=outputs[:,::-1,:]
             return outputs
         else:
             return last_output


### PR DESCRIPTION
When using the parameter "go_backwards" in RNN, we reverse the order of the input sequence going into the layer. We do not, however, reverse the output. In the case of "return_sequences" it means that the first element in output sequence corresponds actually to the last element of the original input sequence. 

This poses following the problems (with "return_sequences"=True):

-  when working with backward RNN we need to reverse the sequence of labels/target values as well. It is not intuitive and not documented anywhere, so its an easy thing to not notice.

-  when wanting to construct a bi-LSTM (or any bidirectional RNN) using a graph model and "go_backward" to create backward branch, we notice that the backward and forward branches will return sequences in opposite order. I did not find any layer allowing to reverse the outputs and make things right. This means it is not possible to construct a sequence-returning bi-LSTM.

Such sequence-returning bi-LSTMs can be useful in, for example: i) gene expression data or ii) when predicting the sentiment of each individual word based on its left and right context.