### PR TITLE
Wrappers

### DIFF
--- a/keras/layers/wrappers.py
+++ b/keras/layers/wrappers.py
@@ -102,7 +102,7 @@ class TimeDistributed(Wrapper):
 
     def get_output_shape(self):
         input_shape = self.input_shape
-        return input_shape[0], input_shape[1] + self.layer.output_shape[1:]
+        return (input_shape[0], input_shape[1]) + self.layer.output_shape[1:]
 
     def get_input_shape(self):
         layer_input_shape = self.layer.input_shape

--- a/keras/layers/wrappers.py
+++ b/keras/layers/wrappers.py
@@ -117,7 +117,7 @@ class TimeDistributed(Wrapper):
 
 def get_output(self, train=False):
     X = self.get_input(train)  # (nb_samples, timesteps, ..., input_dim)
-    if self.layer.input_sahpe[0]:
+    if self.layer.input_shape[0]:
         # batch size matters, use rnn-based implementation
         def step(x, states):
             return self.layer(x), []

--- a/keras/layers/wrappers.py
+++ b/keras/layers/wrappers.py
@@ -102,13 +102,13 @@ class TimeDistributed(Wrapper):
 
     def get_output_shape(self):
         input_shape = self.input_shape
-        return (input_shape[0], input_shape[1]) + (self.layer.output_shape[1:])
+        return input_shape[0], input_shape[1] + self.layer.output_shape[1:]
 
     def get_input_shape(self):
         layer_input_shape = self.layer.input_shape
         self.input_ndim = 1 + len(layer_input_shape)
         timesteps = None if not hasattr(self, '_input_shape') else self._input_shape[1]
-        return (layer_input_shape[0], timesteps) + (layer_input_shape[1:])
+        return (layer_input_shape[0], timesteps) + layer_input_shape[1:]
 
     def get_child_input_shape(self):
         input_shape = list(self.input_shape)

--- a/keras/layers/wrappers.py
+++ b/keras/layers/wrappers.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from ..layers.core import Layer, MaskedLayer
+from ..import backend as K
+
+
+class Wrapper(MaskedLayer):
+    '''
+    Abstract Wrapper class
+    '''
+    def __init__(self, layer, initial_weights=None, **kwargs):
+        self.layer = layer
+        super(Wrapper, self).__init__(**kwargs)
+        if hasattr(layer, '_input_shape'): #Layer is already built.
+            self.set_input_shape(self.get_input_shape())
+            self.set_params()
+        if initial_weights:
+            self.set_weights(initial_weights)
+            del initial_weights
+
+    @property
+    def output_shape(self):
+        return self.get_output_shape()
+
+    @property
+    def cache_enabled(self):
+        return self._cache_enabled
+
+    @cache_enabled.setter
+    def cache_enabled(self, value):
+        self._cache_enabled = value
+        self.layer.cache_enabled = value
+
+    def reset_states(self):
+        # If child layer is a stateful RNN
+        self.layer.reset_states()
+
+    def set_params(self):
+        layer_params = self.layer.get_params()
+        self.trainable_weights = layer_params[0]
+        self.regularizers = layer_params[1]
+        self.constraints = layer_params[2]
+        self.updates = layer_params[3]
+
+    def build(self):
+        if not hasattr(self.layer, '_input_shape'):
+            self.layer.set_input_shape(self.get_child_input_shape())
+            self.set_params()
+
+    def get_input_shape(self):
+        '''
+        Get input shape of the wrapper from the child layer's input shape
+        '''
+        return self.layer.input_shape
+
+    def get_child_input_shape(self):
+        '''
+        Get the child layer's input shape from the wrapper's input shape
+        '''
+        return self.input_shape
+
+    def get_output_shape(self):
+        '''
+        Get output shape of the wrapper from the child layer's output shape
+        '''
+        return self.layer.output_shape
+
+    @property
+    def trainable_weights(self):
+        return self.layer.trainable_weights
+
+    @trainable_weights.setter
+    def trainable_weights(self, value):
+        self.layer.trainable_weights = value
+
+    @property
+    def non_trainable_weights(self):
+        return self.layer.non_trainable_weights
+
+    @non_trainable_weights.setter
+    def non_trainable_weights(self, value):
+        self.layer.non_trainable_weights = value
+
+    def get_weights(self):
+        return self.layer.get_weights()
+
+    def set_weights(self, weights):
+        self.layer.set_weights(weights)
+
+    def get_output(self, train=False):
+        x = self.get_input(train)
+        return self.layer(x, None, train)
+
+    def get_config(self):
+        config = {'name': self.__class__.__name__,
+                  'layer': self.layer.get_config()}
+        base_config = super(Wrapper, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))

--- a/keras/utils/layer_utils.py
+++ b/keras/utils/layer_utils.py
@@ -71,6 +71,13 @@ def container_from_config(original_layer_dict, custom_objects={}):
                 kwargs[kwarg] = layer_dict[kwarg]
         return AutoEncoder(**kwargs)
 
+    elif name == 'TimeDistributed':
+        child_layer = container_from_config(layer_dict.pop('layer'))
+        # the "name" keyword argument of layers is saved as "custom_name"
+        if 'custom_name' in layer_dict:
+            layer_dict['name'] = layer_dict.pop('custom_name')
+        return TimeDistributed(child_layer, **layer_dict)
+
     else:  # this is a non-topological layer (e.g. Dense, etc.)
         layer_dict.pop('name')
 

