### PR TITLE
changeable print_summary

### DIFF
--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -2337,7 +2337,7 @@ class Container(Layer):
         }
         return yaml.dump(model_config, **kwargs)
 
-    def summary(self):
+    def summary(self, line_length=100, positions=[.33, .55, .67, 1.]):
         from keras.utils.layer_utils import print_summary
 
         if hasattr(self, 'flattened_layers'):
@@ -2346,7 +2346,7 @@ class Container(Layer):
         else:
             flattened_layers = self.layers
 
-        print_summary(flattened_layers, getattr(self, 'container_nodes', None))
+        print_summary(flattened_layers, getattr(self, 'container_nodes', None), line_length=line_length, positions=positions)
 
 
 def get_source_inputs(tensor, layer=None, node_index=None):

--- a/keras/utils/layer_utils.py
+++ b/keras/utils/layer_utils.py
@@ -37,7 +37,7 @@ def layer_from_config(config, custom_objects={}):
 
 def print_summary(layers, relevant_nodes=None, line_length=100, positions=[.33, .55, .67, 1.]):
     # line_length: total length of printed lines
-    # positions: absolute positions of log elements in each line
+    # positions: relative or absolute positions of log elements in each line
     if positions[-1] <= 1:
         positions = [int(line_length * p) for p in positions]
     # header names for the different log elements

--- a/keras/utils/layer_utils.py
+++ b/keras/utils/layer_utils.py
@@ -35,9 +35,11 @@ def layer_from_config(config, custom_objects={}):
     return layer_class.from_config(config['config'])
 
 
-def print_summary(layers, relevant_nodes=None):
-    line_length = 100  # total length of printed lines
-    positions = [35, 55, 67, 100]  # absolute positions of log elements in each line
+def print_summary(layers, relevant_nodes=None, line_length=100, positions=[.33, .55, .67, 1.]):
+    # line_length: total length of printed lines
+    # positions: absolute positions of log elements in each line
+    if positions[-1] <= 1:
+        positions = [int(line_length * p) for p in positions]
     # header names for the different log elements
     to_display = ['Layer (type)', 'Output Shape', 'Param #', 'Connected to']
 


### PR DESCRIPTION
Saw @joelthchao 's reply in https://github.com/fchollet/keras/issues/2757 , so tried `model.print_summary()` , which doesn't print my network model well, cause when layer name is long, and dimension is also relatively long, it can't print whole info. So here's a small fix, makes the `print_summary` function more flexible.