### PR TITLE
add support for subtensor updates

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -748,3 +748,12 @@ def random_binomial(shape, p=0.0, dtype=_FLOATX, seed=None):
         seed = np.random.randint(10e6)
     return tf.select(tf.random_uniform(shape, dtype=dtype, seed=seed) <= p,
                      tf.ones(shape), tf.zeros(shape))
+
+
+# SUBTENSOR UPDATES
+
+def scatter_add(tensor, indices, updates):
+    return tf.scatter_add(tensor, indices, updates)
+
+def scatter_update(tensor, indices, updates):
+    return tf.scatter_update(tensor[indices], updates)

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -884,6 +884,24 @@ def random_binomial(shape, p=0.0, dtype=_FLOATX, seed=None):
     rng = RandomStreams(seed=seed)
     return rng.binomial(shape, p=p, dtype=dtype)
 
+
+# SUBTENSOR UPDATES
+
+
+def scatter_add(tensor, indices, updates):
+    return T.inc_subtensor(tensor[indices], updates)
+
+
+def scatter_update(tensor, indices, updates):
+    # Theano current has a bug when the indices of the subtensor is an n-dim
+    # tensor (n > 1). We have to flatten indices, call set_subtensor and then
+    # reshape the result
+    flattened_indices = T.flatten(indices)
+    flattened_updates = updates.reshape((T.prod(updates.shape[:-1]),
+                                         updates.shape[-1]))
+    return T.set_subtensor(tensor[flattened_indices], flattened_updates)
+
+
 '''
 more TODO:
 

--- a/keras/layers/containers.py
+++ b/keras/layers/containers.py
@@ -80,6 +80,21 @@ class Sequential(Layer):
         return weights
 
     @property
+    def grad_dictionary(self):
+        grad_dict = {}
+        for l in self.layers:
+            layer_grad_dict = l.grad_dictionary
+            for param in layer_grad_dict:
+                if param not in grad_dict:
+                    grad_dict[param] = layer_grad_dict[param]
+                else:
+                    for key in [x for x in grad_dict[param] if x in layer_grad_dict[param]]:
+                        assert grad_dict[param][key] == layer_grad_dict[param][key], \
+                        "inconsistent gradient variable associated with param {}, key {}".format(param, key)
+                    grad_dict[param].update(layer_grad_dict[param])
+        return grad_dict
+
+    @property
     def regularizers(self):
         regularizers = []
         for l in self.layers:
@@ -264,6 +279,21 @@ class Graph(Layer):
     @property
     def nb_output(self):
         return len(self.outputs)
+
+    @property
+    def grad_dictionary(self):
+        grad_dict = {}
+        for l in self.nodes.values():
+            layer_grad_dict = l.grad_dictionary
+            for param in layer_grad_dict:
+                if param not in grad_dict:
+                    grad_dict[param] = layer_grad_dict[param]
+                else:
+                    for key in [x for x in grad_dict[param] if x in layer_grad_dict[param]]:
+                        assert grad_dict[param][key] == layer_grad_dict[param][key], \
+                        "inconsistent gradient variable associated with param {}, key {}".format(param, key)
+                    grad_dict[param].update(layer_grad_dict[param])
+        return grad_dict
 
     @property
     def trainable_weights(self):

--- a/keras/models.py
+++ b/keras/models.py
@@ -545,8 +545,11 @@ class Sequential(Model, containers.Sequential):
 
         for r in self.regularizers:
             train_loss = r(train_loss)
-        updates = self.optimizer.get_updates(self.trainable_weights,
-                                             self.constraints,
+
+        constraint_dictionary = dict(zip(self.trainable_weights,
+                                         self.constraints))
+        updates = self.optimizer.get_updates(self.grad_dictionary,
+                                             constraint_dictionary,
                                              train_loss)
         updates += self.updates
 
@@ -1296,9 +1299,12 @@ class Graph(Model, containers.Graph):
 
         for r in self.regularizers:
             train_loss = r(train_loss)
+
+        constraint_dictionary = dict(zip(self.trainable_weights,
+                                         self.constraints))
         self.optimizer = optimizers.get(optimizer)
-        updates = self.optimizer.get_updates(self.trainable_weights,
-                                             self.constraints,
+        updates = self.optimizer.get_updates(self.grad_dictionary,
+                                             constraint_dictionary,
                                              train_loss)
         updates += self.updates
         self.loss = loss


### PR DESCRIPTION
This is a fairly involved change, to add support for subtensor updates for Embedding layers.
The main changes are:
1. We may now need to get gradients with respect to several variables to get the update expression for a single parameter. This is achieved by layers passing a grad_variables property, which tells the optimizer what the variables to take gradients wrt are (an Embedding layer can be shared across multiple inputs, and thus create multiple subtensors). This is a dictionary, whose keys are the parameters to update, and whose values are dictionaries, which contain the subtensors associated with the parameter, keyed by the indices which gave rise to those subtensors.
2. We need to either work out whether to make subtensor or normal updates. This is solved by wrapping both normal variable assignment and subtensor updating in a tensor_set function. This takes as parameters the tensor to update, the dictionary of gradient variables to update that parameter with, and an update expression, together with some further parameters for that update expression. Finally, we now pass in a dictionary of {param: constraint on param} - as the input to get_updates is now a dictionary rather than a list, we cannot assume that the constraints and the param list from the dicionary will always coincide.
