### PR TITLE
stop gradients

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -702,6 +702,13 @@ def gradients(loss, variables):
     return tf.gradients(loss, variables)
 
 
+def stop_gradient(variables):
+    '''Returns `variables` but with zero gradient with respect to every other
+    variables.
+    '''
+    return tf.stop_gradient(variables)
+
+
 # CONTROL FLOW
 
 def rnn(step_function, inputs, initial_states,

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -544,6 +544,13 @@ def gradients(loss, variables):
     return T.grad(loss, variables)
 
 
+def stop_gradient(variables):
+    '''Returns `variables` but with zero gradient with respect to every other
+    variables.
+    '''
+    return theano.gradient.disconnected_grad(variables)
+
+
 # CONTROL FLOW
 
 def rnn(step_function, inputs, initial_states,

--- a/keras/utils/np_utils.py
+++ b/keras/utils/np_utils.py
@@ -110,16 +110,13 @@ def convert_kernel(kernel, dim_ordering='th'):
     return new_kernel
 
 
-def conv_output_length(input_length, filter_size, border_mode, stride, dilation=1, transpose=False):
+def conv_output_length(input_length, filter_size, border_mode, stride, dilation=1):
     if input_length is None:
         return None
     assert border_mode in {'same', 'valid'}
-    dilated_filter_size = filter_size + (filter_size -1) * (dilation - 1)
+    dilated_filter_size = filter_size + (filter_size - 1) * (dilation - 1)
     if border_mode == 'same':
         output_length = input_length
     elif border_mode == 'valid':
         output_length = input_length - dilated_filter_size + 1
-    if transpose:
-      return (output_length + stride - 1) * stride
-    else:
-      return (output_length + stride - 1) // stride
+    return (output_length + stride - 1) // stride

--- a/keras/utils/np_utils.py
+++ b/keras/utils/np_utils.py
@@ -110,7 +110,7 @@ def convert_kernel(kernel, dim_ordering='th'):
     return new_kernel
 
 
-def conv_output_length(input_length, filter_size, border_mode, stride, dilation=1):
+def conv_output_length(input_length, filter_size, border_mode, stride, dilation=1, transpose=False):
     if input_length is None:
         return None
     assert border_mode in {'same', 'valid'}
@@ -119,4 +119,7 @@ def conv_output_length(input_length, filter_size, border_mode, stride, dilation=
         output_length = input_length
     elif border_mode == 'valid':
         output_length = input_length - dilated_filter_size + 1
-    return (output_length + stride - 1) // stride
+    if transpose:
+      return (output_length + stride - 1) * stride
+    else:
+      return (output_length + stride - 1) // stride

--- a/tests/keras/backend/test_backends.py
+++ b/tests/keras/backend/test_backends.py
@@ -57,7 +57,7 @@ def check_composed_tensor_operations(first_function_name, first_function_args,
     ztf = KTF.eval(getattr(KTF, second_function_name)(ytf, **second_function_args))
 
     assert zth.shape == ztf.shape
-    assert_allclose(zth, ztf, atol=1e-05)   
+    assert_allclose(zth, ztf, atol=1e-05)
 
 class TestBackend(object):
 
@@ -90,8 +90,8 @@ class TestBackend(object):
         check_single_tensor_operation('expand_dims', (4, 3), dim=-1)
         check_single_tensor_operation('expand_dims', (4, 3, 2), dim=1)
         check_single_tensor_operation('squeeze', (4, 3, 1), axis=2)
-        check_composed_tensor_operations('reshape', {'shape':(4,3,1,1)}, 
-                                         'squeeze', {'axis':2}, 
+        check_composed_tensor_operations('reshape', {'shape':(4,3,1,1)},
+                                         'squeeze', {'axis':2},
                                          (4, 3, 1, 1))
 
     def test_repeat_elements(self):
@@ -208,14 +208,22 @@ class TestBackend(object):
         exptf = xtf * KTF.exp(xtf)
         lossth = KTH.sum(expth)
         losstf = KTF.sum(exptf)
+        zero_lossth = KTH.stop_gradient(expth)
+        zero_losstf = KTF.stop_gradient(exptf)
 
         gradth = KTH.gradients(lossth, [expth])
         gradtf = KTF.gradients(losstf, [exptf])
+        zero_gradth = KTH.gradients(zero_lossth, [expth])
+        zero_gradtf = KTF.gradients(zero_losstf, [exptf])
 
         zth = KTH.eval(gradth[0])
         ztf = KTF.eval(gradtf[0])
+        zero_zth = KTH.eval(zero_gradth[0])
+        zero_ztf = KTF.eval(zero_gradtf[0])
         assert zth.shape == ztf.shape
+        assert zero_zth.shape == zero_ztf.shape
         assert_allclose(zth, ztf, atol=1e-05)
+        assert_allclose(zero_zth, zero_ztf, atol=1e-05)
 
     def test_function(self):
         val = np.random.random((4, 2))

--- a/tests/keras/backend/test_backends.py
+++ b/tests/keras/backend/test_backends.py
@@ -208,13 +208,13 @@ class TestBackend(object):
         exptf = xtf * KTF.exp(xtf)
         lossth = KTH.sum(expth)
         losstf = KTF.sum(exptf)
-        zero_lossth = KTH.stop_gradient(expth)
-        zero_losstf = KTF.stop_gradient(exptf)
+        zero_lossth = KTH.stop_gradient(lossth)
+        zero_losstf = KTF.stop_gradient(losstf)
 
         gradth = KTH.gradients(lossth, [expth])
         gradtf = KTF.gradients(losstf, [exptf])
-        zero_gradth = KTH.gradients(zero_lossth, [expth])
-        zero_gradtf = KTF.gradients(zero_losstf, [exptf])
+        zero_gradth = KTH.gradients(lossth + zero_lossth, [expth])
+        zero_gradtf = KTF.gradients(losstf + zero_losstf, [exptf])
 
         zth = KTH.eval(gradth[0])
         ztf = KTF.eval(gradtf[0])
@@ -224,6 +224,8 @@ class TestBackend(object):
         assert zero_zth.shape == zero_ztf.shape
         assert_allclose(zth, ztf, atol=1e-05)
         assert_allclose(zero_zth, zero_ztf, atol=1e-05)
+        assert_allclose(zero_zth, zth, atol=1e-05)
+        assert_allclose(zero_ztf, ztf, atol=1e-05)
 
     def test_function(self):
         val = np.random.random((4, 2))


### PR DESCRIPTION
stop gradient operations are used for complicated graphs such as RNNs that feed previous outputs as new inputs:
https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/ops/seq2seq.py#L103