### PR TITLE
Make __call__ work properly for Graph

### DIFF
--- a/keras/layers/containers.py
+++ b/keras/layers/containers.py
@@ -26,29 +26,6 @@ class Sequential(Layer):
             self.add(layer)
         self._cache_enabled = True
 
-    def __call__(self, X, mask=None, train=False):
-        # turn off layer cache temporarily
-        tmp_cache_enabled = self.cache_enabled
-        self.cache_enabled = False
-        # recursively search for a layer which is not a Sequential model
-        layer = self
-        while issubclass(layer.__class__, Sequential):
-            layer = layer.layers[0]
-        # set temporary input to first layer
-        tmp_input = layer.get_input
-        tmp_mask = None
-        layer.get_input = lambda _: X
-        if hasattr(layer, 'get_input_mask'):
-            tmp_mask = layer.get_input_mask
-            layer.get_input_mask = lambda _: mask
-        Y = self.get_output(train=train)
-        # return input from first layer to what it was
-        layer.get_input = tmp_input
-        if hasattr(layer, 'get_input_mask'):
-            layer.get_input_mask = tmp_mask
-        self.cache_enabled = tmp_cache_enabled
-        return Y
-
     @property
     def cache_enabled(self):
         return self._cache_enabled
@@ -59,8 +36,11 @@ class Sequential(Layer):
         for l in self.layers:
             l.cache_enabled = value
 
-    def set_previous(self, layer):
-        self.layers[0].previous = layer
+    def set_previous(self, layer, reset_weights=True):
+        self.layers[0].set_previous(layer, reset_weights)
+
+    def clear_previous(self, reset_weights=True):
+        self.layers[0].clear_previous(reset_weights)
 
     def add(self, layer):
         layer.layer_cache = self.layer_cache
@@ -191,6 +171,47 @@ class Graph(Layer):
         self.node_config = []  # dicts
         self.layer_cache = {}
         self.shape_cache = {}
+        self._cache_enabled = True
+
+    def __call__(self, X, mask=None, train=False):
+        if type(X) != dict:
+            return super(Graph, self).__call__(X, mask, train)
+        else:
+            # turn off layer cache temporarily
+            tmp_cache_enabled = self.cache_enabled
+            self.cache_enabled = False
+            # create a temporary layer for each input
+            tmp_previous = {}
+            for name, input in self.inputs.items():
+                layer = Layer(batch_input_shape=input.input_shape)
+                layer.input = X[name]
+                if hasattr(self, 'get_input_mask'):
+                    layer.get_input_mask = lambda _: mask[name]
+                # set temporary previous
+                if hasattr(input, 'previous'):
+                    tmp_previous[name] = input.previous
+                input.set_previous(layer, False)
+            Y = self.get_output(train=train)
+            # return previous to what it was
+            for name, input in self.inputs.items():
+                if name in tmp_previous:
+                    input.set_previous(tmp_previous[name], False)
+                else:
+                    input.clear_previous(False)
+            self.cache_enabled = tmp_cache_enabled
+            return Y
+
+    @property
+    def cache_enabled(self):
+        return self._cache_enabled
+
+    @cache_enabled.setter
+    def cache_enabled(self, value):
+        self._cache_enabled = value
+        for l in self.nodes.values():
+            l.cache_enabled = value
+        for l in self.inputs.values():
+            l.cache_enabled = value
 
     @property
     def nb_input(self):
@@ -251,21 +272,34 @@ class Graph(Layer):
             if hasattr(l, 'reset_states') and getattr(l, 'stateful', False):
                 l.reset_states()
 
-    def set_previous(self, layer, connection_map={}):
+    def set_previous(self, layer, connection_map={}, reset_weights=True):
         if self.nb_input != layer.nb_output:
             raise Exception('Cannot connect layers: '
                             'input count does not match output count.')
         if self.nb_input == 1:
-            self.inputs[self.input_order[0]].set_previous(layer)
+            self.inputs[self.input_order[0]].set_previous(layer, reset_weights)
         else:
             if not connection_map:
                 raise Exception('Cannot attach multi-input layer: '
                                 'no connection_map provided.')
             for k, v in connection_map.items():
                 if k in self.inputs and v in layer.outputs:
-                    self.inputs[k].set_previous(layer.outputs[v])
+                    self.inputs[k].set_previous(layer.outputs[v], reset_weights)
                 else:
                     raise Exception('Invalid connection map.')
+
+    def clear_previous(self, reset_weights=True):
+        for k in self.inputs.values():
+            k.clear_previous(reset_weights)
+
+    @property
+    def input_shape(self):
+        if self.nb_input == 1:
+            # return tuple
+            return self.inputs[self.input_order[0]].input_shape
+        else:
+            # return dictionary mapping input names to shape tuples
+            return dict([(k, v.input_shape) for k, v in self.inputs.items()])
 
     def get_input(self, train=False):
         if len(self.inputs) == len(self.outputs) == 1:

