### PR TITLE
Update the reference of Batch Normalization

### DIFF
--- a/keras/layers/normalization.py
+++ b/keras/layers/normalization.py
@@ -47,7 +47,7 @@ class BatchNormalization(Layer):
         Same shape as input.
 
     # References
-        - [Batch Normalization: Accelerating Deep Network Training by Reducing Internal Covariate Shift](http://arxiv.org/pdf/1502.03167v3.pdf)
+        - [Batch Normalization: Accelerating Deep Network Training by Reducing Internal Covariate Shift](http://jmlr.org/proceedings/papers/v37/ioffe15.html)
     '''
     def __init__(self, epsilon=1e-6, mode=0, axis=-1, momentum=0.9,
                  weights=None, beta_init='zero', gamma_init='one', **kwargs):


### PR DESCRIPTION
We should refer the paper accepted in ICML 2015, instead of arXiv.

When I translated normalization.md into Japanese, I noticed that the reference was old :)