### PR TITLE
Fix SiameseHead naming

### DIFF
--- a/keras/layers/containers.py
+++ b/keras/layers/containers.py
@@ -488,6 +488,7 @@ class Graph(Layer):
                 sh = SiameseHead(i)
                 sh.previous = s
                 sh_name = outputs[i]
+                sh.name =sh_name
                 self.namespace.add(sh_name)
                 self.nodes[sh_name] = sh
                 self.node_config.append({'name': sh_name,


### PR DESCRIPTION
In `keras.containers.Graph.add_shared_node` When setting` merge_mode=None ` (In order to add outputs of layer to the graph) output names provided in `outputs` kwarg is not set for `SiameseHead`s created.
So trying to use then in another shared layer with `merge_mode='join'` will not work. (Because all of them have name `simesehead` and they will replace each other in the dictionary created)

The following example will produce the issue I described. (`base_network` and `euclidean_distance` same as [this example](https://github.com/fchollet/keras/blob/99991779e5234c57feee1723addd5b523acfc852/examples/mnist_siamese_graph.py))

`g.add_shared_node(base_network, name='shared', inputs=['in1', 'in2'], merge_mode=None, outputs=['mid1', 'mid2'])`
`g.add_shared_node(Dense(85), inputs=['shared'], merge_mode=None, name='shared2')`
`g.add_node(Lambda(euclidean_distance), name='dist', inputs=['mid1', 'mid2'], merge_mode='join')`