### PR TITLE
Fitting a keras model using scipy.optimize.minimize

### DIFF
--- a/keras/fit_scipy.py
+++ b/keras/fit_scipy.py
@@ -16,8 +16,9 @@ def pack_theta(trainable_weights):
     """ Flattens a set of shared variables (trainable_weights)"""
     x = np.empty(0)
     for t in trainable_weights:
-        x = np.concatenate((x,K.get_value(t).reshape(-1)))
+        x = np.concatenate((x, K.get_value(t).reshape(-1)))
     return x
+
 
 def unpack_theta(model, theta):
     """ Converts flattened theta back to tensor shapes of Keras model params """
@@ -27,11 +28,18 @@ def unpack_theta(model, theta):
         layer_weights = []
         for param in layer.get_weights():
             plen = np.prod(param.shape)
-            layer_weights.append(np.asarray(theta[idx:(idx+plen)].reshape(param.shape),
-                                    dtype=np.float32))
+            layer_weights.append(
+                np.asarray(
+                    theta[
+                        idx:(
+                            idx +
+                            plen)].reshape(
+                        param.shape),
+                    dtype=np.float32))
             idx += plen
         weights.append(layer_weights)
     return weights
+
 
 def set_model_params(model, theta):
     """ Sets the Keras model params from a flattened numpy array of theta """
@@ -39,27 +47,32 @@ def set_model_params(model, theta):
     for trainable_param, layer in zip(trainable_params, model.layers):
         layer.set_weights(trainable_param)
 
+
 def get_cost_grads(model):
     """ Returns the cost and flattened gradients for the model """
     trainable_params = get_trainable_params(model)
 
     cost = model.model.total_loss
     grads = K.gradients(cost, trainable_params)
-    
+
     return cost, grads
+
 
 def flatten_grads(grads):
     """ Flattens a set tensor variables (gradients) """
     x = np.empty(0)
     for g in grads:
-        x = np.concatenate((x,g.reshape(-1)))
+        x = np.concatenate((x, g.reshape(-1)))
     return x
+
 
 def get_trainable_params(model):
     trainable_weights = []
     for layer in model.layers:
-        trainable_weights += keras.engine.training.collect_trainable_weights(layer)
+        trainable_weights += keras.engine.training.collect_trainable_weights(
+            layer)
     return trainable_weights
+
 
 def get_training_function(model, x, y):
     cost, grads = get_cost_grads(model)
@@ -67,14 +80,20 @@ def get_training_function(model, x, y):
     if type(grads) in {list, tuple}:
         outs += grads
     else:
-        outs.append(grads) 
+        outs.append(grads)
 
-    fn = K.function(inputs=[], outputs=outs,
-            givens={model.model.inputs[0]         : x,
-                    model.model.targets[0]        : y,
-                    model.model.sample_weights[0] : np.ones((x.shape[0],), dtype=np.float32),
-                    K.learning_phase()            : np.uint8(1)})
-    
+    fn = K.function(
+        inputs=[],
+        outputs=outs,
+        givens={
+            model.model.inputs[0]: x,
+            model.model.targets[0]: y,
+            model.model.sample_weights[0]: np.ones(
+                (x.shape[0],
+                 ),
+                dtype=np.float32),
+            K.learning_phase(): np.uint8(1)})
+
     def train_fn(theta):
         set_model_params(model, theta)
         cost_grads = fn([])
@@ -85,21 +104,16 @@ def get_training_function(model, x, y):
 
     return train_fn
 
+
 def fit_scipy(model, x, y, nb_epoch=300, method='L-BFGS-B', **kwargs):
     trainable_params = get_trainable_params(model)
     theta0 = pack_theta(trainable_params)
 
     train_fn = get_training_function(model, x, y)
 
-    weights = sp.optimize.minimize(train_fn, theta0,
-        method=method, jac=True, 
-        options={'maxiter':nb_epoch,'disp':False}, 
-        **kwargs)
+    weights = sp.optimize.minimize(
+        train_fn, theta0, method=method, jac=True, options={
+            'maxiter': nb_epoch, 'disp': False}, **kwargs)
 
     theta_final = weights.x
     set_model_params(model, theta_final)
-
-
-
-
-

