### PR TITLE
Fix test_image path non-exist error in ci-travis

### DIFF
--- a/examples/inception_v3.py
+++ b/examples/inception_v3.py
@@ -95,7 +95,7 @@ branch3x3dbl = conv2D_bn(branch3x3dbl, 96, 3, 3)
 branch3x3dbl = conv2D_bn(branch3x3dbl, 96, 3, 3)
 
 branch_pool = AveragePooling2D((3, 3), strides=(1, 1), border_mode='same', dim_ordering=DIM_ORDERING)(x)
-branch_pool = conv2D_bn(branch_pool, 32, 1, 1)
+branch_pool = conv2D_bn(branch_pool, 64, 1, 1)
 x = merge([branch1x1, branch5x5, branch3x3dbl, branch_pool], mode='concat', concat_axis=CONCAT_AXIS)
 
 # mixed2: 35 x 35 x 288
@@ -136,24 +136,6 @@ branch7x7dbl = conv2D_bn(x, 128, 1, 1)
 branch7x7dbl = conv2D_bn(branch7x7dbl, 128, 7, 1)
 branch7x7dbl = conv2D_bn(branch7x7dbl, 128, 1, 7)
 branch7x7dbl = conv2D_bn(branch7x7dbl, 128, 7, 1)
-branch7x7dbl = conv2D_bn(branch7x7dbl, 128, 1, 7)
-
-branch_pool = AveragePooling2D((3, 3), strides=(1, 1), border_mode='same', dim_ordering=DIM_ORDERING)(x)
-branch_pool = conv2D_bn(branch_pool, 192, 1, 1)
-x = merge([branch1x1, branch7x7, branch7x7dbl, branch_pool], mode='concat', concat_axis=CONCAT_AXIS)
-
-# mixed5: 17 x 17 x 768
-
-branch1x1 = conv2D_bn(x, 192, 1, 1)
-
-branch7x7 = conv2D_bn(x, 160, 1, 1)
-branch7x7 = conv2D_bn(branch7x7, 160, 1, 7)
-branch7x7 = conv2D_bn(branch7x7, 192, 7, 1)
-
-branch7x7dbl = conv2D_bn(x, 160, 1, 1)
-branch7x7dbl = conv2D_bn(branch7x7dbl, 160, 7, 1)
-branch7x7dbl = conv2D_bn(branch7x7dbl, 192, 1, 7)
-branch7x7dbl = conv2D_bn(branch7x7dbl, 160, 7, 1)
 branch7x7dbl = conv2D_bn(branch7x7dbl, 192, 1, 7)
 
 branch_pool = AveragePooling2D((3, 3), strides=(1, 1), border_mode='same', dim_ordering=DIM_ORDERING)(x)
@@ -170,7 +152,25 @@ branch7x7 = conv2D_bn(branch7x7, 192, 7, 1)
 
 branch7x7dbl = conv2D_bn(x, 160, 1, 1)
 branch7x7dbl = conv2D_bn(branch7x7dbl, 160, 7, 1)
+branch7x7dbl = conv2D_bn(branch7x7dbl, 160, 1, 7)
+branch7x7dbl = conv2D_bn(branch7x7dbl, 160, 7, 1)
 branch7x7dbl = conv2D_bn(branch7x7dbl, 192, 1, 7)
+
+branch_pool = AveragePooling2D((3, 3), strides=(1, 1), border_mode='same', dim_ordering=DIM_ORDERING)(x)
+branch_pool = conv2D_bn(branch_pool, 192, 1, 1)
+x = merge([branch1x1, branch7x7, branch7x7dbl, branch_pool], mode='concat', concat_axis=CONCAT_AXIS)
+
+# mixed5: 17 x 17 x 768
+
+branch1x1 = conv2D_bn(x, 192, 1, 1)
+
+branch7x7 = conv2D_bn(x, 160, 1, 1)
+branch7x7 = conv2D_bn(branch7x7, 160, 1, 7)
+branch7x7 = conv2D_bn(branch7x7, 192, 7, 1)
+
+branch7x7dbl = conv2D_bn(x, 160, 1, 1)
+branch7x7dbl = conv2D_bn(branch7x7dbl, 160, 7, 1)
+branch7x7dbl = conv2D_bn(branch7x7dbl, 160, 1, 7)
 branch7x7dbl = conv2D_bn(branch7x7dbl, 160, 7, 1)
 branch7x7dbl = conv2D_bn(branch7x7dbl, 192, 1, 7)
 
