### PR TITLE
Add HTTP support to `preprocessing.image.load_image`

### DIFF
--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -162,6 +162,12 @@ def img_to_array(img, dim_ordering='default'):
 
 def load_img(path, grayscale=False, target_size=None):
     from PIL import Image
+
+    if path[:4] == 'http': # Allow loading from http URL
+        import urllib
+        import cStringIO
+        path = cStringIO.StringIO(urllib.urlopen(path).read())
+
     img = Image.open(path)
     if grayscale:
         img = img.convert('L')


### PR DESCRIPTION
Allow `preprocessing.image.load_image` to accept an HTTP URL