### PR TITLE
Allow 'tf' ordering in ImageDataGenerator

### DIFF
--- a/tests/keras/preprocessing/test_image.py
+++ b/tests/keras/preprocessing/test_image.py
@@ -55,5 +55,33 @@ def test_image_data_generator():
             assert x.shape[1:] == images.shape[1:]
             break
 
+def test_img_flip():
+    x = np.array(range(4)).reshape([1,1,2,2])
+    assert (flip_axis(x, 0) == x).all()
+    assert (flip_axis(x, 1) == x).all()
+    assert (flip_axis(x, 2) == [[[[2, 3], [0, 1]]]]).all()
+    assert (flip_axis(x, 3) == [[[[1, 0], [3, 2]]]]).all()
+
+    dim_ordering_and_col_index = (('tf', 2), ('th', 3))
+    for dim_ordering, col_index in dim_ordering_and_col_index:
+        image_generator_th = ImageDataGenerator(
+            featurewise_center=False,
+            samplewise_center=False,
+            featurewise_std_normalization=False,
+            samplewise_std_normalization=False,
+            zca_whitening=False,
+            rotation_range=0,
+            width_shift_range=0,
+            height_shift_range=0,
+            shear_range=0,
+            horizontal_flip=True,
+            vertical_flip=False,
+            dim_ordering=dim_ordering).flow(x, [1])
+        for i in range(10):
+            potentially_flipped_x, _ = next(image_generator_th)
+            assert (potentially_flipped_x==x).all() or \
+                   (potentially_flipped_x==flip_axis(x, col_index)).all()
+
+
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
This PR addresses issue #2286 to allow the use of ImageDataGenerator with data in the 'tf' format (which is row, column, channel). 

I removed the hard coded indices in the rotation and shifting functions, and adding axis numbers as arguments to these functions. The axis number is set in ImageDataGenerator based on whether it is called with 'tf' or 'th', and then the appropriate index is passed to the utility functions.

There are a couple of unrelated issues with ImageDataGenerator that I didn't address in this PR, hoping to keep this atomic, and come back to those once I have something acceptable on this issue.

Thanks for any feedback.