### PR TITLE
update examples/neural_style_transfer.py

### DIFF
--- a/examples/neural_style_transfer.py
+++ b/examples/neural_style_transfer.py
@@ -80,6 +80,7 @@ total_variation_weight = 1.
 style_weight = 1.
 content_weight = 0.025
 
+
 # dimensions of the generated picture.
 img_width = 400
 img_height = 400
@@ -88,13 +89,21 @@ assert img_height == img_width, 'Due to the use of the Gram matrix, width and he
 # util function to open, resize and format pictures into appropriate tensors
 def preprocess_image(image_path):
     img = imresize(imread(image_path), (img_width, img_height))
-    img = img.transpose((2, 0, 1)).astype('float64')
+    img = img[:, :, ::-1].astype('float64')
+    img[:, :, 0] -= 103.939
+    img[:, :, 1] -= 116.779
+    img[:, :, 2] -= 123.68
+    img = img.transpose((2, 0, 1))
     img = np.expand_dims(img, axis=0)
     return img
 
 # util function to convert a tensor into a valid image
 def deprocess_image(x):
     x = x.transpose((1, 2, 0))
+    x[:, :, 0] += 103.939
+    x[:, :, 1] += 116.779
+    x[:, :, 2] += 123.68
+    x = x[:, :, ::-1]
     x = np.clip(x, 0, 255).astype('uint8')
     return x
 
@@ -275,6 +284,9 @@ evaluator = Evaluator()
 # run scipy-based optimization (L-BFGS) over the pixels of the generated image
 # so as to minimize the neural style loss
 x = np.random.uniform(0, 255, (1, 3, img_width, img_height))
+x[0, 0, :, :] -= 103.939
+x[0, 1, :, :] -= 116.779
+x[0, 2, :, :] -= 123.68
 for i in range(10):
     print('Start of iteration', i)
     start_time = time.time()
@@ -282,7 +294,7 @@ for i in range(10):
                                      fprime=evaluator.grads, maxfun=20)
     print('Current loss value:', min_val)
     # save current generated image
-    img = deprocess_image(x.reshape((3, img_width, img_height)))
+    img = deprocess_image(x.copy().reshape((3, img_width, img_height)))
     fname = result_prefix + '_at_iteration_%d.png' % i
     imsave(fname, img)
     end_time = time.time()


### PR DESCRIPTION
Changes made to the example to make it more consistent with documented usage of VGG16 weights. Detailed discussion can be found at #3340 . The following changes are made to images before passing through VGG,
1. Convert RGB to BGR
2. Mean-Centering