### PR TITLE
Refactoring of sklearn (#same as 1825)

### DIFF
--- a/keras/wrappers/scikit_learn.py
+++ b/keras/wrappers/scikit_learn.py
@@ -1,266 +1,243 @@
 from __future__ import absolute_import
-import abc
 import copy
+import inspect
+import types
 import numpy as np
 
 from ..utils.np_utils import to_categorical
+from ..models import Sequential
 
 
 class BaseWrapper(object):
-    """
-    Base class for the Keras scikit-learn wrapper.
 
-    Warning: This class should not be used directly. Use derived classes instead.
+    '''Base class for the Keras scikit-learn wrapper.
 
-    Parameters
-    ----------
-    train_batch_size : int, optional
-        Number of training samples evaluated at a time.
-    test_batch_size : int, optional
-        Number of test samples evaluated at a time.
-    nb_epochs : int, optional
-        Number of training epochs.
-    shuffle : boolean, optional
-        Whether to shuffle the samples at each epoch.
-    show_accuracy : boolean, optional
-        Whether to display class accuracy in the logs at each epoch.
-    validation_split : float [0, 1], optional
-        Fraction of the data to use as held-out validation data.
-    validation_data : tuple (X, y), optional
-        Data to be used as held-out validation data. Will override validation_split.
-    callbacks : list, optional
-        List of callbacks to apply during training.
-    verbose : int, optional
-        Verbosity level.
-    """
-    __metaclass__ = abc.ABCMeta
+    Warning: This class should not be used directly.
+    Use derived classes instead.
 
-    @abc.abstractmethod
-    def __init__(self, model, optimizer, loss,
-                 train_batch_size=128, test_batch_size=128,
-                 nb_epoch=100, shuffle=True, show_accuracy=False,
-                 validation_split=0, validation_data=None, callbacks=None,
-                 verbose=0,):
-        self.model = model
-        self.optimizer = optimizer
-        self.loss = loss
-        self.compiled_model_ = None
-        self.classes_ = []
-        self.config_ = []
-        self.weights_ = []
+    # Arguments
+        build_fn: callable function or class instance,  optional
+            Implementing the logic of the model.
+        sk_params: model parameters & fitting parameters
 
-        self.train_batch_size = train_batch_size
-        self.test_batch_size = test_batch_size
-        self.nb_epoch = nb_epoch
-        self.shuffle = shuffle
-        self.show_accuracy = show_accuracy
-        self.validation_split = validation_split
-        self.validation_data = validation_data
-        self.callbacks = [] if callbacks is None else callbacks
+    The build_fn should construct, compile and return a Keras model, which
+    will then be used to fit data or predict unknow data. One of the following
+    three values could be passed to build_fn:
+    1. A function instance
+    2. An instance of a class that implements the __call__ function
+    3. None. This means you implement a class that inherits either
+    KerasClassifier or KerasRegressor. The __call__ function of the class will
+    then be treated as the default build_fn
 
-        self.verbose = verbose
+    'sk_params' takes both model parameters and fitting parameters. Legal model
+    parameters are the arguments of 'build_fn'. Note that like all other
+    estimators in scikit_learn, 'build_fn' should provide defalult velues for
+    its arguments, so that you could create the estimator without passing any
+    values to 'sk_params'.
+
+    'sk_params' could also accept parameters for calling 'fit', 'predict',
+    'predict_proba', and 'score' function (e.g., nb_epoch, batch_size).
+    fitting (predicting) parameters are adopts in the following order:
+
+    1. Values passed to the dictionary arguments of
+    'fit', 'predict', 'predict_proba', and 'score' functions
+    2. Values passed to 'sk_params'
+    3. The default values of the keras.models.Sequential's
+    'fit', 'predict', 'predict_proba' and 'score' functions
+
+    When using scikit_learn's grid_search api, legal tunable parameters are
+    those you could pass to 'sk_params', including fitting parameters.
+    In other words, you could use grid_search to search for the best
+    batch_size or nb_epoch as well as the model parameters.
+    '''
+
+    def __init__(self, build_fn=None, **sk_params):
+        self.build_fn = build_fn
+        self.sk_params = sk_params
 
     def get_params(self, deep=True):
-        """
-        Get parameters for this estimator.
+        '''Get parameters for this estimator.
 
-        Parameters
-        ----------
-        deep: boolean, optional
-            If True, will return the parameters for this estimator and
-            contained subobjects that are estimators.
+        # Arguments
+            deep: boolean, optional
+                If True, will return the parameters for this estimator and
+                contained subobjects that are estimators.
 
-        Returns
-        -------
-        params : dict
-            Dictionary of parameter names mapped to their values.
-        """
-        return {'model': self.model, 'optimizer': self.optimizer, 'loss': self.loss}
+        # Returns
+            params : dict
+                Dictionary of parameter names mapped to their values.
+        '''
+        res = copy.deepcopy(self.sk_params)
+        res.update({'build_fn': self.build_fn})
+        return res
 
     def set_params(self, **params):
-        """
-        Set the parameters of this estimator.
+        '''Set the parameters of this estimator.
 
-        Parameters
-        ----------
+        # Arguments
         params: dict
             Dictionary of parameter names mapped to their values.
 
-        Returns
-        -------
-        self
-        """
-        for parameter, value in params.items():
-            setattr(self, parameter, value)
+        # Returns
+            self
+        '''
+        self.sk_params.update(params)
         return self
 
-    def fit(self, X, y):
-        """
-        Fit the model according to the given training data.
+    def fit(self, X, y, **kwargs):
+        '''Construct a new model with build_fn and fit the model according
+        to the given training data.
 
-        Makes a copy of the un-compiled model definition to use for
-        compilation and fitting, leaving the original definition
-        intact.
+        # Arguments
+            X : array-like, shape = (n_samples, n_features)
+                Training samples where n_samples in the number of samples
+                and n_features is the number of features.
+            y : array-like, shape = (n_samples) or (n_samples, n_outputs)
+                True labels for X.
+            kwargs: dictionary arguments
+                Legal arguments are the arguments of Sequential.fit
 
-        Parameters
-        ----------
-        X : array-like, shape = (n_samples, n_features)
-            Training samples where n_samples in the number of samples
-            and n_features is the number of features.
-        y : array-like, shape = (n_samples) or (n_samples, n_outputs)
-            True labels for X.
+        # Returns
+            history : object
+                details about the training history at each epoch.
+        '''
 
-        Returns
-        -------
-        history : object
-            Returns details about the training history at each epoch.
-        """
-        if len(y.shape) == 1:
-            self.classes_ = list(np.unique(y))
-            if self.loss == 'categorical_crossentropy':
-                y = to_categorical(y)
+        if self.build_fn is None:
+            self.model = self.__call__(**self.filter_sk_params(self.__call__))
+        elif not isinstance(self.build_fn, types.FunctionType):
+            self.model = self.build_fn(
+                **self.filter_sk_params(self.build_fn.__call__))
         else:
-            self.classes_ = np.arange(0, y.shape[1])
+            self.model = self.build_fn(**self.filter_sk_params(self.build_fn))
 
-        self.compiled_model_ = copy.deepcopy(self.model)
-        self.compiled_model_.compile(optimizer=self.optimizer, loss=self.loss)
-        history = self.compiled_model_.fit(
-            X, y, batch_size=self.train_batch_size, nb_epoch=self.nb_epoch, verbose=self.verbose,
-            shuffle=self.shuffle, show_accuracy=self.show_accuracy,
-            validation_split=self.validation_split, validation_data=self.validation_data,
-            callbacks=self.callbacks)
+        if self.model.loss.__name__ == 'categorical_crossentropy'\
+                and len(y.shape) != 2:
+            y = to_categorical(y)
 
-        self.config_ = self.model.get_config()
-        self.weights_ = self.model.get_weights()
+        fit_args = copy.deepcopy(self.filter_sk_params(Sequential.fit))
+        fit_args.update(kwargs)
+
+        history = self.model.fit(X, y, **fit_args)
 
         return history
 
+    def filter_sk_params(self, fn, override={}):
+        '''Filter sk_params and return those in fn's arguments
+
+        # Arguments
+            fn : arbitrary function
+            override: dictionary, values to overrid sk_params
+
+        # Returns
+            res : dictionary dictionary containing variabls
+                in both sk_params and fn's arguments.
+        '''
+        res = {}
+        fn_args = inspect.getargspec(fn)[0]
+        for name, value in self.sk_params.items():
+            if name in fn_args:
+                res.update({name: value})
+        res.update(override)
+        return res
+
 
 class KerasClassifier(BaseWrapper):
-    """
-    Implementation of the scikit-learn classifier API for Keras.
 
-    Parameters
-    ----------
-    model : object
-        An un-compiled Keras model object is required to use the scikit-learn wrapper.
-    optimizer : string
-        Optimization method used by the model during compilation/training.
-    loss : string
-        Loss function used by the model during compilation/training.
-    """
-    def __init__(self, model, optimizer='adam', loss='categorical_crossentropy', **kwargs):
-        super(KerasClassifier, self).__init__(model, optimizer, loss, **kwargs)
+    '''Implementation of the scikit-learn classifier API for Keras.'''
 
-    def predict(self, X):
-        """
-        Returns the class predictions for the given test data.
+    def predict(self, X, **kwargs):
+        '''# Returns the class predictions for the given test data.
 
-        Parameters
-        ----------
-        X : array-like, shape = (n_samples, n_features)
-            Test samples where n_samples in the number of samples
-            and n_features is the number of features.
+        # Arguments
+            X : array-like, shape = (n_samples, n_features)
+                Test samples where n_samples in the number of samples
+                and n_features is the number of features.
+            kwargs: dictionary arguments
+                Legal arguments are the arguments of Sequential.predict_classes
 
-        Returns
-        -------
-        preds : array-like, shape = (n_samples)
-            Class predictions.
-        """
-        return self.compiled_model_.predict_classes(
-            X, batch_size=self.test_batch_size, verbose=self.verbose)
+        # Returns
+            preds : array-like, shape = (n_samples)
+                Class predictions.
+        '''
+        kwargs = self.filter_sk_params(Sequential.predict_classes, kwargs)
+        return self.model.predict_classes(X, **kwargs)
 
-    def predict_proba(self, X):
-        """
-        Returns class probability estimates for the given test data.
+    def predict_proba(self, X, **kwargs):
+        '''# Returns class probability estimates for the given test data.
 
-        Parameters
-        ----------
-        X : array-like, shape = (n_samples, n_features)
-            Test samples where n_samples in the number of samples
-            and n_features is the number of features.
+        # Arguments
+            X : array-like, shape = (n_samples, n_features)
+                Test samples where n_samples in the number of samples
+                and n_features is the number of features.
+            kwargs: dictionary arguments
+                Legal arguments are the arguments of Sequential.predict_classes
 
-        Returns
-        -------
-        proba : array-like, shape = (n_samples, n_outputs)
-            Class probability estimates.
-        """
-        return self.compiled_model_.predict_proba(
-            X, batch_size=self.test_batch_size, verbose=self.verbose)
+        # Returns
+            proba : array-like, shape = (n_samples, n_outputs)
+                Class probability estimates.
+        '''
+        kwargs = self.filter_sk_params(Sequential.predict_proba, kwargs)
+        return self.model.predict_proba(X, **kwargs)
 
-    def score(self, X, y):
-        """
-        Returns the mean accuracy on the given test data and labels.
+    def score(self, X, y, **kwargs):
+        '''# Returns the mean accuracy on the given test data and labels.
 
-        Parameters
-        ----------
-        X : array-like, shape = (n_samples, n_features)
-            Test samples where n_samples in the number of samples
-            and n_features is the number of features.
-        y : array-like, shape = (n_samples) or (n_samples, n_outputs)
-            True labels for X.
+        # Arguments
+            X : array-like, shape = (n_samples, n_features)
+                Test samples where n_samples in the number of samples
+                and n_features is the number of features.
+            y : array-like, shape = (n_samples) or (n_samples, n_outputs)
+                True labels for X.
+            kwargs: dictionary arguments
+                Legal arguments are the arguments of Sequential.evaluate
 
-        Returns
-        -------
-        score : float
-            Mean accuracy of predictions on X wrt. y.
-        """
-        loss, accuracy = self.compiled_model_.evaluate(
-            X, y, batch_size=self.test_batch_size, show_accuracy=True, verbose=self.verbose)
+        # Returns
+            score : float
+                Mean accuracy of predictions on X wrt. y.
+        '''
+        kwargs = self.filter_sk_params(Sequential.evaluate, kwargs)
+        kwargs.update({'show_accuracy': True})
+        loss, accuracy = self.model.evaluate(X, y, **kwargs)
         return accuracy
 
 
 class KerasRegressor(BaseWrapper):
-    """
-    Implementation of the scikit-learn regressor API for Keras.
 
-    Parameters
-    ----------
-    model : object
-        An un-compiled Keras model object is required to use the scikit-learn wrapper.
-    optimizer : string
-        Optimization method used by the model during compilation/training.
-    loss : string
-        Loss function used by the model during compilation/training.
-    """
-    def __init__(self, model, optimizer='adam', loss='mean_squared_error', **kwargs):
-        super(KerasRegressor, self).__init__(model, optimizer, loss, **kwargs)
+    '''Implementation of the scikit-learn regressor API for Keras.'''
 
-    def predict(self, X):
-        """
-        Returns predictions for the given test data.
+    def predict(self, X, **kwargs):
+        ''' Returns predictions for the given test data.
 
-        Parameters
-        ----------
-        X : array-like, shape = (n_samples, n_features)
-            Test samples where n_samples in the number of samples
-            and n_features is the number of features.
+        # Arguments
+            X : array-like, shape = (n_samples, n_features)
+                Test samples where n_samples in the number of samples
+                and n_features is the number of features.
+            kwargs: dictionary arguments
+                Legal arguments are the arguments of Sequential.predict
+        # Returns
+            preds : array-like, shape = (n_samples)
+                Predictions.
+        '''
+        kwargs = self.filter_sk_params(Sequential.predict, kwargs)
+        return self.model.predict(X, **kwargs)
 
-        Returns
-        -------
-        preds : array-like, shape = (n_samples)
-            Predictions.
-        """
-        return self.compiled_model_.predict(
-            X, batch_size=self.test_batch_size, verbose=self.verbose).ravel()
+    def score(self, X, y, **kwargs):
+        '''Returns the mean accuracy on the given test data and labels.
 
-    def score(self, X, y):
-        """
-        Returns the mean accuracy on the given test data and labels.
+        # Arguments
+            X : array-like, shape = (n_samples, n_features)
+                Test samples where n_samples in the number of samples
+                and n_features is the number of features.
+            y : array-like, shape = (n_samples)
+                True labels for X.
+            kwargs: dictionary arguments
+                Legal arguments are the arguments of Sequential.evaluate
 
-        Parameters
-        ----------
-        X : array-like, shape = (n_samples, n_features)
-            Test samples where n_samples in the number of samples
-            and n_features is the number of features.
-        y : array-like, shape = (n_samples)
-            True labels for X.
-
-        Returns
-        -------
-        score : float
-            Loss from predictions on X wrt. y.
-        """
-        loss = self.compiled_model_.evaluate(
-            X, y, batch_size=self.test_batch_size, show_accuracy=False, verbose=self.verbose)
+        # Returns
+            score : float
+                Mean accuracy of predictions on X wrt. y.
+        '''
+        kwargs = self.filter_sk_params(Sequential.evaluate, kwargs)
+        kwargs.update({'show_accuracy': False})
+        loss = self.model.evaluate(X, y, **kwargs)
         return loss

--- a/tests/keras/wrappers/test_scikit_learn.py
+++ b/tests/keras/wrappers/test_scikit_learn.py
@@ -37,33 +37,85 @@ y_test = np_utils.to_categorical(y_test, nb_classes=nb_class)
                                                                      output_shape=(1,))
 
 
