### PR TITLE
Fix a issue when only specify one dot_axes for in the Merge layer in the dot mode

### DIFF
--- a/examples/imdb_fasttext.py
+++ b/examples/imdb_fasttext.py
@@ -15,9 +15,9 @@ np.random.seed(1337)  # for reproducibility
 
 from keras.preprocessing import sequence
 from keras.models import Sequential
-from keras.layers import Dense, Dropout, Activation, Flatten
+from keras.layers import Dense, Activation, Flatten
 from keras.layers import Embedding
-from keras.layers import Convolution1D, MaxPooling1D, AveragePooling1D
+from keras.layers import AveragePooling1D
 from keras.datasets import imdb
 from keras import backend as K
 
@@ -49,7 +49,8 @@ model.add(Embedding(max_features,
                     embedding_dims,
                     input_length=maxlen))
 
-# we add a AveragePooling1D, which
+# we add a AveragePooling1D, which will average the embeddings
+# of all words in the document
 model.add(AveragePooling1D(pool_length=model.output_shape[1]))
 
 # We flatten the output of the conv layer,
@@ -57,9 +58,7 @@ model.add(AveragePooling1D(pool_length=model.output_shape[1]))
 model.add(Flatten())
 
 # We project onto a single unit output layer, and squash it with a sigmoid:
