### PR TITLE
Add a check for output layer(s) in graph model

### DIFF
--- a/keras/models.py
+++ b/keras/models.py
@@ -1232,6 +1232,8 @@ class Graph(Model, containers.Graph):
         weights = []
         train_loss = 0.
         test_loss = 0.
+
+        assert len(self.output_order) > 0, 'There must be at least one output layer in a graph model.'
         for output_name in self.output_order:
             loss_fn = loss[output_name]
             output = self.outputs[output_name]

--- a/tests/keras/test_graph_model.py
+++ b/tests/keras/test_graph_model.py
@@ -420,6 +420,14 @@ def test_count_params():
 
     assert(n == graph.count_params())
 
+def test_no_output_layer():
+    # Catch the when there are no output layers early
+
+    graph = Graph()
+    graph.add_input(name='input1', input_shape=(32,))
+    graph.add_node(Dense(2), name='dense3', input='input1')
+
+    pytest.raises(AssertionError, graph.compile, 'rmsprop', {})
 
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
This prevents new users from running into debugging hell if they make the innocent mistake of forgetting to add an output layer to a graph model.
