### PR TITLE
Print op

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -827,6 +827,13 @@ def batch_set_value(tuples):
         get_session().run(ops)
 
 
+def print_tensor(x, message=''):
+    '''Print the message and the tensor when evaluated and return the same
+    tensor.
+    '''
+    return tf.Print(x, [x], message)
+
+
 # GRAPH MANIPULATION
 
 class Function(object):

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -3,6 +3,7 @@ from theano import tensor as T
 from theano.sandbox.rng_mrg import MRG_RandomStreams as RandomStreams
 from theano.tensor.signal import pool
 from theano.tensor.nnet import conv3d2d
+from theano.printing import Print
 try:
     from theano.tensor.nnet.nnet import softsign as T_softsign
 except ImportError:
@@ -617,6 +618,14 @@ def set_value(x, value):
 def batch_set_value(tuples):
     for x, value in tuples:
         x.set_value(np.asarray(value, dtype=x.dtype))
+
+
+def print_tensor(x, message=''):
+    '''Print the message and the tensor when evaluated and return the same
+    tensor.
+    '''
+    p_op = Print(message)
+    return p_op(x)
 
 
 # GRAPH MANIPULATION

--- a/tests/keras/backend/test_backends.py
+++ b/tests/keras/backend/test_backends.py
@@ -151,6 +151,12 @@ class TestBackend(object):
         # count_params
         assert KTH.count_params(xth) == KTF.count_params(xtf)
 
+        # print_tensor
+        check_single_tensor_operation('print_tensor', ())
+        check_single_tensor_operation('print_tensor', (2,))
+        check_single_tensor_operation('print_tensor', (4, 3))
+        check_single_tensor_operation('print_tensor', (1, 2, 3))
+
     def test_elementwise_operations(self):
         check_single_tensor_operation('max', (4, 2))
         check_single_tensor_operation('max', (4, 2), axis=1, keepdims=True)


### PR DESCRIPTION
This PR is adding the print_op that will behave as the identity function but will print the tensor value when evaluated.
I decided to name it print_op because print is a reserved word in python but I'm open to suggestions.