### PR TITLE
Fixed get_config for SReLU.

### DIFF
--- a/keras/layers/advanced_activations.py
+++ b/keras/layers/advanced_activations.py
@@ -280,7 +280,6 @@ class SReLU(MaskedLayer):
 
     def get_config(self):
         return {'name': self.__class__.__name__,
-                'input_shape': self.input_shape,
                 't_left_init': self.t_left_init.__name__,
                 'a_left_init': self.a_left_init.__name__,
                 't_right_init': self.t_right_init.__name__,

--- a/keras/layers/advanced_activations.py
+++ b/keras/layers/advanced_activations.py
@@ -281,7 +281,7 @@ class SReLU(MaskedLayer):
     def get_config(self):
         return {'name': self.__class__.__name__,
                 'input_shape': self.input_shape,
-                't_left_init': self.t_left_init,
-                'a_left_init': self.a_left_init,
-                't_right_init': self.t_right_init,
-                'a_right_init': self.a_right_init}
+                't_left_init': self.t_left_init.__name__,
+                'a_left_init': self.a_left_init.__name__,
+                't_right_init': self.t_right_init.__name__,
+                'a_right_init': self.a_right_init.__name__}


### PR DESCRIPTION
A model with ```SReLU``` can't be saved as JSON. Halts with ```TypeError: Not JSON Serializable```. This fixes this issue.