-model.add(Dense(1))
-model.add(Dropout(0.2))
-model.add(Activation('sigmoid'))
+model.add(Dense(1, activation = 'sigmoid'))
 
 model.compile(loss='binary_crossentropy',
               optimizer='adam',

--- a/examples/imdb_fasttext.py
+++ b/examples/imdb_fasttext.py
@@ -53,7 +53,7 @@ model.add(Embedding(max_features,
 # of all words in the document
 model.add(AveragePooling1D(pool_length=model.output_shape[1]))
 
-# We flatten the output of the conv layer
+# We flatten the output of the AveragePooling1D layer
 model.add(Flatten())
 
 # We project onto a single unit output layer, and squash it with a sigmoid:

--- a/examples/imdb_fasttext.py
+++ b/examples/imdb_fasttext.py
@@ -1,0 +1,71 @@
+'''This example demonstrates the use of fasttext for text classification
+
+Based on Joulin et al's paper:
+
+Bags of Tricks for Efficient Text Classification
+https://arxiv.org/abs/1607.01759
+
+Can achieve accuracy around 88% after 5 epochs in 70s.
+
+'''
+
+from __future__ import print_function
+import numpy as np
+np.random.seed(1337)  # for reproducibility
+
+from keras.preprocessing import sequence
+from keras.models import Sequential
+from keras.layers import Dense, Dropout, Activation, Flatten
+from keras.layers import Embedding
+from keras.layers import Convolution1D, MaxPooling1D, AveragePooling1D
+from keras.datasets import imdb
+from keras import backend as K
+
+
+# set parameters:
+max_features = 20000
+maxlen = 400
+batch_size = 32
+embedding_dims = 20
+nb_epoch = 5
+
+print('Loading data...')
+(X_train, y_train), (X_test, y_test) = imdb.load_data(nb_words=max_features)
+print(len(X_train), 'train sequences')
+print(len(X_test), 'test sequences')
+
+print('Pad sequences (samples x time)')
+X_train = sequence.pad_sequences(X_train, maxlen=maxlen)
+X_test = sequence.pad_sequences(X_test, maxlen=maxlen)
+print('X_train shape:', X_train.shape)
+print('X_test shape:', X_test.shape)
+
+print('Build model...')
+model = Sequential()
+
+# we start off with an efficient embedding layer which maps
+# our vocab indices into embedding_dims dimensions
+model.add(Embedding(max_features,
+                    embedding_dims,
+                    input_length=maxlen))
+
+# we add a AveragePooling1D, which
+model.add(AveragePooling1D(pool_length=model.output_shape[1]))
+
+# We flatten the output of the conv layer,
+# so that we can add a dense layer:
+model.add(Flatten())
+
+# We project onto a single unit output layer, and squash it with a sigmoid:
+model.add(Dense(1))
+model.add(Dropout(0.2))
+model.add(Activation('sigmoid'))
+
+model.compile(loss='binary_crossentropy',
+              optimizer='adam',
+              metrics=['accuracy'])
+
+model.fit(X_train, y_train,
+          batch_size=batch_size,
+          nb_epoch=nb_epoch,
+          validation_data=(X_test, y_test))

--- a/examples/imdb_fasttext.py
+++ b/examples/imdb_fasttext.py
@@ -53,8 +53,7 @@ model.add(Embedding(max_features,
 # of all words in the document
 model.add(AveragePooling1D(pool_length=model.output_shape[1]))
 
-# We flatten the output of the conv layer,
-# so that we can add a dense layer:
+# We flatten the output of the conv layer
 model.add(Flatten())
 
 # We project onto a single unit output layer, and squash it with a sigmoid:

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -1222,7 +1222,7 @@ class Merge(Layer):
                 if dot_axes < 0:
                     dot_axes = [dot_axes % n1, dot_axes % n2]
                 else:
-                    dot_axes = [n1 - dot_axes, n2 - dot_axes]
+                    dot_axes = [dot_axes, ] * 2
             if type(dot_axes) not in [list, tuple]:
                 raise Exception('Invalid type for dot_axes - should be a list.')
             if len(dot_axes) != 2:

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -1143,8 +1143,6 @@ class Merge(Layer):
         self.mode = mode
         self.concat_axis = concat_axis
         self.dot_axes = dot_axes
-        if type(self.dot_axes) == int:
-            self.dot_axes = [self.dot_axes, ] * 2
         self._output_shape = output_shape
         self.node_indices = node_indices
         self._output_mask = output_mask
@@ -1220,16 +1218,16 @@ class Merge(Layer):
             n2 = len(shape2)
             if type(dot_axes) == int:
                 if dot_axes < 0:
-                    dot_axes = [dot_axes % n1, dot_axes % n2]
+                    self.dot_axes = [dot_axes % n1, dot_axes % n2]
                 else:
-                    dot_axes = [dot_axes, ] * 2
-            if type(dot_axes) not in [list, tuple]:
+                    self.dot_axes = [dot_axes, ] * 2
+            if type(self.dot_axes) not in [list, tuple]:
                 raise Exception('Invalid type for dot_axes - should be a list.')
-            if len(dot_axes) != 2:
+            if len(self.dot_axes) != 2:
                 raise Exception('Invalid format for dot_axes - should contain two elements.')
-            if type(dot_axes[0]) is not int or type(dot_axes[1]) is not int:
+            if type(self.dot_axes[0]) is not int or type(self.dot_axes[1]) is not int:
                 raise Exception('Invalid format for dot_axes - list elements should be "int".')
-            if shape1[dot_axes[0]] != shape2[dot_axes[1]]:
+            if shape1[self.dot_axes[0]] != shape2[self.dot_axes[1]]:
                 raise Exception('Dimension incompatibility using dot mode: ' +
                                 '%s != %s. ' % (shape1[dot_axes[0]], shape2[dot_axes[1]]) +
                                 'Layer shapes: %s, %s' % (shape1, shape2))


### PR DESCRIPTION
@farizrahman4u Just wonder if there is a bug in line 1225. When there is only one dot_axes specified in the Merge layer in the dot mode, should not we change the dot_axes = [dot_axes, dot_axes] just as done in line 1147-1148? After the this fix, the following code can be ran correctly(only specify one dot_axes) otherwise will fail:
```
model_word = Sequential()
model_word.add(Embedding(1e4, 300, input_length=1))
model_word.add(Reshape((1,300)))
models.append(model_word)

model_context = Sequential()
model_context.add(Embedding(1e4, 300, input_length=5))
model_context.add(Reshape((5,300)))
models.append(model_context)

model = Sequential()
# Both dot_axes = 2 and dot_axes = [2, 2] will work now, otherwise only [2,2] will work
model.add(Merge(models, mode='dot', dot_axes = 2))
print model.layers[-1].output_shape
model.add(Reshape((5,)))
print model.layers[-1].output_shape
model.add(Dense(5))
model.add(Activation('sigmoid'))
model.compile(loss='mean_squared_error', optimizer='sgd')
```