### PR TITLE
fix get_output_shape_for in Merge, when mode is callable

### DIFF
--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -1286,7 +1286,7 @@ class Merge(Layer):
                 output_shape = self._output_shape(input_shape)
                 return output_shape
             elif self._output_shape is not None:
-                return (input_shape[0],) + tuple(self._output_shape)
+                return (input_shape[0][0],) + tuple(self._output_shape)
             else:
                 # TODO: consider shape auto-inference with TF
                 raise Exception('The Merge layer ' + self.name +


### PR DESCRIPTION
Merge's `get_output_shape_for` returns an invalid shape when using a callable mode and a fixed output shape. `input_shape` is a list of shape tuples, so the returned output shape will have have a tuple as its first dimension.