### PR TITLE
Calling ProgbarLogger before other callbacks

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -775,7 +775,7 @@ class Model(Container):
         self.history = cbks.History()
         callbacks = [cbks.BaseLogger()] + callbacks + [self.history]
         if verbose:
-            callbacks += [cbks.ProgbarLogger()]
+            callbacks = [cbks.ProgbarLogger()] + callbacks
         callbacks = cbks.CallbackList(callbacks)
 
         # it's possible to callback a different model than self


### PR DESCRIPTION
As stated in #2354, printing something inside a Callback will break the progress bar logging (verbose=1).

This bug is fixed if I change the callbacks list to call the ProgbarLogger first. The test suite doesn't point out any other bugs with this change, but I'm skeptical.
Someone with more knowledge about Keras could have a better view on this change.