### PR TITLE
Implement Pop Last Layer on Sequential Model

### DIFF
--- a/docs/templates/getting-started/sequential-model-guide.md
+++ b/docs/templates/getting-started/sequential-model-guide.md
@@ -135,7 +135,7 @@ model.compile(optimizer='rmsprop',
 
 ## Training
 
-Keras models are trained on Numpy arrays of input data and labels. For training a model, you will typically use the `fit` function. [Read its documentation here](/models/sequential). 
+Keras models are trained on Numpy arrays of input data and labels. For training a model, you will typically use the `fit` function. [Read its documentation here](/models/sequential).
 
 ```python
 # for a single-input model with 2 classes (binary):
@@ -311,6 +311,52 @@ sgd = SGD(lr=0.1, decay=1e-6, momentum=0.9, nesterov=True)
 model.compile(loss='categorical_crossentropy', optimizer=sgd)
 
 model.fit(X_train, Y_train, batch_size=32, nb_epoch=1)
+```
+
+In addition to this model, it could be also possible to extract the features
+after the convolutional layers.
+
+```python
+from keras.models import Sequential
+from keras.layers import Dense, Dropout, Activation, Flatten
+from keras.layers import Convolution2D, MaxPooling2D
+from keras.optimizers import SGD
+
+model = Sequential()
+# input: 100x100 images with 3 channels -> (3, 100, 100) tensors.
+# this applies 32 convolution filters of size 3x3 each.
+model.add(Convolution2D(32, 3, 3, border_mode='valid', input_shape=(3, 100, 100)))
+model.add(Activation('relu'))
+model.add(Convolution2D(32, 3, 3))
+model.add(Activation('relu'))
+model.add(MaxPooling2D(pool_size=(2, 2)))
+model.add(Dropout(0.25))
+
+model.add(Convolution2D(64, 3, 3, border_mode='valid'))
+model.add(Activation('relu'))
+model.add(Convolution2D(64, 3, 3))
+model.add(Activation('relu'))
+model.add(MaxPooling2D(pool_size=(2, 2)))
+model.add(Dropout(0.25))
+
+model.add(Flatten())
+# Note: Keras does automatic shape inference.
+model.add(Dense(256))
+model.add(Activation('relu'))
+model.add(Dropout(0.5))
+
+model.add(Dense(10))
+model.add(Activation('softmax'))
+
+model.load_weights('VGG_model.h5')
+for _ in range(4):
+    model.pop_layer()
+
+# It don't really matters the loss and the optimizer if the purpose is to
+# extract the features
+model.compile(loss='mse', optimizer='sgd')
+
+Y = model.predict(X_test, batch_size=32)
 ```
 
 

--- a/keras/models.py
+++ b/keras/models.py
@@ -1,10 +1,11 @@
 from __future__ import print_function
-import warnings
+
 import copy
+import warnings
 
 from . import backend as K
+from .engine.topology import Node, get_source_inputs
 from .engine.training import Model
-from .engine.topology import get_source_inputs, Node
 from .legacy.models import Graph
 
 
@@ -155,6 +156,22 @@ class Sequential(Model):
             self.inbound_nodes[0].output_shapes = [self.outputs[0]._keras_shape]
 
         self.layers.append(layer)
+        self.built = False
+
+    def pop_layer(self):
+        '''Removes a layer instance on top of the layer stack.
+        '''
+        if not self.outputs:
+            raise Exception('Sequential model cannot be popped: model is empty.')
+
+        self.layers.pop()
+        if not self.layers:
+            self.outputs = []
+            self.inbound_nodes = []
+            self.outbound_nodes = []
+        else:
+            self.layers[-1].outbound_nodes = []
+            self.outputs = [self.layers[-1].output]
         self.built = False
 
     def call(self, x, mask=None):

--- a/tests/keras/test_sequential_model.py
+++ b/tests/keras/test_sequential_model.py
@@ -447,6 +447,8 @@ def test_sequential_count_params():
     model = Sequential()
     model.add(Dense(nb_units, input_shape=(input_dim,)))
     model.add(Dense(nb_units))
+    model.add(Dense(1234))
+    model.pop_layer()
     model.add(Dense(nb_classes))
     model.add(Activation('softmax'))
     model.build()


### PR DESCRIPTION
Implement the feature to pop the last layer of the stack at the sequential model.
Now it would be only necessary to call one method to pop the last layer of an existing model:
```python
model.pop_layer()
```
Added to test and documented.
This comes from the proposal at #2371 made by @joelthchao