@@ -225,7 +225,7 @@ aux_preds = Dense(NB_CLASS, activation='softmax')(aux_logits)
 # mixed8: 8 x 8 x 1280
 
 branch3x3 = conv2D_bn(x, 192, 1, 1)
-branch3x3 = conv2D_bn(branch3x3, 192, 3, 3, subsample=(2, 2), border_mode='valid')
+branch3x3 = conv2D_bn(branch3x3, 320, 3, 3, subsample=(2, 2), border_mode='valid')
 
 branch7x7x3 = conv2D_bn(x, 192, 1, 1)
 branch7x7x3 = conv2D_bn(branch7x7x3, 192, 1, 7)

--- a/tests/keras/preprocessing/test_image.py
+++ b/tests/keras/preprocessing/test_image.py
@@ -4,91 +4,94 @@ from PIL import Image
 import numpy as np
 import os
 import shutil
+import tempfile
 
 
-def setup_function(func):
-    paths = ['test_images', 'test_images/rgb', 'test_images/gsc']
-    for path in paths:
-        if not os.path.exists(path):
-            os.mkdir(path)
+class TestImage:
 
-    img_w = img_h = 20
-    for n in range(8):
-        bias = np.random.rand(img_w, img_h, 1) * 64
-        variance = np.random.rand(img_w, img_h, 1) * (255-64)
-        imarray = np.random.rand(img_w, img_h, 3) * variance + bias
-        im = Image.fromarray(imarray.astype('uint8')).convert('RGBA')
-        im.save('test_images/rgb/rgb_test_image_'+str(n)+'.png')
+    def setup_class(cls):
+        img_w = img_h = 20
+        rgb_images = []
+        gray_images = []
+        for n in range(8):
+            bias = np.random.rand(img_w, img_h, 1) * 64
+            variance = np.random.rand(img_w, img_h, 1) * (255-64)
+            imarray = np.random.rand(img_w, img_h, 3) * variance + bias
+            im = Image.fromarray(imarray.astype('uint8')).convert('RGB')
+            rgb_images.append(im)
 
-        imarray = np.random.rand(img_w, img_h, 1) * variance + bias
-        im = Image.fromarray(imarray.astype('uint8').squeeze()).convert('L')
-        im.save('test_images/gsc/gsc_test_image_'+str(n)+'.png')
+            imarray = np.random.rand(img_w, img_h, 1) * variance + bias
+            im = Image.fromarray(imarray.astype('uint8').squeeze()).convert('L')
+            gray_images.append(im)
 
-
-def teardown_function(func):
-    shutil.rmtree('test_images')
+        cls.all_test_images = [rgb_images, gray_images]
 
 
-def test_image_data_generator():
-    for color_mode in ['gsc', 'rgb']:
-        file_list = list_pictures('test_images/' + color_mode)
-        img_list = []
-        for f in file_list:
-            img_list.append(img_to_array(load_img(f))[None, ...])
-
-        images = np.vstack(img_list)
-        generator = ImageDataGenerator(
-            featurewise_center=True,
-            samplewise_center=True,
-            featurewise_std_normalization=True,
-            samplewise_std_normalization=True,
-            zca_whitening=True,
-            rotation_range=90.,
-            width_shift_range=0.1,
-            height_shift_range=0.1,
-            shear_range=0.5,
-            zoom_range=0.2,
-            channel_shift_range=0.,
-            fill_mode='nearest',
-            cval=0.5,
-            horizontal_flip=True,
-            vertical_flip=True)
-        generator.fit(images, augment=True)
-
-        for x, y in generator.flow(images, np.arange(images.shape[0]),
-                                   shuffle=True, save_to_dir='test_images'):
-            assert x.shape[1:] == images.shape[1:]
-            break
+    def teardown_class(cls):
+        del cls.all_test_images
 
 
-def test_img_flip():
-    x = np.array(range(4)).reshape([1, 1, 2, 2])
-    assert (flip_axis(x, 0) == x).all()
-    assert (flip_axis(x, 1) == x).all()
-    assert (flip_axis(x, 2) == [[[[2, 3], [0, 1]]]]).all()
-    assert (flip_axis(x, 3) == [[[[1, 0], [3, 2]]]]).all()
+    def test_image_data_generator(self):
+        for test_images in self.all_test_images:
+            img_list = []
+            for im in test_images:
+                img_list.append(img_to_array(im)[None, ...])
 
