### PR TITLE
fixed formatting error in the docstring

### DIFF
--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -972,8 +972,10 @@ class TimeDistributedDense(Layer):
 
     # Input shape
         3D tensor with shape `(nb_sample, time_dimension, input_dim)`.
+
     # Output shape
         3D tensor with shape `(nb_sample, time_dimension, output_dim)`.
+
     # Arguments
         output_dim: int > 0.
         init: name of initialization function for the weights of the layer

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -85,11 +85,9 @@ class Recurrent(Layer):
             If set to "cpu", the RNN will use
             an implementation that uses fewer, larger matrix products,
             thus running faster on CPU but consuming more memory.
-
             If set to "mem", the RNN will use more matrix products,
             but smaller ones, thus running slower (may actually be faster on GPU)
             while consuming less memory.
-
             If set to "gpu" (LSTM/GRU only), the RNN will combine the input gate,
             the forget gate and the output gate into a single matrix,
             enabling more time-efficient parallelization on the GPU. Note: RNN


### PR DESCRIPTION
Empty lines lead to formatting errors in [http://keras.io/layers/recurrent/](http://keras.io/layers/recurrent/).
Missing newlines lead to formatting errors in [http://keras.io/layers/core/](http://keras.io/layers/core/).