--- a/tests/keras/layers/test_call.py
+++ b/tests/keras/layers/test_call.py
@@ -6,7 +6,7 @@ from numpy.testing import assert_allclose
 
 from keras import backend as K
 from keras.layers.core import Dense
-from keras.models import Sequential
+from keras.models import Sequential, Graph
 
 
 def test_layer_call():
@@ -52,6 +52,158 @@ def test_sequential_call():
 
     y1 = f([x])[0].astype(K.floatx())
     y2 = model2.predict(x)
+    # results of __call__ should match model.predict
+    assert_allclose(y1, y2)
+
+
+def test_graph_call():
+    """Test keras.models.Graph.__call__"""
+    nb_samples, input_dim, output_dim = 3, 10, 5
+    model = Graph()
+    model.add_input('input', input_shape=(input_dim, ))
+    model.add_node(Dense(output_dim=output_dim, input_dim=input_dim),
+                   input='input', name='output', create_output=True)
+
+    model.compile('sgd', {'output': 'mse'})
+
+    # test flat model
+    X = K.placeholder(ndim=2)
+    Y = model(X)
+    f = K.function([X], [Y])
+
+    x = np.ones((nb_samples, input_dim)).astype(K.floatx())
+    y1 = f([x])[0].astype(K.floatx())
+    y2 = model.predict({'input': x})['output']
+    # results of __call__ should match model.predict
+    assert_allclose(y1, y2)
+
+    # test nested Graph models
+    model2 = Graph()
+    model2.add_input('input', input_shape=(input_dim, ))
+    model2.add_node(model, input='input', name='output', create_output=True)
+    # need to turn off cache because we're reusing model
+    model2.cache_enabled = False
+    model2.compile('sgd', {'output': 'mse'})
+
+    Y2 = model2(X)
+    f = K.function([X], [Y2])
+
+    y1 = f([x])[0].astype(K.floatx())
+    y2 = model2.predict({'input': x})['output']
+    # results of __call__ should match model.predict
+    assert_allclose(y1, y2)
+
+
+def test_graph_multiple_in_out_call():
+    """Test keras.models.Graph.__call__ with multiple inputs"""
+    nb_samples, input_dim, output_dim = 3, 10, 5
+    model = Graph()
+    model.add_input('input1', input_shape=(input_dim, ))
+    model.add_input('input2', input_shape=(input_dim, ))
+    model.add_node(Dense(output_dim=output_dim, input_dim=input_dim),
+                   inputs=['input1', 'input2'], merge_mode='sum', name='output', create_output=True)
+
+    model.compile('sgd', {'output': 'mse'})
+
+    # test flat model
+    X1 = K.placeholder(ndim=2)
+    X2 = K.placeholder(ndim=2)
+    Y = model({'input1': X1, 'input2': X2})['output']
+    f = K.function([X1, X2], [Y])
+
+    x1 = np.ones((nb_samples, input_dim)).astype(K.floatx())
+    x2 = np.ones((nb_samples, input_dim)).astype(K.floatx()) * -2
+    y1 = f([x1, x2])[0].astype(K.floatx())
+    y2 = model.predict({'input1': x1, 'input2': x2})['output']
+    # results of __call__ should match model.predict
+    assert_allclose(y1, y2)
+
+    # test with single input, multiple outputs
+    model2 = Graph()
+    model2.add_input('input', input_shape=(input_dim, ))
+    model2.add_node(Dense(output_dim=output_dim, input_dim=input_dim),
+                    input='input', name='output1', create_output=True)
+    model2.add_node(Dense(output_dim=output_dim, input_dim=input_dim),
+                    input='input', name='output2', create_output=True)
+
+    model2.compile('sgd', {'output1': 'mse', 'output2': 'mse'})
+
+    # test flat model
+    X = K.placeholder(ndim=2)
+    Y = model2(X)
+    f = K.function([X], [Y['output1'], Y['output2']])
+
+    x = np.ones((nb_samples, input_dim)).astype(K.floatx())
+    out = f([x])
+    y1a = out[0].astype(K.floatx())
+    y1b = out[1].astype(K.floatx())
+    y2 = model2.predict({'input': x})
+    # results of __call__ should match model.predict
+    assert_allclose(y1a, y2['output1'])
+    assert_allclose(y1b, y2['output2'])
+
+    # test with multiple inputs, multiple outputs
+    model3 = Graph()
+    model3.add_input('input1', input_shape=(input_dim, ))
+    model3.add_input('input2', input_shape=(input_dim, ))
+    model3.add_shared_node(Dense(output_dim=output_dim, input_dim=input_dim),
+                           inputs=['input1', 'input2'], name='output',
+                           outputs=['output1', 'output2'], create_output=True)
+    model3.compile('sgd', {'output1': 'mse', 'output2': 'mse'})
+
+    # test flat model
+    Y = model3({'input1': X1, 'input2': X2})
+    f = K.function([X1, X2], [Y['output1'], Y['output2']])
+
+    x1 = np.ones((nb_samples, input_dim)).astype(K.floatx())
+    x2 = np.ones((nb_samples, input_dim)).astype(K.floatx()) * -2
+    out = f([x1, x2])
+    y1a = out[0].astype(K.floatx())
+    y1b = out[1].astype(K.floatx())
+    y2 = model3.predict({'input1': x1, 'input2': x2})
+    # results of __call__ should match model.predict
+    assert_allclose(y1a, y2['output1'])
+    assert_allclose(y1b, y2['output2'])
+
+
+def test_nested_call():
+    """Test nested Sequential and Graph models"""
+    nb_samples, input_dim, output_dim = 3, 10, 5
+    X = K.placeholder(ndim=2)
+    x = np.ones((nb_samples, input_dim)).astype(K.floatx())
+
+    # test Graph model nested inside Sequential model
+    model = Graph()
+    model.add_input('input', input_shape=(input_dim, ))
+    model.add_node(Dense(output_dim=output_dim, input_dim=input_dim),
+                   input='input', name='output', create_output=True)
+
+    model2 = Sequential()
+    model2.add(model)
+    model2.compile('sgd', 'mse')
+
+    Y2 = model2(X)
+    f = K.function([X], [Y2])
+
+    y1 = f([x])[0].astype(K.floatx())
+    y2 = model2.predict(x)
+    # results of __call__ should match model.predict
+    assert_allclose(y1, y2)
+
+    # test Sequential model inside Graph model
+    model3 = Sequential()
+    model3.add(Dense(output_dim=output_dim, input_dim=input_dim))
+
+    model4 = Graph()
+    model4.add_input('input', input_shape=(input_dim, ))
+    model4.add_node(model3, input='input', name='output', create_output=True)
+    model4.compile('sgd', {'output': 'mse'})
+
+    Y2 = model4(X)
+    f = K.function([X], [Y2])
+
+    y1 = f([x])[0].astype(K.floatx())
+    y2 = model4.predict({'input': x})['output']
     # results of __call__ should match model.predict
     assert_allclose(y1, y2)
 


