### PR TITLE
Avoid double key lookup on callback.py

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -210,10 +210,7 @@ class History(Callback):
     def on_epoch_end(self, epoch, logs={}):
         self.epoch.append(epoch)
         for k, v in logs.items():
-            if k not in self.history:
-                self.history[k] = []
-            self.history[k].append(v)
-
+            self.history.setdefault(k, []).append(v)
 
 class ModelCheckpoint(Callback):
     '''Save the model after every epoch.


### PR DESCRIPTION
On method on_epoch_end, to add new keys to the history dict, first it is
verified if a key is not on the history dict and if that is the case, a new key
is created on the history dict with an empty list as value.

However, this operation search for a key twice in the dict. This same behavior
can be achieved in a single step using dict setdefault method.