### PR TITLE
doc: fix example for recurrent layer

### DIFF
--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -54,7 +54,7 @@ class Recurrent(Layer):
         # as the first layer in a Sequential model
         model = Sequential()
         model.add(LSTM(32, input_shape=(10, 64)))
-        # now model.output_shape == (None, 10, 32)
+        # now model.output_shape == (None, 32)
         # note: `None` is the batch dimension.
 
         # the following is identical:


### PR DESCRIPTION
Hi,

i think i found a typo in the first example of the recurrent layer documentation:
```python
# as the first layer in a Sequential model
model = Sequential()
model.add(LSTM(32, input_shape=(10, 64)))
# now model.output_shape == (None, 32)
# note: `None` is the batch dimension.
```
Because of `return_sequences=False` (default value), i think only the last output is returned.


```python
print model.output_shape
``` 
yields on my system (Using Theano backend)
`(None, 32)`

Or did i miss smth.?

Best,
André