### PR TITLE
Use defaultdict for _UID_PREFIXES

### DIFF
--- a/keras/backend/common.py
+++ b/keras/backend/common.py
@@ -1,9 +1,11 @@
 import numpy as np
 
+from collections import defaultdict
+
 # the type of float to use throughout the session.
 _FLOATX = 'float32'
 _EPSILON = 10e-8
-_UID_PREFIXES = {}
+_UID_PREFIXES = defaultdict(int)
 _IMAGE_DIM_ORDERING = 'th'
 
 
@@ -60,9 +62,5 @@ def set_image_dim_ordering(dim_ordering):
 
 
 def get_uid(prefix=''):
-    if prefix not in _UID_PREFIXES:
-        _UID_PREFIXES[prefix] = 1
-        return 1
-    else:
-        _UID_PREFIXES[prefix] += 1
-        return _UID_PREFIXES[prefix]
+    _UID_PREFIXES[prefix] += 1
+    return _UID_PREFIXES[prefix]


### PR DESCRIPTION
The method get_uid on common.py first check if a prefix is in _UID_PREFIXED dict
and if it is not, a variable is added to the dict.

However, using a defaultdict, this check is no longer necessary.