### PR TITLE
Fixed load_weights to not create empty/corrupt .h5 files

### DIFF
--- a/keras/models.py
+++ b/keras/models.py
@@ -845,7 +845,7 @@ class Sequential(Model, containers.Sequential):
         '''Load all layer weights from a HDF5 save file.
         '''
         import h5py
-        f = h5py.File(filepath)
+        f = h5py.File(filepath,mode="r")
         for k in range(f.attrs['nb_layers']):
             # This method does not make use of Sequential.set_weights()
             # for backwards compatibility.


### PR DESCRIPTION
Fixes issue #1734 non-existant .h5 files will not be created, IOError will be raised.

I'm sorry about the earlier pull request that included an unrelated patch. This one fixes one and only one issue.