### PR TITLE
Add ascii diagrams to existing examples

### DIFF
--- a/examples/addition_rnn.py
+++ b/examples/addition_rnn.py
@@ -24,6 +24,15 @@ Four digits inverted:
 Five digits inverted:
 + One layer LSTM (128 HN), 550k training examples = 99% train/test accuracy in 30 epochs
 
+Diagram:
+
+      InputLayer (None, 7, 12)
+            LSTM (None, 128)
+    RepeatVector (None, 4, 128)
+            LSTM (None, 4, 128)
+ TimeDistributed (None, 4, 12)
+         Softmax (None, 4, 12)
+
 '''
 
 from __future__ import print_function

--- a/examples/babi_rnn.py
+++ b/examples/babi_rnn.py
@@ -54,6 +54,20 @@ these RNNs can achieve 100% accuracy on many tasks. Memory networks and neural
 networks that use attentional processes can efficiently search through this
 noise to find the relevant statements, improving performance substantially.
 This becomes especially obvious on QA2 and QA3, both far longer than QA1.
+
+Diagram:
+
+                                   InputLayer (None, 5)
+                                    Embedding (None, 5, 50)
+  InputLayer (None, 552)              Dropout (None, 5, 50)
+   Embedding (None, 552, 50)             LSTM (None, 50)
+     Dropout (None, 552, 50)     RepeatVector (None, 552, 50)
+             \______________________________/
+                            |
+                       Merge (None, 552, 50)
+                        LSTM (None, 50)
+                     Dropout (None, 50)
+                       Dense (None, 36)
 '''
 
 from __future__ import print_function

--- a/examples/cifar10_cnn.py
+++ b/examples/cifar10_cnn.py
@@ -9,6 +9,29 @@ It gets down to 0.65 test logloss in 25 epochs, and down to 0.55 after 50 epochs
 Note: the data was pickled with Python 2, and some encoding issues might prevent you
 from loading it in Python 3. You might have to load it in Python 2,
 save it in a different format, load it in Python 3 and repickle it.
+
+Diagram:
+
+         InputLayer (None, 3, 32, 32)
+      Convolution2D (None, 32, 32, 32)
+               Relu (None, 32, 32, 32)
+      Convolution2D (None, 32, 30, 30)
+               Relu (None, 32, 30, 30)
+       MaxPooling2D (None, 32, 15, 15)
+            Dropout (None, 32, 15, 15)
+      Convolution2D (None, 64, 15, 15)
+               Relu (None, 64, 15, 15)
+      Convolution2D (None, 64, 13, 13)
+               Relu (None, 64, 13, 13)
+       MaxPooling2D (None, 64, 6, 6)
+            Dropout (None, 64, 6, 6)
+            Flatten (None, 2304)
+              Dense (None, 512)
+               Relu (None, 512)
+            Dropout (None, 512)
+              Dense (None, 10)
+            Softmax (None, 10)
+
 '''
 
 from __future__ import print_function


### PR DESCRIPTION
Add an ascii diagram to the comment block showing model layers and their output shapes. 

I've found the examples very helpful in learning Keras. Figuring out the layer shapes is usually the first step in understanding an example. 

Currently, this PR just adds diagrams to a few examples. If you like this PR will add to the other examples.

