### PR TITLE
add KERAS_DIR environment var

### DIFF
--- a/keras/backend/__init__.py
+++ b/keras/backend/__init__.py
@@ -15,13 +15,7 @@ from .common import is_keras_tensor
 from .common import legacy_weight_ordering
 from .common import set_legacy_weight_ordering
 
-_keras_base_dir = os.path.expanduser('~')
-if not os.access(_keras_base_dir, os.W_OK):
-    _keras_base_dir = '/tmp'
-
-_keras_dir = os.path.join(_keras_base_dir, '.keras')
-if not os.path.exists(_keras_dir):
-    os.makedirs(_keras_dir)
+from ..config import KERAS_DIR as _keras_dir
 
 _BACKEND = 'theano'
 _config_path = os.path.expanduser(os.path.join(_keras_dir, 'keras.json'))

--- a/keras/config.py
+++ b/keras/config.py
@@ -1,0 +1,13 @@
+from __future__ import absolute_import, print_function
+
+import os
+
+KERAS_DIR = os.environ.get('KERAS_DIR', os.path.expanduser('~/.keras'))
+
+if not os.path.exists(KERAS_DIR):
+    os.mkdir(KERAS_DIR)
+
+if not os.access(KERAS_DIR, os.W_OK):
+    import tempfile
+    KERAS_DIR = tempfile.mkdtemp('','keras')
+

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -39,10 +39,8 @@ else:
 
 def get_file(fname, origin, untar=False,
              md5_hash=None, cache_subdir='datasets'):
-    datadir_base = os.path.expanduser(os.path.join('~', '.keras'))
-    if not os.access(datadir_base, os.W_OK):
-        datadir_base = os.path.join('/tmp', '.keras')
-    datadir = os.path.join(datadir_base, cache_subdir)
+    from ..config import KERAS_DIR
+    datadir = os.path.join(KERAS_DIR, cache_subdir)
     if not os.path.exists(datadir):
         os.makedirs(datadir)
 


### PR DESCRIPTION
Allow overriding `~/.keras/` with `KERAS_DIR` environment variable.

Then, if `KERAS_DIR` isn't writable, use `tempfile.mkdtemp` to create tmp
directory instead of defaulting to `/tmp/.keras/`.

Prompted by trying to run multiple keras jobs on a single node, and seeing the error:

```
OSError: [Errno 17] File exists: '/tmp/.keras' 
```
