### PR TITLE
fix h5py string encoding

### DIFF
--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -2184,7 +2184,9 @@ class Container(Layer):
             flattened_layers = self.layers
 
         f = h5py.File(filepath, 'w')
-        f.attrs['layer_names'] = [layer.name for layer in flattened_layers]
+        for layer in flattened_layers:
+            print(layer.name)
+        f.attrs['layer_names'] = [layer.name.encode('utf8') for layer in flattened_layers]
 
         for layer in flattened_layers:
             g = f.create_group(layer.name)
@@ -2196,7 +2198,7 @@ class Container(Layer):
                     name = str(w.name)
                 else:
                     name = 'param_' + str(i)
-                weight_names.append(name)
+                weight_names.append(name.encode('utf8'))
             g.attrs['weight_names'] = weight_names
             for name, val in zip(weight_names, weight_values):
                 param_dset = g.create_dataset(name, val.shape,
@@ -2232,7 +2234,7 @@ class Container(Layer):
                 flattened_layers[k].set_weights(weights)
         else:
             # new file format
-            layer_names = f.attrs['layer_names']
+            layer_names = [n.decode('utf8') for n in f.attrs['layer_names']]
             if len(layer_names) != len(flattened_layers):
                 raise Exception('You are trying to load a weight file '
                                 'containing ' + str(len(layer_names)) +
@@ -2241,7 +2243,7 @@ class Container(Layer):
 
             for k, name in enumerate(layer_names):
                 g = f[name]
-                weight_names = g.attrs['weight_names']
+                weight_names = [n.decode('utf8') for n in g.attrs['weight_names']]
                 if len(weight_names):
                     weights = [g[weight_name] for weight_name in weight_names]
                     flattened_layers[k].set_weights(weights)


### PR DESCRIPTION
When saving the weights a TypeError is raised by h5py.

```
[gw1] linux -- Python 3.5.1 /usr/bin/python
def test_merge_overlap():
        (X_train, y_train), (X_test, y_test) = _get_test_data()
        left = Sequential()
        left.add(Dense(nb_hidden, input_shape=(input_dim,)))
        left.add(Activation('relu'))

        model = Sequential()
        model.add(Merge([left, left], mode='sum'))
        model.add(Dense(nb_class))
        model.add(Activation('softmax'))
        model.compile(loss='categorical_crossentropy', optimizer='rmsprop')

        model.fit(X_train, y_train, batch_size=batch_size, nb_epoch=nb_epoch, verbose=1, validation_data=(X_test, y_test))
        model.fit(X_train, y_train, batch_size=batch_size, nb_epoch=nb_epoch, verbose=2, validation_split=0.1)
        model.fit(X_train, y_train, batch_size=batch_size, nb_epoch=nb_epoch, verbose=0)
        model.fit(X_train, y_train, batch_size=batch_size, nb_epoch=nb_epoch, verbose=1, shuffle=False)

        model.train_on_batch(X_train[:32], y_train[:32])

        loss = model.evaluate(X_test, y_test, verbose=0)
        model.predict(X_test, verbose=0)
        model.predict_classes(X_test, verbose=0)
        model.predict_proba(X_test, verbose=0)

        fname = 'test_merge_overlap_temp.h5'
        print(model.layers)
>       model.save_weights(fname, overwrite=True)

tests/keras/test_sequential_model.py:412:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
keras/engine/topology.py:2187: in save_weights
    f.attrs['layer_names'] = [layer.name for layer in flattened_layers]
h5py/_objects.pyx:54: in h5py._objects.with_phil.wrapper (/build/python-h5py/src/h5py-2.5.0/h5py/_objects.c:2574)
    ???
h5py/_objects.pyx:55: in h5py._objects.with_phil.wrapper (/build/python-h5py/src/h5py-2.5.0/h5py/_objects.c:2533)
    ???
/usr/lib/python3.5/site-packages/h5py/_hl/attrs.py:87: in __setitem__
    self.create(name, data=value, dtype=base.guess_dtype(value))
/usr/lib/python3.5/site-packages/h5py/_hl/attrs.py:163: in create
    htype = h5t.py_create(original_dtype, logical=True)
h5py/h5t.pyx:1448: in h5py.h5t.py_create (/build/python-h5py/src/h5py-2.5.0/h5py/h5t.c:16157)
    ???
h5py/h5t.pyx:1468: in h5py.h5t.py_create (/build/python-h5py/src/h5py-2.5.0/h5py/h5t.c:15988)
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

>   ???
E   TypeError: No conversion path for dtype: dtype('<U13')

h5py/h5t.pyx:1529: TypeError

****
```
See this [issue](https://github.com/h5py/h5py/issues/289) for details.
As it is recommended in the issue, the strings are now encoded as utf8.