### PR TITLE
add weight sharing across layers

### DIFF
--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -21,6 +21,13 @@ def variable(value, dtype=_FLOATX, name=None):
     return theano.shared(value=value, name=name, strict=False)
 
 
+def is_variable(x):
+    '''
+    returns True iff x is a TensorSharedVariable instance.
+    '''
+    return isinstance(x, (T.sharedvar.TensorSharedVariable, theano.sandbox.cuda.var.CudaNdarraySharedVariable))
+
+
 def placeholder(shape=None, ndim=None, dtype=_FLOATX, name=None):
     '''Instantiate an input data placeholder variable.
     '''

--- a/tests/keras/layers/test_core.py
+++ b/tests/keras/layers/test_core.py
@@ -240,6 +240,18 @@ def test_siamese_all():
         siamese_layer.get_output()
 
 
+def test_clone_layer():
+    shared_layer1 = core.Dense(5,input_dim=7)
+    shared_layer2 = core.Dense(5,input_dim=7, weights=shared_layer1.trainable_weights)
+    assert shared_layer1.W is shared_layer2.W
+    assert shared_layer1.b is shared_layer2.b
+
+    shared_layer1 = core.Dense(5,input_dim=7)
+    shared_layer2 = core.Dense(5,input_dim=7, weights=[w.eval() for w in shared_layer1.trainable_weights])
+    assert shared_layer1.W is not shared_layer2.W
+    assert shared_layer1.b is not shared_layer2.b
+
+
 @pytest.mark.skipif(K._BACKEND == 'tensorflow',
                     reason='currently not working with TensorFlow')
 def test_siamese_theano_only():


### PR DESCRIPTION
Weight sharing is currently only implemented by Siamese, which can be problematic when one shared layer depends on the output of another.
This PR hijacks the `weights` parameter supported by the constructor of most existing layers.
If a sharedvariable is passed instead of a numpy variable, it overwrites the weight member itself (not its value!).
