### PR TITLE
Add caching for layer input/output sizes

### DIFF
--- a/keras/layers/containers.py
+++ b/keras/layers/containers.py
@@ -21,6 +21,7 @@ class Sequential(Layer):
     def __init__(self, layers=[]):
         self.layers = []
         self.layer_cache = {}
+        self.shape_cache = {}
         for layer in layers:
             self.add(layer)
         self._cache_enabled = True
@@ -63,6 +64,7 @@ class Sequential(Layer):
 
     def add(self, layer):
         layer.layer_cache = self.layer_cache
+        layer.shape_cache = self.shape_cache
         self.layers.append(layer)
         if len(self.layers) > 1:
             self.layers[-1].set_previous(self.layers[-2])
@@ -188,6 +190,7 @@ class Graph(Layer):
         self.output_config = []  # dicts
         self.node_config = []  # dicts
         self.layer_cache = {}
+        self.shape_cache = {}
 
     @property
     def nb_input(self):
@@ -374,6 +377,7 @@ class Graph(Layer):
 
         self.namespace.add(name)
         layer.layer_cache = self.layer_cache
+        layer.shape_cache = self.shape_cache
         self.nodes[name] = layer
         self.node_config.append({'name': name,
                                  'input': input,

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -137,7 +137,15 @@ class Layer(object):
         # if layer is not connected (e.g. input layer),
         # input shape can be set manually via _input_shape attribute.
         if hasattr(self, 'previous'):
-            return self.previous.output_shape
+            if hasattr(self, 'shape_cache') and self.cache_enabled:
+                previous_layer_id = id(self.previous)
+                if previous_layer_id in self.shape_cache:
+                    return self.shape_cache[previous_layer_id]
+            previous_size = self.previous.output_shape
+            if hasattr(self, 'shape_cache') and self.cache_enabled:
+                previous_layer_id = id(self.previous)
+                self.shape_cache[previous_layer_id] = previous_size
+            return previous_size
         elif hasattr(self, '_input_shape'):
             return self._input_shape
         else:


### PR DESCRIPTION
This dramatically speeds up constructing large networks. Implementation follows that of layer caching introduced in e8e8f7.