### PR TITLE
Customized initializing function

### DIFF
--- a/keras/initializations.py
+++ b/keras/initializations.py
@@ -84,6 +84,14 @@ def one(shape, name=None):
     return K.ones(shape, name=name)
 
 
+def fn_wrapper(fn):
+    def wrapper(*args, **kwargs):
+        name = kwargs.pop('name') if 'name' in kwargs else None
+        return K.variable(fn(*args, **kwargs), name=name)
+    return wrapper
 from .utils.generic_utils import get_from_module
 def get(identifier):
-    return get_from_module(identifier, globals(), 'initialization')
+    if isinstance(identifier, str):
+        return get_from_module(identifier, globals(), 'initialization')
+    else:
+        return fn_wrapper(identifier)

--- a/tests/integration_tests/test_customized_initialization.py
+++ b/tests/integration_tests/test_customized_initialization.py
@@ -1,0 +1,51 @@
+from __future__ import print_function
+import numpy as np
+import pytest
+
+from keras.utils.test_utils import get_test_data
+from keras.models import Sequential
+from keras.layers.core import Dense, Flatten, Activation
+from keras.layers.convolutional import Convolution2D, MaxPooling2D
+from keras.utils.np_utils import to_categorical
+
+
+import numpy as np
+
+def MyInit(shape):
+    return np.random.uniform(low=-0.3, high=0.3, size=shape)
+
+def test_customized_initialization():
+    '''
+    Classify random 16x16 color images into several classes using logistic regression
+    with convolutional hidden layer.
+    '''
+    np.random.seed(1337)
+    input_shape = (3, 16, 16)
+    (X_train, y_train), (X_test, y_test) = get_test_data(nb_train=500,
+                                                         nb_test=200,
+                                                         input_shape=input_shape,
+                                                         classification=True,
+                                                         nb_class=4)
+    y_train = to_categorical(y_train)
+    y_test = to_categorical(y_test)
+    # convolution kernel size
+    nb_conv = 3
+    # size of pooling area for max pooling
+    nb_pool = 2
+
+    model = Sequential([
+        Convolution2D(nb_filter=8, nb_row=nb_conv, nb_col=nb_conv, input_shape=input_shape, init=MyInit),
+        MaxPooling2D(pool_size=(nb_pool, nb_pool)),
+        Flatten(),
+        Activation('relu'),
+        Dense(y_test.shape[-1], activation='softmax')
+    ])
+    model.compile(loss='categorical_crossentropy', optimizer='sgd')
+    history = model.fit(X_train, y_train, nb_epoch=10, batch_size=16,
+                        validation_data=(X_test, y_test),
+                        show_accuracy=True, verbose=0)
+    assert(history.history['val_acc'][-1] > 0.85)
+
+
+if __name__ == '__main__':
+    pytest.main([__file__])


### PR DESCRIPTION
Currently, to initialize a layer with keras, we use either `init` or `weights` arguments. While it is easy to specify the `init` arguments as one of the provided initializing function, it's rather awkward to initialize the `weights` function. We need to know how many trainable tensor is in that layer and the shape of each tensor, which means that the user needs to look into the source code to accomplish the task.

The limitation of using `init` arguments to initialize a layer is that we can not pass arguments to the initializing function. For example, I was trying to adopt uniform initialization for convolution layer with different `low`, `high` values. I found that the only solution is that I initialize an numpy array outside and then assign it to `weights` argument, which is very awkward, as mentioned.

I modified [keras.initializations.get()](https://github.com/fchollet/keras/blob/master/keras/initializations.py#L88) to solve this problem. However, many documents (especially for layers) need to be rewrite if this change .