### PR TITLE
Fix initial variable in Evaluator.

### DIFF
--- a/examples/deep_dream.py
+++ b/examples/deep_dream.py
@@ -189,7 +189,7 @@ def eval_loss_and_grads(x):
 class Evaluator(object):
     def __init__(self):
         self.loss_value = None
-        self.grads_values = None
+        self.grad_values = None
 
     def loss(self, x):
         assert self.loss_value is None


### PR DESCRIPTION
In the example for Deep Dream, the name of an attribute `grad_values` in Evaluator object was wrong.  I fixed it.