### PR TITLE
add doc for layers/normalization/BatchNormalization

### DIFF
--- a/keras/layers/normalization.py
+++ b/keras/layers/normalization.py
@@ -35,6 +35,7 @@ class BatchNormalization(Layer):
         weights: Initialization weights.
             List of 2 Numpy arrays, with shapes:
             `[(input_shape,), (input_shape,)]`
+			Note that the order of this list is [Gamma, Beta, mean, std]
         beta_init: name of initialization function for shift parameter
             (see [initializations](../initializations.md)), or alternatively,
             Theano/TensorFlow function to use for weights initialization.

--- a/keras/layers/normalization.py
+++ b/keras/layers/normalization.py
@@ -35,7 +35,7 @@ class BatchNormalization(Layer):
         weights: Initialization weights.
             List of 2 Numpy arrays, with shapes:
             `[(input_shape,), (input_shape,)]`
-			Note that the order of this list is [gamma, beta, mean, std]
+            Note that the order of this list is [gamma, beta, mean, std]
         beta_init: name of initialization function for shift parameter
             (see [initializations](../initializations.md)), or alternatively,
             Theano/TensorFlow function to use for weights initialization.

--- a/keras/layers/normalization.py
+++ b/keras/layers/normalization.py
@@ -35,7 +35,7 @@ class BatchNormalization(Layer):
         weights: Initialization weights.
             List of 2 Numpy arrays, with shapes:
             `[(input_shape,), (input_shape,)]`
-			Note that the order of this list is [Gamma, Beta, mean, std]
+			Note that the order of this list is [gamma, beta, mean, std]
         beta_init: name of initialization function for shift parameter
             (see [initializations](../initializations.md)), or alternatively,
             Theano/TensorFlow function to use for weights initialization.


### PR DESCRIPTION
The BN layer use ```set_weights``` to load weights provided by user, and in ```set_weights```:
```python
params = self.trainable_weights + self.non_trainable_weights
```
In BN, the trainable_weights are Gamma and Beta, non_trainable_weights are Mean and Std, So it important to point out that the weights list must be organized as [Gamma, Beta, Mean, Std] so that it could work properly. Cause by defualt, people may want to organize their weight list as [Mean, Std, Gamma, Beta], this is just the computation order of BN.

The wrong-order list won't get any warnings or errors cause the shape of these 4 parameters are exactly same.

I think this doc will be helpful.