### PR TITLE
Softsign activation function

### DIFF
--- a/docs/templates/activations.md
+++ b/docs/templates/activations.md
@@ -30,6 +30,7 @@ model.add(Activation(tanh))
 
 - __softmax__: Softmax applied across inputs last dimension. Expects shape either `(nb_samples, nb_timesteps, nb_dims)` or `(nb_samples, nb_dims)`.
 - __softplus__
+- __softsign__
 - __relu__
 - __tanh__
 - __sigmoid__

--- a/keras/activations.py
+++ b/keras/activations.py
@@ -19,6 +19,10 @@ def softplus(x):
     return K.softplus(x)
 
 
+def softsign(x):
+    return K.softsign(x)
+
+
 def relu(x, alpha=0., max_value=None):
     return K.relu(x, alpha=alpha, max_value=max_value)
 

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -797,6 +797,10 @@ def softplus(x):
     return tf.nn.softplus(x)
 
 
+def softsign(x):
+    return tf.nn.softsign(x)
+
+
 def categorical_crossentropy(output, target, from_logits=False):
     '''Categorical crossentropy between an output tensor
     and a target tensor, where the target is a tensor of the same

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -3,6 +3,7 @@ from theano import tensor as T
 from theano.sandbox.rng_mrg import MRG_RandomStreams as RandomStreams
 from theano.tensor.signal import pool
 from theano.tensor.nnet import conv3d2d
+from theano.sandbox import softsign as T_softsign
 import inspect
 import numpy as np
 from .common import _FLOATX, _EPSILON
@@ -704,6 +705,10 @@ def softmax(x):
 
 def softplus(x):
     return T.nnet.softplus(x)
+
+
+def softsign(x):
+    return T_softsign.softsign(x)
 
 
 def categorical_crossentropy(output, target, from_logits=False):

--- a/tests/keras/test_activations.py
+++ b/tests/keras/test_activations.py
@@ -56,6 +56,22 @@ def test_softplus():
     assert_allclose(result, expected, rtol=1e-05)
 
 
+def test_softsign():
+    '''
+    Test using a reference softsign implementation
+    '''
+    def softsign(x):
+        return np.divide(x, np.ones_like(x) + np.absolute(x))
+
+    x = K.placeholder(ndim=2)
+    f = K.function([x],  [activations.softsign(x)])
+    test_values = get_standard_values()
+
+    result = f([test_values])[0]
+    expected = softsign(test_values)
+    assert_allclose(result, expected, rtol=1e-05)
+
+
 def test_sigmoid():
     '''
     Test using a numerically stable reference sigmoid implementation


### PR DESCRIPTION
I have tried implementing the softsign activation function proposed by (Bergstra et al., 2009).

My net of LSTMs compiles and runs, but during training it outputs ```loss: nan``` and the net doesn't seem to output very much of anything. I'm not sure what is going wrong.

### Formula and motivation

The formula is ```x/(1 + |x|)```

As Glorot says:
> The softsign is similar to the hyperbolic tangent (its range is -1 to 1) but its tails are quadratic polynomials rather than exponentials, i.e., it approaches its asymptotes much slower.

Some say that softsign is better than tanh because it is faster and less prone to saturation.