### PR TITLE
Remove restriction on strides in theano backend conv2d

### DIFF
--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -790,8 +790,6 @@ def conv2d(x, kernel, strides=(1, 1), border_mode='valid', dim_ordering='th',
     if border_mode == 'same':
         th_border_mode = 'half'
         np_kernel = kernel.eval()
-        assert strides[0] <= np_kernel.shape[2], 'strides should be smaller than the convolution window.'
-        assert strides[1] <= np_kernel.shape[3], 'strides should be smaller than the convolution window.'
     elif border_mode == 'valid':
         th_border_mode = 'valid'
     else:


### PR DESCRIPTION
Previously, strides were required to be smaller than the convolution kernel. Usually, this is what a user wants, but there are edge cases where one might want to do this (for instance, projection shortcuts in Residual Networks).

I don't see any technical reason why the assert was there, but please correct me if I missed something.