### PR TITLE
Fix predict_proba method of KerasClassifier

### DIFF
--- a/keras/wrappers/scikit_learn.py
+++ b/keras/wrappers/scikit_learn.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 import copy
 import inspect
 import types
+import numpy
 
 from ..utils.np_utils import to_categorical
 from ..models import Sequential
@@ -202,9 +203,17 @@ class KerasClassifier(BaseWrapper):
         # Returns
             proba: array-like, shape `(n_samples, n_outputs)`
                 Class probability estimates.
+                In the case of binary classification (i.e. 1 output of 0 or 1)
+                 will return '(n_samples, 2)'
         '''
         kwargs = self.filter_sk_params(Sequential.predict_proba, kwargs)
-        return self.model.predict_proba(X, **kwargs)
+        probs = self.model.predict_proba(X, **kwargs)
+
+        # check if binary classification
+        if probs.shape[1] == 1:
+            # first column is probability of class 0 and second is of class 1
+            probs = numpy.hstack([1 - probs, probs])
+        return probs
 
     def score(self, X, y, **kwargs):
         '''Returns the mean accuracy on the given test data and labels.


### PR DESCRIPTION
KerasClassifier was returning a single probability when n_outputs was 1.
However, scikit requires the predict_proba method to return 2 columns in the case of binary classification.
This is needed for using threshold based evaluation metrics such as roc_auc.
Fixes #2864 