### PR TITLE
Update ImageDataGenerator to allow channelwise standardization

### DIFF
--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -176,10 +176,15 @@ class ImageDataGenerator(object):
     real-time data augmentation.
 
     # Arguments
-        featurewise_center: set input mean to 0 over the dataset.
-        samplewise_center: set each sample mean to 0.
-        featurewise_std_normalization: divide inputs by std of the dataset.
-        samplewise_std_normalization: divide each input by its std.
+        featurewise_center: set input mean to 0 over the dataset (entire batch)
+        samplewise_center: set input mean to 0 over the sample (individual image
+            in batch)
+        featurewise_std_normalization: divide inputs by std of the dataset 
+            (entire batch)
+        samplewise_std_normalization: divide each input by its std (individual 
+            image in batch)
+        channelwise: apply centering and std_normalization separately for each   
+                     channel 
         zca_whitening: apply ZCA whitening.
         rotation_range: degrees (0 to 180).
         width_shift_range: fraction of total width.
@@ -210,6 +215,7 @@ class ImageDataGenerator(object):
                  samplewise_center=False,
                  featurewise_std_normalization=False,
                  samplewise_std_normalization=False,
+                 channelwise=False, 
                  zca_whitening=False,
                  rotation_range=0.,
                  width_shift_range=0.,
@@ -278,10 +284,17 @@ class ImageDataGenerator(object):
             x *= self.rescale
         # x is a single image, so it doesn't have image number at index 0
         img_channel_index = self.channel_index - 1
+        img_row_index = self.row_index - 1
+        img_col_index = self.col_index - 1
+        if self.channelwise: 
+            standardize_axis = (img_row_index, img_col_index)
+        else: 
+            standardize_axis = img_channel_index
+
         if self.samplewise_center:
-            x -= np.mean(x, axis=img_channel_index, keepdims=True)
+            x -= np.mean(x, axis=standardize_axis, keepdims=True)
         if self.samplewise_std_normalization:
-            x /= (np.std(x, axis=img_channel_index, keepdims=True) + 1e-7)
+            x /= (np.std(x, axis=standardize_axis, keepdims=True) + 1e-7)
 
         if self.featurewise_center:
             x -= self.mean
@@ -382,13 +395,26 @@ class ImageDataGenerator(object):
                     aX[i + r * X.shape[0]] = self.random_transform(X[i])
             X = aX
 
+        if self.channelwise: 
+            standardize_axis = (0, self.row_index, self.col_index)
+            keep_dims = True
+        else: 
+            standardize_axis = 0 
+            keep_dims = False
+
         if self.featurewise_center:
-            self.mean = np.mean(X, axis=0)
+            self.mean = np.mean(X, axis=standardize_axis, keepdims=keep_dims)
             X -= self.mean
+            
+            if self.channelwise: 
+                self.mean = self.mean[0]
 
         if self.featurewise_std_normalization:
-            self.std = np.std(X, axis=0)
+            self.std = np.std(X, axis=standardize_axis, keepdims=keep_dims)
             X /= (self.std + 1e-7)
+            
+            if self.channelwise: 
+                self.std = self.std[0]
 
         if self.zca_whitening:
             flatX = np.reshape(X, (X.shape[0], X.shape[1] * X.shape[2] * X.shape[3]))

--- a/tests/keras/preprocessing/test_image.py
+++ b/tests/keras/preprocessing/test_image.py
@@ -41,6 +41,7 @@ class TestImage:
                 samplewise_center=True,
                 featurewise_std_normalization=True,
                 samplewise_std_normalization=True,
+                channelwise=True, 
                 zca_whitening=True,
                 rotation_range=90.,
                 width_shift_range=0.1,
@@ -90,6 +91,69 @@ class TestImage:
                 assert ((potentially_flipped_x == x).all() or
                         (potentially_flipped_x == flip_axis(x, col_index)).all())
 
+    def test_standardize(self): 
+        eps = 1e-5
+
+        for test_images in self.all_test_images:
+            img_list = []
+            for im in test_images:
+                img_list.append(img_to_array(im)[None, ...])
+
+            imgs = np.vstack(img_list)
+            for dim_ordering in ('tf', 'th'):
+                if dim_ordering == 'th': 
+                    imgs = imgs.swapaxes(1, 3)
+                generator = ImageDataGenerator(
+                    featurewise_center=True,
+                    samplewise_center=False,
+                    featurewise_std_normalization=True,
+                    samplewise_std_normalization=False,
+                    channelwise=False, 
+                    zca_whitening=False,
+                    rotation_range=0,
+                    width_shift_range=0,
+                    height_shift_range=0,
+                    shear_range=0,
+                    zoom_range=0,
+                    channel_shift_range=0,
+                    horizontal_flip=False,
+                    vertical_flip=False,
+                    dim_ordering=dim_ordering)
+                generator.fit(imgs)
+
+                eps = 1e-5
+
+                standardized_imgs = np.array([generator.standardize(img) for img in imgs])
+                assert np.all(np.abs(standardized_imgs.mean(axis=0)) < eps)
+                assert np.all(np.abs(standardized_imgs.std(axis=0) - 1) < eps)
+
+                generator.channelwise = True 
+                generator.fit(imgs)
+                collapse_axis = (0, generator.row_index, generator.col_index)
+
+                standardized_imgs = np.array([generator.standardize(img) for img in imgs])
+                assert np.all(np.abs(standardized_imgs.mean(axis=collapse_axis)) < eps)
+                assert np.all(np.abs(standardized_imgs.std(axis=collapse_axis) - 1) < eps)
+
+                generator.featurewise_center = False
+                generator.featurewise_std_normalization = False
+                generator.samplewise_center = True
+                generator.samplewise_std_normalization = True
+                generator.channelwise = False
+                generator.fit(imgs)
+
+                collapse_axis = generator.channel_index - 1
+                standardized_img = generator.standardize(imgs[0])
+                assert np.all(np.abs(standardized_img.mean(axis=collapse_axis)) < eps)
+                assert np.all(np.abs(standardized_img.std(axis=collapse_axis) - 1) < eps)
+
+                generator.channelwise = True 
+                generator.fit(imgs)
+
+                collapse_axis = (generator.row_index - 1, generator.col_index - 1)
+                standardized_img = generator.standardize(imgs[0])
+                assert np.all(np.abs(standardized_img.mean(axis=collapse_axis)) < eps)
+                assert np.all(np.abs(standardized_img.std(axis=collapse_axis) - 1) < eps)
 
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
This is somewhat related to the issue  here (https://github.com/fchollet/keras/issues/2559#issuecomment-222501765), but also looks to be on a to-do list in the `random_transform` method of the `ImageDataGenerator`. 

Two notes: 
1. If we call `samplewise_center` without passing the boolean for `channelwise` (which is the default on master right now) for grayscale images, this 0's out the image (this is the line that leads to that: https://github.com/fchollet/keras/blob/master/keras/preprocessing/image.py#L323). This is noted in the issue linked above. It might be worth putting in some kind of warning or something like that in the future to let people know.  
2. In the `random_transform` method, there is "channel-wise normalization" on the to-do (https://github.com/fchollet/keras/blob/master/keras/preprocessing/image.py#L400). I'm not certain whether that refers to what I've done here (I think yes, but it's in the `random_transform` method). So, that might be something that could be removed if this PR is accepted. 
