### PR TITLE
replace x_generator with x_data_func

### DIFF
--- a/tests/keras/test_callbacks.py
+++ b/tests/keras/test_callbacks.py
@@ -161,13 +161,6 @@ def test_TensorBoard():
                 else:
                     return (X_test[i * batch_size: (i + 1) * batch_size], y_test[i * batch_size: (i + 1) * batch_size])
 
-    def data_generator_graph(train):
-        while 1:
-            if train:
-                yield {'X_vars': X_train, 'output': y_train}
-            else:
-                yield {'X_vars': X_test, 'output': y_test}
-
     # case 1 Sequential
 
     with tf.Graph().as_default():
@@ -245,12 +238,12 @@ def test_TensorBoard():
                   callbacks=cbks, nb_epoch=2)
 
         # fit function with validation
-        model.fit_data_func(data_generator_graph(True).get_data, 1000, nb_epoch=2,
+        model.fit_data_func(data_generator(True).get_data, 1000, nb_epoch=2,
                             validation_data={'X_vars': X_test, 'output': y_test},
                             callbacks=cbks)
 
         # fit function wo validation
-        model.fit_data_func(data_generator_graph(True).get_data, 1000, nb_epoch=2,
+        model.fit_data_func(data_generator(True).get_data, 1000, nb_epoch=2,
                             callbacks=cbks)
 
         assert os.path.exists(filepath)

--- a/tests/keras/test_graph_model.py
+++ b/tests/keras/test_graph_model.py
@@ -26,13 +26,18 @@ batch_size = 32
                                                                                  output_shape=(1,))
 
 
-def test_graph_fit_generator():
-    def data_generator_graph(train):
-        while 1:
-            if train:
-                yield {'input1': X_train_graph, 'output1': y_train_graph}
-            else:
-                yield {'input1': X_test_graph, 'output1': y_test_graph}
+def test_graph_fit_data_func():
+
+    class data_generator_graph:
+        def __init__(self, train):
+            self.train = train
+
+        def get_data(self):
+            while 1:
+                if self.train:
+                    return {'input1': X_train_graph, 'output1': y_train_graph}
+                else:
+                    return {'input1': X_test_graph, 'output1': y_test_graph}
 
     graph = Graph()
     graph.add_input(name='input1', input_shape=(32,))
@@ -46,16 +51,16 @@ def test_graph_fit_generator():
                      merge_mode='sum')
     graph.compile('rmsprop', {'output1': 'mse'})
 
-    graph.fit_generator(data_generator_graph(True), 1000, nb_epoch=4)
-    graph.fit_generator(data_generator_graph(True), 1000, nb_epoch=4)
-    graph.fit_generator(data_generator_graph(True), 1000, nb_epoch=4, validation_data={'input1': X_test_graph, 'output1': y_test_graph})
-    graph.fit_generator(data_generator_graph(True), 1000, nb_epoch=4, validation_data={'input1': X_test_graph, 'output1': y_test_graph})
-    graph.fit_generator(data_generator_graph(True), 1000, nb_epoch=4,
-                        validation_data=data_generator_graph(False), nb_val_samples=batch_size * 3)
-    graph.fit_generator(data_generator_graph(True), 1000, nb_epoch=4,
-                        validation_data=data_generator_graph(False), nb_val_samples=batch_size * 3)
+    graph.fit_data_func(data_generator_graph(True).get_data, 1000, nb_epoch=4)
+    graph.fit_data_func(data_generator_graph(True).get_data, 1000, nb_epoch=4)
+    graph.fit_data_func(data_generator_graph(True).get_data, 1000, nb_epoch=4, validation_data={'input1': X_test_graph, 'output1': y_test_graph})
+    graph.fit_data_func(data_generator_graph(True).get_data, 1000, nb_epoch=4, validation_data={'input1': X_test_graph, 'output1': y_test_graph})
+    graph.fit_data_func(data_generator_graph(True).get_data, 1000, nb_epoch=4,
+                        validation_data=data_generator_graph(False).get_data, nb_val_samples=batch_size * 3)
+    graph.fit_data_func(data_generator_graph(True).get_data, 1000, nb_epoch=4,
+                        validation_data=data_generator_graph(False).get_data, nb_val_samples=batch_size * 3)
 
-    gen_loss = graph.evaluate_generator(data_generator_graph(True), 128, verbose=0)
+    gen_loss = graph.evaluate_data_func(data_generator_graph(True).get_data, 128, verbose=0)
     assert(gen_loss < 3.)
 
     loss = graph.evaluate({'input1': X_test_graph, 'output1': y_test_graph}, verbose=0)
@@ -401,4 +406,5 @@ def test_count_params():
 
 
 if __name__ == '__main__':
-    pytest.main([__file__])
+    test_graph_fit_data_func()
+    # pytest.main([__file__])


### PR DESCRIPTION
Replaced methods accepting generators with methods accepting callables returning the data object; changed associated tests.

The fundamental justification:
 - as discovered in #1857 `nb_worker` is useless with generators because Python by design does not allow more than one thread to execute a generator. Multiple worker threads simply fight over which one will get the generator next. Letting the methods take a simple callable instead allows for true parallelism, at the expense of slightly more verbose data-preprocessing functions. I don't believe this can be avoided in a truly parallel solution.

Some obvious reasons against merging this request:
 - it will break any existing code using `x_generator` in a nontrivial way
 - it's a big, and therefore risky, change
 - it might be simpler to simply get rid of `nb_worker` and say that if the user wants parallelism he must implement it within-generator

Nonetheless I put this code up for consideration.