### PR TITLE
Add softmax versions of *categorical_crossentropy objectives

### DIFF
--- a/keras/activations.py
+++ b/keras/activations.py
@@ -3,16 +3,7 @@ from . import backend as K
 
 
 def softmax(x):
-    ndim = K.ndim(x)
-    if ndim == 2:
-        return K.softmax(x)
-    elif ndim == 3:
-        e = K.exp(x - K.max(x, axis=-1, keepdims=True))
-        s = K.sum(e, axis=-1, keepdims=True)
-        return e / s
-    else:
-        raise Exception('Cannot apply softmax to a tensor that is not 2D or 3D. ' +
-                        'Here, ndim=' + str(ndim))
+    return K.softmax_3d(x)
 
 
 def softplus(x):

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -846,6 +846,21 @@ def softmax(x):
     return tf.nn.softmax(x)
 
 
+def softmax_3d(x):
+    '''Softmax on the last axis of a 2d or 3d tensor.
+    '''
+    nd = ndim(x)
+    if nd == 2:
+        return softmax(x)
+    elif nd == 3:
+        e = exp(x - max(x, axis=-1, keepdims=True))
+        s = sum(e, axis=-1, keepdims=True)
+        return e / s
+    else:
+        raise Exception('Cannot apply softmax to a tensor that is not 2D or 3D. ' +
+                        'Here, ndim=' + str(nd))
+
+
 def softplus(x):
     '''Softplus of a tensor.
     '''

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -721,13 +721,28 @@ def softmax(x):
     return T.nnet.softmax(x)
 
 
+def softmax_3d(x):
+    '''Softmax on the last axis of a 2d or 3d tensor.
+    '''
+    nd = ndim(x)
+    if nd == 2:
+        return softmax(x)
+    elif nd == 3:
+        e = exp(x - max(x, axis=-1, keepdims=True))
+        s = sum(e, axis=-1, keepdims=True)
+        return e / s
+    else:
+        raise Exception('Cannot apply softmax to a tensor that is not 2D or 3D. ' +
+                        'Here, ndim=' + str(nd))
+
+
 def softplus(x):
     return T.nnet.softplus(x)
 
 
 def categorical_crossentropy(output, target, from_logits=False):
     if from_logits:
-        output = T.nnet.softmax(output)
+        output = softmax_3d(output)
     else:
         # scale preds so that the class probas of each sample sum to 1
         output /= output.sum(axis=-1, keepdims=True)

--- a/keras/objectives.py
+++ b/keras/objectives.py
@@ -33,15 +33,34 @@ def hinge(y_true, y_pred):
 def categorical_crossentropy(y_true, y_pred):
     '''Expects a binary class matrix instead of a vector of scalar classes.
     '''
-    return K.categorical_crossentropy(y_pred, y_true)
+    return K.categorical_crossentropy(y_pred, y_true, from_logits=False)
+
+
+def softmax_categorical_crossentropy(y_true, y_pred):
+    '''Expects a binary class matrix instead of a vector of scalar classes.
+    This objective already includes a softmax activation, so the
+    network output must be on a logit scale (-inf; +inf).
+    '''
+    return K.categorical_crossentropy(y_pred, y_true, from_logits=True)
 
 
 def sparse_categorical_crossentropy(y_true, y_pred):
-    '''expects an array of integer classes.
+    '''expects an array of integer classes (labels) and predicted probabilities
+    for each class, for instance the output of a softmax activation.
     Note: labels shape must have the same number of dimensions as output shape.
     If you get a shape error, add a length-1 dimension to labels.
     '''
-    return K.sparse_categorical_crossentropy(y_pred, y_true)
+    return K.sparse_categorical_crossentropy(y_pred, y_true, from_logits=False)
+
+
+def sparse_softmax_categorical_crossentropy(y_true, y_pred):
+    '''expects an array of integer classes (labels) and predicted logit-probabilities
+    for each class. This objective already includes a softmax activation, so the
+    network output must be on a logit scale (-inf; +inf).
+    Note: labels shape must have the same number of dimensions as output shape.
+    If you get a shape error, add a length-1 dimension to labels.
+    '''
+    return K.sparse_categorical_crossentropy(y_pred, y_true, from_logits=True)
 
 
 def binary_crossentropy(y_true, y_pred):

--- a/tests/keras/test_objectives.py
+++ b/tests/keras/test_objectives.py
@@ -43,5 +43,17 @@ def test_cce_one_hot():
     assert K.eval(objectives.sparse_categorical_crossentropy(y_a, y_b)).shape == (6,)
 
 
+def test_sparse_softmax_categorical_crossentropy():
+    y_labels = K.variable(np.random.randint(0, 7, (5, 6)))
+    y_logits = K.variable(np.random.random((5, 6, 7)) * 12)
+    objective_value = K.eval(objectives.sparse_softmax_categorical_crossentropy(y_labels, y_logits))
+    assert objective_value.shape == (5, 6)
+
+    y_a = K.variable(np.random.randint(0, 7, (6,)))
+    y_b = K.variable(np.random.random((6, 7)))
+    objective_value = K.eval(objectives.sparse_softmax_categorical_crossentropy(y_a, y_b))
+    assert objective_value.shape == (6,)
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
#2532

And clarifications in doc strings
Allow the use of the integrated softmax+crossentropy from Tensorflow without extraneous conversions
