### PR TITLE
changed doc `(input_dim,)` to `(output_dim,)`

### DIFF
--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -968,8 +968,8 @@ class Dense(Layer):
             If you don't specify anything, no activation is applied
             (ie. "linear" activation: a(x) = x).
         weights: list of numpy arrays to set as initial weights.
-            The list should have 2 elements, of shape `(input_dim, output_dim)`,
-            and (input_dim,) for weights and biases respectively.
+            The list should have 2 elements, of shape `(input_dim, output_dim)`
+            and (output_dim,) for weights and biases respectively.
         W_regularizer: instance of [WeightRegularizer](../regularizers.md)
             (eg. L1 or L2 regularization), applied to the main weights matrix.
         b_regularizer: instance of [WeightRegularizer](../regularizers.md),
@@ -1082,8 +1082,8 @@ class TimeDistributedDense(MaskedLayer):
             If you don't specify anything, no activation is applied
             (ie. "linear" activation: a(x) = x).
         weights: list of numpy arrays to set as initial weights.
-            The list should have 2 elements, of shape `(input_dim, output_dim)`,
-            and (input_dim,) for weights and biases respectively.
+            The list should have 2 elements, of shape `(input_dim, output_dim)`
+            and (output_dim,) for weights and biases respectively.
         W_regularizer: instance of [WeightRegularizer](../regularizers.md)
             (eg. L1 or L2 regularization), applied to the main weights matrix.
         b_regularizer: instance of [WeightRegularizer](../regularizers.md),
@@ -1964,8 +1964,8 @@ class Highway(Layer):
             If you don't specify anything, no activation is applied
             (ie. "linear" activation: a(x) = x).
         weights: list of numpy arrays to set as initial weights.
-            The list should have 2 elements, of shape `(input_dim, output_dim)`,
-            and (input_dim,) for weights and biases respectively.
+            The list should have 2 elements, of shape `(input_dim, output_dim)`
+            and (output_dim,) for weights and biases respectively.
         W_regularizer: instance of [WeightRegularizer](../regularizers.md)
             (eg. L1 or L2 regularization), applied to the main weights matrix.
         b_regularizer: instance of [WeightRegularizer](../regularizers.md),


### PR DESCRIPTION
Sorry about that. Here's the corrected documentation.

Alternatively, if you want to overwrite the other commit, I amended the https://github.com/kylemcdonald/keras/tree/patch-2 branch in my repo, so if you force merge it you can rewrite history and squash the two commits into one. I don't know if there's a precedent for keeping the history clean with Keras or not, so I wanted to provide the option.

Thanks!