### PR TITLE
Fixed problem where load_weights would create corrupt .h5 files if the file did not exist.

### DIFF
--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -443,7 +443,7 @@ def rnn(step_function, inputs, initial_states,
         mask = mask.dimshuffle(axes)
 
         # build an all-zero tensor of shape (samples, output_dim)
-        initial_output = step_function(inputs[0], initial_states)[0] * 0
+        initial_output = step_function(inputs[0 if not go_backwards else -1], initial_states)[0] * 0
         # Theano gets confused by broadcasting patterns in the scan op
         initial_output = T.unbroadcast(initial_output, 0, 1)
 
@@ -482,7 +482,10 @@ def rnn(step_function, inputs, initial_states,
 
     outputs = T.squeeze(outputs)
     last_output = outputs[-1]
-
+    
+    if go_backwards:
+        outputs = outputs[-1::-1]
+    
     axes = [1, 0] + list(range(2, outputs.ndim))
     outputs = outputs.dimshuffle(axes)
     states = [T.squeeze(state[-1]) for state in states]

--- a/keras/models.py
+++ b/keras/models.py
@@ -845,7 +845,7 @@ class Sequential(Model, containers.Sequential):
         '''Load all layer weights from a HDF5 save file.
         '''
         import h5py
-        f = h5py.File(filepath)
+        f = h5py.File(filepath,mode="r")
         for k in range(f.attrs['nb_layers']):
             # This method does not make use of Sequential.set_weights()
             # for backwards compatibility.


### PR DESCRIPTION
This fixes issue #1734 . Since load_weights does not do anything to create the internal structure of a file it should be loading, there would be an exception ( "nb_layers does not exist" ) whenever a user tried to load a non-existent weights file. An empty .h5 file with that path would also be silently created, possibly corrupting workflows based on loading checkpoints.
This patch causes load_weights to raise an IOError if the filepath does not exist, and not create an empty file. (It loads as read-only. To my mind, this is appropriate for "load_weights".)