### PR TITLE
Depreciate input argument of add_node & add_output

### DIFF
--- a/keras/layers/containers.py
+++ b/keras/layers/containers.py
@@ -460,7 +460,7 @@ class Graph(Layer):
         layer.shape_cache = self.shape_cache
         self.nodes[name] = layer
         self.node_config.append({'name': name,
-                                 'input': input,
+                                 'inputs': inputs,
                                  'merge_mode': merge_mode,
                                  'concat_axis': concat_axis,
                                  'dot_axes': dot_axes,

--- a/keras/layers/containers.py
+++ b/keras/layers/containers.py
@@ -433,7 +433,7 @@ class Graph(Layer):
         layer.name = name
         if 'input' in kwargs:
             print ('input will be depreciated, please use inputs instead')
-            inputs = input
+            inputs = kwargs['input']
         if not isinstance(inputs, list):  # Single input
             input =inputs
             if input not in self.namespace:
@@ -567,7 +567,7 @@ class Graph(Layer):
             raise Exception('Duplicate output identifier: ' + name)
         if 'input' in kwargs:
             print ('input will be depreciated, please use inputs instead')
-            inputs = input
+            inputs = kwargs['input']
         if not isinstance(inputs, list):  # Single input
             input =inputs
             if input not in self.namespace:

--- a/keras/layers/containers.py
+++ b/keras/layers/containers.py
@@ -434,7 +434,8 @@ class Graph(Layer):
         if 'input' in kwargs:
             print ('input will be depreciated, please use inputs instead')
             inputs = kwargs['input']
-        if not isinstance(inputs, list):  # Single input
+        # Single input
+        if not isinstance(inputs, list) or (isinstance(inputs, list) and len(inputs)==1):
             input =inputs
             if input not in self.namespace:
                 raise Exception('Unknown node/input identifier: ' + input)
@@ -442,7 +443,8 @@ class Graph(Layer):
                 layer.set_previous(self.nodes[input])
             elif input in self.inputs:
                 layer.set_previous(self.inputs[input])
-        else:                           # Mutiple inputs
+        # Mutiple inputs
+        else:
             to_merge = []
             for n in inputs:
                 if n in self.nodes:
@@ -568,7 +570,8 @@ class Graph(Layer):
         if 'input' in kwargs:
             print ('input will be depreciated, please use inputs instead')
             inputs = kwargs['input']
-        if not isinstance(inputs, list):  # Single input
+        # Single input
+        if not isinstance(inputs, list) or (isinstance(inputs, list) and len(inputs)==1):
             input =inputs
             if input not in self.namespace:
                 raise Exception('Unknown node/input identifier: ' + input)
@@ -576,6 +579,7 @@ class Graph(Layer):
                 self.outputs[name] = self.nodes[input]
             elif input in self.inputs:
                 self.outputs[name] = self.inputs[input]
+        # Mutiple inputs
         else:
             to_merge = []
             for n in inputs:

--- a/keras/layers/containers.py
+++ b/keras/layers/containers.py
@@ -410,7 +410,7 @@ class Graph(Layer):
 
     def add_node(self, layer, name, inputs=[],
                  merge_mode='concat', concat_axis=-1, dot_axes=-1,
-                 create_output=False):
+                 create_output=False, **kwargs):
         '''Add a node in the graph. It can be connected to multiple
         inputs, which will first be merged into one tensor
         according to the mode specified.


### PR DESCRIPTION
I found the `input` and `inputs` argument of `add_node` and `add_output` not quite convenient for user. An example:
```python
        c = containers.Graph()
        c.add_input(name='input', input_shape=(inp_dim, embedding_dim))
        inps = []
        for i in filter_length:
            c.add_node(containers.Sequential([Convolution1D(nb_filter=nb_filter,
                                                            filter_length=i,
                                                            border_mode='valid',
                                                            activation='relu',
                                                            subsample_length=1,
                                                            input_shape=(inp_dim, embedding_dim),),
                                              MaxPooling1D(pool_length=inp_dim-i+1),
                                              Flatten()]),
                       name='Conv{}'.format(i), input='input')
            inps.append('Conv{}'.format(i))

        if len(inps) == 1:
            c.add_output('output', input=inps[0])
        else:
            c.add_output('output', inputs=inps)

```

User needs to check the number of input themselves, which I think should be done by keras.
I modified the api so that user can squash the last four lines into:
```python
c.add_output('output', inputs=inps)
```