### PR TITLE
correctly serialize loss function (one liner)

### DIFF
--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -2358,7 +2358,7 @@ class Container(Layer):
 
         if hasattr(self, 'optimizer'):
             model_config['optimizer'] = self.optimizer.get_config()
-            model_config['loss'] = self.loss.__class__.__name__
+            model_config['loss'] = getattr(self.loss, '__name__', self.loss)
             model_config['sample_weight_mode'] = self.sample_weight_mode
 
         if hasattr(self, 'loss_weights'):


### PR DESCRIPTION
This fixes a bug I introduced during review of #2690, which caused the loss function to be incorrectly serialized. 😞