### PR TITLE
Add `batch_get_value` to backends

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -601,11 +601,16 @@ def get_value(x):
     '''
     return x.eval(session=get_session())
 
-def get_values(xs):
+
+def batch_get_value(xs):
     '''Returns the value of more than one tensor variable,
     as a list of Numpy arrays.
     '''
-    return get_session().run([xs])
+    if xs:
+        return get_session().run(xs)
+    else:
+        return []
+
 
 def set_value(x, value):
     '''Sets the value of a tensor variable,

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -601,6 +601,11 @@ def get_value(x):
     '''
     return x.eval(session=get_session())
 
+def get_values(xs):
+    '''Returns the value of more than one tensor variable,
+    as a list of Numpy arrays.
+    '''
+    return get_session().run([xs])
 
 def set_value(x, value):
     '''Sets the value of a tensor variable,

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -484,7 +484,7 @@ def get_value(x):
     return x.get_value()
 
 
-def get_values(xs):
+def batch_get_value(xs):
     '''Returns the value of more than one tensor variable,
     as a list of Numpy arrays.
     '''

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -484,6 +484,13 @@ def get_value(x):
     return x.get_value()
 
 
+def get_values(xs):
+    '''Returns the value of more than one tensor variable,
+    as a list of Numpy arrays.
+    '''
+    return [get_value(x) for x in xs]
+
+
 def set_value(x, value):
     x.set_value(np.asarray(value, dtype=x.dtype))
 

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -847,10 +847,11 @@ class Layer(object):
         if not params:
             return
         weight_value_tuples = []
-        for p, w in zip(params, weights):
-            if K.get_value(p).shape != w.shape:
+        param_values = K.batch_get_value(params)
+        for pv, p, w in zip(param_values, params, weights):
+            if pv.shape != w.shape:
                 raise Exception('Layer weight shape ' +
-                                str(K.get_value(p).shape) +
+                                str(pv.shape.shape) +
                                 ' not compatible with '
                                 'provided weight shape ' + str(w.shape))
             weight_value_tuples.append((p, w))
@@ -861,7 +862,7 @@ class Layer(object):
         as a list of numpy arrays.
         '''
         params = self.trainable_weights + self.non_trainable_weights
-        return K.get_values(params)
+        return K.batch_get_value(params)
 
     def get_config(self):
         '''Returns a Python dictionary (serializable)

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -851,7 +851,7 @@ class Layer(object):
         for pv, p, w in zip(param_values, params, weights):
             if pv.shape != w.shape:
                 raise Exception('Layer weight shape ' +
-                                str(pv.shape.shape) +
+                                str(pv.shape) +
                                 ' not compatible with '
                                 'provided weight shape ' + str(w.shape))
             weight_value_tuples.append((p, w))

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -861,10 +861,7 @@ class Layer(object):
         as a list of numpy arrays.
         '''
         params = self.trainable_weights + self.non_trainable_weights
-        weights = []
-        for p in params:
-            weights.append(K.get_value(p))
-        return weights
+        return K.get_values(params)
 
     def get_config(self):
         '''Returns a Python dictionary (serializable)


### PR DESCRIPTION
This function parallels the existing batch_set_value function. I've also changed a few places in topology to use the new function.

For tensorflow, this can provide big speed-ups when, for example, running `get_weights` on a big model. I have a complicated multi-gpu model where `get_weights` (via `save_weights`) currently takes a few minutes to run the first time. With this PR, it runs in about 10 seconds.