### PR TITLE
Embedding layer - cast float to int implicitly

### DIFF
--- a/keras/layers/embeddings.py
+++ b/keras/layers/embeddings.py
@@ -125,7 +125,8 @@ class Embedding(Layer):
         return (input_shape[0], input_length, self.output_dim)
 
     def call(self, x, mask=None):
-        x = K.cast(x, 'int32')
+        if K.dtype(x) != 'int32':
+            x = K.cast(x, 'int32')
         if 0. < self.dropout < 1.:
             retain_p = 1. - self.dropout
             B = K.random_binomial((self.input_dim,), p=retain_p) * (1. / retain_p)

--- a/keras/layers/embeddings.py
+++ b/keras/layers/embeddings.py
@@ -125,6 +125,7 @@ class Embedding(Layer):
         return (input_shape[0], input_length, self.output_dim)
 
     def call(self, x, mask=None):
+        x = K.cast(x, 'int32')
         if 0. < self.dropout < 1.:
             retain_p = 1. - self.dropout
             B = K.random_binomial((self.input_dim,), p=retain_p) * (1. / retain_p)


### PR DESCRIPTION
In functional API, the user has to specify that input to an Embedding layer is int, which is redundant because Keras already has information about the input dtype in input_spec :  

```python
a = Input((100,), dtype='int32')
b = Embedding(....)(a)
```
