### PR TITLE
Warn when epoch sees more samples than expected

### DIFF
--- a/keras/models.py
+++ b/keras/models.py
@@ -1160,6 +1160,8 @@ class Sequential(Model, containers.Sequential):
                 samples_seen += batch_size
 
                 # epoch finished
+                if samples_seen > samples_per_epoch:
+                    warnings.warn('Epoch contained duplicated samples which might affect learning results. Set "samples_per_epoch" correctly to avoid this warning.')
                 if samples_seen >= samples_per_epoch and do_validation:
                     if val_gen:
                         val_outs = self.evaluate_generator(validation_data,

--- a/keras/models.py
+++ b/keras/models.py
@@ -1161,7 +1161,7 @@ class Sequential(Model, containers.Sequential):
 
                 # epoch finished
                 if samples_seen > samples_per_epoch:
-                    warnings.warn('Epoch contained duplicated samples which might affect learning results. Set "samples_per_epoch" correctly to avoid this warning.')
+                    warnings.warn('Epoch contained too many samples which might affect learning results. Set "samples_per_epoch" correctly to avoid this warning.')
                 if samples_seen >= samples_per_epoch and do_validation:
                     if val_gen:
                         val_outs = self.evaluate_generator(validation_data,


### PR DESCRIPTION
Added a warning in `model.fit_generator()` if the batch generator produces more samples than expected by `samples_per_epoch`. However, the training could continue as before because learned weights would probably not be too affected in most cases.