### PR TITLE
remove usage of tf.assign() in part of tensorflow backend (#3316)

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -859,7 +859,10 @@ def set_value(x, value):
     '''Sets the value of a tensor variable,
     from a Numpy array.
     '''
-    tf.assign(x, np.asarray(value)).op.run(session=get_session())
+    tf_dtype = _convert_string_dtype(dtype(value))
+    assign_placeholder = tf.placeholder(tf_dtype, shape=value.shape)
+    assign_op = x.assign(assign_placeholder)
+    get_session().run(assign_op, feed_dict={assign_placeholder: value})
 
 
 def batch_set_value(tuples):
@@ -870,8 +873,7 @@ def batch_set_value(tuples):
             `value` should be a Numpy array.
     '''
     if tuples:
-        ops = [tf.assign(x, np.asarray(value)) for x, value in tuples]
-        get_session().run(ops)
+        [set_value(x,np.asarray(value)) for x, value in tuples]
 
 
 def print_tensor(x, message=''):

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -859,7 +859,8 @@ def set_value(x, value):
     '''Sets the value of a tensor variable,
     from a Numpy array.
     '''
-    tf_dtype = _convert_string_dtype(dtype(value))
+    value = np.asarray(value)
+    tf_dtype = _convert_string_dtype((x*1.).dtype)
     assign_placeholder = tf.placeholder(tf_dtype, shape=value.shape)
     assign_op = x.assign(assign_placeholder)
     get_session().run(assign_op, feed_dict={assign_placeholder: value})

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -860,7 +860,7 @@ def set_value(x, value):
     from a Numpy array.
     '''
     value = np.asarray(value)
-    tf_dtype = _convert_string_dtype((x*1.).dtype)
+    tf_dtype = _convert_string_dtype(x.dtype.name.split('_')[0])
     assign_placeholder = tf.placeholder(tf_dtype, shape=value.shape)
     assign_op = x.assign(assign_placeholder)
     get_session().run(assign_op, feed_dict={assign_placeholder: value})

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -874,7 +874,15 @@ def batch_set_value(tuples):
             `value` should be a Numpy array.
     '''
     if tuples:
-        [set_value(x,np.asarray(value)) for x, value in tuples]
+        assign_ops = []
+        feed_dict = {}
+        for x, value in tuples:
+            value = np.asarray(value)
+            tf_dtype = _convert_string_dtype(x.dtype.name.split('_')[0])
+            assign_placeholder = tf.placeholder(tf_dtype, shape=value.shape)
+            assign_ops.append(x.assign(assign_placeholder))
+            feed_dict[assign_placeholder] = value
+        get_session().run(assign_ops, feed_dict=feed_dict)
 
 
 def print_tensor(x, message=''):


### PR DESCRIPTION
Usage of the tf.assign() function in the set_value() and batch_set_values() functions creates new nodes on the Tensorflow graph which can eventually lead to memory overflow.
Therefore, the function has been rewritten using placeholders and feed_dict to avoid this issue.