### PR TITLE
fixed TensorBoard callback

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -446,7 +446,7 @@ class TensorBoard(Callback):
 
         self.model = model
         self.sess = KTF.get_session()
-        if self.histogram_freq and not self.merged:
+        if self.histogram_freq and self.merged is None:
             layers = self.model.layers
             for layer in layers:
                 if hasattr(layer, 'W'):


### PR DESCRIPTION
Using the TensorBoard callback, I get an exception

> TypeError: Using a `tf.Tensor` as a Python `bool` is not allowed. Use `if t is not None:` instead of `if t:` to test if a tensor is defined, and use the logical TensorFlow ops to test the value of a tensor.

Not sure if this is a 0.8.0 thing, but it seems to be an easy fix.