### PR TITLE
Use T.nnet.conv2d interface

### DIFF
--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -681,12 +681,10 @@ def conv2d(x, kernel, strides=(1, 1), border_mode='valid', dim_ordering='th',
                              filter_shape=filter_shape)
 
     if border_mode == 'same':
-        slices = [slice(None)] * 4
         if np_kernel.shape[2] % 2 == 0:
-            slices[2] = slice((x.shape[2]+strides[0]-1) // strides[0])
+            conv_out = conv_out[:,:,:(x.shape[2]+strides[0]-1) // strides[0],:]
         if np_kernel.shape[3] % 2 == 0:
-            slices[3] = slice((x.shape[3]+strides[1]-1) // strides[1])
-        conv_out = conv_out[slices]
+            conv_out = conv_out[:,:,:,:(x.shape[3]+strides[1]-1) // strides[1]]
 
     if dim_ordering == 'tf':
         conv_out = conv_out.dimshuffle((0, 2, 3, 1))

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -663,8 +663,10 @@ def conv2d(x, kernel, strides=(1, 1), border_mode='valid', dim_ordering='th',
 
     # Theano might not accept like longs
     def int_or_none(value):
-        try: return int(value)
-        except TypeError: return None
+        try:
+            return int(value)
+        except TypeError:
+            return None
 
     if image_shape is not None:
         image_shape = tuple(int_or_none(v) for v in image_shape)


### PR DESCRIPTION
T.nnet.conv.conv2d has been deprecated in favor of [T.nnet.conv2d](http://deeplearning.net/software/theano/library/tensor/nnet/conv.html#theano.tensor.nnet.conv2d).

I also removed the direct usage of cuDNN ops (they're used by default anyway)