### PR TITLE
fix bug: rename duplicated loss name

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1040,6 +1040,10 @@ class Model(Container):
 
         # prepare display labels
         out_labels = self.metrics_names
+
+        # rename duplicated metrics name
+        out_labels = map(lambda x: x[1] + str(out_labels[:x[0]].count(x[1]) + 1) if out_labels.count(x[1]) > 1 else x[1], enumerate(out_labels))
+
         if do_validation:
             callback_metrics = copy.copy(out_labels) + ['val_' + n for n in out_labels]
         else:

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1042,7 +1042,7 @@ class Model(Container):
         out_labels = self.metrics_names
 
         # rename duplicated metrics name
-        out_labels = map(lambda x: x[1] + str(out_labels[:x[0]].count(x[1]) + 1) if out_labels.count(x[1]) > 1 else x[1], enumerate(out_labels))
+        out_labels = list(map(lambda x: x[1] + str(out_labels[:x[0]].count(x[1]) + 1) if out_labels.count(x[1]) > 1 else x[1], enumerate(out_labels)))
 
         if do_validation:
             callback_metrics = copy.copy(out_labels) + ['val_' + n for n in out_labels]

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1042,7 +1042,14 @@ class Model(Container):
         out_labels = self.metrics_names
 
         # rename duplicated metrics name
-        out_labels = list(map(lambda x: x[1] + str(out_labels[:x[0]].count(x[1]) + 1) if out_labels.count(x[1]) > 1 else x[1], enumerate(out_labels)))
+        new_out_labels = []
+        for i, label in enumerate(out_labels):
+            new_label = label
+            if out_labels.count(label) > 1:
+                dup_idx = out_labels[:i].count(label)
+                new_label += str(dup_idx + 1)
+            new_out_labels.append(new_label)
+        out_labels = new_out_labels
 
         if do_validation:
             callback_metrics = copy.copy(out_labels) + ['val_' + n for n in out_labels]


### PR DESCRIPTION
While users use a shared layer to get two different outputs but have one same name, the batch_logs/epoch_logs will only left one loss, because it's a `dict`.

```
import numpy as np
from keras.models import *
from keras.layers import *

train_d = np.random.rand(128, 64)
test_d  = np.random.rand(2, 128, 32)

x = Input(shape=(64, ))
a = Dense(32)(x)
b = Dense(32)(x)

shared_dense = Dense(32, name='shared_dense')
out1 = shared_dense(a)
out2 = shared_dense(b)

model = Model(input=x, output=[out1, out2])
model.compile(optimizer='rmsprop', loss='mse')

his = model.fit(train_d, [test_d[0], test_d[1]])
```

The code above will get output like below, but it should have two shared_dense_loss.

![image](https://cloud.githubusercontent.com/assets/17693755/15631854/8d1d9868-25b0-11e6-8cc2-ed211e3ef996.png)

To solve this problem, I rename the duplicates name by appending it a number. Then it works well:

![image](https://cloud.githubusercontent.com/assets/17693755/15631865/df869e6a-25b0-11e6-92e4-f9287e7b0f7f.png)

 