### PR TITLE
Residual connection should have the same dimension in case of no proj…

### DIFF
--- a/docs/templates/getting-started/functional-api-guide.md
+++ b/docs/templates/getting-started/functional-api-guide.md
@@ -309,8 +309,8 @@ from keras.layers import merge, Convolution2D, Input
 
 # input tensor for a 3-channel 256x256 image
 x = Input(shape=(3, 256, 256))
-# 3x3 conv with 16 output channels
-y = Convolution2D(16, 3, 3, border_mode='same')
+# 3x3 conv with 3 output channels (same as input channels)
+y = Convolution2D(3, 3, 3, border_mode='same')
 # this returns x + y.
 z = merge([x, y], mode='sum')
 ```


### PR DESCRIPTION
…ection matrix

In [documentation](http://keras.io/getting-started/functional-api-guide/#more-examples), residual connection example does not work due to inconsistent output shape. We can see they should have same dimension in [original paper](http://arxiv.org/abs/1512.03385).

> The dimensions of x and F must be equal in Eqn.(1).

```
Using TensorFlow backend.
Tensor("input_1:0", shape=(?, 3, 256, 256), dtype=float32)
Tensor("add:0", shape=(?, 16, 256, 256), dtype=float32)
Traceback (most recent call last):
  File "t.py", line 12, in <module>
    z = merge([x, y], mode='sum')
  File "/usr/local/lib/python2.7/site-packages/keras/engine/topology.py", line 1442, in merge
    name=name)
  File "/usr/local/lib/python2.7/site-packages/keras/engine/topology.py", line 1116, in __init__
    node_indices, tensor_indices)
  File "/usr/local/lib/python2.7/site-packages/keras/engine/topology.py", line 1151, in _arguments_validation
    'Layer shapes: %s' % input_shapes)
Exception: Only layers of same output shape can be merged using sum mode. Layer shapes: [(None, 3, 256, 256), (None, 16, 256, 256)]
```