### PR TITLE
added bettter reset() function to sequential model

### DIFF
--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -1011,7 +1011,11 @@ class Dense(Layer):
         super(Dense, self).__init__(**kwargs)
 
     def build(self):
-        self.init_weights()
+        self.input_dim = self.input_shape[1]
+
+        (self.W, self.b) = self.init_weights()
+
+        self.trainable_weights = [self.W, self.b]
 
         self.regularizers = []
         if self.W_regularizer:
@@ -1031,20 +1035,18 @@ class Dense(Layer):
             del self.initial_weights
 
     def init_weights(self):
-        input_dim = self.input_shape[1]
-
-        self.W = self.init((input_dim, self.output_dim),
+        W = self.init((self.input_dim, self.output_dim),
                            name='{}_W'.format(self.name))
-        self.b = K.zeros((self.output_dim,),
+        b = K.zeros((self.output_dim,),
                          name='{}_b'.format(self.name))
 
-        self.trainable_weights = [self.W, self.b]
+        return (W, b)
 
     def reinit_weights(self):
-        input_dim = self.input_shape[1]
-        new_weights = self.init((input_dim, self.output_dim), name='{}_W'.format(self.name))
+        new_weights = self.init_weights()
 
-        self.trainable_weights[0].set_value(new_weights.get_value())
+        self.trainable_weights[0].set_value(new_weights[0].get_value())
+        self.trainable_weights[1].set_value(new_weights[1].get_value())
 
     @property
     def output_shape(self):
@@ -1139,7 +1141,11 @@ class TimeDistributedDense(MaskedLayer):
         super(TimeDistributedDense, self).__init__(**kwargs)
 
     def build(self):
-        self.init_weights()
+        self.input_dim = self.input_shape[2]
+
+        (self.W, self.b) = self.init_weights()
+
+        self.trainable_weights = [self.W, self.b]
 
         self.regularizers = []
 
@@ -1160,21 +1166,18 @@ class TimeDistributedDense(MaskedLayer):
             del self.initial_weights
 
     def init_weights(self):
-        input_dim = self.input_shape[2]
-
-        self.W = self.init((input_dim, self.output_dim),
+        W = self.init((self.input_dim, self.output_dim),
                            name='{}_W'.format(self.name))
-        self.b = K.zeros((self.output_dim,),
+        b = K.zeros((self.output_dim,),
                          name='{}_b'.format(self.name))
 
-        self.trainable_weights = [self.W, self.b]
+        return (W, b)
 
     def reinit_weights(self):
-        input_dim = self.input_shape[2]
-        new_weights = self.W = self.init((input_dim, self.output_dim),
-                           name='{}_W'.format(self.name))
+        new_weights = self.init_weights()
 
-        self.trainable_weights[0].set_value(new_weights.get_value())
+        self.trainable_weights[0].set_value(new_weights[0].get_value())
+        self.trainable_weights[1].set_value(new_weights[1].get_value())
 
     @property
     def output_shape(self):
@@ -1459,7 +1462,10 @@ class MaxoutDense(Layer):
         super(MaxoutDense, self).__init__(**kwargs)
 
     def build(self):
-        self.init_weights()
+        self.input_dim = self.input_shape[1]
+        (self.W, self.b) = self.init_weights()
+
+        self.trainable_weights = [self.W, self.b]
 
         self.regularizers = []
 
@@ -1480,21 +1486,17 @@ class MaxoutDense(Layer):
             del self.initial_weights
 
     def init_weights(self):
-        input_dim = self.input_shape[1]
-
-        self.W = self.init((self.nb_feature, input_dim, self.output_dim),
-                           name='{}_W'.format(self.name))
-        self.b = K.zeros((self.nb_feature, self.output_dim),
-                         name='{}_b'.format(self.name))
-
-        self.trainable_weights = [self.W, self.b]
+        W = self.init((self.nb_feature, self.input_dim, self.output_dim),
+                      name='{}_W'.format(self.name))
+        b = K.zeros((self.nb_feature, self.output_dim),
+                    name='{}_b'.format(self.name))
+        return (W, b)
 
     def reinit_weights(self):
-        input_dim = self.input_shape[1]
-        new_weights = self.init((self.nb_feature, input_dim, self.output_dim),
-                           name='{}_W'.format(self.name))
+        new_weights = self.init_weights()
 
-        self.trainable_weights[0].set_value(new_weights.get_value())
+        self.trainable_weights[0].set_value(new_weights[0].get_value())
+        self.trainable_weights[1].set_value(new_weights[1].get_value())
 
     @property
     def output_shape(self):
@@ -2048,7 +2050,11 @@ class Highway(Layer):
         super(Highway, self).__init__(**kwargs)
 
     def build(self):
-        self.init_weights()
+        self.input_dim = self.input_shape[1]
+
+        (self.W, self.b, self.W_carry, self.b_carry) = self.init_weights()
+
+        self.trainable_weights = [self.W, self.b, self.W_carry, self.b_carry]
 
         self.regularizers = []
         if self.W_regularizer:
@@ -2068,29 +2074,23 @@ class Highway(Layer):
             del self.initial_weights
 
     def init_weights(self):
-        input_dim = self.input_shape[1]
-
-        self.W = self.init((input_dim, input_dim),
+        W = self.init((self.input_dim, self.input_dim),
                            name='{}_W'.format(self.name))
-        self.W_carry = self.init((input_dim, input_dim),
+        W_carry = self.init((self.input_dim, self.input_dim),
                                  name='{}_W_carry'.format(self.name))
 
-        self.b = K.zeros((input_dim,), name='{}_b'.format(self.name))
+        b = K.zeros((self.input_dim,), name='{}_b'.format(self.name))
         # initialize with a vector of values `transform_bias`
-        self.b_carry = K.variable(np.ones((input_dim,)) * self.transform_bias,
+        b_carry = K.variable(np.ones((self.input_dim,)) * self.transform_bias,
                                   name='{}_b_carry'.format(self.name))
 
-        self.trainable_weights = [self.W, self.b, self.W_carry, self.b_carry]
+        return (W, b, W_carry, b_carry)
 
     def reinit_weights(self):
-        input_dim = self.input_shape[1]
-        new_weights = self.init((input_dim, input_dim),
-                           name='{}_W'.format(self.name))
-        new_weights_carry = self.init((input_dim, input_dim),
-                                 name='{}_W_carry'.format(self.name))
+        new_weights = self.init_weights()
 
-        self.trainable_weights[0].set_value(new_weights.get_value())
-        self.trainable_weights[2].set_value(new_weights_carry.get_value())
+        for i in range(len(self.trainable_weights)):
+            self.trainable_weights[i].set_value(new_weights[i].get_value())
 
     @property
     def output_shape(self):

--- a/keras/layers/embeddings.py
+++ b/keras/layers/embeddings.py
@@ -53,6 +53,8 @@ class Embedding(Layer):
                  W_constraint=None,
                  mask_zero=False,
                  weights=None, dropout=0., **kwargs):
+        self.resettable = True
+
         self.input_dim = input_dim
         self.output_dim = output_dim
         self.init = initializations.get(init)
@@ -73,8 +75,7 @@ class Embedding(Layer):
     def build(self):
         self.input = K.placeholder(shape=(self.input_shape[0], self.input_length),
                                    dtype='int32')
-        self.W = self.init((self.input_dim, self.output_dim),
-                           name='{}_W'.format(self.name))
+        self.W = self.init_weights()
         self.trainable_weights = [self.W]
         self.regularizers = []
         if self.W_regularizer:
@@ -87,6 +88,14 @@ class Embedding(Layer):
 
         if self.initial_weights is not None:
             self.set_weights(self.initial_weights)
+
+    def init_weights(self):
+        return self.init((self.input_dim, self.output_dim),
+                           name='{}_W'.format(self.name))
+
+    def reinit_weights(self):
+        W = self.init_weights()
+        self.trainable_weights[0].set_value(W.get_value())
 
     def get_output_mask(self, train=None):
         X = self.get_input(train)

--- a/keras/models.py
+++ b/keras/models.py
@@ -181,6 +181,7 @@ def model_from_config(config, custom_objects={}, reset=False):
     elif model_name == 'Sequential':
         model.__class__ = Sequential
         model.name = model_name
+        model.name = model_name
         if reset:
             for layer in model.layers:
                 layer.build()

--- a/keras/models.py
+++ b/keras/models.py
@@ -468,7 +468,7 @@ class Model(object):
         model_summary(self)
 
     def reset(self):
-        ''' Reset all weights and biases to random values
+        ''' Reset all weights and biases to random values, then recompiles
 
         Returns: Model
         '''

--- a/keras/models.py
+++ b/keras/models.py
@@ -181,7 +181,6 @@ def model_from_config(config, custom_objects={}, reset=False):
     elif model_name == 'Sequential':
         model.__class__ = Sequential
         model.name = model_name
-        model.name = model_name
         if reset:
             for layer in model.layers:
                 layer.build()

--- a/keras/models.py
+++ b/keras/models.py
@@ -468,7 +468,7 @@ class Model(object):
         model_summary(self)
 
     def reset(self):
-        ''' Reset all weights and biases to random values, then recompiles
+        ''' Reset all weights and biases to random values
 
         Returns: Model
         '''

--- a/keras/models.py
+++ b/keras/models.py
@@ -166,7 +166,7 @@ def model_from_json(json_string, custom_objects={}):
     return model_from_config(config, custom_objects=custom_objects)
 
 
-def model_from_config(config, custom_objects={}):
+def model_from_config(config, custom_objects={}, reset=False):
     '''
     '''
     model_name = config.get('name')
@@ -181,6 +181,10 @@ def model_from_config(config, custom_objects={}):
     elif model_name == 'Sequential':
         model.__class__ = Sequential
         model.name = model_name
+        model.name = model_name
+        if reset:
+            for layer in model.layers:
+                layer.build()
 
     if 'optimizer' in config:
         # if it has an optimizer, the model is assumed to be compiled
@@ -462,6 +466,14 @@ class Model(object):
         include parameter count information.
         '''
         model_summary(self)
+
+    def reset(self):
+        ''' Reset all weights and biases to random values
+
+        Returns: Model
+        '''
+
+        return model_from_config(self.get_config(), reset=True)
 
 
 class Sequential(Model, containers.Sequential):

--- a/keras/models.py
+++ b/keras/models.py
@@ -166,7 +166,7 @@ def model_from_json(json_string, custom_objects={}):
     return model_from_config(config, custom_objects=custom_objects)
 
 
-def model_from_config(config, custom_objects={}, reset=False):
+def model_from_config(config, custom_objects={}):
     '''
     '''
     model_name = config.get('name')
@@ -181,10 +181,6 @@ def model_from_config(config, custom_objects={}, reset=False):
     elif model_name == 'Sequential':
         model.__class__ = Sequential
         model.name = model_name
-        model.name = model_name
-        if reset:
-            for layer in model.layers:
-                layer.build()
 
     if 'optimizer' in config:
         # if it has an optimizer, the model is assumed to be compiled
@@ -466,14 +462,6 @@ class Model(object):
         include parameter count information.
         '''
         model_summary(self)
-
-    def reset(self):
-        ''' Reset all weights and biases to random values
-
-        Returns: Model
-        '''
-
-        return model_from_config(self.get_config(), reset=True)
 
 
 class Sequential(Model, containers.Sequential):


### PR DESCRIPTION
Hi folks,

after my first attempt I now added a better reset function to the Sequential model.

It works like this:

``` python
model = Sequential()

# add layers as usual
model.add(...)

# compile & fit as usual
model.compile(...)
model.fit(...)

# then RESET and fit again. No compilation needed
model.reset()
model.fit(...)
```

There are two new functions, of better 1 function, 2 modes of operation:
- **hard reset** (default setting) - will reset the model weights and biases to **random values**
- **soft reset** (with parameter `use_stored=True`) - will reset the model to the **stored weights and baises** as after compilation, i.e. to the same parameters it started with before.

So it's either

``` python
model.reset() # hard reset or
model.reset(use_stored=True) # soft reset
```

Give me your opinion. The fork was made at commit
8ba647c19641bbcf8c742e01446ad10a55514846
