### PR TITLE
Fix VAE example

### DIFF
--- a/examples/variational_autoencoder.py
+++ b/examples/variational_autoencoder.py
@@ -5,33 +5,30 @@ Reference: "Auto-Encoding Variational Bayes" https://arxiv.org/abs/1312.6114
 import numpy as np
 import matplotlib.pyplot as plt
 
-from keras.layers import Input, Dense, Lambda
+from keras.layers import Input, Dense, merge
 from keras.models import Model
 from keras import backend as K
 from keras import objectives
 from keras.datasets import mnist
 
-batch_size = 16
+batch_size = 100
 original_dim = 784
 latent_dim = 2
-intermediate_dim = 128
-epsilon_std = 0.01
-nb_epoch = 40
+intermediate_dim = 500
+nb_epoch = 100
 
 x = Input(batch_shape=(batch_size, original_dim))
 h = Dense(intermediate_dim, activation='relu')(x)
 z_mean = Dense(latent_dim)(h)
-z_log_std = Dense(latent_dim)(h)
+z_log_var = Dense(latent_dim)(h)
 
 def sampling(args):
-    z_mean, z_log_std = args
-    epsilon = K.random_normal(shape=(batch_size, latent_dim),
-                              mean=0., std=epsilon_std)
-    return z_mean + K.exp(z_log_std) * epsilon
+    z_mean, z_log_var = args
+    epsilon = K.random_normal(shape=(batch_size, latent_dim), mean=0.)
+    return z_mean + K.exp(z_log_var/2) * epsilon
 
 # note that "output_shape" isn't necessary with the TensorFlow backend
-# so you could write `Lambda(sampling)([z_mean, z_log_std])`
-z = Lambda(sampling, output_shape=(latent_dim,))([z_mean, z_log_std])
+z = merge([z_mean, z_log_var], mode=sampling, output_shape=(latent_dim,))
 
 # we instantiate these layers separately so as to reuse them later
 decoder_h = Dense(intermediate_dim, activation='relu')
@@ -40,8 +37,8 @@ h_decoded = decoder_h(z)
 x_decoded_mean = decoder_mean(h_decoded)
 
 def vae_loss(x, x_decoded_mean):
-    xent_loss = objectives.binary_crossentropy(x, x_decoded_mean)
-    kl_loss = - 0.5 * K.mean(1 + z_log_std - K.square(z_mean) - K.exp(z_log_std), axis=-1)
+    xent_loss = original_dim * objectives.binary_crossentropy(x, x_decoded_mean)
+    kl_loss = - 0.5 * K.sum(1 + z_log_var - K.square(z_mean) - K.exp(z_log_var), axis=-1)
     return xent_loss + kl_loss
 
 vae = Model(x, x_decoded_mean)
@@ -87,7 +84,7 @@ grid_y = np.linspace(-15, 15, n)
 
 for i, yi in enumerate(grid_x):
     for j, xi in enumerate(grid_y):
-        z_sample = np.array([[xi, yi]]) * epsilon_std
+        z_sample = np.array([[xi, yi]])
         x_decoded = generator.predict(z_sample)
         digit = x_decoded[0].reshape(digit_size, digit_size)
         figure[i * digit_size: (i + 1) * digit_size,


### PR DESCRIPTION
A number of changes:
1. Switch from Lambda to merge, otherwise code will not run in keras==1.0.5.
2. Rename z_log_std to z_log_var in order for the objective function to make sense
3. Adjust reparameterization trick to reflect use of z_log_var, not z_log_std
4. Remove epsilon_std, since (standard) VAE uses isotropic gaussian prior.
5. Re-balance the weighting of KL and reconstruction terms
6. Use adam instead of rmsprop
7. Increase hidden unit size to improve model
8. Increase batch size to speed up training