### PR TITLE
Model: Run user callbacks before history and logger

### DIFF
--- a/keras/models.py
+++ b/keras/models.py
@@ -240,9 +240,9 @@ class Model(object):
 
         history = cbks.History()
         if verbose:
-            callbacks = [history, cbks.BaseLogger()] + callbacks
+            callbacks = callbacks + [history, cbks.BaseLogger()]
         else:
-            callbacks = [history] + callbacks
+            callbacks = callbacks + [history]
         callbacks = cbks.CallbackList(callbacks)
 
         callbacks._set_model(self)
@@ -931,9 +931,9 @@ class Sequential(Model, containers.Sequential):
         # prepare callbacks
         history = cbks.History()
         if verbose:
-            callbacks = [history, cbks.BaseLogger()] + callbacks
+            callbacks = callbacks + [history, cbks.BaseLogger()]
         else:
-            callbacks = [history] + callbacks
+            callbacks = callbacks + [history]
         callbacks = cbks.CallbackList(callbacks)
 
         callbacks._set_model(self)
@@ -1403,9 +1403,9 @@ class Graph(Model, containers.Graph):
         # prepare callbacks
         history = cbks.History()
         if verbose:
-            callbacks = [history, cbks.BaseLogger()] + callbacks
+            callbacks = callbacks + [history, cbks.BaseLogger()]
         else:
-            callbacks = [history] + callbacks
+            callbacks = callbacks + [history]
         callbacks = cbks.CallbackList(callbacks)
 
         callbacks._set_model(self)


### PR DESCRIPTION
This allows user callbacks to generate and store extra accuracy statistics on the validation set, like MRR/MAP for ranking tasks.

I'm not sure if this is the best solution, even though it doesn't seem to break anything here.