### PR TITLE
Added learning phase to callbacks (#2297)

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -462,7 +462,6 @@ class TensorBoard(Callback):
 
     def on_epoch_end(self, epoch, logs={}):
         import tensorflow as tf
-	import keras.backend.tensorflow_backend as KTF
 
         if self.model.validation_data and self.histogram_freq:
             if epoch % self.histogram_freq == 0:
@@ -470,7 +469,7 @@ class TensorBoard(Callback):
                 # (current call will likely go OOM on GPU)
 		cut_v_data = len(self.model.inputs)
 		val_data = self.model.validation_data[:cut_v_data] + [0]
-		tensors = self.model.inputs + [KTF.learning_phase()]
+		tensors = self.model.inputs + [K.learning_phase()]
 		feed_dict = dict(zip(tensors, val_data))
                 result = self.sess.run([self.merged], feed_dict=feed_dict)
                 summary_str = result[0]

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -467,10 +467,10 @@ class TensorBoard(Callback):
             if epoch % self.histogram_freq == 0:
                 # TODO: implement batched calls to sess.run
                 # (current call will likely go OOM on GPU)
-		cut_v_data = len(self.model.inputs)
-		val_data = self.model.validation_data[:cut_v_data] + [0]
-		tensors = self.model.inputs + [K.learning_phase()]
-		feed_dict = dict(zip(tensors, val_data))
+                cut_v_data = len(self.model.inputs)
+                val_data = self.model.validation_data[:cut_v_data] + [0]
+                tensors = self.model.inputs + [K.learning_phase()]
+                feed_dict = dict(zip(tensors, val_data))
                 result = self.sess.run([self.merged], feed_dict=feed_dict)
                 summary_str = result[0]
                 self.writer.add_summary(summary_str, epoch)

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -462,13 +462,16 @@ class TensorBoard(Callback):
 
     def on_epoch_end(self, epoch, logs={}):
         import tensorflow as tf
+	import keras.backend.tensorflow_backend as KTF
 
         if self.model.validation_data and self.histogram_freq:
             if epoch % self.histogram_freq == 0:
                 # TODO: implement batched calls to sess.run
                 # (current call will likely go OOM on GPU)
-                feed_dict = dict(zip(self.model.inputs,
-                                     self.model.validation_data))
+		cut_v_data = len(self.model.inputs)
+		val_data = self.model.validation_data[:cut_v_data] + [0]
+		tensors = self.model.inputs + [KTF.learning_phase()]
+		feed_dict = dict(zip(tensors, val_data))
                 result = self.sess.run([self.merged], feed_dict=feed_dict)
                 summary_str = result[0]
                 self.writer.add_summary(summary_str, epoch)

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -467,9 +467,13 @@ class TensorBoard(Callback):
             if epoch % self.histogram_freq == 0:
                 # TODO: implement batched calls to sess.run
                 # (current call will likely go OOM on GPU)
-                cut_v_data = len(self.model.inputs)
-                val_data = self.model.validation_data[:cut_v_data] + [0]
-                tensors = self.model.inputs + [K.learning_phase()]
+                if self.model.uses_learning_phase:
+                    cut_v_data = len(self.model.inputs)
+                    val_data = self.model.validation_data[:cut_v_data] + [0]
+                    tensors = self.model.inputs + [K.learning_phase()]
+                else:
+                    val_data = self.model.validation_data
+                    tensors = self.model.inputs
                 feed_dict = dict(zip(tensors, val_data))
                 result = self.sess.run([self.merged], feed_dict=feed_dict)
                 summary_str = result[0]

--- a/tests/keras/test_callbacks.py
+++ b/tests/keras/test_callbacks.py
@@ -253,4 +253,3 @@ def test_TensorBoard():
 
 if __name__ == '__main__':
     pytest.main([__file__])
-

--- a/tests/keras/test_callbacks.py
+++ b/tests/keras/test_callbacks.py
@@ -126,7 +126,7 @@ def test_LearningRateScheduler():
     assert (float(K.get_value(model.optimizer.lr)) - 0.2) < K.epsilon()
 
 
-@pytest.mark.skipif((K._BACKEND != 'tensorflow') or (sys.version_info[0] == 3),
+@pytest.mark.skipif((K._BACKEND != 'tensorflow'),
                     reason="Requires tensorflow backend")
 def test_TensorBoard():
     import shutil
@@ -252,8 +252,5 @@ def test_TensorBoard():
     KTF.set_session(old_session)
 
 if __name__ == '__main__':
-    # pytest.main([__file__])
-    # test_ModelCheckpoint()
-    # test_EarlyStopping()
-    # test_LearningRateScheduler()
-    test_TensorBoard()
+    pytest.main([__file__])
+


### PR DESCRIPTION
This PR closes #2297.

The `_LEARNING_PHASE` tensor was not added to the `feed_dict` passed to the TensorFlow session.
The `model.validation_data` also had too much information (the target validation data).
I chose to append a 0 to the list instead of cutting it to be concise.

I'm not sure about how we could retrieve the info in a cleaner way so let me know if it's ok!

If we add some more metrics it should be taken in account but for now it does the job and it's explicit.
This could be changed to use the information already contained in the list.

