### PR TITLE
Fix plot with show_shapes and multiple inputs/outputs.

### DIFF
--- a/keras/utils/visualize_util.py
+++ b/keras/utils/visualize_util.py
@@ -29,14 +29,17 @@ def model_to_dot(model, show_shapes=False):
         if show_shapes:
             # Build the label that will actually contain a table with the
             # input/output
-            outputlabels = str(layer.output_shape)
+            try:
+                outputlabels = str(layer.output_shape)
+            except:
+                outputlabels = 'multiple'
             if hasattr(layer, 'input_shape'):
                 inputlabels = str(layer.input_shape)
             elif hasattr(layer, 'input_shapes'):
                 inputlabels = ', '.join(
                     [str(ishape) for ishape in layer.input_shapes])
             else:
-                inputlabels = ''
+                inputlabels = 'multiple'
             label = '%s\n|{input:|output:}|{{%s}|{%s}}' % (label, inputlabels, outputlabels)
 
         node = pydot.Node(layer_id, label=label)


### PR DESCRIPTION
Visualizing a model with `show_shapes=True` that has multiple outputs results in the following crash. According to how this is handled for `model.summary()` ([keras/utils/layer_utils.py](https://github.com/fchollet/keras/blob/master/keras/utils/layer_utils.py#L60)), this patch displays the string `multiple` in case of multiple inputs or outputs.

```python
from keras.utils.visualize_util import plot
plot(model, to_file="model.png", show_shapes=True)
```

```
Traceback (most recent call last):
  File "./train.py", line 228, in <module>
    plot(model, to_file=model_png, show_shapes=True)
  File "./venv/src/keras/keras/utils/visualize_util.py", line 60, in plot
    dot = model_to_dot(model, show_shapes)
  File "./venv/src/keras/keras/utils/visualize_util.py", line 32, in model_to_dot
    outputlabels = str(layer.output_shape)
  File "./venv/src/keras/keras/engine/topology.py", line 829, in output_shape
    'Use `get_output_shape_at(node_index)` instead.')
Exception: The layer "words_embedding has multiple inbound nodes, with different output shapes. Hence the notion of "output shape" is ill-defined for the layer. Use `get_output_shape_at(node_index)` instead.
```