### PR TITLE
save keras version & compile args when serializing models

### DIFF
--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -2107,8 +2107,6 @@ class Container(Layer):
         return output_tensors, output_masks, output_shapes
 
     def get_config(self):
-        '''TODO: add keras version information
-        '''
         config = {
             'name': self.name,
         }
@@ -2348,6 +2346,41 @@ class Container(Layer):
             K.batch_set_value(weight_value_tuples)
         f.close()
 
+    def prepare_config(self):
+        '''shared between different serialization methods'''
+        from six import string_types
+        from keras import __version__ as keras_version
+
+        def prepare(obj):
+            if isinstance(obj, dict):
+                return {k: prepare(v) for k, v in obj.items()}
+            elif isinstance(obj, list):
+                return [prepare(v) for v in obj]
+            elif isinstance(obj, string_types):
+                return obj
+            elif isinstance(obj, object):
+                return obj.__class__.__name__
+            elif hasattr(obj, '__name__'):
+                return obj.__name__
+            else:
+                raise Exception('unable to get name for item ' + obj)
+
+        config = self.get_config()
+        model_config = {
+            'class_name': self.__class__.__name__,
+            'config': config,
+            'keras_version': keras_version
+        }
+
+        if hasattr(self, 'optimizer'):
+            model_config['optimizer'] = prepare(self.optimizer)
+            model_config['loss'] = prepare(self.loss)
+            model_config['sample_weight_mode'] = self.sample_weight_mode
+
+        if hasattr(self, 'loss_weights'):
+            model_config['loss_weights'] = self.loss_weights
+        return model_config
+
     def to_json(self, **kwargs):
         '''Returns a JSON string containing the network configuration.
 
@@ -2367,11 +2400,7 @@ class Container(Layer):
 
             raise TypeError('Not JSON Serializable')
 
-        config = self.get_config()
-        model_config = {
-            'class_name': self.__class__.__name__,
-            'config': config,
-        }
+        model_config = self.prepare_config()
         return json.dumps(model_config, default=get_json_type, **kwargs)
 
     def to_yaml(self, **kwargs):
@@ -2385,12 +2414,7 @@ class Container(Layer):
         functions / classes.
         '''
         import yaml
-        config = self.get_config()
-        model_config = {
-            'class_name': self.__class__.__name__,
-            'config': config,
-        }
-        return yaml.dump(model_config, **kwargs)
+        return yaml.dump(self.prepare_config(), **kwargs)
 
     def summary(self):
         from keras.utils.layer_utils import print_summary

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -452,6 +452,7 @@ class Model(Container):
         self.optimizer = optimizers.get(optimizer)
         self.sample_weight_mode = sample_weight_mode
         self.loss = loss
+        self.loss_weights = loss_weights
 
         # prepare loss weights
         if loss_weights is None:


### PR DESCRIPTION
I frequently load and retrain models serialized weeks and months earlier, and it's useful to know the `optimizer` and `loss` + other args that a model was compiled with. Other people have mentioned this as well.

Thought this was simple enough that I'd take a stab. This doesn't effect any existing functionality, but it lets me manually get the required information out of a json/yaml file.

I also took the liberty of saving the keras version number, which was mentioned in a `TODO` comment.

if @fchollet or anyone else has a better idea for how to do this (or why not to do this) I'm happy to revisit.

(fixes #2498)


edit: failing a pep8 test, I'll take a look in a bit and push again