### PR TITLE
added two activation functions

### DIFF
--- a/keras/activations.py
+++ b/keras/activations.py
@@ -27,6 +27,14 @@ def relu(x, alpha=0., max_value=None):
     return K.relu(x, alpha=alpha, max_value=max_value)
 
 
+def leaky(x):
+    return K.relu(x, alpha=0.1)
+
+
+def ramp(x):
+    return 0.1 * x + K.relu(x)
+
+
 def tanh(x):
     return K.tanh(x)
 


### PR DESCRIPTION
These activation functions are used in [Darknet](http://pjreddie.com/darknet/). The leaky relu is already available as an advanced activation layer, but using it for very deep networks artificially increases the size of the network.

Alternatively, it should be possible to add support for keywords inside **activations.get(identifier)** and when initializing activations, so that one could use, for example, the following:

Convolution2D(32, 3, 3, activation="relu", activation_kwargs={"alpha": 0.1})

or something similar.