### PR TITLE
Upsampling layer fix to work when input shape is None

### DIFF
--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -1045,7 +1045,8 @@ class UpSampling1D(Layer):
         super(UpSampling1D, self).__init__(**kwargs)
 
     def get_output_shape_for(self, input_shape):
-        return (input_shape[0], self.length * input_shape[1], input_shape[2])
+        length = self.length * input_shape[1] if input_shape[1] is not None else None
+        return (input_shape[0], length, input_shape[2])
 
     def call(self, x, mask=None):
         output = K.repeat_elements(x, self.length, axis=1)
@@ -1094,14 +1095,18 @@ class UpSampling2D(Layer):
 
     def get_output_shape_for(self, input_shape):
         if self.dim_ordering == 'th':
+            width = self.size[0] * input_shape[2] if input_shape[2] is not None else None
+            height = self.size[1] * input_shape[3] if input_shape[3] is not None else None
             return (input_shape[0],
                     input_shape[1],
-                    self.size[0] * input_shape[2],
-                    self.size[1] * input_shape[3])
+                    width,
+                    height)
         elif self.dim_ordering == 'tf':
+            width = self.size[0] * input_shape[1] if input_shape[1] is not None else None
+            height = self.size[1] * input_shape[2] if input_shape[2] is not None else None
             return (input_shape[0],
-                    self.size[0] * input_shape[1],
-                    self.size[1] * input_shape[2],
+                    width,
+                    height,
                     input_shape[3])
         else:
             raise Exception('Invalid dim_ordering: ' + self.dim_ordering)
@@ -1153,16 +1158,22 @@ class UpSampling3D(Layer):
 
     def get_output_shape_for(self, input_shape):
         if self.dim_ordering == 'th':
+            dim1 = self.size[0] * input_shape[2] if input_shape[2] is not None else None
+            dim2 = self.size[1] * input_shape[3] if input_shape[3] is not None else None
+            dim3 = self.size[2] * input_shape[4] if input_shape[4] is not None else None
             return (input_shape[0],
                     input_shape[1],
-                    self.size[0] * input_shape[2],
-                    self.size[1] * input_shape[3],
-                    self.size[2] * input_shape[4])
+                    dim1,
+                    dim2,
+                    dim3)
         elif self.dim_ordering == 'tf':
+            dim1 = self.size[0] * input_shape[1] if input_shape[1] is not None else None
+            dim2 = self.size[1] * input_shape[2] if input_shape[2] is not None else None
+            dim3 = self.size[2] * input_shape[3] if input_shape[3] is not None else None
             return (input_shape[0],
-                    self.size[0] * input_shape[1],
-                    self.size[1] * input_shape[2],
-                    self.size[2] * input_shape[3],
+                    dim1,
+                    dim2,
+                    dim3,
                     input_shape[4])
         else:
             raise Exception('Invalid dim_ordering: ' + self.dim_ordering)


### PR DESCRIPTION
Currently, the UpSamplingND layers do not work when specifying an input shape of None.
This code:

	m = Sequential()
	m.add(Convolution2D(1, 3, 3, border_mode='same', input_shape=(1, None, None)))
	m.add(UpSampling2D(size=(2,2)))


Gives the following output:


	Traceback (most recent call last):
	  File "keras_test_input.py", line 11, in <module>
	    m.add(UpSampling2D(size=(2,2)))
	  File "/usr/local/lib/python2.7/dist-packages/Keras-1.0.7-py2.7.egg/keras/models.py", line 307, in add
	    output_tensor = layer(self.outputs[0])
	  File "/usr/local/lib/python2.7/dist-packages/Keras-1.0.7-py2.7.egg/keras/engine/topology.py", line 511, in __call__
	    self.add_inbound_node(inbound_layers, node_indices, tensor_indices)
	  File "/usr/local/lib/python2.7/dist-packages/Keras-1.0.7-py2.7.egg/keras/engine/topology.py", line 569, in add_inbound_node
	    Node.create_node(self, inbound_layers, node_indices, tensor_indices)
	  File "/usr/local/lib/python2.7/dist-packages/Keras-1.0.7-py2.7.egg/keras/engine/topology.py", line 153, in create_node
	    output_shapes = to_list(outbound_layer.get_output_shape_for(input_shapes[0]))
	  File "/usr/local/lib/python2.7/dist-packages/Keras-1.0.7-py2.7.egg/keras/layers/convolutional.py", line 1099, in get_output_shape_for
	    self.size[0] * input_shape[2],
	TypeError: unsupported operand type(s) for *: 'int' and 'NoneType'

With this PR, the output is as follows:

	____________________________________________________________________________________________________
	Layer (type)                     Output Shape          Param #     Connected to                     
	====================================================================================================
	convolution2d_1 (Convolution2D)  (None, 1, None, None) 10          convolution2d_input_1[0][0]      
	____________________________________________________________________________________________________
	upsampling2d_1 (UpSampling2D)    (None, 1, None, None) 0           convolution2d_1[0][0]            
	====================================================================================================
	Total params: 10
	____________________________________________________________________________________________________


This PR fixes this issue by properly handling the case where input_shape is None. Fixes #2456 and #3108 