### PR TITLE
Lambda layer enhancements

### DIFF
--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -1524,11 +1524,11 @@ class Lambda(Layer):
         else:
             if py3:
                 assert hasattr(output_shape, '__code__'), ('The Lambda layer "output_shape"'
-                                                    ' argument must be either None, a tuple or a Python function.')                
+                                                    ' argument must be either None, a tuple or a Python function.')
                 self._output_shape = marshal.dumps(output_shape.__code__)
             else:
-                assert hasattr(output_shape, 'unc_code'), ('The Lambda layer "output_shape"'
-                                                    ' argument must be either None, a tuple or a Python function.')  
+                assert hasattr(output_shape, 'func_code'), ('The Lambda layer "output_shape"'
+                                                    ' argument must be either None, a tuple or a Python function.')
                 self._output_shape = marshal.dumps(output_shape.func_code)
         super(Lambda, self).__init__()
 
@@ -1627,7 +1627,7 @@ class LambdaMerge(Lambda):
             assert hasattr(function, 'func_code'), ('The Lambda layer "function"'
                                                     ' argument must be a Python function.')
             self.function = marshal.dumps(function.func_code)
-        arguments = self.arguments
+        self.arguments = arguments
         if output_shape is None:
             self._output_shape = None
         elif type(output_shape) in {tuple, list}:
@@ -1635,11 +1635,11 @@ class LambdaMerge(Lambda):
         else:
             if py3:
                 assert hasattr(output_shape, '__code__'), ('The Lambda layer "output_shape"'
-                                                    ' argument must be either None, a tuple or a Python function.')                
+                                                    ' argument must be either None, a tuple or a Python function.')
                 self._output_shape = marshal.dumps(output_shape.__code__)
             else:
-                assert hasattr(output_shape, 'unc_code'), ('The Lambda layer "output_shape"'
-                                                    ' argument must be either None, a tuple or a Python function.')  
+                assert hasattr(output_shape, 'func_code'), ('The Lambda layer "output_shape"'
+                                                    ' argument must be either None, a tuple or a Python function.') 
                 self._output_shape = marshal.dumps(output_shape.func_code)
         super(Lambda, self).__init__()
 

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -1524,11 +1524,11 @@ class Lambda(Layer):
         else:
             if py3:
                 assert hasattr(output_shape, '__code__'), ('The Lambda layer "output_shape"'
-                                                    ' argument must be either None, a tuple or a Python function.')
+                                                            ' argument must be either None, a tuple or a Python function.')
                 self._output_shape = marshal.dumps(output_shape.__code__)
             else:
                 assert hasattr(output_shape, 'func_code'), ('The Lambda layer "output_shape"'
-                                                    ' argument must be either None, a tuple or a Python function.')
+                                                            ' argument must be either None, a tuple or a Python function.')
                 self._output_shape = marshal.dumps(output_shape.func_code)
         super(Lambda, self).__init__()
 
@@ -1621,10 +1621,10 @@ class LambdaMerge(Lambda):
         py3 = sys.version_info[0] == 3
         if py3:
             self.function = marshal.dumps(function.__code__)
