### PR TITLE
Make DirectoryIterator case insensitive

### DIFF
--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -559,7 +559,7 @@ class DirectoryIterator(Iterator):
             for fname in os.listdir(subpath):
                 is_valid = False
                 for extension in white_list_formats:
-                    if fname.endswith('.' + extension):
+                    if fname.lower().endswith('.' + extension):
                         is_valid = True
                         break
                 if is_valid:

--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -543,7 +543,7 @@ class DirectoryIterator(Iterator):
             for fname in os.listdir(subpath):
                 is_valid = False
                 for extension in white_list_formats:
-                    if fname.endswith('.' + extension):
+                    if fname.lower().endswith('.' + extension):
                         is_valid = True
                         break
                 if is_valid:


### PR DESCRIPTION
Since the file extension of images can be either upper case or lower case, especially for those downloaded from the web, I suggest to use fname.lower().endswith('.' + extension) in DirectoryIterator to make it case insensitive. 