### PR TITLE
Lambda output shape

### DIFF
--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -389,8 +389,12 @@ class Lambda(Layer):
         output_shape: Expected output shape from function.
             Can be a tuple or function.
             If a tuple, it only specifies the first dimension onward; 
-                 sample dimension is assumed the same as the input
-            If a function, it specifies the entire shape
+                 sample dimension is assumed either the same as the input:
+                 `output_shape = (input_shape[0], ) + output_shape`
+                 or, the input is `None` and the sample dimension is also `None`:
+                 `output_shape = (None, ) + output_shape`
+            If a function, it specifies the entire shape as a function of 
+                 the input shape: `output_shape = f(input_shape)`
         arguments: optional dictionary of keyword arguments to be passed
             to the function.
 

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -387,7 +387,10 @@ class Lambda(Layer):
         function: The function to be evaluated.
             Takes one argument: the output of previous layer
         output_shape: Expected output shape from function.
-            Could be a tuple or a function of the shape of the input
+            Can be a tuple or function.
+            If a tuple, it only specifies the first dimension onward; 
+                 sample dimension is assumed the same as the input
+            If a function, it specifies the entire shape
         arguments: optional dictionary of keyword arguments to be passed
             to the function.
 


### PR DESCRIPTION
Lambda has a weird thing right now that either needs to be pointed out or changed.

In this PR, I point it out but I'd be glad to change it as well.  

Essentially: if you pass in a tuple into `output_shape`, Keras assumes `(nb_samples,)+output_shape`.  If you pass a function into output shape, Keras assumes `tuple(output_shape())`.  