### PR TITLE
fix initialization of BatchNormalization

### DIFF
--- a/keras/layers/normalization.py
+++ b/keras/layers/normalization.py
@@ -37,13 +37,21 @@ class BatchNormalization(Layer):
         weights: Initialization weights.
             List of 2 numpy arrays, with shapes:
             `[(input_shape,), (input_shape,)]`
-
+        beta_init: name of initialization function for shift parameter
+            (see [initializations](../initializations.md)), or alternatively,
+            Theano function to use for weights initialization. This parameter
+            is only relevant if you don't pass a `weights` argument.
+        gamma_init: name of initialization function for scale parameter (see
+            [initializations](../initializations.md)), or alternatively, Theano
+            function to use for weights initialization. This parameter is only
+            relevant if you don't pass a `weights` argument.
     # References
         - [Batch Normalization: Accelerating Deep Network Training by Reducing Internal Covariate Shift](http://arxiv.org/pdf/1502.03167v3.pdf)
     '''
     def __init__(self, epsilon=1e-6, mode=0, axis=-1, momentum=0.9,
-                 weights=None, **kwargs):
-        self.init = initializations.get("uniform")
+                 weights=None, beta_init="zero", gamma_init="one", **kwargs):
+        self.beta_init = initializations.get(beta_init)
+        self.gamma_init = initializations.get(gamma_init)
         self.epsilon = epsilon
         self.mode = mode
         self.axis = axis
@@ -55,9 +63,8 @@ class BatchNormalization(Layer):
         input_shape = self.input_shape  # starts with samples axis
         shape = (input_shape[self.axis],)
 
-        self.gamma = self.init(shape,
-                               name='{}_gamma'.format(self.name))
-        self.beta = K.zeros(shape, name='{}_beta'.format(self.name))
+        self.gamma = self.gamma_init(shape, name='{}_gamma'.format(self.name))
+        self.beta = self.beta_init(shape, name='{}_beta'.format(self.name))
         self.trainable_weights = [self.gamma, self.beta]
 
         self.running_mean = K.zeros(shape,


### PR DESCRIPTION
Currently the scaling parameter gamma is uniformly sampled between
-0.05 and 0.05. This also brings the std -0.05 and 0.05 and not to
1 as claimed by the docstring of the BatchNormalization class.

This commit fixes it by initializing gamma to 1.  The same
initialization is used by
(lasagne)[http://lasagne.readthedocs.org/en/latest/modules/layers/normalization.html#lasagne.layers.BatchNormLayer]