### PR TITLE
Correction to fan_out initializaiton

### DIFF
--- a/keras/initializations.py
+++ b/keras/initializations.py
@@ -16,7 +16,7 @@ def get_fans(shape, dim_ordering='th'):
             fan_in = shape[1] * receptive_field_size
             fan_out = shape[0] * receptive_field_size
         elif dim_ordering == 'tf':
-            kernel_size = np.prod(shape[:2])
+            receptive_field_size = np.prod(shape[:2])
             fan_in = shape[-2] * receptive_field_size
             fan_out = shape[-1] * receptive_field_size
         else:

--- a/keras/initializations.py
+++ b/keras/initializations.py
@@ -12,11 +12,13 @@ def get_fans(shape, dim_ordering='th'):
         # TH kernel shape: (depth, input_depth, ...)
         # TF kernel shape: (..., input_depth, depth)
         if dim_ordering == 'th':
-            fan_in = np.prod(shape[1:])
-            fan_out = shape[0]
+            receptive_field_size = np.prod(shape[2:])
+            fan_in = shape[1] * receptive_field_size
+            fan_out = shape[0] * receptive_field_size
         elif dim_ordering == 'tf':
-            fan_in = np.prod(shape[:-1])
-            fan_out = shape[-1]
+            kernel_size = np.prod(shape[:2])
+            fan_in = shape[-2] * receptive_field_size
+            fan_out = shape[-1] * receptive_field_size
         else:
             raise Exception('Invalid dim_ordering: ' + dim_ordering)
     else:

--- a/tests/keras/test_initializations.py
+++ b/tests/keras/test_initializations.py
@@ -4,8 +4,14 @@ import numpy as np
 from keras import initializations
 from keras import backend as K
 
-SHAPE = (100, 100)
+# 2D tensor test fixture
+FC_SHAPE = (100, 100)
 
+# 4D convolution in th order. This shape has the same effective shape as FC_SHAPE
+CONV_SHAPE = (25, 25, 2, 2)
+
+# The equivalent shape of both test fixtures
+SHAPE = (100, 100)
 
 def _runner(init, shape, target_mean=None, target_std=None,
             target_max=None, target_min=None):
