### PR TITLE
[Discuss] relax constraint when loading weights from file

### DIFF
--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -2319,21 +2319,18 @@ class Container(Layer):
         else:
             # new file format
             layer_names = [n.decode('utf8') for n in f.attrs['layer_names']]
-            if len(layer_names) != len(flattened_layers):
-                raise Exception('You are trying to load a weight file '
-                                'containing ' + str(len(layer_names)) +
-                                ' layers into a model with ' +
-                                str(len(flattened_layers)) + ' layers.')
 
             # we batch weight value assignments in a single backend call
             # which provides a speedup in TensorFlow.
             weight_value_tuples = []
-            for k, name in enumerate(layer_names):
+            for layer in flattened_layers:
+                name = layer.name
+                if name not in layer_names: continue
+                
                 g = f[name]
                 weight_names = [n.decode('utf8') for n in g.attrs['weight_names']]
                 if len(weight_names):
                     weight_values = [g[weight_name] for weight_name in weight_names]
-                    layer = flattened_layers[k]
                     symbolic_weights = layer.trainable_weights + layer.non_trainable_weights
                     if len(weight_values) != len(symbolic_weights):
                         raise Exception('Layer #' + str(k) +


### PR DESCRIPTION
Maybe we can relax the constraint in the load_weights, and loading weights in a more current-model central way. Thus transfering learning and layer-wise pretraining can be more easily conducted.

e.g. first train a 2 layer LSTM, and save the weights to file
model = Sequential()
model.add(LSTM(100, input_dim=40, return_sequences=True, name='lstm1'))
model.add(LSTM(100, return_sequences=True, name='lstm2'))
model.add(TimeDistributedDense(10, activation='softmax', name='dense3'))

then we can training a new 3 laye LSTM with the first 2 layers initialized by the trained weights
model = Sequential()
model.add(LSTM(100, input_dim=40, return_sequences=True, name='lstm1'))
model.add(LSTM(100, return_sequences=True, name='lstm2'))
model.add(LSTM(100, return_sequences=True, name='lstm3'))
model.add(TimeDistributedDense(10, activation='softmax', name='dense4'))
