### PR TITLE
Fix LeakyReLU return dtype

### DIFF
--- a/keras/layers/advanced_activations.py
+++ b/keras/layers/advanced_activations.py
@@ -23,7 +23,7 @@ class LeakyReLU(Layer):
     '''
     def __init__(self, alpha=0.3, **kwargs):
         self.supports_masking = True
-        self.alpha = K.cast_to_floatx(alpha)
+        self.alpha = alpha
         super(LeakyReLU, self).__init__(**kwargs)
 
     def call(self, x, mask=None):

--- a/keras/utils/test_utils.py
+++ b/keras/utils/test_utils.py
@@ -35,7 +35,7 @@ def get_test_data(nb_train=1000, nb_test=500, input_shape=(10,),
 
 
 def layer_test(layer_cls, kwargs={}, input_shape=None, input_dtype=None,
-               input_data=None, expected_output=None):
+               input_data=None, expected_output=None, expected_output_dtype=None):
     '''Test routine for a layer with a single input tensor
     and single output tensor.
     '''
@@ -46,6 +46,9 @@ def layer_test(layer_cls, kwargs={}, input_shape=None, input_dtype=None,
         input_data = (10 * np.random.random(input_shape)).astype(input_dtype)
     elif input_shape is None:
         input_shape = input_data.shape
+
+    if expected_output_dtype is None:
+        expected_output_dtype = input_dtype
 
     # instantiation
     layer = layer_cls(**kwargs)
@@ -62,6 +65,8 @@ def layer_test(layer_cls, kwargs={}, input_shape=None, input_dtype=None,
     # test in functional API
     x = Input(shape=input_shape[1:], dtype=input_dtype)
     y = layer(x)
+    assert K.dtype(y) == expected_output_dtype
+
     model = Model(input=x, output=y)
     model.compile('rmsprop', 'mse')
 

--- a/tests/keras/layers/test_embeddings.py
+++ b/tests/keras/layers/test_embeddings.py
@@ -1,13 +1,15 @@
 import pytest
 from keras.utils.test_utils import layer_test
 from keras.layers.embeddings import Embedding
+import keras.backend as K
 
 
 def test_embedding():
     layer_test(Embedding,
                kwargs={'output_dim': 4., 'input_dim': 10, 'input_length': 2},
                input_shape=(3, 2),
-               input_dtype='int32')
+               input_dtype='int32',
+               expected_output_dtype=K.floatx())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
LeakyReLU returns a tensor with float64 dtype.
It is stupid, but this line actually produces a float64 array:

```
    0.5*np.array(0.2, dtype=np.float32)
```

The theano nnet.relu function does something similar like this with the
LeakyReLU alpha parameter, which lead to a float64 tensor.
The solution is to not cast the alpha to float32.

Furthermore I tighten the `test_utils.layer_test`. It is now
required that the layer's output dtype is equal to the input dtype.