### PR TITLE
Enable cache optimization for __call__

### DIFF
--- a/keras/layers/containers.py
+++ b/keras/layers/containers.py
@@ -36,6 +36,26 @@ class Sequential(Layer):
         for l in self.layers:
             l.cache_enabled = value
 
+    @property
+    def layer_cache(self):
+        return super(Sequential, self).layer_cache
+
+    @layer_cache.setter
+    def layer_cache(self, value):
+        self._layer_cache = value
+        for layer in self.layers:
+            layer.layer_cache = self._layer_cache
+
+    @property
+    def shape_cache(self):
+        return super(Sequential, self).shape_cache
+
+    @shape_cache.setter
+    def shape_cache(self, value):
+        self._shape_cache = value
+        for layer in self.layers:
+            layer.shape_cache = self._shape_cache
+
     def set_previous(self, layer, reset_weights=True):
         self.layers[0].set_previous(layer, reset_weights)
 
@@ -212,6 +232,30 @@ class Graph(Layer):
             l.cache_enabled = value
         for l in self.inputs.values():
             l.cache_enabled = value
+
+    @property
+    def layer_cache(self):
+        return super(Graph, self).layer_cache
+
+    @layer_cache.setter
+    def layer_cache(self, value):
+        self._layer_cache = value
+        for layer in self.nodes.values():
+            layer.layer_cache = self._layer_cache
+        for layer in self.inputs.values():
+            layer.layer_cache = self._layer_cache
+
+    @property
+    def shape_cache(self):
+        return super(Graph, self).shape_cache
+
+    @shape_cache.setter
+    def shape_cache(self, value):
+        self._shape_cache = value
+        for layer in self.nodes.values():
+            layer.shape_cache = self._shape_cache
+        for layer in self.inputs.values():
+            layer.shape_cache = self._shape_cache
 
     @property
     def nb_input(self):


### PR DESCRIPTION

Reset instead of disabling layer and shape cache  in `__call__`

Previously, `__call__` did not get the speed benefits from caching because it disabled it in order to feed the layer new input. This meant that `__call__` could be very slow on complicated structures. This was especially apparent when creating complex Siamese networks.

Now, instead of disabling the caches, we temporarily empty them, then restore the originals when we're done.

To make this work, move caches to properties so that containers can override the implementation to ensure that the cache gets propagated correctly to child layers when it is changed. This way we can guarantee that all layers are pointing at the same cache objects.
