### PR TITLE
MaxoutDense no activation; incorrect docs

### DIFF
--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -702,11 +702,6 @@ class MaxoutDense(Layer):
             or alternatively, Theano function to use for weights
             initialization. This parameter is only relevant
             if you don't pass a `weights` argument.
-        activation: name of activation function to use
-            (see [activations](../activations.md)),
-            or alternatively, elementwise Theano function.
-            If you don't specify anything, no activation is applied
-            (ie. "linear" activation: a(x) = x).
         weights: list of numpy arrays to set as initial weights.
             The list should have 2 elements, of shape `(input_dim, output_dim)`
             and (output_dim,) for weights and biases respectively.


### PR DESCRIPTION
Since MaxoutDense does not have activation it might be misleading to include "activation" as one of the arguments in the function docs.