### PR TITLE
Re-raise exceptions to preserve stack trace

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1361,7 +1361,7 @@ class Model(Container):
                                                class_weight=class_weight)
                 except Exception as e:
                     _stop.set()
-                    raise e
+                    raise
 
                 if type(outs) != list:
                     outs = [outs]
@@ -1463,7 +1463,7 @@ class Model(Container):
                 outs = self.test_on_batch(x, y, sample_weight=sample_weight)
             except Exception as e:
                 _stop.set()
-                raise e
+                raise
 
             if type(x) is list:
                 nb_samples = len(x[0])
@@ -1535,7 +1535,7 @@ class Model(Container):
                 outs = self.predict_on_batch(x)
             except Exception as e:
                 _stop.set()
-                raise e
+                raise
 
             if type(x) is list:
                 nb_samples = len(x[0])

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -73,7 +73,7 @@ def get_file(fname, origin, untar=False):
         except (Exception, KeyboardInterrupt) as e:
             if os.path.exists(fpath):
                 os.remove(fpath)
-            raise e
+            raise
         progbar = None
 
     if untar:
@@ -88,7 +88,7 @@ def get_file(fname, origin, untar=False):
                         os.remove(untar_fpath)
                     else:
                         shutil.rmtree(untar_fpath)
-                raise e
+                raise
             tfile.close()
         return untar_fpath
 


### PR DESCRIPTION
This might be specific to Python 2.7, but the some exceptions that pass through `Model.fit_generator`, for example, are not very useful because they are first caught and then re-raised by `raise e`. This removes the original stack trace, which makes it difficult to find the source of the original exception. This patch re-raises the exception while keeping the original stack trace.