### PR TITLE
make training data accessible for callbacks (e.g., on_epoch_end)

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -763,6 +763,7 @@ class Model(Container):
         callbacks.on_train_begin()
         callback_model.stop_training = False
         self.validation_data = val_ins
+        self.training_data = ins
 
         for epoch in range(nb_epoch):
             callbacks.on_epoch_begin(epoch)


### PR DESCRIPTION
make it possible to access training data through callbacks. Can be used to calculate the actual loss of the training set for each epoch
