### PR TITLE
Add support for weighted loss functions as metrics.

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -566,6 +566,7 @@ class Model(Container):
             self.targets.append(K.placeholder(ndim=len(shape), name=name + '_target'))
 
         # compute total loss
+        output_losses = []
         total_loss = None
         for i in range(len(self.outputs)):
             y_true = self.targets[i]
@@ -576,6 +577,7 @@ class Model(Container):
             loss_weight = loss_weights_list[i]
             output_loss = loss_weight * weighted_loss(y_true, y_pred,
                                                       sample_weight, mask)
+            output_losses.append(output_loss)
             if total_loss is None:
                 total_loss = output_loss
             else:
@@ -609,6 +611,11 @@ class Model(Container):
                         self.metrics_names.append('acc')
                     else:
                         self.metrics_names.append(self.output_layers[i].name + '_acc')
+                elif metric == 'loss':
+                    # custom handling of weighted loss functions as metrics
+                    if len(self.output_names) > 1:
+                        self.metrics.append(output_losses[i])
+                        self.metrics_names.append(self.output_layers[i].name + '_loss')
                 else:
                     metric_fn = metrics_module.get(metric)
                     self.metrics.append(metric_fn(y_true, y_pred))


### PR DESCRIPTION
In multi-task learning one might also want to monitor loss functions of specific outputs. By passing just `metrics=['loss']` it is even possible to see what contributes how much to the `loss` function. Anyway, with the refactored metrics in Keras 1.0 the implementation seems straightforward.

```python
import numpy as np
from keras.layers import Input, Dense
from keras.models import Sequential, Model

data = np.random.random((1000, 20))
labelsA = np.zeros((1000, 1))
labelsB = np.random.randint(2, size=(1000, 1))

inputs = Input(shape=(20,))

x1 = Dense(1000, activation='relu', name="x1")(inputs)
x2 = Dense(1000, activation='relu', name="x2")(x1)
predictionsA = Dense(1, activation='sigmoid', name="predA")(x1)
predictionsB = Dense(1, activation='sigmoid', name="predB")(x2)

model = Model(input=inputs, output=[predictionsA, predictionsB])
model.compile(optimizer='rmsprop', loss='mse', metrics=['accuracy', 'loss'])
#model.summary()

model.fit(data, [labelsA, labelsB], nb_epoch=10)  # starts training
```

```
$ python test01.py 
Using Theano backend.
Epoch 1/10
1000/1000 [==============================] - 1s - loss: 0.2797 - predA_acc: 0.9780 - predA_loss: 0.0237 - predB_acc: 0.4760 - predB_loss: 0.2560     
Epoch 2/10
1000/1000 [==============================] - 1s - loss: 0.2546 - predA_acc: 1.0000 - predA_loss: 0.0013 - predB_acc: 0.5170 - predB_loss: 0.2533     
Epoch 3/10
1000/1000 [==============================] - 1s - loss: 0.2499 - predA_acc: 1.0000 - predA_loss: 6.0532e-04 - predB_acc: 0.5310 - predB_loss: 0.2493     
Epoch 4/10
1000/1000 [==============================] - 1s - loss: 0.2527 - predA_acc: 1.0000 - predA_loss: 4.5196e-04 - predB_acc: 0.5280 - predB_loss: 0.2522     
Epoch 5/10
1000/1000 [==============================] - 1s - loss: 0.2460 - predA_acc: 1.0000 - predA_loss: 3.5053e-04 - predB_acc: 0.5700 - predB_loss: 0.2456     
Epoch 6/10
1000/1000 [==============================] - 1s - loss: 0.2454 - predA_acc: 1.0000 - predA_loss: 3.0161e-04 - predB_acc: 0.5460 - predB_loss: 0.2451     
Epoch 7/10
1000/1000 [==============================] - 1s - loss: 0.2429 - predA_acc: 1.0000 - predA_loss: 2.8082e-04 - predB_acc: 0.5580 - predB_loss: 0.2426     
Epoch 8/10
1000/1000 [==============================] - 1s - loss: 0.2447 - predA_acc: 1.0000 - predA_loss: 2.7690e-04 - predB_acc: 0.5630 - predB_loss: 0.2445     
Epoch 9/10
1000/1000 [==============================] - 1s - loss: 0.2434 - predA_acc: 1.0000 - predA_loss: 3.2246e-04 - predB_acc: 0.5700 - predB_loss: 0.2431     
Epoch 10/10
1000/1000 [==============================] - 1s - loss: 0.2402 - predA_acc: 1.0000 - predA_loss: 2.9543e-04 - predB_acc: 0.5940 - predB_loss: 0.2399
```