### PR TITLE
fix to_categorical(Categorical)

### DIFF
--- a/keras/utils/np_utils.py
+++ b/keras/utils/np_utils.py
@@ -10,7 +10,7 @@ def to_categorical(y, nb_classes=None):
     to binary class matrix, for use with categorical_crossentropy.
     '''
     if not nb_classes:
-        nb_classes = np.max(y)+1
+        nb_classes = np.max(np.array(y))+1
     Y = np.zeros((len(y), nb_classes))
     for i in range(len(y)):
         Y[i, y[i]] = 1.


### PR DESCRIPTION
When applying `to_categorical` to `Categorical` type, `to_categorical` throw an error because `Categorical is not ordered for operation max`. Forcing `Categorical` into `int` will make original code working.

Detail Traceback:
  File "ref/get_feature.py", line 211, in <module>
    dp=DP)
  File "ref/get_feature.py", line 187, in build_and_fit_model
    Y_test=np_utils.to_categorical(y_test.cat.rename_categories(range(len(y_test.unique()))))
  File "/xxx/.local/lib/python2.7/site-packages/keras/utils/np_utils.py", line 13, in to_categorical
    nb_classes = np.max(y)+1
  File "/xxx/.local/lib/python2.7/site-packages/numpy/core/fromnumeric.py", line 2265, in amax
    return amax(axis=axis, out=out)
  File "/xxx/.local/lib/python2.7/site-packages/pandas-0.18.1-py2.7-linux-x86_64.egg/pandas/core/generic.py", line 5310, in stat_func
    numeric_only=numeric_only)
  File "/xxx/.local/lib/python2.7/site-packages/pandas-0.18.1-py2.7-linux-x86_64.egg/pandas/core/series.py", line 2249, in _reduce
    filter_type=filter_type, **kwds)
  File "/xxx/.local/lib/python2.7/site-packages/pandas-0.18.1-py2.7-linux-x86_64.egg/pandas/core/categorical.py", line 1668, in _reduce
    return func(numeric_only=numeric_only, **kwds)
  File "/xxx/.local/lib/python2.7/site-packages/pandas-0.18.1-py2.7-linux-x86_64.egg/pandas/core/categorical.py", line 1709, in max
    self.check_for_ordered('max')
  File "/xxx/.local/lib/python2.7/site-packages/pandas-0.18.1-py2.7-linux-x86_64.egg/pandas/core/categorical.py", line 1178, in check_for_ordered
    "Categorical to an ordered one\n".format(op=op))
TypeError: Categorical is not ordered for operation max