-            assert hasattr(function, '__code__'), ('The Lambda layer "function"'
+            assert hasattr(function, '__code__'), ('The LambdaMerge layer "function"'
                                                     ' argument must be a Python function.')
         else:
-            assert hasattr(function, 'func_code'), ('The Lambda layer "function"'
+            assert hasattr(function, 'func_code'), ('The LambdaMerge layer "function"'
                                                     ' argument must be a Python function.')
             self.function = marshal.dumps(function.func_code)
         self.arguments = arguments
@@ -1634,11 +1634,11 @@ class LambdaMerge(Lambda):
             self._output_shape = tuple(output_shape)
         else:
             if py3:
-                assert hasattr(output_shape, '__code__'), ('The Lambda layer "output_shape"'
+                assert hasattr(output_shape, '__code__'), ('The LambdaMerge layer "output_shape"'
                                                     ' argument must be either None, a tuple or a Python function.')
                 self._output_shape = marshal.dumps(output_shape.__code__)
             else:
-                assert hasattr(output_shape, 'func_code'), ('The Lambda layer "output_shape"'
+                assert hasattr(output_shape, 'func_code'), ('The LambdaMerge layer "output_shape"'
                                                     ' argument must be either None, a tuple or a Python function.') 
                 self._output_shape = marshal.dumps(output_shape.func_code)
         super(Lambda, self).__init__()

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -1502,6 +1502,8 @@ class Lambda(Layer):
             Takes one argument: the output of previous layer
         output_shape: Expected output shape from function.
             Could be a tuple or a function of the shape of the input
+        arguments: Additional arguments for the function to be evaluated.
+            Could be a list or a dictionary.     
     '''
     def __init__(self, function, output_shape=None, arguments={}, **kwargs):
         super(Lambda, self).__init__(**kwargs)
@@ -1595,6 +1597,8 @@ class LambdaMerge(Lambda):
             list of outputs from input layers
         output_shape - Expected output shape from function.
             Could be a tuple or a function of list of input shapes
+        arguments: Additional arguments for the function to be evaluated.
+            Could be a list or a dictionary.     
     '''
     def __init__(self, layers, function, output_shape=None, arguments={}):
         if len(layers) < 2:

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -1523,11 +1523,11 @@ class Lambda(Layer):
             self._output_shape = tuple(output_shape)
         else:
             if py3:
-            	assert hasattr(output_shape, '__code__'), ('The Lambda layer "output_shape"'
+                assert hasattr(output_shape, '__code__'), ('The Lambda layer "output_shape"'
                                                     ' argument must be either None, a tuple or a Python function.')                
                 self._output_shape = marshal.dumps(output_shape.__code__)
             else:
-            	assert hasattr(output_shape, 'unc_code'), ('The Lambda layer "output_shape"'
+                assert hasattr(output_shape, 'unc_code'), ('The Lambda layer "output_shape"'
                                                     ' argument must be either None, a tuple or a Python function.')  
                 self._output_shape = marshal.dumps(output_shape.func_code)
         super(Lambda, self).__init__()
@@ -1560,16 +1560,16 @@ class Lambda(Layer):
         func = types.FunctionType(func, globals())
         arg_spec = inspect.getargspec(func)
         if 'train' in arg_spec.args:
-        	if type(arguments) == dict:
-        		arguments['train'] = train
-       			return func(X, **arguments)
-       		elif type(arguments) == list:
-       			return func(X, *arguments, train=train)
-       	else:
-       		if type(arguments) == dict:
-       			return func(X, **arguments)
-       		elif type(arguments) == list:
-       			return func(X, *arguments)
+            if type(arguments) == dict:
+                arguments['train'] = train
+                return func(X, **arguments)
+            elif type(arguments) == list:
+                return func(X, *arguments, train=train)
+        else:
+            if type(arguments) == dict:
+                return func(X, **arguments)
+            elif type(arguments) == list:
+                return func(X, *arguments)
 
     def get_config(self):
         config = {'name': self.__class__.__name__,
@@ -1634,11 +1634,11 @@ class LambdaMerge(Lambda):
             self._output_shape = tuple(output_shape)
         else:
             if py3:
-            	assert hasattr(output_shape, '__code__'), ('The Lambda layer "output_shape"'
+                assert hasattr(output_shape, '__code__'), ('The Lambda layer "output_shape"'
                                                     ' argument must be either None, a tuple or a Python function.')                
                 self._output_shape = marshal.dumps(output_shape.__code__)
             else:
-            	assert hasattr(output_shape, 'unc_code'), ('The Lambda layer "output_shape"'
+                assert hasattr(output_shape, 'unc_code'), ('The Lambda layer "output_shape"'
                                                     ' argument must be either None, a tuple or a Python function.')  
                 self._output_shape = marshal.dumps(output_shape.func_code)
         super(Lambda, self).__init__()
@@ -1668,16 +1668,16 @@ class LambdaMerge(Lambda):
         arguments = self.arguments
         arg_spec = inspect.getargspec(func)
         if 'train' in arg_spec.args:
-        	if type(arguments) == dict:
-        		arguments['train'] = train
-        		return func(inputs, **arguments)
-        	elif type(arguments) == list:
-        		return func(inputs, *arguments, train=train)
+            if type(arguments) == dict:
+                arguments['train'] = train
+                return func(inputs, **arguments)
+            elif type(arguments) == list:
+                return func(inputs, *arguments, train=train)
         else:
-        	if type(arguments) == dict:
-        		return func(inputs, **arguments)
-        	elif type(arguments) == list:
-        		return func(inputs, *arguments)
+            if type(arguments) == dict:
+                return func(inputs, **arguments)
+            elif type(arguments) == list:
+                return func(inputs, *arguments)
 
     def get_input(self, train=False):
         res = []
@@ -1716,7 +1716,8 @@ class LambdaMerge(Lambda):
         config = {'name': self.__class__.__name__,
                   'layers': [l.get_config() for l in self.layers],
                   'function': self.function,
-                  'output_shape': self._output_shape}
+                  'output_shape': self._output_shape,
+                  'arguments': self.arguments}
         base_config = super(LambdaMerge, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
 


### PR DESCRIPTION
* Add `get_config` to `Lambda`
* Make it possible to pass additional arguments to `Lambda` and `LambdaMerege` layers.
Example:

```python

def linear(x, a, b):
    return x * a + b

model = Sequential()
model.add(Dense(input_dim=10, output_dim=10))
model.add(Lambda(linear, arguments={'a':5, 'b':10}))
#OR:
model.add(Lambda(linear, arguments=[5, 10]))
```

* Enable `Lambda` and `LambdaMerge` layers to behave differently during test and train phases using `train` argument.

Example:

```python

def dropout(x, p=0.2, train=True):
    if train:
        x = K.dropout(x, p)
    return x

model = Sequential()
model.add(Dense(input_dim=10, output_dim=10))
model.add(Lambda(dropout, arguments=[0.5])) # OR arguments={'p': 0.5}
```

* Added some assertions