### PR TITLE
fixed Merge Layer functional API

### DIFF
--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -1264,6 +1264,9 @@ class Merge(Layer):
                                        node_indices, tensor_indices)
             self.built = True
             self.add_inbound_node(layers, node_indices, tensor_indices)
+
+            outputs = self.inbound_nodes[-1].output_tensors
+            return outputs[0] # merge only returns a single tensor
         else:
             return self.call(inputs, mask)
 

--- a/tests/keras/engine/test_topology.py
+++ b/tests/keras/engine/test_topology.py
@@ -3,7 +3,7 @@ import json
 import numpy as np
 
 from keras.layers import Dense, Dropout
-from keras.engine import merge, Merge, Input, get_source_inputs
+from keras.engine import merge, Input, get_source_inputs
 from keras.models import Model
 from keras import backend as K
 from keras.models import model_from_json, model_from_yaml
@@ -454,57 +454,6 @@ def test_functional_guide():
     # we can then concatenate the two vectors:
     merged_vector = merge([encoded_a, encoded_b],
                           mode='concat', concat_axis=-1)
-
-    # and add a logistic regression on top
-    predictions = Dense(1, activation='sigmoid')(merged_vector)
-
-    # we define a trainable model linking the
-    # tweet inputs to the predictions
-    model = Model(input=[tweet_a, tweet_b], output=predictions)
-
-    model.compile(optimizer='rmsprop',
-                  loss='binary_crossentropy',
-                  metrics=['accuracy'])
-    data_a = np.random.random((1000, 4, 25))
-    data_b = np.random.random((1000, 4, 25))
-    labels = np.random.random((1000,))
-    model.fit([data_a, data_b], labels, nb_epoch=1)
-
-    model.summary()
-    assert model.inputs == [tweet_a, tweet_b]
-    assert model.outputs == [predictions]
-    assert model.input == [tweet_a, tweet_b]
-    assert model.output == predictions
-
-    assert model.output == predictions
-    assert model.input_shape == [(None, 4, 25), (None, 4, 25)]
-    assert model.output_shape == (None, 1)
-
-    assert shared_lstm.get_output_at(0) == encoded_a
-    assert shared_lstm.get_output_at(1) == encoded_b
-    assert shared_lstm.input_shape == (None, 4, 25)
-
-
-def test_functional_merge():
-    from keras.layers import Input, Dense, LSTM
-    from keras.models import Model
-    from keras.utils import np_utils
-
-    tweet_a = Input(shape=(4, 25))
-    tweet_b = Input(shape=(4, 25))
-    # this layer can take as input a matrix
-    # and will return a vector of size 64
-    shared_lstm = LSTM(64)
-
-    # when we reuse the same layer instance
-    # multiple times, the weights of the layer
-    # are also being reused
-    # (it is effectively *the same* layer)
-    encoded_a = shared_lstm(tweet_a)
-    encoded_b = shared_lstm(tweet_b)
-
-    # we can then concatenate the two vectors:
-    merged_vector = Merge(mode='concat', concat_axis=-1)([encoded_a, encoded_b])
 
     # and add a logistic regression on top
     predictions = Dense(1, activation='sigmoid')(merged_vector)

--- a/tests/keras/engine/test_topology.py
+++ b/tests/keras/engine/test_topology.py
@@ -3,7 +3,7 @@ import json
 import numpy as np
 
 from keras.layers import Dense, Dropout
-from keras.engine import merge, Input, get_source_inputs
+from keras.engine import merge, Merge, Input, get_source_inputs
 from keras.models import Model
 from keras import backend as K
 from keras.models import model_from_json, model_from_yaml
@@ -454,6 +454,57 @@ def test_functional_guide():
     # we can then concatenate the two vectors:
     merged_vector = merge([encoded_a, encoded_b],
                           mode='concat', concat_axis=-1)
+
+    # and add a logistic regression on top
+    predictions = Dense(1, activation='sigmoid')(merged_vector)
+
+    # we define a trainable model linking the
+    # tweet inputs to the predictions
+    model = Model(input=[tweet_a, tweet_b], output=predictions)
+
+    model.compile(optimizer='rmsprop',
+                  loss='binary_crossentropy',
+                  metrics=['accuracy'])
+    data_a = np.random.random((1000, 4, 25))
+    data_b = np.random.random((1000, 4, 25))
+    labels = np.random.random((1000,))
+    model.fit([data_a, data_b], labels, nb_epoch=1)
+
+    model.summary()
+    assert model.inputs == [tweet_a, tweet_b]
+    assert model.outputs == [predictions]
+    assert model.input == [tweet_a, tweet_b]
+    assert model.output == predictions
+
+    assert model.output == predictions
+    assert model.input_shape == [(None, 4, 25), (None, 4, 25)]
+    assert model.output_shape == (None, 1)
+
+    assert shared_lstm.get_output_at(0) == encoded_a
+    assert shared_lstm.get_output_at(1) == encoded_b
+    assert shared_lstm.input_shape == (None, 4, 25)
+
+
+def test_functional_merge():
+    from keras.layers import Input, Dense, LSTM
+    from keras.models import Model
+    from keras.utils import np_utils
+
+    tweet_a = Input(shape=(4, 25))
+    tweet_b = Input(shape=(4, 25))
+    # this layer can take as input a matrix
+    # and will return a vector of size 64
+    shared_lstm = LSTM(64)
+
+    # when we reuse the same layer instance
+    # multiple times, the weights of the layer
+    # are also being reused
+    # (it is effectively *the same* layer)
+    encoded_a = shared_lstm(tweet_a)
+    encoded_b = shared_lstm(tweet_b)
+
+    # we can then concatenate the two vectors:
+    merged_vector = Merge(mode='concat', concat_axis=-1)([encoded_a, encoded_b])
 
     # and add a logistic regression on top
     predictions = Dense(1, activation='sigmoid')(merged_vector)

--- a/tests/keras/layers/test_core.py
+++ b/tests/keras/layers/test_core.py
@@ -14,7 +14,7 @@ def test_masking():
 
 
 def test_merge():
-    from keras.layers import Input, merge
+    from keras.layers import Input, merge, Merge
     from keras.models import Model
 
     # test modes: 'sum', 'mul', 'concat', 'ave', 'cos', 'dot'.
@@ -37,6 +37,16 @@ def test_merge():
         config = model.get_config()
         model = Model.from_config(config)
         model.compile('rmsprop', 'mse')
+
+        # test Merge (#2460)
+        merged = Merge(mode=mode)([input_a, input_b])
+        model = Model([input_a, input_b], merged)
+        model.compile('rmsprop', 'mse')
+
+        expected_output_shape = model.get_output_shape_for(input_shapes)
+        actual_output_shape = model.predict(inputs).shape
+        assert expected_output_shape == actual_output_shape
+
 
     # test lambda with output_shape lambda
     input_a = Input(shape=input_shapes[0][1:])


### PR DESCRIPTION
First PR here, so review carefully!  

I noticed that `Merge()([input1, input2])` didn't work as I expected.  This was because the output tensor wasn't returned in `Merge.__call__`.  This fixes it using the same trick in `Layer.__call__` to get the output tensor (suggests that the `super().__call__` perhaps should be called instead??).

This isn't particularly required (due to the `merge` function existing as used in the docs), but it is nice to have a consistent API.  I added a test using this API instead of the merge API.
 
Please let me know if I can do anything else for this.