### PR TITLE
Default values corrected for featurewise_std_normalization and featurewise_center

### DIFF
--- a/docs/templates/preprocessing/image.md
+++ b/docs/templates/preprocessing/image.md
@@ -2,9 +2,9 @@
 ## ImageDataGenerator
 
 ```python
-keras.preprocessing.image.ImageDataGenerator(featurewise_center=True,
+keras.preprocessing.image.ImageDataGenerator(featurewise_center=False,
     samplewise_center=False,
-    featurewise_std_normalization=True,
+    featurewise_std_normalization=False,
     samplewise_std_normalization=False,
     zca_whitening=False,
     rotation_range=0.,


### PR DESCRIPTION
Inside ImageDataGenerator, False is the default value for featurewise_std_normalization and featurewise_center. Document corrected to show the correct default values.