### PR TITLE
Resolve #2969

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -235,10 +235,7 @@ def collect_trainable_weights(layer):
     if not trainable:
         return []
     weights = []
-    if layer.__class__.__name__ in ['Sequential', 'Model']:
-        for sublayer in layer.layers:
-            weights += collect_trainable_weights(sublayer)
-    elif layer.__class__.__name__ == 'Graph':
+    if layer.__class__.__name__ == 'Graph':
         for sublayer in layer._graph_nodes.values():
             weights += collect_trainable_weights(sublayer)
     else:

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -235,7 +235,10 @@ def collect_trainable_weights(layer):
     if not trainable:
         return []
     weights = []
-    if layer.__class__.__name__ == 'Graph':
+    if layer.__class__.__name__ in ['Sequential', 'Model', 'Merge']:
+        for sublayer in layer.layers:
+            weights += collect_trainable_weights(sublayer)
+    elif layer.__class__.__name__ == 'Graph':
         for sublayer in layer._graph_nodes.values():
             weights += collect_trainable_weights(sublayer)
     else:
@@ -657,6 +660,9 @@ class Model(Container):
             trainable_weights = []
             for layer in self.layers:
                 trainable_weights += collect_trainable_weights(layer)
+
+            # remove duplicate weights
+            trainable_weights = list(set(trainable_weights))
 
             training_updates = self.optimizer.get_updates(trainable_weights, self.constraints, self.total_loss)
             updates = self.updates + training_updates


### PR DESCRIPTION
In reference to Issue https://github.com/fchollet/keras/issues/2969, the [following code](https://github.com/fchollet/keras/blob/master/keras/engine/training.py#L238) was preventing two of the embedding layers to be included in the trainable parameters:

```python
    if layer.__class__.__name__ in ['Sequential', 'Model']:
        for sublayer in layer.layers:
            weights += collect_trainable_weights(sublayer)
```

The `trainable_weights` method in `Sequential`, on the other hand, does a great work at returning all trainable parameters in the sub-model. After the patch I'm getting the following:

```bash
$ ./merge_simple.py 
Using Theano backend.
Weights before update: [array([[ 0.]]), array([[ 0.]]), array([[ 0.]])]
Weights after update:  [array([[-0.01]]), array([[-0.01]]), array([[-0.01]])]
```