--- a/keras/utils/layer_utils.py
+++ b/keras/utils/layer_utils.py
@@ -5,6 +5,7 @@ import copy
 
 from ..layers.advanced_activations import *
 from ..layers.core import *
+from ..layers.wrappers import *
 from ..layers.convolutional import *
 from ..layers.embeddings import *
 from ..layers.noise import *

--- a/tests/keras/layers/test_wrappers.py
+++ b/tests/keras/layers/test_wrappers.py
@@ -32,24 +32,24 @@ def test_TimeDistributed():
     reference_output = reference.predict(test_input)
     assert_allclose(test_output, reference_output, atol=1e-05)
 
+    # nested TimeDistributed wrappers
+    model = Sequential()
+    model.add(wrappers.TimeDistributed(wrappers.TimeDistributed(core.Dense(input_dim=3, output_dim=5))))
+    model.add(wrappers.TimeDistributed(wrappers.TimeDistributed(core.Dense(2))))
+
+    model.compile(optimizer='rmsprop', loss='mse')
+    model.train_on_batch(np.random.random((7, 5, 4, 3)), np.random.random((7, 5, 4, 2)))
+
+    model = model_from_json(model.to_json())
+    model.summary()
+
     # test with Convolution2D
     model = Sequential()
     model.add(wrappers.TimeDistributed(convolutional.Convolution2D(5, 2, 2, border_mode='same'), input_shape=(2, 3, 4, 4)))
     model.add(core.Activation('relu'))
 
     model.compile(optimizer='rmsprop', loss='mse')
-    model.train_on_batch(np.random.random((1, 2, 3, 4, 4)), np.random.random((1, 2, 5, 4, 4)))
-
-    model = model_from_json(model.to_json())
-    model.summary()
-
-    # nested TimeDistributed wrappers
-    model = Sequential()
-    model.add(TimeDistributed(TimeDistributed(Dense(input_dim=3, output_dim=5))))
-    model.add(TimeDistributed(TimeDistributed(Dense(2))))
-
-    model.compile(optimizer='rmsprop', loss='mse')
-    model.train_on_batch(np.random.random((7, 5, 4, 3)), np.random.random((7, 5, 4, 2)))
+    model.train_on_batch(np.random.random((10, 5, 1, 2, 3, 4, 4)), np.random.random((10, 5, 1, 2, 5, 4, 4)))
 
     model = model_from_json(model.to_json())
     model.summary()

--- a/tests/keras/layers/test_wrappers.py
+++ b/tests/keras/layers/test_wrappers.py
@@ -1,0 +1,58 @@
+import pytest
+import numpy as np
+from numpy.testing import assert_allclose
+
+from keras.layers import wrappers
+from keras.layers import core, convolutional
+from keras.models import Sequential, model_from_json
+
+
+def test_TimeDistributed():
+    # first, test with Dense layer
+    model = Sequential()
+    model.add(wrappers.TimeDistributed(core.Dense(2), input_shape=(3, 4)))
+    model.add(core.Activation('relu'))
+
+    model.compile(optimizer='rmsprop', loss='mse')
+    model.fit(np.random.random((10, 3, 4)), np.random.random((10, 3, 2)), nb_epoch=1, batch_size=10)
+
+    model.get_config()
+
+    # compare to TimeDistributedDense
+    test_input = np.random.random((1, 3, 4))
+    test_output = model.predict(test_input)
+    weights = model.layers[0].get_weights()
+
+    reference = Sequential()
+    reference.add(core.TimeDistributedDense(2, input_shape=(3, 4), weights=weights))
+    reference.add(core.Activation('relu'))
+
+    reference.compile(optimizer='rmsprop', loss='mse')
+
+    reference_output = reference.predict(test_input)
+    assert_allclose(test_output, reference_output, atol=1e-05)
+
+    # test with Convolution2D
+    model = Sequential()
+    model.add(wrappers.TimeDistributed(convolutional.Convolution2D(5, 2, 2, border_mode='same'), input_shape=(2, 3, 4, 4)))
+    model.add(core.Activation('relu'))
+
+    model.compile(optimizer='rmsprop', loss='mse')
+    model.train_on_batch(np.random.random((1, 2, 3, 4, 4)), np.random.random((1, 2, 5, 4, 4)))
+
+    model = model_from_json(model.to_json())
+    model.summary()
+
+    # nested TimeDistributed wrappers
+    model = Sequential()
+    model.add(TimeDistributed(TimeDistributed(Dense(input_dim=3, output_dim=5))))
+    model.add(TimeDistributed(TimeDistributed(Dense(2))))
+
+    model.compile(optimizer='rmsprop', loss='mse')
+    model.train_on_batch(np.random.random((7, 5, 4, 3)), np.random.random((7, 5, 4, 2)))
+
+    model = model_from_json(model.to_json())
+    model.summary()
+    
+if __name__ == '__main__':
+    pytest.main([__file__])


### PR DESCRIPTION
Base class for Wrappers.
Functions that should be re-implemented in derived classes:

* `get_input_shape()` : Function to infer the wrapper's input shape from the child layer's input shape
* `get_child_input_shape()` : Inverse of the above function. Infer the child's input shape from the wrapper's shape.
* `get_output_shape()` : Function to infer the wrapper's output shape from the child layer's output  shape
* `get_output()`

Does not work for multiple child layers (Such as in Bidirectional RNN, where 2 RNNs have to wrapped into a single layer)