@@ -22,62 +28,78 @@ def _runner(init, shape, target_mean=None, target_std=None,
         assert abs(output.min() - target_min) < lim
 
 
-def test_uniform():
-    _runner(initializations.uniform, SHAPE, target_mean=0.,
+@pytest.mark.parametrize('tensor_shape', [FC_SHAPE, CONV_SHAPE], ids=['FC', 'CONV'])
+def test_uniform(tensor_shape):
+    _runner(initializations.uniform, tensor_shape, target_mean=0.,
             target_max=0.05, target_min=-0.05)
 
 
-def test_normal():
-    _runner(initializations.normal, SHAPE, target_mean=0., target_std=0.05)
+@pytest.mark.parametrize('tensor_shape', [FC_SHAPE, CONV_SHAPE], ids=['FC', 'CONV'])
+def test_normal(tensor_shape):
+    _runner(initializations.normal, tensor_shape, target_mean=0., target_std=0.05)
 
 
-def test_lecun_uniform():
+@pytest.mark.parametrize('tensor_shape', [FC_SHAPE, CONV_SHAPE], ids=['FC', 'CONV'])
+def test_lecun_uniform(tensor_shape):
     scale = np.sqrt(3. / SHAPE[0])
-    _runner(initializations.lecun_uniform, SHAPE,
+    _runner(initializations.lecun_uniform, tensor_shape,
             target_mean=0., target_max=scale, target_min=-scale)
 
 
-def test_glorot_uniform():
+@pytest.mark.parametrize('tensor_shape', [FC_SHAPE, CONV_SHAPE], ids=['FC', 'CONV'])
+def test_glorot_uniform(tensor_shape):
     scale = np.sqrt(6. / (SHAPE[0] + SHAPE[1]))
-    _runner(initializations.glorot_uniform, SHAPE, target_mean=0.,
+    _runner(initializations.glorot_uniform, tensor_shape, target_mean=0.,
             target_max=scale, target_min=-scale)
 
 
-def test_glorot_normal():
+@pytest.mark.parametrize('tensor_shape', [FC_SHAPE, CONV_SHAPE], ids=['FC', 'CONV'])
+def test_glorot_normal(tensor_shape):
     scale = np.sqrt(2. / (SHAPE[0] + SHAPE[1]))
-    _runner(initializations.glorot_normal, SHAPE,
+    _runner(initializations.glorot_normal, tensor_shape,
             target_mean=0., target_std=scale)
 
 
-def test_he_uniform():
+@pytest.mark.parametrize('tensor_shape', [FC_SHAPE, CONV_SHAPE], ids=['FC', 'CONV'])
+def test_he_uniform(tensor_shape):
     scale = np.sqrt(6. / SHAPE[0])
-    _runner(initializations.he_uniform, SHAPE, target_mean=0.,
+    _runner(initializations.he_uniform, tensor_shape, target_mean=0.,
             target_max=scale, target_min=-scale)
 
 
-def test_he_normal():
+@pytest.mark.parametrize('tensor_shape', [FC_SHAPE, CONV_SHAPE], ids=['FC', 'CONV'])
+def test_he_normal(tensor_shape):
     scale = np.sqrt(2. / SHAPE[0])
-    _runner(initializations.he_normal, SHAPE,
+    _runner(initializations.he_normal, tensor_shape,
             target_mean=0., target_std=scale)
 
 
-def test_orthogonal():
-    _runner(initializations.orthogonal, SHAPE,
+@pytest.mark.parametrize('tensor_shape', [FC_SHAPE, CONV_SHAPE], ids=['FC', 'CONV'])
+def test_orthogonal(tensor_shape):
+    _runner(initializations.orthogonal, tensor_shape,
             target_mean=0.)
 
 
-def test_identity():
-    _runner(initializations.identity, SHAPE,
-            target_mean=1./SHAPE[0], target_max=1.)
+@pytest.mark.parametrize('tensor_shape', [FC_SHAPE, CONV_SHAPE], ids=['FC', 'CONV'])
+def test_identity(tensor_shape):
+    if len(tensor_shape) > 2:
+        with pytest.raises(Exception):
+            _runner(initializations.identity, tensor_shape,
+                    target_mean=1./SHAPE[0], target_max=1.)
+    else:
+        _runner(initializations.identity, tensor_shape,
+                target_mean=1./SHAPE[0], target_max=1.)
 
 
-def test_zero():
-    _runner(initializations.zero, SHAPE,
+@pytest.mark.parametrize('tensor_shape', [FC_SHAPE, CONV_SHAPE], ids=['FC', 'CONV'])
+def test_zero(tensor_shape):
+    _runner(initializations.zero, tensor_shape,
             target_mean=0., target_max=0.)
 
 
-def test_one():
-    _runner(initializations.one, SHAPE,
+@pytest.mark.parametrize('tensor_shape', [FC_SHAPE, CONV_SHAPE], ids=['FC', 'CONV'])
+def test_one(tensor_shape):
+    _runner(initializations.one, tensor_shape,
             target_mean=1., target_max=1.)
 
 


### PR DESCRIPTION
This PR addresses an issue in the calculation of `fan_out` in the `get_fans` function used in the initialization module. For convolution layers the number of output connections should be referring the number of "inputs" with respect to the backward pass; however, currently this refers to the outputs with respect to the forward pass. For a reference see equation (14) in this paper from He et al (http://arxiv.org/abs/1502.01852). This is also how `fan_in` and `fan_out` are calculated in Lasagne. 

Of course, weight initialization can be more of an art than a science so if there was a reason to just use the output shape I'd be interested to hear and feel free to close this PR. Regardless, thanks for the wonderful library!

Just for an idea of the impact of this change here is the output of `mnist_cnn.py` with the initialization in this PR:
```
Epoch 1/12
60000/60000 [==============================] - 195s - loss: 0.2598 - acc: 0.9186 - val_loss: 0.0538 - val_acc: 0.9823
Epoch 2/12
60000/60000 [==============================] - 194s - loss: 0.0897 - acc: 0.9728 - val_loss: 0.0429 - val_acc: 0.9865
Epoch 3/12
60000/60000 [==============================] - 196s - loss: 0.0703 - acc: 0.9792 - val_loss: 0.0339 - val_acc: 0.9887
Epoch 4/12
60000/60000 [==============================] - 195s - loss: 0.0571 - acc: 0.9823 - val_loss: 0.0312 - val_acc: 0.9892
Epoch 5/12
60000/60000 [==============================] - 193s - loss: 0.0498 - acc: 0.9852 - val_loss: 0.0289 - val_acc: 0.9901
Epoch 6/12
60000/60000 [==============================] - 193s - loss: 0.0443 - acc: 0.9864 - val_loss: 0.0285 - val_acc: 0.9908
Epoch 7/12
60000/60000 [==============================] - 185s - loss: 0.0418 - acc: 0.9871 - val_loss: 0.0301 - val_acc: 0.9911
Epoch 8/12
60000/60000 [==============================] - 179s - loss: 0.0372 - acc: 0.9881 - val_loss: 0.0272 - val_acc: 0.9915
Epoch 9/12
60000/60000 [==============================] - 186s - loss: 0.0329 - acc: 0.9896 - val_loss: 0.0268 - val_acc: 0.9918
Epoch 10/12
60000/60000 [==============================] - 191s - loss: 0.0302 - acc: 0.9907 - val_loss: 0.0280 - val_acc: 0.9904
Epoch 11/12
60000/60000 [==============================] - 191s - loss: 0.0288 - acc: 0.9914 - val_loss: 0.0274 - val_acc: 0.9925
Epoch 12/12
60000/60000 [==============================] - 192s - loss: 0.0270 - acc: 0.9914 - val_loss: 0.0332 - val_acc: 0.9907
Test score: 0.0331725852626
Test accuracy: 0.9907
```
And the same run on master
```
Epoch 1/12
60000/60000 [==============================] - 192s - loss: 0.2336 - acc: 0.9290 - val_loss: 0.0653 - val_acc: 0.9789
Epoch 2/12
60000/60000 [==============================] - 191s - loss: 0.0867 - acc: 0.9738 - val_loss: 0.0404 - val_acc: 0.9865
Epoch 3/12
60000/60000 [==============================] - 193s - loss: 0.0684 - acc: 0.9797 - val_loss: 0.0344 - val_acc: 0.9882
Epoch 4/12
60000/60000 [==============================] - 191s - loss: 0.0554 - acc: 0.9836 - val_loss: 0.0314 - val_acc: 0.9896
Epoch 5/12
60000/60000 [==============================] - 191s - loss: 0.0484 - acc: 0.9854 - val_loss: 0.0323 - val_acc: 0.9903
Epoch 6/12
60000/60000 [==============================] - 190s - loss: 0.0420 - acc: 0.9870 - val_loss: 0.0298 - val_acc: 0.9900
Epoch 7/12
60000/60000 [==============================] - 186s - loss: 0.0403 - acc: 0.9873 - val_loss: 0.0277 - val_acc: 0.9910
Epoch 8/12
60000/60000 [==============================] - 240s - loss: 0.0353 - acc: 0.9886 - val_loss: 0.0271 - val_acc: 0.9914
Epoch 9/12
60000/60000 [==============================] - 265s - loss: 0.0300 - acc: 0.9905 - val_loss: 0.0267 - val_acc: 0.9916
Epoch 10/12
60000/60000 [==============================] - 209s - loss: 0.0290 - acc: 0.9911 - val_loss: 0.0293 - val_acc: 0.9913
Epoch 11/12
60000/60000 [==============================] - 197s - loss: 0.0300 - acc: 0.9907 - val_loss: 0.0283 - val_acc: 0.9919
Epoch 12/12
60000/60000 [==============================] - 194s - loss: 0.0266 - acc: 0.9911 - val_loss: 0.0317 - val_acc: 0.9916
Test score: 0.0316598327696
Test accuracy: 0.9916
```
If this proposal is adopted, then some of the example scripts may need to be updated.