### PR TITLE
make examples/pretrained_word_embeddings.py more memory efficient

### DIFF
--- a/examples/pretrained_word_embeddings.py
+++ b/examples/pretrained_word_embeddings.py
@@ -97,7 +97,8 @@ y_val = labels[-nb_validation_samples:]
 print('Preparing embedding matrix.')
 
 # prepare embedding matrix
-embedding_matrix = np.zeros((MAX_NB_WORDS + 1, EMBEDDING_DIM))
+NB_WORDS = min(MAX_NB_WORDS, len(word_index))
+embedding_matrix = np.zeros((NB_WORDS + 1, EMBEDDING_DIM))
 for word, i in word_index.items():
     if i > MAX_NB_WORDS:
         continue
@@ -108,7 +109,7 @@ for word, i in word_index.items():
 
 # load pre-trained word embeddings into an Embedding layer
 # note that we set trainable = False so as to keep the embeddings fixed
-embedding_layer = Embedding(MAX_NB_WORDS + 1,
+embedding_layer = Embedding(NB_WORDS + 1,
                             EMBEDDING_DIM,
                             weights=[embedding_matrix],
                             input_length=MAX_SEQUENCE_LENGTH,

--- a/examples/pretrained_word_embeddings.py
+++ b/examples/pretrained_word_embeddings.py
@@ -97,8 +97,10 @@ y_val = labels[-nb_validation_samples:]
 print('Preparing embedding matrix.')
 
 # prepare embedding matrix
-embedding_matrix = np.zeros((len(word_index) + 1, EMBEDDING_DIM))
+embedding_matrix = np.zeros((MAX_NB_WORDS + 1, EMBEDDING_DIM))
 for word, i in word_index.items():
+    if i > MAX_NB_WORDS:
+        continue
     embedding_vector = embeddings_index.get(word)
     if embedding_vector is not None:
         # words not found in embedding index will be all-zeros.
@@ -106,7 +108,7 @@ for word, i in word_index.items():
 
 # load pre-trained word embeddings into an Embedding layer
 # note that we set trainable = False so as to keep the embeddings fixed
-embedding_layer = Embedding(len(word_index) + 1,
+embedding_layer = Embedding(MAX_NB_WORDS + 1,
                             EMBEDDING_DIM,
                             weights=[embedding_matrix],
                             input_length=MAX_SEQUENCE_LENGTH,

--- a/examples/pretrained_word_embeddings.py
+++ b/examples/pretrained_word_embeddings.py
@@ -97,8 +97,8 @@ y_val = labels[-nb_validation_samples:]
 print('Preparing embedding matrix.')
 
 # prepare embedding matrix
-NB_WORDS = min(MAX_NB_WORDS, len(word_index))
-embedding_matrix = np.zeros((NB_WORDS + 1, EMBEDDING_DIM))
+nb_words = min(MAX_NB_WORDS, len(word_index))
+embedding_matrix = np.zeros((nb_words + 1, EMBEDDING_DIM))
 for word, i in word_index.items():
     if i > MAX_NB_WORDS:
         continue
@@ -109,7 +109,7 @@ for word, i in word_index.items():
 
 # load pre-trained word embeddings into an Embedding layer
 # note that we set trainable = False so as to keep the embeddings fixed
-embedding_layer = Embedding(NB_WORDS + 1,
+embedding_layer = Embedding(nb_words + 1,
                             EMBEDDING_DIM,
                             weights=[embedding_matrix],
                             input_length=MAX_SEQUENCE_LENGTH,


### PR DESCRIPTION
Current implementation set the # of rows in `embedding_matrix` to be `1 + len(word_index)`, i.e. # of unique tokens in the text. This could be a memory waste if the `MAX_NB_WORDS` is set to be much smaller, e.g., 20000 in this case. 

Changes to make the size of `embedding_matrix` to be the min of the two numbers.