### PR DESCRIPTION
Previously, `Graph` inherited `__call__` from `Layer`, which doesn't work as expected. I added a bunch of tests that previously failed, but the basic problem is that this example throws an `UnusedInputError`

```{python}
graph = Graph()
graph.add_input("input", input_shape=(10, ))
graph.add_node(Dense(10), input="input", name="output", create_output=True)

inputA = K.placeholder(ndim=2)
outputA = graph(inputA)
fA = K.function([inputA], outputA)
```

It also breaks Siamese graphs, since the Siamese implementation relies on `__call__`. This example also throws an `UnusedInputError`

```{python}
graph = Graph()
graph.add_input("input", input_shape=(10, ))
graph.add_node(Dense(10), input="input", name="output", create_output=True)

model = Graph()
model.add_input("inputA", input_shape=(10, ))
model.add_input("inputB", input_shape=(10, ))
model.add_shared_node(name="output", layer=graph, inputs=["inputA", "inputB"],
                      merge_mode="cos", dot_axes=1, create_output=True)
model.compile(loss={"output": "binary_crossentropy"}, optimizer="sgd")
```

This ended up requiring a number of improvements

### Short version

* Changed implementation of `Layer.__call__`
* Remove overridden `Sequential.__call__` (new inherited implementation works)
* `Layer.set_previous` takes a new parameter to disable rebuild
* Cases that previously set the `previous` attribute manually now use `set_previous`
* Added `clear_previous` methods
* Added `Graph.input_shape` property
* Implemented `Graph.__call__` for multiple inputs
* Implemented `Graph.cache_enabled` property, which passes the property to graph nodes
* Added new tests for `__call__` on `Graph` models

### Long Version
I changed the implementation of `Layer.__call__`, so that instead of messing with `get_input`, it creates a dummy layer and uses `set_previous` to set the bottom layer's input. This implementation works for normal layers as well as `Sequential` and `Graph`s with only 1 input. The reason that this approach works better is that it respects layers with custom `set_previous` methods (like Graph)

To make this work, I ended up adding an option to `Layer.set_previous` to disable the rebuild, so that a layer's input can be changed without re-generating its trainable parameters. This allows us to get rid of a few places where `previous` attributes are set manually, which causes problems for layers that have custom `set_previous` implementations (like Graph).

I also needed to add `clear_previous` methods all around, add an `input_shape` method to `Graph`, and add an implementation of the `Graph.cache_enabled` that passes the property to all the graph nodes.

Finally, I added an override implementation of `Graph.__call__` for cases with multiple inputs. I figured as long as I'm fixing it, I may as well make it feature-complete.

There are new tests to cover all of the things I fixed. Since there were a few preparatory steps before the main change, I split this into a few commits, but I'd be happy to squash them if you'd prefer.