### PR TITLE
Fix YAML serialization when using Regularizers

### DIFF
--- a/keras/regularizers.py
+++ b/keras/regularizers.py
@@ -41,8 +41,8 @@ class WeightRegularizer(Regularizer):
 
     def get_config(self):
         return {'name': self.__class__.__name__,
-                'l1': self.l1,
-                'l2': self.l2}
+                'l1': float(self.l1),
+                'l2': float(self.l2)}
 
 
 class ActivityRegularizer(Regularizer):
@@ -68,8 +68,8 @@ class ActivityRegularizer(Regularizer):
 
     def get_config(self):
         return {'name': self.__class__.__name__,
-                'l1': self.l1,
-                'l2': self.l2}
+                'l1': float(self.l1),
+                'l2': float(self.l2)}
 
 
 def l1(l=0.01):


### PR DESCRIPTION
Fix #2871

the below sample works fine:

```python
from keras.layers import LSTM
from keras.models import Sequential, model_from_yaml, model_from_json
from keras.regularizers import l2

model = Sequential([LSTM(20, input_shape=(2,3), W_regularizer=l2())])

json_str = model.to_json()
model_from_json(json_str)

yml_str = model.to_yaml()
model_from_yaml(yml_str)
```