--- a/keras/fit_scipy.py
+++ b/keras/fit_scipy.py
@@ -1,0 +1,105 @@
+"""
+Fit a Keras model with any method from scipy.optimize.minimize.
+
+fit_scipy(..) is the only function which needs to be called externally.
+"""
+
+from __future__ import division
+import numpy as np
+import scipy as sp
+import scipy.optimize
+import keras
+from keras import backend as K
+
+
+def pack_theta(trainable_weights):
+    """ Flattens a set of shared variables (trainable_weights)"""
+    x = np.empty(0)
+    for t in trainable_weights:
+        x = np.concatenate((x,K.get_value(t).reshape(-1)))
+    return x
+
+def unpack_theta(model, theta):
+    """ Converts flattened theta back to tensor shapes of Keras model params """
+    weights = []
+    idx = 0
+    for layer in model.layers:
+        layer_weights = []
+        for param in layer.get_weights():
+            plen = np.prod(param.shape)
+            layer_weights.append(np.asarray(theta[idx:(idx+plen)].reshape(param.shape),
+                                    dtype=np.float32))
+            idx += plen
+        weights.append(layer_weights)
+    return weights
+
+def set_model_params(model, theta):
+    """ Sets the Keras model params from a flattened numpy array of theta """
+    trainable_params = unpack_theta(model, theta)
+    for trainable_param, layer in zip(trainable_params, model.layers):
+        layer.set_weights(trainable_param)
+
+def get_cost_grads(model):
+    """ Returns the cost and flattened gradients for the model """
+    trainable_params = get_trainable_params(model)
+
+    cost = model.model.total_loss
+    grads = K.gradients(cost, trainable_params)
+    
+    return cost, grads
+
+def flatten_grads(grads):
+    """ Flattens a set tensor variables (gradients) """
+    x = np.empty(0)
+    for g in grads:
+        x = np.concatenate((x,g.reshape(-1)))
+    return x
+
+def get_trainable_params(model):
+    trainable_weights = []
+    for layer in model.layers:
+        trainable_weights += keras.engine.training.collect_trainable_weights(layer)
+    return trainable_weights
+
+def get_training_function(model, x, y):
+    cost, grads = get_cost_grads(model)
+    outs = [cost]
+    if type(grads) in {list, tuple}:
+        outs += grads
+    else:
+        outs.append(grads) 
+
+    fn = K.function(inputs=[], outputs=outs,
+            givens={model.model.inputs[0]         : x,
+                    model.model.targets[0]        : y,
+                    model.model.sample_weights[0] : np.ones((x.shape[0],), dtype=np.float32),
+                    K.learning_phase()            : np.uint8(1)})
+    
+    def train_fn(theta):
+        set_model_params(model, theta)
+        cost_grads = fn([])
+        cost = np.asarray(cost_grads[0], dtype=np.float64)
+        grads = np.asarray(flatten_grads(cost_grads[1:]), dtype=np.float64)
+
+        return cost, grads
+
+    return train_fn
+
+def fit_scipy(model, x, y, nb_epoch=300, method='L-BFGS-B', **kwargs):
+    trainable_params = get_trainable_params(model)
+    theta0 = pack_theta(trainable_params)
+
+    train_fn = get_training_function(model, x, y)
+
+    weights = sp.optimize.minimize(train_fn, theta0,
+        method=method, jac=True, 
+        options={'maxiter':nb_epoch,'disp':False}, 
+        **kwargs)
+
+    theta_final = weights.x
+    set_model_params(model, theta_final)
+
+
+
+
+


### PR DESCRIPTION
Many people (including myself) have been asking about exposing a keras model to an external optimizer. It involves getting the loss and gradients, but this is complicated by the symbolic nature of theano/tensorflow. I wrote this code to fit an arbitrary Keras model with any method from scipy.optimize.minimize. It should work similarly for any other optimization code.

While I understand SGD and variants are useful for computer vision problems, routines such as L-BFGS-B are essential for training neural networks aimed at modeling real biological neural networks (e.g. those in the visual system). My attached example code shows how a Sparse Autoencoder trained on natural images fails to obtain the expected oriented edge filters using SGD (or any other Keras optimizer, trust me I tried) but works perfectly when trained on the L-BFGS-B routine.

This example is taken from the stanford course: http://ufldl.stanford.edu/wiki/index.php/Exercise:Sparse_Autoencoder

In short, this code is essential for researchers in the visual neuroscience domain (myself) who want the flexible and intuitive model building of keras, but need other optimizers.

Any code review/suggestions are obviously welcome. If this idea doesn't fit the scope of the project, no worries. I know it would be best to turn this code into its own "optimizer" but that would involve some changes to the keras internals. 

Also, it doesn't work on TensorFlow because of the weird K.learning_phase() issue.. I figured others would have a good suggestion for that.

Thanks,
Nick

[example.zip](https://github.com/fchollet/keras/files/332479/example.zip)
