### PR TITLE
fix: Sort subdirs before mapping them to classes.

### DIFF
--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -532,7 +532,7 @@ class DirectoryIterator(Iterator):
 
         if not classes:
             classes = []
-            for subdir in os.listdir(directory):
+            for subdir in sorted(os.listdir(directory)):
                 if os.path.isdir(os.path.join(directory, subdir)):
                     classes.append(subdir)
         self.nb_class = len(classes)


### PR DESCRIPTION
The documentation says that [1]: 

> If [classes are] not provided, the list of classes will be automatically inferred (and the order of the classes, which will map to the label indices, will be alphanumeric).

However, the code was adding classes in the order `os.listdir` returned them. This commit alphanumerically sorts the sub-directories before mapping them to label indices.

[1] http://keras.io/preprocessing/image/