-    dim_ordering_and_col_index = (('tf', 2), ('th', 3))
-    for dim_ordering, col_index in dim_ordering_and_col_index:
-        image_generator_th = ImageDataGenerator(
-            featurewise_center=False,
-            samplewise_center=False,
-            featurewise_std_normalization=False,
-            samplewise_std_normalization=False,
-            zca_whitening=False,
-            rotation_range=0,
-            width_shift_range=0,
-            height_shift_range=0,
-            shear_range=0,
-            zoom_range=0,
-            channel_shift_range=0,
-            horizontal_flip=True,
-            vertical_flip=False,
-            dim_ordering=dim_ordering).flow(x, [1])
-        for i in range(10):
-            potentially_flipped_x, _ = next(image_generator_th)
-            assert ((potentially_flipped_x == x).all() or
-                    (potentially_flipped_x == flip_axis(x, col_index)).all())
+            images = np.vstack(img_list)
+            generator = ImageDataGenerator(
+                featurewise_center=True,
+                samplewise_center=True,
+                featurewise_std_normalization=True,
+                samplewise_std_normalization=True,
+                zca_whitening=True,
+                rotation_range=90.,
+                width_shift_range=0.1,
+                height_shift_range=0.1,
+                shear_range=0.5,
+                zoom_range=0.2,
+                channel_shift_range=0.,
+                fill_mode='nearest',
+                cval=0.5,
+                horizontal_flip=True,
+                vertical_flip=True)
+            generator.fit(images, augment=True)
+
+            tmp_folder = tempfile.mkdtemp(prefix='test_images')
+            for x, y in generator.flow(images, np.arange(images.shape[0]),
+                                       shuffle=True, save_to_dir=tmp_folder):
+                assert x.shape[1:] == images.shape[1:]
+                break
+            shutil.rmtree(tmp_folder)
+
+
+    def test_img_flip(self):
+        x = np.array(range(4)).reshape([1, 1, 2, 2])
+        assert (flip_axis(x, 0) == x).all()
+        assert (flip_axis(x, 1) == x).all()
+        assert (flip_axis(x, 2) == [[[[2, 3], [0, 1]]]]).all()
+        assert (flip_axis(x, 3) == [[[[1, 0], [3, 2]]]]).all()
+
+        dim_ordering_and_col_index = (('tf', 2), ('th', 3))
+        for dim_ordering, col_index in dim_ordering_and_col_index:
+            image_generator_th = ImageDataGenerator(
+                featurewise_center=False,
+                samplewise_center=False,
+                featurewise_std_normalization=False,
+                samplewise_std_normalization=False,
+                zca_whitening=False,
+                rotation_range=0,
+                width_shift_range=0,
+                height_shift_range=0,
+                shear_range=0,
+                zoom_range=0,
+                channel_shift_range=0,
+                horizontal_flip=True,
+                vertical_flip=False,
+                dim_ordering=dim_ordering).flow(x, [1])
+            for i in range(10):
+                potentially_flipped_x, _ = next(image_generator_th)
+                assert ((potentially_flipped_x == x).all() or
+                        (potentially_flipped_x == flip_axis(x, col_index)).all())
 
 
 if __name__ == '__main__':

--- a/tests/keras/preprocessing/test_image.py
+++ b/tests/keras/preprocessing/test_image.py
@@ -26,10 +26,8 @@ class TestImage:
 
         cls.all_test_images = [rgb_images, gray_images]
 
-
     def teardown_class(cls):
         del cls.all_test_images
-
 
     def test_image_data_generator(self):
         for test_images in self.all_test_images:
@@ -62,7 +60,6 @@ class TestImage:
                 assert x.shape[1:] == images.shape[1:]
                 break
             shutil.rmtree(tmp_folder)
-
 
     def test_img_flip(self):
         x = np.array(range(4)).reshape([1, 1, 2, 2])


### PR DESCRIPTION
During CI, `test_image.py` sometimes results in path non-exist problem due to parallel issue. Such  as:
```
IOError: [Errno 2] No such file or directory: 'test_images/_0.jpeg'
```
Since the `test_images` folder has been removed. Anyone also faces this problem during your PR? 

Therefore, I modify `test_image.py` into class style and save test images in class attribute rather than save in `test_image` folder. Also use `tempfile` module to create temporary folder for `save_to_dir` to solve parallel problem.