### PR TITLE
Allow passing kwargs down to K.function

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1,6 +1,7 @@
 import tensorflow as tf
 import numpy as np
 import os
+import warnings
 from .common import _FLOATX, _EPSILON
 
 # INTERNAL UTILS
@@ -403,6 +404,12 @@ class Function(object):
 
 
 def function(inputs, outputs, updates=[], **kwargs):
+    if len(kwargs) > 0:
+        msg = [
+            "Expected no kwargs, you passed %s" % len(kwargs),
+            "kwargs passed to function are ignored with Tensorflow backend"
+        ]
+        warnings.warn('\n'.join(msg))
     return Function(inputs, outputs, updates=updates)
 
 

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -402,7 +402,7 @@ class Function(object):
         return updated[:len(self.outputs)]
 
 
-def function(inputs, outputs, updates=[]):
+def function(inputs, outputs, updates=[], **kwargs):
     return Function(inputs, outputs, updates=updates)
 
 

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -3,6 +3,7 @@ from theano import tensor as T
 from theano.sandbox.rng_mrg import MRG_RandomStreams as RandomStreams
 from theano.tensor.signal import pool
 from theano.tensor.nnet import conv3d2d
+import inspect
 import numpy as np
 from .common import _FLOATX, _EPSILON
 
@@ -450,6 +451,12 @@ class Function(object):
 
 
 def function(inputs, outputs, updates=[], **kwargs):
+    if len(kwargs) > 0:
+        function_args = inspect.getargspec(theano.function)[0]
+        for key in kwargs.keys():
+            if key not in function_args:
+                msg = "Invalid argument '%s' passed to K.function" % key
+                raise ValueError(msg)
     return Function(inputs, outputs, updates=updates, **kwargs)
 
 

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -449,8 +449,8 @@ class Function(object):
         return self.function(*inputs)
 
 
-def function(inputs, outputs, updates=[]):
-    return Function(inputs, outputs, updates=updates)
+def function(inputs, outputs, updates=[], **kwargs):
+    return Function(inputs, outputs, updates=updates, **kwargs)
 
 
 def gradients(loss, variables):

--- a/keras/models.py
+++ b/keras/models.py
@@ -471,7 +471,8 @@ class Sequential(Model, containers.Sequential):
     '''
     def compile(self, optimizer, loss,
                 class_mode="categorical",
-                sample_weight_mode=None):
+                sample_weight_mode=None,
+                **kwargs):
         '''Configure the learning process.
 
         # Arguments
@@ -485,6 +486,8 @@ class Sequential(Model, containers.Sequential):
             sample_weight_mode: if you need to do timestep-wise
                 sample weighting (2D weights), set this to "temporal".
                 "None" defaults to sample-wise weights (1D).
+            kwargs: for Theano backend, these are passed into K.function.
+                Ignored for Tensorflow backend.
         '''
         self.optimizer = optimizers.get(optimizer)
         self.sample_weight_mode = sample_weight_mode
@@ -544,11 +547,18 @@ class Sequential(Model, containers.Sequential):
             test_ins = [self.X_test, self.y, self.weights]
             predict_ins = [self.X_test]
 
-        self._train = K.function(train_ins, [train_loss], updates=updates)
-        self._train_with_acc = K.function(train_ins, [train_loss, train_accuracy], updates=updates)
-        self._predict = K.function(predict_ins, [self.y_test], updates=self.state_updates)
-        self._test = K.function(test_ins, [test_loss], updates=self.state_updates)
-        self._test_with_acc = K.function(test_ins, [test_loss, test_accuracy], updates=self.state_updates)
+        self._train = K.function(train_ins, [train_loss],
+                                 updates=updates, **kwargs)
+        self._train_with_acc = K.function(train_ins,
+                                          [train_loss, train_accuracy],
+                                          updates=updates, **kwargs)
+        self._predict = K.function(predict_ins, [self.y_test],
+                                   updates=self.state_updates, **kwargs)
+        self._test = K.function(test_ins, [test_loss],
+                                updates=self.state_updates, **kwargs)
+        self._test_with_acc = K.function(test_ins,
+                                         [test_loss, test_accuracy],
+                                         updates=self.state_updates, **kwargs)
 
     def fit(self, X, y, batch_size=128, nb_epoch=100, verbose=1, callbacks=[],
             validation_split=0., validation_data=None, shuffle=True,
@@ -1173,7 +1183,7 @@ class Graph(Model, containers.Graph):
 
     Inherits from `containers.Graph`.
     '''
-    def compile(self, optimizer, loss, sample_weight_modes={}):
+    def compile(self, optimizer, loss, sample_weight_modes={}, **kwargs):
         '''Configure the learning process.
 
         # Arguments
@@ -1188,6 +1198,8 @@ class Graph(Model, containers.Graph):
                 timestep-wise loss weighting on one of your graph outputs,
                 you will need to set the sample weight mode for this output
                 to "temporal".
+            kwargs: for Theano backend, these are passed into K.function.
+                Ignored for Tensorflow backend.
         '''
         assert type(loss) is dict, 'The "loss" argument should be a dictionary.'
         assert type(sample_weight_modes) is dict, 'The "sample_weight_modes" argument should be a dictionary.'
@@ -1236,10 +1248,12 @@ class Graph(Model, containers.Graph):
         updates += self.updates
         self.loss = loss
 
-        self._train = K.function(train_ins, [train_loss], updates=updates)
-        self._test = K.function(test_ins, [test_loss], updates=self.state_updates)
+        self._train = K.function(train_ins, [train_loss],
+                                 updates=updates, **kwargs)
+        self._test = K.function(test_ins, [test_loss],
+                                updates=self.state_updates, **kwargs)
         self._predict = K.function(inputs=ins, outputs=ys_test,
-                                   updates=self.state_updates)
+                                   updates=self.state_updates, **kwargs)
 
     def fit(self, data, batch_size=128, nb_epoch=100, verbose=1, callbacks=[],
             validation_split=0., validation_data=None, shuffle=True,


### PR DESCRIPTION
This PR allows the user to pass `kwargs` down to `K.function` when calling `model.compile`.  For the Theano backend, there are useful compile time arguments that are not available via environmental variables or other means.  I don't know if there are equivalent flags for Tensorflow and have ignored them in this case.

Specifically, my use case needs to set `on_unused_input` to something other then `'raise'` (see http://deeplearning.net/software/theano/library/compile/function.html#function.function).  I'm using the `Graph` API and have loss functions that don't depend on `y_true`.  I'd also like to expose the results of intermediate layers in the final output without involving them in the final loss function.  In both cases, Theano throws a compile time error if `on_unused_input='raise'` (the default).
