### PR TITLE
Graph fit(): Fix class_weight having no effect (overriden by empty sample_weight)

### DIFF
--- a/keras/models.py
+++ b/keras/models.py
@@ -1281,7 +1281,9 @@ class Graph(Model, containers.Graph):
 
         sample_weight_list = [standardize_weights(y[i],
                                                   sample_weight=sample_weight.get(self.output_order[i]),
-                                                  sample_weight_mode=self.sample_weight_modes.get(self.output_order[i])) for i in range(len(self.output_order))]
+                                                  sample_weight_mode=self.sample_weight_modes.get(self.output_order[i]))
+                              if sample_weight.get(self.output_order[i]) is not None else None
+                              for i in range(len(self.output_order))]
         class_weight_list = [class_weight.get(name) for name in self.output_order]
 
         val_f = None


### PR DESCRIPTION
Graph's fit(class_weight=...) has no effect as sample_weight_list just above gets all-1 weights instead of None and that overrides class_weight when they are fixed a few lines below.  Not sure why the tests aren't catching this.

(I didn't actually understand the purpose of the two-step mixing, why isn't the final sample_weight_list construed right away? Maybe that deserves an in-code comment...)