### PR TITLE
Implement Kim's CNN

### DIFF
--- a/examples/imdb_cnn.py
+++ b/examples/imdb_cnn.py
@@ -2,7 +2,7 @@
 
 Run on GPU: THEANO_FLAGS=mode=FAST_RUN,device=gpu,floatX=float32 python imdb_cnn.py
 
-Get to 0.835 test accuracy after 2 epochs. 100s/epoch on K520 GPU.
+Get to 0.835 test accuracy after 2 epochs. 100s/epoch on K40c GPU.
 '''
 
 from __future__ import print_function

--- a/examples/imdb_cnn.py
+++ b/examples/imdb_cnn.py
@@ -2,7 +2,7 @@
 
 Run on GPU: THEANO_FLAGS=mode=FAST_RUN,device=gpu,floatX=float32 python imdb_cnn.py
 
-Get to 0.845 test accuracy after 2 epochs. 100s/epoch on K520 GPU.
+Get to 0.835 test accuracy after 2 epochs. 100s/epoch on K520 GPU.
 '''
 
 from __future__ import print_function
@@ -76,13 +76,11 @@ model.add(c)
 # so that we can add a vanilla dense layer:
 model.add(Flatten())
 
-# We add a vanilla hidden layer and clip gradients as described in the paper
-model.add(Dense(hidden_dims,  W_constraint=MaxNorm(m=3, axis=0)))
+# Add dropout at penultimate layer
 model.add(Dropout(0.5))
-model.add(Activation('relu'))
 
-# We project onto a single unit output layer, and squash it with a sigmoid:
-model.add(Dense(1))
+# Fully connected with clipping regularization
+model.add(Dense(1,  W_constraint=MaxNorm(m=3, axis=0)))
 model.add(Activation('sigmoid'))
 
 # The paper adopt adadelta.

--- a/examples/imdb_cnn.py
+++ b/examples/imdb_cnn.py
@@ -2,7 +2,7 @@
 
 Run on GPU: THEANO_FLAGS=mode=FAST_RUN,device=gpu,floatX=float32 python imdb_cnn.py
 
-Get to 0.841 test accuracy after 2 epochs. 100s/epoch on K520 GPU.
+Get to 0.845 test accuracy after 2 epochs. 100s/epoch on K520 GPU.
 '''
 
 from __future__ import print_function
@@ -77,7 +77,7 @@ model.add(c)
 model.add(Flatten())
 
 # We add a vanilla hidden layer and clip gradients as described in the paper
-model.add(Dense(hidden_dims,  W_constraint=MaxNorm(m=3, axis=1)))
+model.add(Dense(hidden_dims,  W_constraint=MaxNorm(m=3, axis=0)))
 model.add(Dropout(0.5))
 model.add(Activation('relu'))
 

--- a/examples/imdb_cnn.py
+++ b/examples/imdb_cnn.py
@@ -2,7 +2,7 @@
 
 Run on GPU: THEANO_FLAGS=mode=FAST_RUN,device=gpu,floatX=float32 python imdb_cnn.py
 
-Get to 0.835 test accuracy after 2 epochs. 100s/epoch on K40c GPU.
+Get to 0.835 test accuracy after 2 epochs on K40c GPU.
 '''
 
 from __future__ import print_function


### PR DESCRIPTION
I found that the original imdb_cnn example uses an pool_length=2, which is very different from  Kim's paper "Convolutional Neural Networks for Sentence Classification". I can not reproduce Kim's results with this implementation. It took me a whole two days to find out the cause of the problem. So I think to save others' future hard work, it's better to make it right at the beginning.

A similar implementation can be found at https://gist.github.com/entron/b9bc61a74e7cadeb1fec
The difference between mine ant that is that I implement the regulation of the penultimate layer as described in the paper (though it does not really matter for me to reproduce Kim's result)