### PR TITLE
add support for validation generators in fit_generator for Sequential and Graph

### DIFF
--- a/keras/models.py
+++ b/keras/models.py
@@ -890,8 +890,8 @@ class Sequential(Model, containers.Sequential):
         '''
         if not hasattr(generator_output, '__len__'):
             stop.set()
-            raise Exception('The generator output must be a tuple. Found: '
-                            + str(type(generator_output)))
+            raise Exception('The generator output must be a tuple. Found: ' +
+                            str(type(generator_output)))
         if len(generator_output) == 2:
             X, y = generator_output
             if type(X) == list:

--- a/keras/models.py
+++ b/keras/models.py
@@ -931,7 +931,10 @@ class Sequential(Model, containers.Sequential):
 
         do_validation = bool(validation_data)
         val_gen = False
-        if hasattr(validation_data, '__next__'):
+        # python 2 has 'next', 3 has '__next__'
+        # avoid any explicit version checks
+        if (hasattr(validation_data, 'next') or
+                hasattr(validation_data, '__next__')):
             val_generator = validation_data
             val_gen = True
 
@@ -1446,7 +1449,8 @@ class Graph(Model, containers.Graph):
 
         do_validation = bool(validation_data)
         val_gen = False
-        if hasattr(validation_data, '__next__'):
+        if (hasattr(validation_data, 'next') or
+                hasattr(validation_data, '__next__')):
             val_generator = validation_data
             val_gen = True
 

--- a/keras/models.py
+++ b/keras/models.py
@@ -889,7 +889,7 @@ class Sequential(Model, containers.Sequential):
                 they are assumed to be (input_data, target_data);
                 if 3 elements, they are assumed to be
                 (input_data, target_data, sample weights).
-            validation_generator: generator producing a batch of validation
+            val_generator: generator producing a batch of validation
                 data. At the end of every epoch, a single batch from this
                 generator will be used.
             class_weight: dictionary mapping class indices to a weight
@@ -1407,7 +1407,9 @@ class Graph(Model, containers.Graph):
                 to appropriate numpy arrays to be used as
                 held-out validation data.
                 All arrays should contain the same number of samples.
-            val_generator: generator producting 
+            val_generator: generator producing a batch of validation
+                data. At the end of every epoch, a single batch from this
+                generator will be used.
             class_weight: dictionary mapping class indices to a weight
                 for the class.
             nb_worker: integer, number of workers to use for running

--- a/keras/models.py
+++ b/keras/models.py
@@ -972,7 +972,7 @@ class Sequential(Model, containers.Sequential):
                       verbose=1, show_accuracy=False, callbacks=[],
                       validation_data=None, validation_samples=None,
                       class_weight=None,
-                      nb_worker=1, nb_val_worker=1):
+                      nb_worker=1, nb_val_worker=None):
         '''Fit a model on data generated batch-by-batch by a Python generator.
         The generator is run in parallel to the model, for efficiency,
         and can be run by multiple workers at the same time.
@@ -1021,7 +1021,8 @@ class Sequential(Model, containers.Sequential):
                 using a Python mutex.
             nb_val_worker: same as `nb_worker`, except for validation data.
                 Has no effect if no validation data or validation data is
-                not a generator.
+                not a generator. If `nb_val_worker` is None, defaults to
+                `nb_worker`.
 
         # Returns
 
@@ -1058,6 +1059,8 @@ class Sequential(Model, containers.Sequential):
                    hasattr(validation_data, '__next__'))
         if validation_samples is None:
             validation_samples = samples_per_epoch/5
+        if nb_val_worker is None:
+            nb_val_worker = nb_worker
 
         if show_accuracy:
             out_labels = ['loss', 'acc']
@@ -1493,7 +1496,7 @@ class Graph(Model, containers.Graph):
                       verbose=1, callbacks=[],
                       validation_data=None, validation_samples=None,
                       class_weight={},
