### PR TITLE
ProbarLogger should go ahead than other customized callbacks.

### DIFF
--- a/keras/models.py
+++ b/keras/models.py
@@ -241,9 +241,10 @@ class Model(object):
         index_array = np.arange(nb_train_sample)
 
         self.history = cbks.History()
-        callbacks = [cbks.BaseLogger()] + callbacks + [self.history]
         if verbose:
-            callbacks += [cbks.ProgbarLogger()]
+            callbacks = [cbks.BaseLogger(), cbks.ProgbarLogger()] + callbacks + [self.history]
+        else:
+            callbacks = [cbks.BaseLogger()] + callbacks + [self.history]
         callbacks = cbks.CallbackList(callbacks)
 
         callbacks._set_model(self)


### PR DESCRIPTION
Otherwise, probar will overwrite other callbacks' output on the screen (e.g. checkpoint's if verbose set 1)