### PR TITLE
Fix description about parameter `output_shape` for function `merge`

### DIFF
--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -1409,7 +1409,8 @@ def merge(inputs, mode='sum', concat_axis=-1,
         output_shape: shape tuple (tuple of integers), or lambda/function
             to compute output_shape (only if merge mode is a lambda/function).
             If the latter case, it should take as input a list of shape tuples
-            (1:1 mapping to input tensors) and return a single shape tuple.
+            (1:1 mapping to input tensors) and return a single shape tuple, including the
+            batch size (same convention as the `get_output_shape_for` method of layers).
         node_indices: optional list of integers containing
             the output node index for each input layer
             (in case some input layers have multiple output nodes).


### PR DESCRIPTION
Hi, the parameter `output_shape` for `merge` function in `topology.py` requires exactly output shape including *batchsize* when `mode` is callable, but that is not mentioned in doc. I added that.