-                      nb_worker=1, nb_val_worker=1):
+                      nb_worker=1, nb_val_worker=None):
         '''Fit a model on data generated batch-by-batch by a Python generator.
         The generator is run in parallel to the model, for efficiency,
         and can be run by multiple workers at the same time.
@@ -1536,7 +1539,7 @@ class Graph(Model, containers.Graph):
                 using a Python mutex.
             nb_val_worker: same as `nb_worker`, except for validation data.
                 Has no effect if no validation data or validation data is
-                not a generator.
+                not a generator. If `None`, defaults to nb_worker.
 
 
         # Returns
@@ -1570,6 +1573,8 @@ class Graph(Model, containers.Graph):
                    hasattr(validation_data, '__next__'))
         if validation_samples is None:
             validation_samples = samples_per_epoch/5
+        if nb_val_worker is None:
+            nb_val_worker = nb_worker
 
         out_labels = ['loss']
         metrics = ['loss', 'val_loss']

--- a/tests/keras/test_models.py
+++ b/tests/keras/test_models.py
@@ -69,9 +69,8 @@ def test_sequential_fit_generator():
     model.fit_generator(data_generator(True), len(X_train), nb_epoch, show_accuracy=True)
     model.fit_generator(data_generator(True), len(X_train), nb_epoch, show_accuracy=False, validation_data=(X_test, y_test))
     model.fit_generator(data_generator(True), len(X_train), nb_epoch, show_accuracy=True, validation_data=(X_test, y_test))
-    print('doing val. generator')
-    model.fit_generator(data_generator(True), len(X_train), nb_epoch, show_accuracy=False, val_generator=data_generator(False))
-    model.fit_generator(data_generator(True), len(X_train), nb_epoch, show_accuracy=True, val_generator=data_generator(False))
+    model.fit_generator(data_generator(True), len(X_train), nb_epoch, show_accuracy=False, validation_data=data_generator(False))
+    model.fit_generator(data_generator(True), len(X_train), nb_epoch, show_accuracy=True, validation_data=data_generator(False))
 
     loss = model.evaluate(X_train, y_train, verbose=0)
     assert(loss < 0.9)
@@ -625,9 +624,8 @@ def test_graph_fit_generator():
     graph.fit_generator(data_generator_graph(True), 1000, nb_epoch=4)
     graph.fit_generator(data_generator_graph(True), 1000, nb_epoch=4, validation_data={'input1': X_test_graph, 'output1': y_test_graph})
     graph.fit_generator(data_generator_graph(True), 1000, nb_epoch=4, validation_data={'input1': X_test_graph, 'output1': y_test_graph})
-    print('doing val. generator')
-    graph.fit_generator(data_generator_graph(True), 1000, nb_epoch=4, val_generator=data_generator_graph(False))
-    graph.fit_generator(data_generator_graph(True), 1000, nb_epoch=4, val_generator=data_generator_graph(False))
+    graph.fit_generator(data_generator_graph(True), 1000, nb_epoch=4, validation_data=data_generator_graph(False))
+    graph.fit_generator(data_generator_graph(True), 1000, nb_epoch=4, validation_data=data_generator_graph(False))
 
     loss = graph.evaluate({'input1': X_test_graph, 'output1': y_test_graph}, verbose=0)
     assert(loss < 3.)

--- a/tests/keras/test_models.py
+++ b/tests/keras/test_models.py
@@ -79,6 +79,21 @@ def test_sequential_fit_generator():
 def test_sequential():
     (X_train, y_train), (X_test, y_test) = _get_test_data()
 
+    # TODO: factor out
+    def data_generator(train):
+        if train:
+            max_batch_index = len(X_train) // batch_size
+        else:
+            max_batch_index = len(X_test) // batch_size
+        i = 0
+        while 1:
+            if train:
+                yield (X_train[i * batch_size: (i + 1) * batch_size], y_train[i * batch_size: (i + 1) * batch_size])
+            else:
+                yield (X_test[i * batch_size: (i + 1) * batch_size], y_test[i * batch_size: (i + 1) * batch_size])
+            i += 1
+            i = i % max_batch_index
+
     model = Sequential()
     model.add(Dense(nb_hidden, input_shape=(input_dim,)))
     model.add(Activation('relu'))
@@ -97,6 +112,8 @@ def test_sequential():
     model.train_on_batch(X_train[:32], y_train[:32])
 
     loss = model.evaluate(X_test, y_test, verbose=0)
+    assert(loss < 0.8)
+    loss = model.evaluate_generator(data_generator(True), verbose=0)
     assert(loss < 0.8)
 
     model.predict(X_test, verbose=0)

--- a/tests/keras/test_models.py
+++ b/tests/keras/test_models.py
@@ -69,8 +69,9 @@ def test_sequential_fit_generator():
     model.fit_generator(data_generator(True), len(X_train), nb_epoch, show_accuracy=True)
     model.fit_generator(data_generator(True), len(X_train), nb_epoch, show_accuracy=False, validation_data=(X_test, y_test))
     model.fit_generator(data_generator(True), len(X_train), nb_epoch, show_accuracy=True, validation_data=(X_test, y_test))
-    model.fit_generator(data_generator(True), len(X_train), nb_epoch, show_accuracy=False, validation_generator=data_generator(False))
-    model.fit_generator(data_generator(True), len(X_train), nb_epoch, show_accuracy=True, validation_generator=data_generator(False))
+    print('doing val. generator')
+    model.fit_generator(data_generator(True), len(X_train), nb_epoch, show_accuracy=False, val_generator=data_generator(False))
+    model.fit_generator(data_generator(True), len(X_train), nb_epoch, show_accuracy=True, val_generator=data_generator(False))
 
     loss = model.evaluate(X_train, y_train, verbose=0)
     assert(loss < 0.9)
@@ -624,6 +625,9 @@ def test_graph_fit_generator():
     graph.fit_generator(data_generator_graph(True), 1000, nb_epoch=4)
     graph.fit_generator(data_generator_graph(True), 1000, nb_epoch=4, validation_data={'input1': X_test_graph, 'output1': y_test_graph})
     graph.fit_generator(data_generator_graph(True), 1000, nb_epoch=4, validation_data={'input1': X_test_graph, 'output1': y_test_graph})
+    print('doing val. generator')
+    graph.fit_generator(data_generator_graph(True), 1000, nb_epoch=4, val_generator=data_generator_graph(False))
+    graph.fit_generator(data_generator_graph(True), 1000, nb_epoch=4, val_generator=data_generator_graph(False))
 
     loss = graph.evaluate({'input1': X_test_graph, 'output1': y_test_graph}, verbose=0)
     assert(loss < 3.)
@@ -964,4 +968,5 @@ def test_count_params():
 
 if __name__ == '__main__':
     # pytest.main([__file__])
-    test_lambda()
+    test_sequential_fit_generator()
+    test_graph_fit_generator()

--- a/tests/keras/test_models.py
+++ b/tests/keras/test_models.py
@@ -69,6 +69,8 @@ def test_sequential_fit_generator():
     model.fit_generator(data_generator(True), len(X_train), nb_epoch, show_accuracy=True)
     model.fit_generator(data_generator(True), len(X_train), nb_epoch, show_accuracy=False, validation_data=(X_test, y_test))
     model.fit_generator(data_generator(True), len(X_train), nb_epoch, show_accuracy=True, validation_data=(X_test, y_test))
+    model.fit_generator(data_generator(True), len(X_train), nb_epoch, show_accuracy=False, validation_generator=data_generator(False))
+    model.fit_generator(data_generator(True), len(X_train), nb_epoch, show_accuracy=True, validation_generator=data_generator(False))
 
     loss = model.evaluate(X_train, y_train, verbose=0)
     assert(loss < 0.9)

--- a/tests/keras/test_models.py
+++ b/tests/keras/test_models.py
@@ -111,9 +111,10 @@ def test_sequential():
 
     model.train_on_batch(X_train[:32], y_train[:32])
 
+    gen_loss = model.evaluate_generator(data_generator(True), 256, verbose=0)
+    assert(gen_loss < 0.8)
+
     loss = model.evaluate(X_test, y_test, verbose=0)
-    assert(loss < 0.8)
-    loss = model.evaluate_generator(data_generator(True), verbose=0)
     assert(loss < 0.8)
 
     model.predict(X_test, verbose=0)
@@ -644,6 +645,9 @@ def test_graph_fit_generator():
     graph.fit_generator(data_generator_graph(True), 1000, nb_epoch=4, validation_data=data_generator_graph(False))
     graph.fit_generator(data_generator_graph(True), 1000, nb_epoch=4, validation_data=data_generator_graph(False))
 
+    gen_loss = graph.evaluate_generator(data_generator_graph(True), 128, verbose=0)
+    assert(gen_loss < 3.)
+
     loss = graph.evaluate({'input1': X_test_graph, 'output1': y_test_graph}, verbose=0)
     assert(loss < 3.)
 
@@ -983,5 +987,7 @@ def test_count_params():
 
 if __name__ == '__main__':
     # pytest.main([__file__])
-    test_sequential_fit_generator()
-    test_graph_fit_generator()
+    # test_sequential()
+    # test_sequential_fit_generator()
+    # test_graph_fit_generator()
+    pass


### PR DESCRIPTION
This is a minimal set of additions to support the use of generators for validation data in `fit_generator ` in both Graph and Sequential. ~~This does not go as far as to implement an `evaluate_generator` method (which would allow, presumably, to use validation generators in other fit methods as well).~~
In addition to the above functionality, an `evaluate_generator` method was also added.

Basic tests were added (and passed) in `test_models.py`