### PR TITLE
Skipped a division by zero in ImageDataGenerator that occurs with 0'ed arrays

### DIFF
--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -126,7 +126,9 @@ def array_to_img(x, dim_ordering='default', scale=True):
         x = x.transpose(1, 2, 0)
     if scale:
         x += max(-np.min(x), 0)
-        x /= np.max(x)
+        x_max = np.max(x)
+        if x_max != 0:
+            x /= x_max
         x *= 255
     if x.shape[2] == 3:
         # RGB


### PR DESCRIPTION
When ImageDataGenerator attempts to write arrays to image files (if one is using the save_to_dir arg), it divides by the max value in the array as part of its conversion to pixels. If the entire array was 0's, the process fails because it cannot divide by 0. In this case, the process can be skipped because it does not effect the augmented data.

For my own testing with the occasional completely blank (0s) image mask, I wrote this fix for the division by zero problem on blank images. If it looks appropriate, please merge it with the repo. Thanks!