### PR TITLE
constants in theano rnn; mask in time distributed

### DIFF
--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -635,7 +635,7 @@ def rnn(step_function, inputs, initial_states,
             successive_states = []
             states = initial_states
             for i in indices:
-                output, states = step_function(inputs[i], states)
+                output, states = step_function(inputs[i], states + constants)
                 successive_outputs.append(output)
                 successive_states.append(states)
             outputs = T.stack(*successive_outputs)

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -557,15 +557,16 @@ def rnn(step_function, inputs, initial_states,
 
     axes = [1, 0] + list(range(2, ndim))
     inputs = inputs.dimshuffle(axes)
-
+    if constants is None:
+        constants = []
+        
     if mask is not None:
         if mask.ndim == ndim-1:
             mask = expand_dims(mask)
         assert mask.ndim == ndim
         mask = mask.dimshuffle(axes)
 
-        if constants is None:
-            constants = []
+
 
         if unroll:
             indices = list(range(input_length))

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -565,9 +565,7 @@ def rnn(step_function, inputs, initial_states,
             mask = expand_dims(mask)
         assert mask.ndim == ndim
         mask = mask.dimshuffle(axes)
-
-
-
+        
         if unroll:
             indices = list(range(input_length))
             if go_backwards:

--- a/keras/layers/wrappers.py
+++ b/keras/layers/wrappers.py
@@ -111,7 +111,7 @@ class TimeDistributed(Wrapper):
         if input_shape[0]:
             # batch size matters, use rnn-based implementation
             def step(x, states):
-                output = self.layer.call(x, mask)
+                output = self.layer.call(x)
                 return output, []
 
             last_output, outputs, states = K.rnn(step, X,
@@ -122,7 +122,7 @@ class TimeDistributed(Wrapper):
             # to process batches of any size
             # we can go with reshape-based implementation for performance
             X = K.reshape(X, (-1, ) + input_shape[2:])  # (nb_samples * timesteps, ...)
-            y = self.layer.call(X, mask)  # (nb_samples * timesteps, ...)
+            y = self.layer.call(X)  # (nb_samples * timesteps, ...)
             input_length = input_shape[1]
             if not input_length:
                 input_length = K.shape(X)[1]

--- a/keras/layers/wrappers.py
+++ b/keras/layers/wrappers.py
@@ -108,13 +108,13 @@ class TimeDistributed(Wrapper):
 
     def call(self, X, mask=None):
         input_shape = self.input_spec[0].shape
-        if input_shape[0]:
+        if input_shape[0] or mask is not None:
             # batch size matters, use rnn-based implementation
             def step(x, states):
                 output = self.layer.call(x)
                 return output, []
 
-            last_output, outputs, states = K.rnn(step, X,
+            last_output, outputs, states = K.rnn(step, X, mask=mask,
                                                  initial_states=[])
             y = outputs
         else:

--- a/keras/layers/wrappers.py
+++ b/keras/layers/wrappers.py
@@ -111,7 +111,7 @@ class TimeDistributed(Wrapper):
         if input_shape[0]:
             # batch size matters, use rnn-based implementation
             def step(x, states):
-                output = self.layer.call(x)
+                output = self.layer.call(x, mask)
                 return output, []
 
             last_output, outputs, states = K.rnn(step, X,
@@ -122,7 +122,7 @@ class TimeDistributed(Wrapper):
             # to process batches of any size
             # we can go with reshape-based implementation for performance
             X = K.reshape(X, (-1, ) + input_shape[2:])  # (nb_samples * timesteps, ...)
-            y = self.layer.call(X)  # (nb_samples * timesteps, ...)
+            y = self.layer.call(X, mask)  # (nb_samples * timesteps, ...)
             input_length = input_shape[1]
             if not input_length:
                 input_length = K.shape(X)[1]


### PR DESCRIPTION
In reference to #2376 , this adds the constants to the unmasked version of unrolled theano rnns.  Also, because TimeDistributed is calling the layer directly, it wasn't passing in a mask.  added this as well. 