### PR TITLE
Add a generator for time-delay regression

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -697,7 +697,7 @@ def sparse_categorical_crossentropy(output, target, from_logits=False):
     output_shape = output.get_shape()
     res = tf.nn.sparse_softmax_cross_entropy_with_logits(
         tf.reshape(output, [-1, int(output_shape[-1])]),
-        cast(flatten(target), 'int32'))
+        cast(flatten(target), 'int64'))
     if len(output_shape) == 3:
         # if our output includes timesteps we need to reshape
         return tf.reshape(res, [-1, int(output_shape[-2])])

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -1812,7 +1812,7 @@ class Container(Layer):
     @property
     def input_spec(self):
         specs = []
-        for layer in self.input_layers:
+        for layer in getattr(self, 'input_layers', []):
             if layer.input_spec is None:
                 specs.append(None)
             else:

--- a/keras/generators.py
+++ b/keras/generators.py
@@ -1,0 +1,17 @@
+from .engine.training import make_batches
+import numpy as np
+
+
+def time_delay_generator(x, y, w, delays, batch_size):
+    index_array = np.arange(x.shape[0])
+    tlist = [1, 0] + range(2, len(x.shape) + 1)
+    while 1:
+        np.random.shuffle(index_array)
+        batches = make_batches(x.shape[0], batch_size)
+        for batch_index, (batch_start, batch_end) in enumerate(batches):
+            batch_ids = index_array[batch_start:batch_end]
+            batch_ids = [np.maximum(0, batch_ids-d) for d in range(0, delays)]
+            x_batch = x[batch_ids, :].transpose(tlist)
+            y_batch = y[batch_ids, :]
+            w_batch = w[batch_ids]
+            yield (x_batch, y_batch, w_batch)

--- a/keras/generators.py
+++ b/keras/generators.py
@@ -2,16 +2,42 @@ from .engine.training import make_batches
 import numpy as np
 
 
-def time_delay_generator(x, y, w, delays, batch_size):
+def time_delay_generator(x, y, delays, batch_size, weights=None, shuffle=True):
+    '''A generator to make it easy to fit time-delay regression models,
+    i.e. a model where the value of y depends on past values of x
+
+    # Arguments
+    x: input data, as a Numpy array
+    y: targets, as a Numpy array.
+    delays: number of time-steps to include in model
+    weights: Numpy array of weights for the samples
+    shuffle: Whether or not to shuffle the data (set True for training)
+
+    # Example
+    if X_train is (1000,200), Y_train is (1000,1)
+    train_gen = time_delay_generator(X_train, Y_train, delays=10, batch_size=100)
+
+    train_gen is a generator that gives:
+    x_batch as size (100,10,200) since each of the 100 samples includes the input
+    data at the current and nine previous time steps
+    y_batch as size (100,1)
+    w_batch as size (100,)
+
+    '''
     index_array = np.arange(x.shape[0])
-    tlist = [1, 0] + range(2, len(x.shape) + 1)
+    tlist = [1, 0] + range(2, np.ndim(x) + 1)
     while 1:
-        np.random.shuffle(index_array)
+        if shuffle:
+            np.random.shuffle(index_array)
         batches = make_batches(x.shape[0], batch_size)
         for batch_index, (batch_start, batch_end) in enumerate(batches):
             batch_ids = index_array[batch_start:batch_end]
-            batch_ids = [np.maximum(0, batch_ids-d) for d in range(0, delays)]
+            batch_ids = [np.maximum(0, batch_ids - d) for d in range(delays)]
             x_batch = x[batch_ids, :].transpose(tlist)
-            y_batch = y[batch_ids, :]
-            w_batch = w[batch_ids]
+            y_batch = y[batch_ids[0], :]
+            if weights is not None:
+                w_batch = weights[batch_ids[0], :][:, 0]
+            else:
+                w_batch = np.ones(x_batch.shape[0])
+            w_batch[batch_ids[0] < delays] = 0.
             yield (x_batch, y_batch, w_batch)

--- a/keras/generators.py
+++ b/keras/generators.py
@@ -41,7 +41,7 @@ def time_delay_generator(x, y, delays, batch_size, weights=None, shuffle=True):
                 if weights is not None:
                     w_batch = weights[batch_ids[0], :][:, 0]
                 else:
-                    w_batch = np.ones(x_batch.shape[0])
+                    w_batch = np.ones(x_batch[0].shape[0])
                 w_batch[batch_ids[0] < delays] = 0.
                 w_batch = standardize_sample_weights(w_batch, ['w_batch'])
                 yield (x_batch, y_batch, w_batch)

--- a/tests/keras/layers/test_advanced_activations.py
+++ b/tests/keras/layers/test_advanced_activations.py
@@ -31,12 +31,6 @@ def test_parametric_softplus():
                    input_shape=(2, 3, 4))
 
 
-def test_thresholded_linear():
-    from keras.layers.advanced_activations import ThresholdedLinear
-    layer_test(ThresholdedLinear, kwargs={'theta': 0.5},
-               input_shape=(2, 3, 4))
-
-
 def test_thresholded_relu():
     from keras.layers.advanced_activations import ThresholdedReLU
     layer_test(ThresholdedReLU, kwargs={'theta': 0.5},
@@ -50,5 +44,4 @@ def test_srelu():
 
 
 if __name__ == '__main__':
-    # pytest.main([__file__])
-    test_srelu()
+    pytest.main([__file__])


### PR DESCRIPTION
Here is a useful generator I wrote for generating mini-batches with time-delays. Perhaps we could centralize the location of useful data generators in `generators.py`, like the random image transforms, to make it easy to find? 
