### PR TITLE
Fix get_word_index

### DIFF
--- a/keras/datasets/reuters.py
+++ b/keras/datasets/reuters.py
@@ -4,6 +4,7 @@ from ..utils.data_utils import get_file
 from six.moves import cPickle
 from six.moves import zip
 import numpy as np
+import sys
 
 
 def load_data(path="reuters.pkl", nb_words=None, skip_top=0,
@@ -64,4 +65,11 @@ def load_data(path="reuters.pkl", nb_words=None, skip_top=0,
 def get_word_index(path="reuters_word_index.pkl"):
     path = get_file(path, origin="https://s3.amazonaws.com/text-datasets/reuters_word_index.pkl")
     f = open(path, 'rb')
-    return cPickle.load(f)
+
+    if sys.version_info < (3,):
+        data = cPickle.load(f)
+    else:
+        data = cPickle.load(f, encoding="latin1")
+
+    f.close()
+    return data


### PR DESCRIPTION
I can't load `word_index` of Reuters in python3 (This function is vaild in python 2.7.11.).

In my environment:

- OSX 10.10.5 (yosemite)
- python 3.5.1 (python or anaconda3-4.0.0 via pyenv)


My error message is below:

```
>>> from keras.datasets import reuters
>>> word_index = reuters.get_word_index(path="reuters_word_index.pkl")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/nzw/.pyenv/versions/3.5.1/lib/python3.5/site-packages/keras/datasets/reuters.py", line 67, in get_word_index
    return cPickle.load(f)
UnicodeDecodeError: 'ascii' codec can't decode byte 0xfc in position 0: ordinal not in range(128)
```

So I fix it.
thanks.