### PR TITLE
Fix iteration over modes in merge test.

### DIFF
--- a/tests/keras/layers/test_core.py
+++ b/tests/keras/layers/test_core.py
@@ -26,7 +26,7 @@ def test_merge():
         print(mode)
         input_a = Input(shape=input_shapes[0][1:])
         input_b = Input(shape=input_shapes[1][1:])
-        merged = merge([input_a, input_b], mode='sum')
+        merged = merge([input_a, input_b], mode=mode)
         model = Model([input_a, input_b], merged)
         model.compile('rmsprop', 'mse')
 


### PR DESCRIPTION
I suppose that's the intended behavior.

After this change the test with `mode='cos'` fails for me with `NotImplementedError` in Theano.