### PR TITLE
Nadam optimizer and test for it added

### DIFF
--- a/keras/optimizers.py
+++ b/keras/optimizers.py
@@ -443,7 +443,7 @@ class Nadam(Optimizer):
 
     def get_updates(self, params, constraints, loss):
         grads = self.get_gradients(loss, params)
-        self.updates = [ (self.iterations, self.iterations + 1) ]
+        self.updates = [(self.iterations, self.iterations + 1)]
 
         t = self.iterations + 1
 
@@ -455,8 +455,8 @@ class Nadam(Optimizer):
         m_schedule_next = self.m_schedule * momentum_cache_t * momentum_cache_t_1
         self.updates.append((self.m_schedule, m_schedule_new))
 
-        ms = [ K.variable(np.zeros(K.get_value(p).shape)) for p in params ]
-        vs = [ K.variable(np.zeros(K.get_value(p).shape)) for p in params ]
+        ms = [K.variable(np.zeros(K.get_value(p).shape)) for p in params]
+        vs = [K.variable(np.zeros(K.get_value(p).shape)) for p in params]
 
         self.weights = ms + vs
 
@@ -477,16 +477,16 @@ class Nadam(Optimizer):
 
             # apply constraints
             if p in constraints:
-                c = constraints[ p ]
+                c = constraints[p]
                 new_p = c(new_p)
             self.updates.append((p, new_p))
         return self.updates
 
     def get_config(self):
-        config = { 'lr': float(K.get_value(self.lr)),
-                   'beta_1': float(K.get_value(self.beta_1)),
-                   'beta_2': float(K.get_value(self.beta_2)),
-                   'epsilon': self.epsilon }
+        config = {'lr': float(K.get_value(self.lr)),
+                  'beta_1': float(K.get_value(self.beta_1)),
+                  'beta_2': float(K.get_value(self.beta_2)),
+                  'epsilon': self.epsilon}
         base_config = super(Nadam, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
 

--- a/keras/optimizers.py
+++ b/keras/optimizers.py
@@ -421,6 +421,11 @@ class Nadam(Optimizer):
 
     Default parameters follow those provided in the paper.
 
+    Hard-coded values for warming momentum schedule calculation
+    (used in schedule_decay, momentum_cache_t, momentum_cache_t_1, lines 456-458)
+    are given in [1] with reference in [2] (p.4 eq.5) and strongly motivated
+    to keep these values hard-coded and constant.
+
     # Arguments
         lr: float >= 0. Learning rate.
         beta_1/beta_2: floats, 0 < beta < 1. Generally close to 1.
@@ -448,7 +453,7 @@ class Nadam(Optimizer):
         t = self.iterations + 1
 
         # Due to the recommendations in [2], i.e. warming momentum schedule
-        schedule_decay = 0.004 # Exactly given in [1] and [2]
+        schedule_decay = 0.004  # Exactly given in [1] and [2]
         momentum_cache_t = self.beta_1 * (1. - 0.5 * (K.pow(0.96, t * schedule_decay)))
         momentum_cache_t_1 = self.beta_1 * (1. - 0.5 * (K.pow(0.96, (t + 1) * schedule_decay)))
         m_schedule_new = self.m_schedule * momentum_cache_t

--- a/keras/optimizers.py
+++ b/keras/optimizers.py
@@ -415,6 +415,82 @@ class Adamax(Optimizer):
         return dict(list(base_config.items()) + list(config.items()))
 
 
+class Nadam(Optimizer):
+    '''
+    Nesterov Adam optimizer: Adam ~ RMSProp + momentum, Nadam ~ RMSProp + NAG
+
+    Default parameters follow those provided in the paper.
+
+    # Arguments
+        lr: float >= 0. Learning rate.
+        beta_1/beta_2: floats, 0 < beta < 1. Generally close to 1.
+        epsilon: float >= 0. Fuzz factor.
+
+    # References
+    [1] Nadam report - http://cs229.stanford.edu/proj2015/054_report.pdf
+    [2] On the importance of initialization and momentum in deep learning -
+        http://www.cs.toronto.edu/~fritz/absps/momentum.pdf
+    '''
+    def __init__(self, lr=0.002, beta_1=0.9, beta_2=0.999,
+                 epsilon=1e-8, **kwargs):
+        super(Nadam, self).__init__(**kwargs)
+        self.__dict__.update(locals())
+        self.iterations = K.variable(0.)
+        self.m_schedule = K.variable(1.)
+        self.lr = K.variable(lr)
+        self.beta_1 = K.variable(beta_1)
+        self.beta_2 = K.variable(beta_2)
+
+    def get_updates(self, params, constraints, loss):
+        grads = self.get_gradients(loss, params)
+        self.updates = [ (self.iterations, self.iterations + 1) ]
+
+        t = self.iterations + 1
+
+        # Due to the recommendations in [2], i.e. warming momentum schedule
+        schedule_decay = 0.004 # Exactly given in [1] and [2]
+        momentum_cache_t = self.beta_1 * (1. - 0.5 * (K.pow(0.96, t * schedule_decay)))
+        momentum_cache_t_1 = self.beta_1 * (1. - 0.5 * (K.pow(0.96, (t + 1) * schedule_decay)))
+        m_schedule_new = self.m_schedule * momentum_cache_t
+        m_schedule_next = self.m_schedule * momentum_cache_t * momentum_cache_t_1
+        self.updates.append((self.m_schedule, m_schedule_new))
+
+        ms = [ K.variable(np.zeros(K.get_value(p).shape)) for p in params ]
+        vs = [ K.variable(np.zeros(K.get_value(p).shape)) for p in params ]
+
+        self.weights = ms + vs
+
+        for p, g, m, v in zip(params, grads, ms, vs):
+            # the following equations given in [1]
+            g_prime = g / (1. - m_schedule_new)
+            m_t = self.beta_1 * m + (1. - self.beta_1) * g
+            m_t_prime = m_t / (1. - m_schedule_next)
+            v_t = self.beta_2 * v + (1. - self.beta_2) * K.square(g)
+            v_t_prime = v_t / (1. - K.pow(self.beta_2, t))
+            m_t_bar = (1. - momentum_cache_t) * g_prime + momentum_cache_t_1 * m_t_prime
+
+            self.updates.append((m, m_t))
+            self.updates.append((v, v_t))
+
+            p_t = p - self.lr * m_t_bar / (K.sqrt(v_t_prime) + self.epsilon)
+            new_p = p_t
+
+            # apply constraints
+            if p in constraints:
+                c = constraints[ p ]
+                new_p = c(new_p)
+            self.updates.append((p, new_p))
+        return self.updates
+
+    def get_config(self):
+        config = { 'lr': float(K.get_value(self.lr)),
+                   'beta_1': float(K.get_value(self.beta_1)),
+                   'beta_2': float(K.get_value(self.beta_2)),
+                   'epsilon': self.epsilon }
+        base_config = super(Nadam, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))
+
+
 # aliases
 sgd = SGD
 rmsprop = RMSprop
