### PR TITLE
Small python3 compat fix in backend doc

### DIFF
--- a/docs/templates/backend.md
+++ b/docs/templates/backend.md
@@ -29,7 +29,7 @@ You can also define the environment variable ``KERAS_BACKEND`` and this will
 override what is defined in your config file :
 
 ```bash
-KERAS_BACKEND=tensorflow python -c "from keras import backend; print backend._BACKEND"
+KERAS_BACKEND=tensorflow python -c "from keras import backend; print(backend._BACKEND)"
 Using TensorFlow backend.
 tensorflow
 ```


### PR DESCRIPTION
The `print(backend._BACKEND)` syntax still works under Python 2 as well in this case.