### PR TITLE
Change error message in standardize_input_data

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -31,8 +31,8 @@ def standardize_input_data(data, names, shapes=None, check_batch_dim=True,
         arrays = []
         for name in names:
             if name not in data:
-                raise Exception('No data provided for input "' +
-                                name + '". Input data keys: ' +
+                raise Exception('No data provided for "' +
+                                name + '". Need data for each key in: ' +
                                 str(data.keys()))
             arrays.append(data[name])
     elif type(data) is list:


### PR DESCRIPTION
Because standardize_input_data gets called on both model inputs and outputs when using the graph API, we can get this error message when data is missing for model outputs.

This happened to me, and I found it confusing that layers that I thought were outputs were referred to in the error message as "inputs."

