### PR TITLE
Create initial_state tensor filled with zeros without use of K.zeros

### DIFF
--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -190,9 +190,9 @@ class Recurrent(Layer):
     def get_initial_states(self, x):
         # build an all-zero tensor of shape (samples, output_dim)
         initial_state = K.zeros_like(x)  # (samples, timesteps, input_dim)
-        initial_state = K.sum(initial_state, axis=1)  # (samples, input_dim)
-        reducer = K.zeros((self.input_dim, self.output_dim))
-        initial_state = K.dot(initial_state, reducer)  # (samples, output_dim)
+        initial_state = K.sum(initial_state, axis=(1,2))  # (samples,)
+        initial_state = K.expand_dims(initial_state)  # (samples, 1)
+        initial_state = K.tile(initial_state, [1, self.output_dim])  # (samples, output_dim)
         initial_states = [initial_state for _ in range(len(self.states))]
         return initial_states
 

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -190,7 +190,7 @@ class Recurrent(Layer):
     def get_initial_states(self, x):
         # build an all-zero tensor of shape (samples, output_dim)
         initial_state = K.zeros_like(x)  # (samples, timesteps, input_dim)
-        initial_state = K.sum(initial_state, axis=(1,2))  # (samples,)
+        initial_state = K.sum(initial_state, axis=(1, 2))  # (samples,)
         initial_state = K.expand_dims(initial_state)  # (samples, 1)
         initial_state = K.tile(initial_state, [1, self.output_dim])  # (samples, output_dim)
         initial_states = [initial_state for _ in range(len(self.states))]


### PR DESCRIPTION
`Recurrent.get_initial_states` contains some awkward machinations to get an `initial_state` vector of the appropriate size filled with zeros, which can only be done at graph execution time because the batch size is needed.

The current implementation uses a call to `K.zeros`, which when using the TensorFlow backend creates a Variable.This is not desirable, because
 * By default all Variable objects will be collected and trained by TF optimizers, wasting time computing the (zero) gradients, and
 * By default all Variable objects will be serialzed and saved when using the `tf.train.Saver`, wasting space.

The fix is simple: use only `K.zeros_like`, which creates only operations in the graph, not extra Variables.