### PR TITLE
Bug fix + test - Sequential.pop()

### DIFF
--- a/keras/models.py
+++ b/keras/models.py
@@ -172,6 +172,9 @@ class Sequential(Model):
         else:
             self.layers[-1].outbound_nodes = []
             self.outputs = [self.layers[-1].output]
+            # update self.inbound_nodes
+            self.inbound_nodes[0].output_tensors = self.outputs
+            self.inbound_nodes[0].output_shapes = [self.outputs[0]._keras_shape]
         self.built = False
 
     def call(self, x, mask=None):

--- a/tests/keras/test_sequential_model.py
+++ b/tests/keras/test_sequential_model.py
@@ -13,7 +13,6 @@ from keras.utils.test_utils import get_test_data
 from keras.models import model_from_json, model_from_yaml
 from keras import objectives
 from keras.engine.training import make_batches
-import numpy as np
 
 
 input_dim = 16

--- a/tests/keras/test_sequential_model.py
+++ b/tests/keras/test_sequential_model.py
@@ -13,6 +13,7 @@ from keras.utils.test_utils import get_test_data
 from keras.models import model_from_json, model_from_yaml
 from keras import objectives
 from keras.engine.training import make_batches
+import numpy as np
 
 
 input_dim = 16
@@ -20,6 +21,22 @@ nb_hidden = 8
 nb_class = 4
 batch_size = 32
 nb_epoch = 1
+
+
+def test_sequential_pop():
+    model = Sequential()
+    model.add(Dense(nb_hidden, input_dim=input_dim))
+    model.add(Dense(nb_class))
+    model.compile(loss='mse', optimizer='sgd')
+    x = np.random.random((batch_size, input_dim))
+    y = np.random.random((batch_size, nb_class))
+    model.fit(x, y)
+    model.pop()
+    assert len(model.layers) == 1
+    assert model.output_shape == (None, nb_hidden)
+    model.compile(loss='mse', optimizer='sgd')
+    y = np.random.random((batch_size, nb_hidden))
+    model.fit(x, y)
 
 
 def _get_test_data():


### PR DESCRIPTION
Update inbound nodes after popping last layer. Otherwise `output_shape` of the model will not be updated.

```python
model = Sequential()
model.add(Dense(10, input_dim=10))
model.add(Dense(20))
print model.output_shape  # >> (None, 20)
model.pop()
print model.output_shape  # >> (None, 20) 
```

Also since `pop()` is sort of a hack, I thought it would be good to have a test.