### PR TITLE
limit progress bar update rate

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -192,7 +192,7 @@ class ProgbarLogger(Callback):
             if k in logs:
                 self.log_values.append((k, logs[k]))
         if self.verbose:
-            self.progbar.update(self.seen, self.log_values)
+            self.progbar.update(self.seen, self.log_values, force=True)
 
 
 class History(Callback):

--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -34,7 +34,7 @@ def make_tuple(*args):
 
 
 class Progbar(object):
-    def __init__(self, target, width=30, verbose=1):
+    def __init__(self, target, width=30, verbose=1, interval=0.01):
         '''
             @param target: total number of steps expected
         '''
@@ -43,11 +43,13 @@ class Progbar(object):
         self.sum_values = {}
         self.unique_values = []
         self.start = time.time()
+        self.last_update = 0
+        self.interval = interval
         self.total_width = 0
         self.seen_so_far = 0
         self.verbose = verbose
 
-    def update(self, current, values=[]):
+    def update(self, current, values=[], force=False):
         '''
             @param current: index of current step
             @param values: list of tuples (name, value_for_last_step).
@@ -64,6 +66,9 @@ class Progbar(object):
 
         now = time.time()
         if self.verbose == 1:
+            if not force and (now - self.last_update) < self.interval:
+                return
+
             prev_total_width = self.total_width
             sys.stdout.write("\b" * prev_total_width)
             sys.stdout.write("\r")
@@ -126,6 +131,8 @@ class Progbar(object):
                     else:
                         info += ' %.4e' % avg
                 sys.stdout.write(info + "\n")
+
+        self.last_update = now
 
     def add(self, n, values=[]):
         self.update(self.seen_so_far + n, values)

--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -37,6 +37,7 @@ class Progbar(object):
     def __init__(self, target, width=30, verbose=1, interval=0.01):
         '''
             @param target: total number of steps expected
+            @param interval: minimum visual progress update interval (in seconds)
         '''
         self.width = width
         self.target = target
@@ -54,6 +55,7 @@ class Progbar(object):
             @param current: index of current step
             @param values: list of tuples (name, value_for_last_step).
             The progress bar will display averages for these values.
+            @param force: force visual progress update
         '''
         for k, v in values:
             if k not in self.sum_values:


### PR DESCRIPTION
Limit progress bar update rate in verbose=1 mode. This patch allows to
reduce terminal I/O throughput while keeping reasonable high visual
update rate (defaults to 100 refreshes per second). It helps greatly
when working with large but simple data sets with small batches, which
leads to millions of relatively useless screen updates per second. Also
it helps to keep network traffic at reasonable rates, which
exceptionally useful within laggy networking conditions when using
keras over telnet/ssh, and improve web browser responsibility when
using keras within Jupyter Notebook.