### PR TITLE
Allow multiprocessing on OS X

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -421,7 +421,7 @@ def generator_queue(generator, max_q_size=10,
         def data_generator_task():
             while not _stop.is_set():
                 try:
-                    if q.qsize() < max_q_size:
+                    if pickle_safe or q.qsize() < max_q_size:
                         try:
                             generator_output = next(generator)
                         except ValueError:


### PR DESCRIPTION
multiprocessing.Queue.qsize() raises NotImplementedError on OS X, and the maximum queue size is already being set when the queue is constructed in the multiprocessing case, so skip the qsize() test if pickle_safe is True.