### PR TITLE
Automatically convert convolution weights depending on backend

### DIFF
--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -15,6 +15,7 @@ from six.moves import zip
 
 from .. import backend as K
 from ..utils.io_utils import ask_to_proceed_with_overwrite
+from ..utils.np_utils import convert_kernel
 
 
 def to_list(x):
@@ -2384,6 +2385,7 @@ class Container(Layer):
             flattened_layers = self.layers
 
         f.attrs['layer_names'] = [layer.name.encode('utf8') for layer in flattened_layers]
+        f.attrs['keras_backend'] = K._BACKEND
 
         for layer in flattened_layers:
             g = f.create_group(layer.name)
@@ -2483,6 +2485,20 @@ class Container(Layer):
                                     str(len(weight_values)) +
                                     ' elements.')
                 weight_value_tuples += zip(symbolic_weights, weight_values)
+            K.batch_set_value(weight_value_tuples)
+
+        backend = f.attrs.get('keras_backend')
+        if backend and backend != K._BACKEND:
+            # Weights were originally serialized using a different backend. TensorFlow and Theano
+            # use different implementations for convolutions, which need to be converted.
+            weight_value_tuples = []
+            for layer in flattened_layers:
+                from keras.layers import Convolution1D, Convolution2D, Convolution3D
+                if not isinstance(layer, (Convolution1D, Convolution2D, Convolution3D)):
+                    continue
+                original_w = K.get_value(layer.W)
+                converted_w = convert_kernel(original_w)
+                weight_value_tuples += [(layer.W, converted_w)]
             K.batch_set_value(weight_value_tuples)
 
     def _updated_config(self):

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 from .. import backend as K
 from .. import activations, initializations, regularizers, constraints
 from ..engine import Layer, InputSpec
-from ..utils.np_utils import conv_output_length, conv_input_length
+from ..utils.np_utils import conv_output_length, conv_input_length, convert_kernel
 
 # imports for backwards namespace compatibility
 from .pooling import AveragePooling1D, AveragePooling2D, AveragePooling3D
@@ -163,6 +163,10 @@ class Convolution1D(Layer):
         output = K.permute_dimensions(output, (0, 2, 1))
         output = self.activation(output)
         return output
+
+    def convert_weights(self, weights, from_backend):
+        weights[0] = convert_kernel(weights[0])
+        return weights
 
     def get_config(self):
         config = {'nb_filter': self.nb_filter,
@@ -359,6 +363,10 @@ class Convolution2D(Layer):
                 raise Exception('Invalid dim_ordering: ' + self.dim_ordering)
         output = self.activation(output)
         return output
+
+    def convert_weights(self, weights, from_backend):
+        weights[0] = convert_kernel(weights[0])
+        return weights
 
     def get_config(self):
         config = {'nb_filter': self.nb_filter,
@@ -996,6 +1004,10 @@ class Convolution3D(Layer):
                 raise Exception('Invalid dim_ordering: ' + self.dim_ordering)
         output = self.activation(output)
         return output
+
+    def convert_weights(self, weights, from_backend):
+        weights[0] = convert_kernel(weights[0])
+        return weights
 
     def get_config(self):
         config = {'nb_filter': self.nb_filter,


### PR DESCRIPTION
As discussed in https://github.com/fchollet/keras/issues/3307, I recently had trouble with loading the weights of a network that was trained using Theano but evaluated using TensorFlow. While @EderSantana pointed out that this difference in behavior is properly documented in the Wiki, I think we can do better.

My approach includes the backend when storing the weights. This allows us to automatically detect a difference in backend when loading the weights and to convert the kernel weights appropriately. My solution is fully backwards-compatible.

However, there are a couple of things that I'm not sure I got right:
- Should we include `SeparableConvolution2D` in the list of convertible classes?
- Since we include `Convolution1D` and so on, we also convert `Deconvolution1D` and friends since they inherit from the respective `Convolution` layer. Again, I'm not entirely sure if the conversion process is correct in this case.
- Do we need tests for this?