### PR TITLE
Provide `epoch_logs` to `on_epoch_begin` callbacks as an argument

### DIFF
--- a/keras/models.py
+++ b/keras/models.py
@@ -295,7 +295,8 @@ class Model(object):
 
         self.stop_training = False
         for epoch in range(nb_epoch):
-            callbacks.on_epoch_begin(epoch)
+            epoch_logs = {}
+            callbacks.on_epoch_begin(epoch, epoch_logs)
             if shuffle == 'batch':
                 index_array = batch_shuffle(index_array, batch_size)
             elif shuffle:
@@ -322,7 +323,6 @@ class Model(object):
 
                 callbacks.on_batch_end(batch_index, batch_logs)
 
-                epoch_logs = {}
                 if batch_index == len(batches) - 1:  # last batch
                     # validation
                     if do_validation:


### PR DESCRIPTION
Move `epoch_logs` initialization out of the for loop over the batches and provide `epoch_logs` as an argument to the `on_epoch_begin` callbacks. I find it useful for new callbacks that operate at the beginning of each epoch.