### PR TITLE
Fix issue with model configuration (#3452)

### DIFF
--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -2321,7 +2321,6 @@ class Container(Layer):
             tensor_index = self.output_layers_tensor_indices[i]
             model_outputs.append([layer.name, new_node_index, tensor_index])
         config['output_layers'] = model_outputs
-        return copy.deepcopy(config)
 
     @classmethod
     def from_config(cls, config, custom_objects={}):

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -2321,7 +2321,7 @@ class Container(Layer):
             tensor_index = self.output_layers_tensor_indices[i]
             model_outputs.append([layer.name, new_node_index, tensor_index])
         config['output_layers'] = model_outputs
-        return {'class_name': self.__class__.__name__, 'config': copy.deepcopy(config)}
+        return copy.deepcopy(config)
 
     @classmethod
     def from_config(cls, config, custom_objects={}):

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -2321,6 +2321,7 @@ class Container(Layer):
             tensor_index = self.output_layers_tensor_indices[i]
             model_outputs.append([layer.name, new_node_index, tensor_index])
         config['output_layers'] = model_outputs
+        return {'class_name': self.__class__.__name__, 'config': copy.deepcopy(config)}
 
     @classmethod
     def from_config(cls, config, custom_objects={}):

--- a/keras/models.py
+++ b/keras/models.py
@@ -125,7 +125,7 @@ def load_model(filepath, custom_objects={}):
     if model_config is None:
         raise ValueError('No model found in config file.')
     model_config = json.loads(model_config.decode('utf-8'))
-    model = model_from_config(model_config, custom_objects=custom_objects)
+    model = Model.from_config(model_config['config'], custom_objects=custom_objects)
 
     # set weights
     model.load_weights_from_hdf5_group(f['model_weights'])
@@ -167,14 +167,6 @@ def load_model(filepath, custom_objects={}):
         model.optimizer.set_weights(optimizer_weight_values)
     f.close()
     return model
-
-
-def model_from_config(config, custom_objects={}):
-    from keras.utils.layer_utils import layer_from_config
-    if isinstance(config, list):
-        raise Exception('`model_fom_config` expects a dictionary, not a list. '
-                        'Maybe you meant to use `Sequential.from_config(config)`?')
-    return layer_from_config(config, custom_objects=custom_objects)
 
 
 def model_from_yaml(yaml_string, custom_objects={}):


### PR DESCRIPTION
Remove  model_from_config method (which assumes the 'config' key to
exist).
Use Model.from_config instead (which receives model configuration as it
is returned from Model.get_config, i.e. the value of 'config' key).