### PR TITLE
Make History metrics available to other callbacks on epoch end

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -206,15 +206,21 @@ class History(Callback):
 
     def on_epoch_end(self, epoch, logs={}):
         self.epoch.append(epoch)
+
+        for k, v in logs.items():
+            if k in self.totals:
+                continue
+            if k not in self.history:
+                self.history[k] = []
+            self.history[k].append(v)
+
         for k, v in self.totals.items():
             if k not in self.history:
                 self.history[k] = []
             self.history[k].append(v / self.seen)
 
-        for k, v in logs.items():
-            if k not in self.history:
-                self.history[k] = []
-            self.history[k].append(v)
+            # make metrics available to other callbacks
+            logs[k] = v / self.seen
 
 
 class ModelCheckpoint(Callback):


### PR DESCRIPTION
When chaining callbacks it would make sense to also have an average `loss` metric available in `on_epoch_end()` (not just `val_loss`). With this modification callbacks that monitor a value become useful even if you do not provide any validation data (and without writing a custom Callback class).

```
callbacks = [
    ModelCheckpoint(monitor='loss', mode='min', filepath='foo.hdf5', save_best_only=True),
    EarlyStopping(monitor='loss', mode='min', patience=100),
]
```