### PR TITLE
fix soft sign deprecation warning

### DIFF
--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -3,7 +3,10 @@ from theano import tensor as T
 from theano.sandbox.rng_mrg import MRG_RandomStreams as RandomStreams
 from theano.tensor.signal import pool
 from theano.tensor.nnet import conv3d2d
-from theano.sandbox import softsign as T_softsign
+try:
+    from theano.tensor.nnet.nnet import softsign as T_softsign
+except ImportError:
+    from theano.sandbox.softsign import softsign as T_softsign
 import inspect
 import numpy as np
 from .common import _FLOATX, _EPSILON
@@ -734,7 +737,7 @@ def softplus(x):
 
 
 def softsign(x):
-    return T_softsign.softsign(x)
+    return T_softsign(x)
 
 
 def categorical_crossentropy(output, target, from_logits=False):


### PR DESCRIPTION
softsign was moved from theano.sandbox.softsign to theano.tensor.nnet.nnet