### PR TITLE
Merge: handle none in input_shapes

### DIFF
--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -1236,6 +1236,9 @@ class Merge(Layer):
         elif self.mode == 'concat':
             output_shape = list(input_shapes[0])
             for shape in input_shapes[1:]:
+                if output_shape[self.concat_axis] is None or shape[self.concat_axis] is None:
+                    output_shape[self.concat_axis] = None
+                    break
                 output_shape[self.concat_axis] += shape[self.concat_axis]
             return tuple(output_shape)
         elif self.mode == 'join':


### PR DESCRIPTION
The `Merge` Layer `concat` mode has problems with `None` in its `input_shapes`.
In my opinion if any `input_shape` is None on the `concat_axis`, then this means that
the actual shape is unknown on this axis, which implies that the `output_shape[concat_axis]` should be `None` as well.


