### PR TITLE
fix accuracy with sparse_categorical_crossentropy

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -608,8 +608,12 @@ class Model(Container):
                     if output_shape[-1] == 1:
                         # case: binary accuracy
                         self.metrics.append(metrics_module.binary_accuracy(y_true, y_pred))
+                    elif self.loss_functions[i] == objectives.sparse_categorical_crossentropy:
+                        # case: categorical accuracy with sparse targets
+                        self.metrics.append(
+                            metrics_module.sparse_categorical_accuracy(y_true, y_pred))
                     else:
-                        # case: categorical accuracy
+                        # case: categorical accuracy with dense targets
                         self.metrics.append(metrics_module.categorical_accuracy(y_true, y_pred))
                     if len(self.output_names) == 1:
                         self.metrics_names.append('acc')

--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -10,6 +10,11 @@ def categorical_accuracy(y_true, y_pred):
                   K.argmax(y_pred, axis=-1)))
 
 
+def sparse_categorical_accuracy(y_true, y_pred):
+    return K.mean(K.equal(K.max(y_true, axis=-1),
+                          K.argmax(y_pred, axis=-1)))
+
+
 from .utils.generic_utils import get_from_module
 def get(identifier):
     return get_from_module(identifier, globals(), 'metric')


### PR DESCRIPTION
It seems that currently the metric 'accuracy' won't work with `sparse_categorical_crossentropy` loss. 

Since #2450 suggests adding an additional dimension with length-1 to target, a reasonable fix would be a new `sparse_categorical_accuracy` function which removes the additional dimension instead of taking `argmax` along that dimension.