@@ -422,6 +498,7 @@ adagrad = Adagrad
 adadelta = Adadelta
 adam = Adam
 adamax = Adamax
+nadam = Nadam
 
 
 def get(identifier, kwargs=None):

--- a/tests/keras/test_optimizers.py
+++ b/tests/keras/test_optimizers.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 import pytest
 
 from keras.utils.test_utils import get_test_data
-from keras.optimizers import SGD, RMSprop, Adagrad, Adadelta, Adam, Adamax
+from keras.optimizers import SGD, RMSprop, Adagrad, Adadelta, Adam, Adamax, Nadam
 from keras.models import Sequential
 from keras.layers.core import Dense, Activation
 from keras.utils.np_utils import to_categorical
@@ -61,6 +61,10 @@ def test_adam():
 
 def test_adamax():
     _test_optimizer(Adamax())
+
+
+def test_nadam():
+    _test_optimizer(Nadam())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hello @fchollet, this is my first ever PR sorry for any mistakes. 
in my experiments I tried the combination of Adam and NAG from [here](http://cs229.stanford.edu/proj2015/054_report.pdf), and it was better than pure Adam optimizer, today I added it to Keras optimizer module and created this PR. I hope it will be helpful for someone =)

Here is some small experiments which I did, but authors from the report did bigger experiments.

The test passed ok for Theano backend, I don't have TF installed, but if it is necessary I can install it and check.

This is my results comparison for default CIFAR cnn demo from examples folder. (Mini batch = 128, the rest is default).

SGD + NAG:
Using Theano backend.
Using gpu device 0: GeForce GTX 970 (CNMeM is disabled, cuDNN 5004)
X_train shape: (50000, 3, 32, 32)
50000 train samples
10000 test samples
Using real-time data augmentation.
Epoch 1/10
50000/50000 - 22s - loss: 1.8430 - acc: 0.3180 - val_loss: 1.4731 - val_acc: 0.4604
Epoch 2/10
50000/50000 - 19s - loss: 1.4929 - acc: 0.4531 - val_loss: 1.2950 - val_acc: 0.5366
Epoch 3/10
50000/50000 - 19s - loss: 1.3450 - acc: 0.5133 - val_loss: 1.1525 - val_acc: 0.5932
Epoch 4/10
50000/50000 - 19s - loss: 1.2316 - acc: 0.5584 - val_loss: 1.0146 - val_acc: 0.6413
Epoch 5/10
50000/50000 - 15s - loss: 1.1343 - acc: 0.5966 - val_loss: 0.9389 - val_acc: 0.6674
Epoch 6/10
50000/50000 - 12s - loss: 1.0642 - acc: 0.6212 - val_loss: 0.8569 - val_acc: 0.7000
Epoch 7/10
50000/50000 - 12s - loss: 1.0075 - acc: 0.6422 - val_loss: 0.8149 - val_acc: 0.7147
Epoch 8/10
50000/50000 - 12s - loss: 0.9612 - acc: 0.6606 - val_loss: 0.7856 - val_acc: 0.7289
Epoch 9/10
50000/50000 - 12s - loss: 0.9298 - acc: 0.6715 - val_loss: 0.7820 - val_acc: 0.7272
Epoch 10/10
50000/50000 - 12s - loss: 0.8945 - acc: 0.6837 - val_loss: 0.7276 - val_acc: 0.7493

Adam:
Using Theano backend.
Using gpu device 0: GeForce GTX 970 (CNMeM is disabled, cuDNN 5004)
X_train shape: (50000, 3, 32, 32)
50000 train samples
10000 test samples
Using real-time data augmentation.
Epoch 1/10
50000/50000 - 13s - loss: 1.7587 - acc: 0.3508 - val_loss: 1.3012 - val_acc: 0.5314
Epoch 2/10
50000/50000 - 13s - loss: 1.3630 - acc: 0.5087 - val_loss: 1.1107 - val_acc: 0.6094
Epoch 3/10
50000/50000 - 13s - loss: 1.1711 - acc: 0.5831 - val_loss: 0.9536 - val_acc: 0.6626
Epoch 4/10
50000/50000 - 13s - loss: 1.0511 - acc: 0.6275 - val_loss: 0.8502 - val_acc: 0.7025
Epoch 5/10
50000/50000 - 13s - loss: 0.9661 - acc: 0.6589 - val_loss: 0.8260 - val_acc: 0.7083
Epoch 6/10
50000/50000 - 13s - loss: 0.9174 - acc: 0.6780 - val_loss: 0.7416 - val_acc: 0.7409
Epoch 7/10
50000/50000 - 13s - loss: 0.8853 - acc: 0.6883 - val_loss: 0.7118 - val_acc: 0.7529
Epoch 8/10
50000/50000 - 13s - loss: 0.8412 - acc: 0.7022 - val_loss: 0.7058 - val_acc: 0.7527
Epoch 9/10
50000/50000 - 13s - loss: 0.8131 - acc: 0.7156 - val_loss: 0.6746 - val_acc: 0.7623
Epoch 10/10
50000/50000 - 13s - loss: 0.7941 - acc: 0.7191 - val_loss: 0.6801 - val_acc: 0.7622

NAG + Adam (this PR):
Using Theano backend.
Using gpu device 0: GeForce GTX 970 (CNMeM is disabled, cuDNN 5004)
X_train shape: (50000, 3, 32, 32)
50000 train samples
10000 test samples
Using real-time data augmentation.
Epoch 1/10
50000/50000 - 13s - loss: 1.7984 - acc: 0.3485 - val_loss: 1.2916 - val_acc: 0.5318
Epoch 2/10
50000/50000 - 13s - loss: 1.3098 - acc: 0.5289 - val_loss: 1.0351 - val_acc: 0.6300
Epoch 3/10
50000/50000 - 13s - loss: 1.1152 - acc: 0.6049 - val_loss: 0.8808 - val_acc: 0.6840
Epoch 4/10
50000/50000 - 13s - loss: 0.9938 - acc: 0.6498 - val_loss: 0.8003 - val_acc: 0.7159
Epoch 5/10
50000/50000 - 13s - loss: 0.9211 - acc: 0.6755 - val_loss: 0.7352 - val_acc: 0.7422
Epoch 6/10
50000/50000 - 14s - loss: 0.8693 - acc: 0.6952 - val_loss: 0.7321 - val_acc: 0.7469
Epoch 7/10
50000/50000 - 15s - loss: 0.8414 - acc: 0.7066 - val_loss: 0.7250 - val_acc: 0.7552
Epoch 8/10
50000/50000 - 13s - loss: 0.8122 - acc: 0.7186 - val_loss: 0.6938 - val_acc: 0.7627
Epoch 9/10
50000/50000 - 13s - loss: 0.7910 - acc: 0.7261 - val_loss: 0.6349 - val_acc: 0.7838
Epoch 10/10
50000/50000 - 15s - loss: 0.7747 - acc: 0.7319 - val_loss: 0.6148 - val_acc: 0.7902