### PR TITLE
Fix support for custom metrics functions

### DIFF
--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -8,3 +8,8 @@ def binary_accuracy(y_true, y_pred):
 def categorical_accuracy(y_true, y_pred):
     return K.mean(K.equal(K.argmax(y_true, axis=-1),
                   K.argmax(y_pred, axis=-1)))
+
+
+from .utils.generic_utils import get_from_module
+def get(identifier):
+    return get_from_module(identifier, globals(), 'metric')

--- a/tests/keras/engine/test_training.py
+++ b/tests/keras/engine/test_training.py
@@ -144,6 +144,18 @@ def test_model_methods():
                               [output_a_np, output_b_np])
     assert len(out) == 2
 
+    # test with a custom metric function
+    mse = lambda y_true, y_pred: K.mean(K.pow(y_true - y_pred, 2))
+    model.compile(optimizer, loss, metrics=[mse],
+                  sample_weight_mode=None)
+
+    out = model.train_on_batch([input_a_np, input_b_np],
+                               [output_a_np, output_b_np])
+    assert len(out) == 3
+    out = model.test_on_batch([input_a_np, input_b_np],
+                              [output_a_np, output_b_np])
+    assert len(out) == 3
+
     input_a_np = np.random.random((10, 3))
     input_b_np = np.random.random((10, 3))
 


### PR DESCRIPTION
The `Model.compile` function [supports custom metrics functions](https://github.com/fchollet/keras/blob/b32248d615abfd7835886a0f50962856f7d7c986/keras/engine/training.py#L612-L618), but this doesn't work because the `keras.metrics` module does not implement a `get` function. I've copied the function from the `keras.objectives` module.