### PR TITLE
generalize pad_sequences

### DIFF
--- a/keras/preprocessing/sequence.py
+++ b/keras/preprocessing/sequence.py
@@ -35,7 +35,15 @@ def pad_sequences(sequences, maxlen=None, dtype='int32', padding='pre', truncati
     if maxlen is None:
         maxlen = np.max(lengths)
 
-    x = (np.ones((nb_samples, maxlen)) * value).astype(dtype)
+    # take the sample shape from the first non empty sequence
+    # checking for consistency in the main loop below.
+    sample_shape = tuple()
+    for s in sequences:
+        if len(s) > 0:
+            sample_shape = np.asarray(s).shape[1:]
+            break
+
+    x = (np.ones((nb_samples, maxlen) + sample_shape) * value).astype(dtype)
     for idx, s in enumerate(sequences):
         if len(s) == 0:
             continue # empty list was found
@@ -45,6 +53,12 @@ def pad_sequences(sequences, maxlen=None, dtype='int32', padding='pre', truncati
             trunc = s[:maxlen]
         else:
             raise ValueError("Truncating type '%s' not understood" % padding)
+
+        # check `trunc` has expected shape
+        trunc = np.asarray(trunc, dtype=dtype)
+        if trunc.shape[1:] != sample_shape:
+            raise ValueError("Shape of sample %s of sequence at position %s is different from expected shape %s"
+                             % (trunc.shape[1:], idx, sample_shape))
 
         if padding == 'post':
             x[idx, :len(trunc)] = trunc

--- a/tests/keras/preprocessing/test_sequence.py
+++ b/tests/keras/preprocessing/test_sequence.py
@@ -28,6 +28,39 @@ def test_pad_sequences():
     assert_allclose(b, [[1, 1, 1], [1, 1, 2], [1, 2, 3]])
 
 
+def test_pad_sequences_vector():
+    a = [[[1, 1]],
+         [[2, 1], [2, 2]],
+         [[3, 1], [3, 2], [3, 3]]]
+
+    # test padding
+    b = pad_sequences(a, maxlen=3, padding='pre')
+    assert_allclose(b, [[[0, 0], [0, 0], [1, 1]],
+                        [[0, 0], [2, 1], [2, 2]],
+                        [[3, 1], [3, 2], [3, 3]]])
+    b = pad_sequences(a, maxlen=3, padding='post')
+    assert_allclose(b, [[[1, 1], [0, 0], [0, 0]],
+                        [[2, 1], [2, 2], [0, 0]],
+                        [[3, 1], [3, 2], [3, 3]]])
+
+    # test truncating
+    b = pad_sequences(a, maxlen=2, truncating='pre')
+    assert_allclose(b, [[[0, 0], [1, 1]],
+                        [[2, 1], [2, 2]],
+                        [[3, 2], [3, 3]]])
+
+    b = pad_sequences(a, maxlen=2, truncating='post')
+    assert_allclose(b, [[[0, 0], [1, 1]],
+                        [[2, 1], [2, 2]],
+                        [[3, 1], [3, 2]]])
+
+    # test value
+    b = pad_sequences(a, maxlen=3, value=1)
+    assert_allclose(b, [[[1, 1], [1, 1], [1, 1]],
+                        [[1, 1], [2, 1], [2, 2]],
+                        [[3, 1], [3, 2], [3, 3]]])
+
+
 def test_make_sampling_table():
     a = make_sampling_table(3)
     assert_allclose(a, np.asarray([0.00315225,  0.00315225,  0.00547597]),


### PR DESCRIPTION
Currently pad_sequences only support 1-dimensional samples e.g. word/char sequences. Support images (2D), volumetric (3D) or any nD time sequences to be padded as well. See  #1718.