### PR TITLE
Fix `Sequential.set_weights` for nested containers

### DIFF
--- a/keras/layers/containers.py
+++ b/keras/layers/containers.py
@@ -156,9 +156,9 @@ class Sequential(Layer):
         return weights
 
     def set_weights(self, weights):
-        for i in range(len(self.layers)):
-            nb_param = len(self.layers[i].trainable_weights) + len(self.layers[i].non_trainable_weights)
-            self.layers[i].set_weights(weights[:nb_param])
+        for layer in self.layers:
+            nb_param = len(layer.get_weights())
+            layer.set_weights(weights[:nb_param])
             weights = weights[nb_param:]
 
     def get_config(self):


### PR DESCRIPTION
`Sequential.set_weights` would fail for nested `Sequential` containers. This PR borrows the implementation of `Graph.set_weights` to get it working. It also adds tests for triply-nested `Sequential` models.

Resolves #1730.