### PR TITLE
Speed up TimeDistributedDense, 3D Softmax and RNNs

### DIFF
--- a/keras/activations.py
+++ b/keras/activations.py
@@ -7,13 +7,9 @@ def softmax(x):
     if ndim == 2:
         return K.softmax(x)
     elif ndim == 3:
-        # apply softmax to each timestep
-        def step(x, states):
-            return K.softmax(x), []
-        last_output, outputs, states = K.rnn(step, x,
-                                             [],
-                                             mask=None)
-        return outputs
+        e = K.exp(x)
+        s = K.sum(e, axis=-1, keepdims=True)
+        return e / s
     else:
         raise Exception('Cannot apply softmax to a tensor that is not 2D or 3D. ' +
                         'Here, ndim=' + str(ndim))

--- a/keras/activations.py
+++ b/keras/activations.py
@@ -7,7 +7,7 @@ def softmax(x):
     if ndim == 2:
         return K.softmax(x)
     elif ndim == 3:
-        e = K.exp(x)
+        e = K.exp(x - K.max(x, axis=-1, keepdims=True))
         s = K.sum(e, axis=-1, keepdims=True)
         return e / s
     else:

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -353,6 +353,8 @@ def spatial_2d_padding(x, padding=(1, 1), dim_ordering='th'):
                    [0, 0]]
     return tf.pad(x, pattern)
 
+def pack(x):
+    return tf.pack(x)
 
 # VALUE MANIPULATION
 

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -415,6 +415,8 @@ def spatial_3d_padding(x, padding=(1, 1, 1), dim_ordering='th'):
         raise Exception('Invalid dim_ordering: ' + dim_ordering)
     return T.set_subtensor(output[indices], x)
 
+def pack(x):
+    return T.stack(*x)
 
 # VALUE MANIPULATION
 

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -1121,34 +1121,19 @@ class TimeDistributedDense(MaskedLayer):
 
     def get_output(self, train=False):
         X = self.get_input(train)
-        input_length = self.input_shape[1]
-        if input_length and K._BACKEND == 'theano':
+        if K._BACKEND == 'theano':
             import theano.tensor as T
-            #X: (nb_samples, timesteps, input_dim)
-            X = K.permute_dimensions(X, (1, 0, 2))
-            #X: (timesteps, nb_samples, input_dim)
-            W = [self.W] * input_length
-            W = T.stack(*W)
-            #W: (timesteps, input_dim, output_dim)
-            z = T.batched_tensordot(X, W, axes=[(2), (1)])
-            #z: (timesteps, nb_samples, output_dim)
-            z = K.permute_dimensions(z, (1, 0, 2))
-            #z: (nb_samples, timesteps, output_dim)
-            b = [self.b] * input_length
-            b = T.stack(*b)
-            #b: (timesteps, output_dim)
-            Y = self.activation(z + b)
+            z = T.tensordot(X, self.W, axes=[(2), (0)])
+            Y = z + self.b
+            Y = self.activation(Y)
             return Y
-            
-        def step(x, states):
-            output = K.dot(x, self.W) + self.b
-            return output, []
-
-        last_output, outputs, states = K.rnn(step, X,
-                                             initial_states=[],
-                                             mask=None)
-        outputs = self.activation(outputs)
-        return outputs
+        elif K._BACKEND == 'tensorflow':
+            shape = self.input_shape
+            X = K.reshape(X, (-1, shape[-1]))
+            Y = K.dot(X, self.W) + self.b
+            Y = K.reshape(Y, (-1, shape[1], shape[2]))
+            Y = self.activation(Y)
+            return Y
 
     def get_config(self):
         config = {'name': self.__class__.__name__,

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -121,10 +121,9 @@ class Recurrent(MaskedLayer):
 
     def get_initial_states(self, X):
         # build an all-zero tensor of shape (samples, output_dim)
-        initial_state = K.zeros_like(X)  # (samples, timesteps, input_dim)
-        initial_state = K.sum(initial_state, axis=1)  # (samples, input_dim)
-        reducer = K.zeros((self.input_dim, self.output_dim))
-        initial_state = K.dot(initial_state, reducer)  # (samples, output_dim)
+        initial_state = X[:, 0, 0] * 0  # (samples, )
+        initial_state = K.pack([initial_state] * self.output_dim)  # (output_dim, samples)
+        initial_state = K.permute_dimensions(initial_state, (1, 0))  # (samples, output_dim)
         initial_states = [initial_state for _ in range(len(self.states))]
         return initial_states
 


### PR DESCRIPTION
Found some serious bottlenecks in core parts of Keras:

* Currently `TimeDistributedDense` is implemented using `K.rnn()`, i.e, each vector in the sequence is dot with `W` sequentially, one after the other. Since each time step of the rnn is independent of the previous time step (no state involved), instead of looping through the sequence, it is possible to obtain the output in one single huge matrix operation.

* Similarly, softmax activiation for 3D data is also implemented using `rnn()`, which translates to 1 softmax op per vector.

* Now if you were to combine these two, i.e, `TimeDistributedDense(10, activation='softmax')`, Keras will loop through each of your sequence **twice**, one for the dot operation and the other for the activation. Sad ):

* Instead of making use of shaping ops such as `permute_dimesions` (which come at no cost), Dot and sum ops are used to initialize RNN hidden states.