### PR TITLE
Compare versions through pkg_resources.parse_version

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -9,6 +9,7 @@ import warnings
 from collections import deque
 from .utils.generic_utils import Progbar
 from keras import backend as K
+from pkg_resources import parse_version
 
 
 class CallbackList(object):
@@ -478,7 +479,7 @@ class TensorBoard(Callback):
                                          layer.output)
         self.merged = tf.merge_all_summaries()
         if self.write_graph:
-            if tf.__version__ >= '0.8.0':
+            if parse_version(tf.__version__) >= parse_version('0.8.0'):
                 self.writer = tf.train.SummaryWriter(self.log_dir,
                                                      self.sess.graph)
             else:


### PR DESCRIPTION
The latest TensorFlow release broke the version check in `callbacks.TensorBoard` once again, `'0.10.0rc0'` compares lexicographically less than `'0.8.0'`:

``` python
>>> tf.__version__
'0.10.0rc0'
>>> tf.__version__ >= '0.8.0'
False
```

 Thus once again TensorFlow issues this warning: "Passing a `GraphDef` to the SummaryWriter is deprecated. Pass a `Graph` object instead, such as `sess.graph`." (See previous discussions and fixes here: https://github.com/fchollet/keras/issues/2570 https://github.com/fchollet/keras/pull/2574 https://github.com/fchollet/keras/commit/ebbc4d9fb83e36b1f19ffce1b8e5c0386eeb214a).

To (hopefully) fix this issue for good I propose using `pkg_resources.parse_version`.  Quoting from the [docs](https://setuptools.readthedocs.io/en/latest/pkg_resources.html#parsing-utilities):

> `parse_version(version)`
Parsed a project’s version string as defined by PEP 440. The returned value will be an object that represents the version. These objects may be compared to each other and sorted. The sorting algorithm is as defined by PEP 440 with the addition that any version which is not a valid PEP 440 version will be considered less than any valid PEP 440 version and the invalid versions will continue sorting using the original algorithm.

Further References:
- [PEP440](https://www.python.org/dev/peps/pep-0440/)
- [Relevant StackOverflow Answer](http://stackoverflow.com/a/21065570/2528077) 

It's worth noting that `pkg_resources` is part of `setuptools` and thus does not introduce further dependencies. [`keras/setup.py`](https://github.com/fchollet/keras/blob/master/setup.py#L1-L2) already  assumes`setuptools` exists. 

Proof of Fix:

``` python
>>> from pkg_resources import parse_version
>>> parse_version(tf.__version__) >= parse_version('0.8.0')
True
```