### PR TITLE
functional API intermediate output doc in faq

### DIFF
--- a/docs/templates/getting-started/faq.md
+++ b/docs/templates/getting-started/faq.md
@@ -146,7 +146,21 @@ layer_output = get_3rd_layer_output([X, 0])[0]
 layer_output = get_3rd_layer_output([X, 1])[0]
 ```
 
-Another more flexible way of getting output from intermediate layers is to use the [functional API](/getting-started/functional-api-guide).
+Another more flexible way of getting output from intermediate layers is to use the [functional API](/getting-started/functional-api-guide). For example, if you have created an autoencoder for MNIST:
+
+```python
+inputs = Input(shape=(784,))
+encoded = Dense(32, activation='relu')(inputs)
+decoded = Dense(784)(encoded)
+model = Model(input=inputs, output=decoded)
+```
+
+After compiling and training the model, you can get the output of the data from the encoder like this:
+
+```python
+encoder = Model(input=inputs, output=encoded)
+X_encoded = encoder.predict(X)
+```
 
 ---
 


### PR DESCRIPTION
This closes #2664 where @GelliFrancesco asks for more info about what was meant by "just use the functional API".

I would show an example of getting a decoder too, but I don't see a simple way to do that without doing something like:

```python
encoded_input = Input(shape=(32,)
third = Dense(512)(merge(second, encoded_input))
```

Otherwise I get `UserWarning: Model inputs must come from a Keras Input layer, they cannot be the output of a previous non-Input layer.`
