### PR TITLE
clarify use of old-style get_config method

### DIFF
--- a/keras/models.py
+++ b/keras/models.py
@@ -10,6 +10,10 @@ from .legacy.models import Graph
 
 def model_from_config(config, custom_objects={}):
     from keras.utils.layer_utils import layer_from_config
+    if isinstance(config, list):
+        raise Exception('model_fom_config expects a dictionary.'
+                        'To load an old-style config use the appropiate'
+                        '`load_config` method on Sequential or Graph')
     return layer_from_config(config, custom_objects=custom_objects)
 
 
@@ -703,7 +707,7 @@ class Sequential(Model):
 
     def get_config(self):
         '''Returns the model configuration
-        as a Python dictionary.
+        as a Python list.
         '''
         config = []
         if self.layers[0].__class__.__name__ == 'Merge':


### PR DESCRIPTION
Was trying to use the `get_config` method on `Sequential`, and was confused that I couldn't load the resulting config via `models.model_from_config`.

The behaviour of `Sequential.get_config` seems like a strange inconsistency but it also seems very intentional, so I assume it's about backwards compatibility.


edit:

the more I think about it the stranger it is that `Sequential` has this special behaviour. I'd like to be able to get the config as a dict, and the best way to do that right now is a round-trip through JSON.

One possible option would be to add a `legacy=True` argument to `Sequential.get_config`? If passed `False` we could return a dict.

I presume there's some reason that the `normalize_legacy_config` function is defined in `from_config` and not `get_config`, although it isn't immediately clear to me what that is.
