### PR TITLE
Tensorflow: reverse mask on go_backwards.

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -469,6 +469,9 @@ def rnn(step_function, inputs, initial_states,
         mask = tf.cast(tf.transpose(mask, axes), tf.bool)
         mask_list = tf.unpack(mask)
 
+        if go_backwards:
+            mask_list.reverse()
+
         for input, mask_t in zip(input_list, mask_list):
             output, new_states = step_function(input, states + constants)
 


### PR DESCRIPTION
Results on backwards RNNs were dramatically lower on Tensorflow, compared to Theano. It turns out that in Tensorflow the reversed input is used in conjunction with the mask in non-reversed order. This change reverses the mask when going backwards.