### PR TITLE
Add support to negative axis value for squeeze(x, axis) of theano backend.

### DIFF
--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -398,6 +398,8 @@ def expand_dims(x, dim=-1):
 def squeeze(x, axis):
     '''Remove a 1-dimension from the tensor at index "axis".
     '''
+    if axis < 0
+        axis = x.ndim + axis
     broadcastable = x.broadcastable[:axis] + x.broadcastable[axis+1:]
     x = T.patternbroadcast(x, [i == axis for i in range(x.type.ndim)])
     x = T.squeeze(x)


### PR DESCRIPTION
Add support to negative axis value for squeeze(x, axis) of theano backend.
```python
import keras.backend as K
import numpy as np
a = np.random.uniform(low=-1, high=1, size=(3, 1, 1))
b = K.variable(a, name='b')
print b.eval()
"""
[[[-0.38140643]]

 [[-0.81984013]]

 [[ 0.21176814]]]
"""
bb = K.squeeze(b, axis = -1)
print bb.eval()
"""
[[-0.38140643]
 [-0.81984013]
 [ 0.21176814]]
"""
```