-@pytest.mark.skipif(K._BACKEND=='tensorflow', reason="currently not working with TensorFlow")
-def test_keras_classifier():
+def build_fn_clf(hidden_dims=50):
     model = Sequential()
     model.add(Dense(input_dim, input_shape=(input_dim,)))
+    model.add(Activation('relu'))
+    model.add(Dense(hidden_dims))
     model.add(Activation('relu'))
     model.add(Dense(nb_class))
     model.add(Activation('softmax'))
-
-    sklearn_clf = KerasClassifier(model, optimizer=optim, loss=loss,
-                                  train_batch_size=batch_size,
-                                  test_batch_size=batch_size,
-                                  nb_epoch=nb_epoch)
-    sklearn_clf.fit(X_train, y_train)
-    sklearn_clf.score(X_test, y_test)
+    model.compile(optimizer='sgd', loss='categorical_crossentropy',
+                  class_mode='binary')
+    return model
 
 
-@pytest.mark.skipif(K._BACKEND=='tensorflow', reason="currently not working with TensorFlow")
-def test_keras_regressor():
+class Class_build_fn_clf(object):
+    def __call__(self, hidden_dims):
+        return build_fn_clf(hidden_dims)
+
+
+class Inherit_class_build_fn_clf(KerasClassifier):
+    def __call__(self, hidden_dims):
+        return build_fn_clf(hidden_dims)
+
+
+def build_fn_reg(hidden_dims=50):
     model = Sequential()
     model.add(Dense(input_dim, input_shape=(input_dim,)))
     model.add(Activation('relu'))
