### PR TITLE
Moved epoch_logs = {} before batch loop to avoid UnboundLocalError.

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -778,6 +778,7 @@ class Model(Container):
                 np.random.shuffle(index_array)
 
             batches = make_batches(nb_train_sample, batch_size)
+            epoch_logs = {}
             for batch_index, (batch_start, batch_end) in enumerate(batches):
                 batch_ids = index_array[batch_start:batch_end]
                 try:
@@ -802,7 +803,6 @@ class Model(Container):
 
                 callbacks.on_batch_end(batch_index, batch_logs)
 
-                epoch_logs = {}
                 if batch_index == len(batches) - 1:  # last batch
                     # validation
                     if do_validation:


### PR DESCRIPTION
I accidentally ran an example with empty batches. Of course that is not useful, but in any case, looking at the code, epoch_logs = {} should clearly be moved in front of the loop.

It is only used in the last batch to collect logging information, which is only one useful initialization in the loop. The others are useless (nothing happens to epoch_logs), therefore, it should be safe and correct to move out of the loop.

Note:
The first error I got was UnboundLocalError: local variable epoch_logs referenced before assignment.

After this fix, I got the much more useful error message about incorrect input data dimensions:
Error when checking model input: expected input_1 to have 4 dimensions but got array with shape (0, 1).

