### PR TITLE
Correcting the reconstruction loss in Variational Autoencoder example.

### DIFF
--- a/examples/variational_autoencoder.py
+++ b/examples/variational_autoencoder.py
@@ -39,7 +39,7 @@ x_decoded_mean = decoder_mean(h_decoded)
 
 
 def vae_loss(x, x_decoded_mean):
-    xent_loss = objectives.binary_crossentropy(x, x_decoded_mean)
+    xent_loss = original_dim * objectives.binary_crossentropy(x, x_decoded_mean)
     kl_loss = - 0.5 * K.sum(1 + z_log_var - K.square(z_mean) - K.exp(z_log_var), axis=-1)
     return xent_loss + kl_loss
 


### PR DESCRIPTION
As discussed in #3373, the Variational Autoencoder example is not working properly due to the extremely small reconstruction loss which looks introduces in the commit [f6bcaffe4a6](https://github.com/fchollet/keras/commit/f6bcaffe4a67012b4b067038bdbc5d43b807540b). This code simply brings back the multiplication of `original_dim` in the xent_loss term to match the size with the KL loss.

Thanks,
Shuhei