### PR TITLE
rename z_log_sigma to z_log_std to match z_mean (which is not z_mu)

### DIFF
--- a/examples/variational_autoencoder.py
+++ b/examples/variational_autoencoder.py
@@ -21,17 +21,17 @@ nb_epoch = 40
 x = Input(batch_shape=(batch_size, original_dim))
 h = Dense(intermediate_dim, activation='relu')(x)
 z_mean = Dense(latent_dim)(h)
-z_log_sigma = Dense(latent_dim)(h)
+z_log_std = Dense(latent_dim)(h)
 
 def sampling(args):
-    z_mean, z_log_sigma = args
+    z_mean, z_log_std = args
     epsilon = K.random_normal(shape=(batch_size, latent_dim),
                               mean=0., std=epsilon_std)
-    return z_mean + K.exp(z_log_sigma) * epsilon
+    return z_mean + K.exp(z_log_std) * epsilon
 
 # note that "output_shape" isn't necessary with the TensorFlow backend
-# so you could write `Lambda(sampling)([z_mean, z_log_sigma])`
-z = Lambda(sampling, output_shape=(latent_dim,))([z_mean, z_log_sigma])
+# so you could write `Lambda(sampling)([z_mean, z_log_std])`
+z = Lambda(sampling, output_shape=(latent_dim,))([z_mean, z_log_std])
 
 # we instantiate these layers separately so as to reuse them later
 decoder_h = Dense(intermediate_dim, activation='relu')
@@ -41,7 +41,7 @@ x_decoded_mean = decoder_mean(h_decoded)
 
 def vae_loss(x, x_decoded_mean):
     xent_loss = objectives.binary_crossentropy(x, x_decoded_mean)
-    kl_loss = - 0.5 * K.mean(1 + z_log_sigma - K.square(z_mean) - K.exp(z_log_sigma), axis=-1)
+    kl_loss = - 0.5 * K.mean(1 + z_log_std - K.square(z_mean) - K.exp(z_log_std), axis=-1)
     return xent_loss + kl_loss
 
 vae = Model(x, x_decoded_mean)


### PR DESCRIPTION
This is the simplest VAE example i've come across. nice work!
The only trivial nit I had was the naming of `z_log_sigma` which I had to read twice (since the corresponding mean variable wasn't called `z_mu`