### PR TITLE
Fix zero division in merge mode='cos'

### DIFF
--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -1220,7 +1220,7 @@ class Merge(Layer):
             l2 = inputs[1]
             denominator = K.sqrt(K.batch_dot(l1, l1, self.dot_axes) *
                                  K.batch_dot(l2, l2, self.dot_axes))
-            denominator = K.maximum(denominator, 1e-15)
+            denominator = K.maximum(denominator, K.epsilon())
             output = K.batch_dot(l1, l2, self.dot_axes) / denominator
             output = K.expand_dims(output, 1)
             return output

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -1220,6 +1220,7 @@ class Merge(Layer):
             l2 = inputs[1]
             denominator = K.sqrt(K.batch_dot(l1, l1, self.dot_axes) *
                                  K.batch_dot(l2, l2, self.dot_axes))
+            denominator = K.maximum(denominator, 1e-15)
             output = K.batch_dot(l1, l2, self.dot_axes) / denominator
             output = K.expand_dims(output, 1)
             return output


### PR DESCRIPTION
In issue #2672, zero division problem was reported and it can be reproduced by:
```python
a = np.reshape(np.array([0, 0]), (1, 2, 1)) # zero vector has zero length
b = np.reshape(np.array([0.6, 0.8]), (1, 2, 1))

input_a = Input((2, 1))
input_b = Input((2, 1))

cos = merge([input_a, input_b], mode='cos', dot_axes=1)

model = Model(input=[input_a, input_b], output=[cos])
result = model.predict([a, b])
# before fix: result  == [[[[ nan ]]]]
# after fix: result == [[[[ 0. ]]]]
```
`K.maximum` can easily solve the problem.