### PR TITLE
Implement a fasttext example

### DIFF
--- a/examples/imdb_fasttext.py
+++ b/examples/imdb_fasttext.py
@@ -15,9 +15,9 @@ np.random.seed(1337)  # for reproducibility
 
 from keras.preprocessing import sequence
 from keras.models import Sequential
-from keras.layers import Dense, Dropout, Activation, Flatten
+from keras.layers import Dense, Activation, Flatten
 from keras.layers import Embedding
-from keras.layers import Convolution1D, MaxPooling1D, AveragePooling1D
+from keras.layers import AveragePooling1D
 from keras.datasets import imdb
 from keras import backend as K
 
@@ -49,7 +49,8 @@ model.add(Embedding(max_features,
                     embedding_dims,
                     input_length=maxlen))
 
-# we add a AveragePooling1D, which
+# we add a AveragePooling1D, which will average the embeddings
+# of all words in the document
 model.add(AveragePooling1D(pool_length=model.output_shape[1]))
 
 # We flatten the output of the conv layer,
@@ -57,9 +58,7 @@ model.add(AveragePooling1D(pool_length=model.output_shape[1]))
 model.add(Flatten())
 
 # We project onto a single unit output layer, and squash it with a sigmoid:
-model.add(Dense(1))
-model.add(Dropout(0.2))
-model.add(Activation('sigmoid'))
+model.add(Dense(1, activation = 'sigmoid'))
 
 model.compile(loss='binary_crossentropy',
               optimizer='adam',

--- a/examples/imdb_fasttext.py
+++ b/examples/imdb_fasttext.py
@@ -53,7 +53,7 @@ model.add(Embedding(max_features,
 # of all words in the document
 model.add(AveragePooling1D(pool_length=model.output_shape[1]))
 
-# We flatten the output of the conv layer
+# We flatten the output of the AveragePooling1D layer
 model.add(Flatten())
 
 # We project onto a single unit output layer, and squash it with a sigmoid:

--- a/examples/imdb_fasttext.py
+++ b/examples/imdb_fasttext.py
@@ -1,0 +1,71 @@
+'''This example demonstrates the use of fasttext for text classification
+
+Based on Joulin et al's paper:
+
+Bags of Tricks for Efficient Text Classification
+https://arxiv.org/abs/1607.01759
+
+Can achieve accuracy around 88% after 5 epochs in 70s.
+
+'''
+
+from __future__ import print_function
+import numpy as np
+np.random.seed(1337)  # for reproducibility
+
+from keras.preprocessing import sequence
+from keras.models import Sequential
+from keras.layers import Dense, Dropout, Activation, Flatten
+from keras.layers import Embedding
+from keras.layers import Convolution1D, MaxPooling1D, AveragePooling1D
+from keras.datasets import imdb
+from keras import backend as K
+
+
+# set parameters:
+max_features = 20000
+maxlen = 400
+batch_size = 32
+embedding_dims = 20
+nb_epoch = 5
+
+print('Loading data...')
+(X_train, y_train), (X_test, y_test) = imdb.load_data(nb_words=max_features)
+print(len(X_train), 'train sequences')
+print(len(X_test), 'test sequences')
+
+print('Pad sequences (samples x time)')
+X_train = sequence.pad_sequences(X_train, maxlen=maxlen)
+X_test = sequence.pad_sequences(X_test, maxlen=maxlen)
+print('X_train shape:', X_train.shape)
+print('X_test shape:', X_test.shape)
+
+print('Build model...')
+model = Sequential()
+
+# we start off with an efficient embedding layer which maps
+# our vocab indices into embedding_dims dimensions
+model.add(Embedding(max_features,
+                    embedding_dims,
+                    input_length=maxlen))
+
+# we add a AveragePooling1D, which
+model.add(AveragePooling1D(pool_length=model.output_shape[1]))
+
+# We flatten the output of the conv layer,
+# so that we can add a dense layer:
+model.add(Flatten())
+
+# We project onto a single unit output layer, and squash it with a sigmoid:
+model.add(Dense(1))
+model.add(Dropout(0.2))
+model.add(Activation('sigmoid'))
+
+model.compile(loss='binary_crossentropy',
+              optimizer='adam',
+              metrics=['accuracy'])
+
+model.fit(X_train, y_train,
+          batch_size=batch_size,
+          nb_epoch=nb_epoch,
+          validation_data=(X_test, y_test))

--- a/examples/imdb_fasttext.py
+++ b/examples/imdb_fasttext.py
@@ -53,8 +53,7 @@ model.add(Embedding(max_features,
 # of all words in the document
 model.add(AveragePooling1D(pool_length=model.output_shape[1]))
 
-# We flatten the output of the conv layer,
-# so that we can add a dense layer:
+# We flatten the output of the conv layer
 model.add(Flatten())
 
 # We project onto a single unit output layer, and squash it with a sigmoid:


### PR DESCRIPTION
This commit implements a fasttext example. Fasttext is a very efficient text classification model proposed by A. Joulin, E. Grave, P. Bojanowski and T. Mikolov in the paper "[Bag of Tricks for Efficient Text Classification](https://arxiv.org/abs/1607.01759)". The idea is quite similar with SkipGram, however, instead of predict the current word based on the context words, fasttext predict the category of the document based on the average of all word embeddings in the document.

I have evaluate fasttext model using the IMDB datasets. The fasttext can achieve accuracy of 88.15% after 5 epochs in 70s on a machine with Intel(R) Xeon(R) CPU E5-2670 0 @ 2.60GHz, while the CNN achieve accuracy of 88.10% after 1 epochs in 272s.