### PR TITLE
remove creation of np.asarray in to_categorical

### DIFF
--- a/keras/utils/np_utils.py
+++ b/keras/utils/np_utils.py
@@ -9,7 +9,6 @@ def to_categorical(y, nb_classes=None):
     '''Convert class vector (integers from 0 to nb_classes)
     to binary class matrix, for use with categorical_crossentropy.
     '''
-    y = np.asarray(y, dtype='int32')
     if not nb_classes:
         nb_classes = np.max(y)+1
     Y = np.zeros((len(y), nb_classes))


### PR DESCRIPTION
This closes #1461 by avoiding the creation of the numpy matrix completely, which can fail depending on the type of y, or when y is not rectangular.

It's a simple change, but I'd like to try this PR to see how the CI handles it.

Edit: while looking at this function, I noticed it might also make sense to explicitly allocate the array as `dtype=np.float32`, to help avoid a common error.