### PR TITLE
Typo in check_array_lengths

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -153,7 +153,7 @@ def check_array_lengths(X, Y, W):
         raise Exception('All input arrays (x) should have '
                         'the same number of samples.')
     set_y = set(y_lengths)
-    if len(set_x) != 1:
+    if len(set_y) != 1:
         raise Exception('All target arrays (y) should have '
                         'the same number of samples.')
     set_w = set(w_lengths)


### PR DESCRIPTION
The attached commit fixes an obvious typo in the check_array_lengths function which has the effect that the consistency of the target arrays doesn't get checked.

On a side note, I'd appreciate having a way to disable the length checks completely as some of my networks legitimately have multiple input arrays of unequal length. However, this pull request contains no such thing, it just fixes the original and intended behaviour.