### PR TITLE
Multi-input RNN and TimeDistributed wrapper

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1042,7 +1042,7 @@ def rnn(step_function, inputs, initial_states,
             x = tf.transpose(x, (axes))
             input_list += [tf.unpack(x)]
         assert len(set(map(len, input_list))) == 1, "All input sequences should be of equal length."
-        input_list = [ map(lambda x: x[t], input_list) for t in range(len(input_list[0]))]
+        input_list = [map(lambda x: x[t], input_list) for t in range(len(input_list[0]))]
     else:
         ndim = len(inputs.get_shape())
         assert ndim >= 3, "Input should be at least 3D."

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1039,7 +1039,7 @@ def rnn(step_function, inputs, initial_states,
             ndim = len(x.get_shape())
             assert ndim >= 3, "Input should be at least 3D."
             for t in range(input_length):
-                    input_list[t] += [x[(slice(None), t) + (slice(None),) * (ndim - 2)]]
+                input_list[t] += [x[(slice(None), t) + (slice(None),) * (ndim - 2)]]
     else:
         ndim = len(inputs.get_shape())
         assert ndim >= 3, "Input should be at least 3D."

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1034,15 +1034,12 @@ def rnn(step_function, inputs, initial_states,
             the step function, of shape (samples, ...).
     '''
     if type(inputs) == list:
-        input_list = []
+        input_list = [[]] * input_length    
         for x in inputs:
             ndim = len(x.get_shape())
             assert ndim >= 3, "Input should be at least 3D."
-            axes = [1, 0] + list(range(2, ndim))
-            x = tf.transpose(x, (axes))
-            input_list += [tf.unpack(x)]
-        assert len(set(map(len, input_list))) == 1, "All input sequences should be of equal length."
-        input_list = [map(lambda x: x[t], input_list) for t in range(len(input_list[0]))]
+            for t in range(input_length):
+                    input_list[t] += [x[(slice(None), t) + (slice(None),) * (ndim - 2)]]
     else:
         ndim = len(inputs.get_shape())
         assert ndim >= 3, "Input should be at least 3D."

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1034,7 +1034,7 @@ def rnn(step_function, inputs, initial_states,
             the step function, of shape (samples, ...).
     '''
     if type(inputs) == list:
-        input_list = [[]] * input_length    
+        input_list = [[] for _ in range(input_length)]
         for x in inputs:
             ndim = len(x.get_shape())
             assert ndim >= 3, "Input should be at least 3D."

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -856,7 +856,7 @@ def rnn(step_function, inputs, initial_states,
                     output, new_states = step_function(inputs, states)
                     return [output] + new_states
             else:
-                def _step(input, states):
+                def _step(input, *states):
                     output, new_states = step_function(input, states)
                     return [output] + new_states
             results, _ = theano.scan(

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -849,12 +849,16 @@ def rnn(step_function, inputs, initial_states,
                 states.append(T.stack(*[states_at_step[i] for states_at_step in successive_states]))
 
         else:
-            def _step(*args):
-                input = args[:len(inputs)]
-                states = args[len(inputs):]
-                output, new_states = step_function(input, states)
-                return [output] + new_states
-
+            if type(inputs) == list:
+                def _step(*args):
+                    inputs = args[:len(inputs)]
+                    states = args[len(inputs):]
+                    output, new_states = step_function(inputs, states)
+                    return [output] + new_states
+            else:
+                def _step(input, states):
+                    output, new_states = step_function(input, states)
+                    return [output] + new_states
             results, _ = theano.scan(
                 _step,
                 sequences=inputs,

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -781,6 +781,7 @@ def rnn(step_function, inputs, initial_states,
                 initial_output = step_function([x[0] for x in inputs], initial_states + constants)[0] * 0
                 # Theano gets confused by broadcasting patterns in the scan op
                 initial_output = T.unbroadcast(initial_output, 0, 1)
+
                 def _step(*args):
                     input = args[:len(inputs)]
                     mask = args[len(inputs)]
@@ -805,6 +806,7 @@ def rnn(step_function, inputs, initial_states,
                 initial_output = step_function(inputs[0], initial_states + constants)[0] * 0
                 # Theano gets confused by broadcasting patterns in the scan op
                 initial_output = T.unbroadcast(initial_output, 0, 1)
+
                 def _step(input, mask, output_tm1, *states):
                     output, new_states = step_function(input, states)
                     # output previous output if masked.
@@ -850,12 +852,14 @@ def rnn(step_function, inputs, initial_states,
 
         else:
             if type(inputs) == list:
+
                 def _step(*args):
                     inputs = args[:len(inputs)]
                     states = args[len(inputs):]
                     output, new_states = step_function(inputs, states)
                     return [output] + new_states
             else:
+
                 def _step(input, *states):
                     output, new_states = step_function(input, states)
                     return [output] + new_states
@@ -881,7 +885,6 @@ def rnn(step_function, inputs, initial_states,
     outputs = outputs.dimshuffle(axes)
     states = [T.squeeze(state[-1]) for state in states]
     return last_output, outputs, states
-
 
 def switch(condition, then_expression, else_expression):
     '''condition: scalar tensor.

--- a/keras/layers/wrappers.py
+++ b/keras/layers/wrappers.py
@@ -84,34 +84,58 @@ class TimeDistributed(Wrapper):
         super(TimeDistributed, self).__init__(layer, **kwargs)
 
     def build(self, input_shape):
-        assert len(input_shape) >= 3
-        self.input_spec = [InputSpec(shape=input_shape)]
+        if type(input_shape) != list:
+            input_shape = [input_shape]
+        for shape in input_shape:
+            assert len(shape) >= 3
+        self.input_spec = [InputSpec(shape=shape) for shape in input_shape]
         if K._BACKEND == 'tensorflow':
-            if not input_shape[1]:
-                raise Exception('When using TensorFlow, you should define '
-                                'explicitly the number of timesteps of '
-                                'your sequences.\n'
-                                'If your first layer is an Embedding, '
-                                'make sure to pass it an "input_length" '
-                                'argument. Otherwise, make sure '
-                                'the first layer has '
-                                'an "input_shape" or "batch_input_shape" '
-                                'argument, including the time axis.')
-        child_input_shape = (input_shape[0],) + input_shape[2:]
+            for shape in input_shape:
+                if not shape[1]:
+                    raise Exception('When using TensorFlow, you should define '
+                                    'explicitly the number of timesteps of '
+                                    'your sequences.\n'
+                                    'If your first layer is an Embedding, '
+                                    'make sure to pass it an "input_length" '
+                                    'argument. Otherwise, make sure '
+                                    'the first layer has '
+                                    'an "input_shape" or "batch_input_shape" '
+                                    'argument, including the time axis.')
+        child_input_shape = [((shape[0],) + shape[2:]) for shape in input_shape]
+        if len(input_shape) == 1:
+            child_input_shape = child_input_shape[0]
         if not self.layer.built:
             self.layer.build(child_input_shape)
             self.layer.built = True
         super(TimeDistributed, self).build()
 
     def get_output_shape_for(self, input_shape):
-        child_input_shape = (input_shape[0],) + input_shape[2:]
+        if type(input_shape) == list:
+            child_input_shape = [((shape[0],) + shape[2:]) for shape in input_shape]
+            timesteps = input_shape[0][1]
+           
+        else:
+            child_input_shape = (input_shape[0],) + input_shape[2:]
+            timesteps = input_shape[1]
         child_output_shape = self.layer.get_output_shape_for(child_input_shape)
-        timesteps = input_shape[1]
         return (child_output_shape[0], timesteps) + child_output_shape[1:]
 
+    def compute_mask(self, input, input_mask):
+        if type(input_mask) != list:
+            return input_mask
+        elif not any(input_mask):
+            return None
+        else:
+            return K.prod(input_mask, axis=0)
+
     def call(self, X, mask=None):
-        input_shape = self.input_spec[0].shape
-        if input_shape[0]:
+        input_shapes = [input_spec.shape for input_spec in self.input_spec]
+        batch_size = False
+        for shape in input_shapes:
+            if shape[0] is not None:
+                batch_size = True
+                break
+        if batch_size:
             # batch size matters, use rnn-based implementation
             def step(x, states):
                 output = self.layer.call(x)
@@ -124,12 +148,16 @@ class TimeDistributed(Wrapper):
             # no batch size specified, therefore the layer will be able
             # to process batches of any size
             # we can go with reshape-based implementation for performance
-            input_length = input_shape[1]
+            if type(X) != list:
+                X = [X]
+            input_length = input_shapes[0][1]
             if not input_length:
-                input_length = K.shape(X)[1]
-            X = K.reshape(X, (-1, ) + input_shape[2:])  # (nb_samples * timesteps, ...)
+                input_length = K.shape(X[0])[1]
+            X = [K.reshape(X[i], (-1, ) + input_shapes[i][2:]) for i in range(len(X))] # (nb_samples * timesteps, ...)
+            if len(X) == 1:
+                X = X[0]
             y = self.layer.call(X)  # (nb_samples * timesteps, ...)
             # (nb_samples, timesteps, ...)
-            output_shape = self.get_output_shape_for(input_shape)
+            output_shape = self.get_output_shape_for(input_shapes)
             y = K.reshape(y, (-1, input_length) + output_shape[2:])
         return y

--- a/keras/layers/wrappers.py
+++ b/keras/layers/wrappers.py
@@ -137,6 +137,7 @@ class TimeDistributed(Wrapper):
                 break
         if batch_size:
             # batch size matters, use rnn-based implementation
+
             def step(x, states):
                 output = self.layer.call(x)
                 return output, []
@@ -156,8 +157,11 @@ class TimeDistributed(Wrapper):
             X = [K.reshape(X[i], (-1, ) + input_shapes[i][2:]) for i in range(len(X))] # (nb_samples * timesteps, ...)
             if len(X) == 1:
                 X = X[0]
+                input_shape = input_shapes[0]
+            else:
+                input_shape = input_shapes
             y = self.layer.call(X)  # (nb_samples * timesteps, ...)
             # (nb_samples, timesteps, ...)
-            output_shape = self.get_output_shape_for(input_shapes)
+            output_shape = self.get_output_shape_for(input_shape)
             y = K.reshape(y, (-1, input_length) + output_shape[2:])
         return y


### PR DESCRIPTION
Theano scan op allows looping through multiple sequences simultaneously, but this feature is currently hidden by Keras's abstraction, forcing users to concatenate sequences(followed by unpacking them in the step function).
- Backward compatible. The API is pretty simple; now the `inputs` argument can be a tensor or a list of tensors with same input lengths.