+    model.add(Dense(hidden_dims))
+    model.add(Activation('relu'))
     model.add(Dense(1))
-    model.add(Activation('softmax'))
+    model.add(Activation('linear'))
+    model.compile(optimizer='sgd', loss='mean_absolute_error')
+    return model
 
-    sklearn_regressor = KerasRegressor(model, optimizer=optim, loss=loss,
-                                       train_batch_size=batch_size,
-                                       test_batch_size=batch_size,
-                                       nb_epoch=nb_epoch)
-    sklearn_regressor.fit(X_train_reg, y_train_reg)
-    sklearn_regressor.score(X_test_reg, y_test_reg)
+
+class Class_build_fn_reg(object):
+    def __call__(self, hidden_dims):
+        return build_fn_reg(hidden_dims)
+
+
+class Inherit_class_build_fn_reg(KerasRegressor):
+    def __call__(self, hidden_dims):
+        return build_fn_reg(hidden_dims)
+
+for fn in [build_fn_clf, Class_build_fn_clf(), Inherit_class_build_fn_clf]:
+    if fn is Inherit_class_build_fn_clf:
+        classifier = Inherit_class_build_fn_clf(
+            build_fn=None, hidden_dims=50, batch_size=batch_size, nb_epoch=nb_epoch)
+    else:
+        classifier = KerasClassifier(
+            build_fn=fn, hidden_dims=50, batch_size=batch_size, nb_epoch=nb_epoch)
+
+    classifier.fit(X_train, y_train, batch_size=batch_size, nb_epoch=nb_epoch)
+    score = classifier.score(X_train, y_train, batch_size=batch_size)
+    preds = classifier.predict(X_test, batch_size=batch_size)
+    proba = classifier.predict_proba(X_test, batch_size=batch_size)
+
+
+for fn in [build_fn_reg, Class_build_fn_reg(), Inherit_class_build_fn_reg]:
+    if fn is Inherit_class_build_fn_reg:
+        regressor = Inherit_class_build_fn_reg(
+            build_fn=None, hidden_dims=50, batch_size=batch_size, nb_epoch=nb_epoch)
+    else:
+        regressor = KerasRegressor(
+            build_fn=fn, hidden_dims=50, batch_size=batch_size, nb_epoch=nb_epoch)
+
+    regressor.fit(X_train_reg, y_train_reg,
+                  batch_size=batch_size, nb_epoch=nb_epoch)
+    score = regressor.score(X_train_reg, y_train_reg, batch_size=batch_size)
+    preds = regressor.predict(X_test, batch_size=batch_size)
+
+
+# Usage of sklearn's grid_search
+# from sklearn import grid_search
+# parameters = dict(hidden_dims = [20, 30], batch_size=[64, 128], nb_epoch=[2], verbose=[0])
+# classifier = Inherit_class_build_fn_clf()
+# clf = grid_search.GridSearchCV(classifier, parameters)
+# clf.fit(X_train, y_train)
+# parameters = dict(hidden_dims = [20, 30], batch_size=[64, 128], nb_epoch=[2], verbose=[0])
+# regressor = Inherit_class_build_fn_reg()
+# reg = grid_search.GridSearchCV(regressor, parameters, scoring='mean_squared_error', n_jobs=1, cv=2, verbose=2)
+# reg.fit(X_train_reg, y_train_reg)


### PR DESCRIPTION
Sorry, I don't know how to solve the problem. So I fork again. Please adopt this pull request.

#1825 messages:
Currently, the scikit_learn wrapper can not be used with scikit learn's grid_search api.
Also it's awkward to pass all the parameters used for 'fit', 'predict'... to the init of the wrapper.

I attempt to solve this two problem by refactoring the wrapper. Details are documented in BaseWrapper. Use cases can be seen from the modified check_wrappers.py.