### PR TITLE
added weighted binary cross entropy and weighted MSE objectives

### DIFF
--- a/keras/objectives.py
+++ b/keras/objectives.py
@@ -64,23 +64,23 @@ def cosine_proximity(y_true, y_pred):
     return -K.mean(y_true * y_pred, axis=-1)
 
 def get_weighted_mean_squared_error(w0_weights,w1_weights,thresh=0.5): 
-    w0_weights=np.array(w0_weights); 
-    w1_weights=np.array(w1_weights);
+    w0_weights=np.array(w0_weights)
+    w1_weights=np.array(w1_weights)
     def weighted_mean_squared_error(y_true,y_pred): 
         y_true_binarized=(y_true<thresh).astype(int) 
-        weightVectors = y_true_binarized*w1_weights[None,:] + (1-y_true_binarized)*w0_weights[None,:] 
-        return K.mean(K.square(y_pred-y_true)*weightVectors, axis=-1);
-    return weighted_mean_squared_error; 
+        weight_vectors = y_true_binarized*w1_weights[None,:] + (1-y_true_binarized)*w0_weights[None,:] 
+        return K.mean(K.square(y_pred-y_true)*weight_vectors, axis=-1)
+    return weighted_mean_squared_error 
 
 def get_weighted_binary_crossentropy(w0_weights, w1_weights):
     # Compute the task-weighted cross-entropy loss, where every task is weighted by 1 - (fraction of non-ambiguous examples that are positive)
     # In addition, weight everything with label -1 to 0
-    w0_weights=np.array(w0_weights);
-    w1_weights=np.array(w1_weights);
+    w0_weights=np.array(w0_weights)
+    w1_weights=np.array(w1_weights)
     def weighted_binary_crossentropy(y_true,y_pred): 
-        weightsPerTaskRep = y_true*w1_weights[None,:] + (1-y_true)*w0_weights[None,:]
-        return K.mean(K.binary_crossentropy(y_pred, y_true)*weightsPerTask, axis=-1);
-    return weighted_binary_crossentropy; 
+        weights_per_task = y_true*w1_weights[None,:] + (1-y_true)*w0_weights[None,:]
+        return K.mean(K.binary_crossentropy(y_pred, y_true)*weights_per_task, axis=-1)
+    return weighted_binary_crossentropy
 
 
 # aliases

--- a/keras/objectives.py
+++ b/keras/objectives.py
@@ -66,10 +66,12 @@ def cosine_proximity(y_true, y_pred):
 def get_weighted_mean_squared_error(w0_weights,w1_weights,thresh=0.5): 
     w0_weights=np.array(w0_weights)
     w1_weights=np.array(w1_weights)
+
     def weighted_mean_squared_error(y_true,y_pred): 
         y_true_binarized=(y_true<thresh).astype(int) 
         weight_vectors = y_true_binarized*w1_weights[None,:] + (1-y_true_binarized)*w0_weights[None,:] 
         return K.mean(K.square(y_pred-y_true)*weight_vectors, axis=-1)
+
     return weighted_mean_squared_error 
 
 def get_weighted_binary_crossentropy(w0_weights, w1_weights):
@@ -77,9 +79,11 @@ def get_weighted_binary_crossentropy(w0_weights, w1_weights):
     # In addition, weight everything with label -1 to 0
     w0_weights=np.array(w0_weights)
     w1_weights=np.array(w1_weights)
+
     def weighted_binary_crossentropy(y_true,y_pred): 
         weights_per_task = y_true*w1_weights[None,:] + (1-y_true)*w0_weights[None,:]
         return K.mean(K.binary_crossentropy(y_pred, y_true)*weights_per_task, axis=-1)
+
     return weighted_binary_crossentropy
 
 

--- a/keras/objectives.py
+++ b/keras/objectives.py
@@ -79,9 +79,7 @@ def get_weighted_binary_crossentropy(w0_weights, w1_weights):
     w1_weights=np.array(w1_weights);
     def weighted_binary_crossentropy(y_true,y_pred): 
         weightsPerTaskRep = y_true*w1_weights[None,:] + (1-y_true)*w0_weights[None,:]
-        nonAmbig = (y_true > -0.5)
-        nonAmbigTimesWeightsPerTask = nonAmbig * weightsPerTaskRep
-        return K.mean(K.binary_crossentropy(y_pred, y_true)*nonAmbigTimesWeightsPerTask, axis=-1);
+        return K.mean(K.binary_crossentropy(y_pred, y_true)*weightsPerTask, axis=-1);
     return weighted_binary_crossentropy; 
 
 

--- a/keras/objectives.py
+++ b/keras/objectives.py
@@ -63,6 +63,27 @@ def cosine_proximity(y_true, y_pred):
     y_pred = K.l2_normalize(y_pred, axis=-1)
     return -K.mean(y_true * y_pred, axis=-1)
 
+def get_weighted_mean_squared_error(w0_weights,w1_weights,thresh=0.5): 
+    w0_weights=np.array(w0_weights); 
+    w1_weights=np.array(w1_weights);
+    def weighted_mean_squared_error(y_true,y_pred): 
+        y_true_binarized=(y_true<thresh).astype(int) 
+        weightVectors = y_true_binarized*w1_weights[None,:] + (1-y_true_binarized)*w0_weights[None,:] 
+        return K.mean(K.square(y_pred-y_true)*weightVectors, axis=-1);
+    return weighted_mean_squared_error; 
+
+def get_weighted_binary_crossentropy(w0_weights, w1_weights):
+    # Compute the task-weighted cross-entropy loss, where every task is weighted by 1 - (fraction of non-ambiguous examples that are positive)
+    # In addition, weight everything with label -1 to 0
+    w0_weights=np.array(w0_weights);
+    w1_weights=np.array(w1_weights);
+    def weighted_binary_crossentropy(y_true,y_pred): 
+        weightsPerTaskRep = y_true*w1_weights[None,:] + (1-y_true)*w0_weights[None,:]
+        nonAmbig = (y_true > -0.5)
+        nonAmbigTimesWeightsPerTask = nonAmbig * weightsPerTaskRep
+        return K.mean(K.binary_crossentropy(y_pred, y_true)*nonAmbigTimesWeightsPerTask, axis=-1);
+    return weighted_binary_crossentropy; 
+
 
 # aliases
 mse = MSE = mean_squared_error


### PR DESCRIPTION
weighted objective functions for binary cross-entropy and mean-squared error objective functions. 
w0 and w1 are lists of weights for the negative & positive class, respectively, with w0_i and w1_i corresponding to task i in a multi-tasked model. 

The benefit of the weighted objective functions is the ability to handle cases when some tasks have a much higher degree of class imbalance then others. This functionality is different from the existing weights argument to model.train because the weights argument is assigned with w_j for datapoint j, whereas the proposed objectives would assign weights at the task rather than the datapoint level.  