### PR TITLE
Minor imbd dataset documentation update, added docstring to reuters

### DIFF
--- a/docs/templates/datasets.md
+++ b/docs/templates/datasets.md
@@ -53,10 +53,14 @@ As a convention, "0" does not stand for a specific word, but instead is used to 
 ```python
 from keras.datasets import imdb
 
-(X_train, y_train), (X_test, y_test) = imdb.load_data(path="imdb.pkl",
+(X_train, y_train), (X_test, y_test) = imdb.load_data(path="imdb_full.pkl",
                                                       nb_words=None,
                                                       skip_top=0,
-                                                      maxlen=None)
+                                                      maxlen=None,
+                                                      seed=113,
+                                                      start_char=1,
+                                                      oov_char=2,
+                                                      index_from=3)
 ```
 - __Return:__
     - 2 tuples:
@@ -91,7 +95,11 @@ from keras.datasets import reuters
                                                          nb_words=None,
                                                          skip_top=0,
                                                          maxlen=None,
-                                                         test_split=0.1)
+                                                         test_split=0.2,
+                                                         seed=113,
+                                                         start_char=1,
+                                                         oov_char=2,
+                                                         index_from=3)
 ```
 
 The specifications are the same as that of the IMDB dataset, with the addition of:

--- a/docs/templates/datasets.md
+++ b/docs/templates/datasets.md
@@ -56,8 +56,7 @@ from keras.datasets import imdb
 (X_train, y_train), (X_test, y_test) = imdb.load_data(path="imdb.pkl",
                                                       nb_words=None,
                                                       skip_top=0,
-                                                      maxlen=None,
-                                                      test_split=0.1)
+                                                      maxlen=None)
 ```
 - __Return:__
     - 2 tuples:
@@ -70,8 +69,12 @@ from keras.datasets import imdb
     - __nb_words__: integer or None. Top most frequent words to consider. Any less frequent word will appear as 0 in the sequence data.
     - __skip_top__: integer. Top most frequent words to ignore (they will appear as 0s in the sequence data).
     - __maxlen__: int. Maximum sequence length. Any longer sequence will be truncated.
-    - __test_split__: float. Fraction of the dataset to be used as test data.
     - __seed__: int. Seed for reproducible data shuffling.
+    - __start_char__: char. The start of a sequence will be marked with this character.
+        Set to 1 because 0 is usually the padding character.
+    - __oov_char__: char. words that were cut out because of the `nb_words`
+        or `skip_top` limit will be replaced with this character.
+    - __index_from__: int. Index actual words with this index and higher.
 
 ---
 
@@ -91,7 +94,9 @@ from keras.datasets import reuters
                                                          test_split=0.1)
 ```
 
-The specifications are the same as that of the IMDB dataset.
+The specifications are the same as that of the IMDB dataset, with the addition of:
+
+    - __test_split__: float. Fraction of the dataset to be used as test data.
 
 This dataset also makes available the word index used for encoding the sequences:
 

--- a/keras/datasets/reuters.py
+++ b/keras/datasets/reuters.py
@@ -10,6 +10,29 @@ import sys
 def load_data(path='reuters.pkl', nb_words=None, skip_top=0,
               maxlen=None, test_split=0.2, seed=113,
               start_char=1, oov_char=2, index_from=3):
+    '''
+    # Arguments
+        path: where to store the data (in `/.keras/dataset`)
+        nb_words: max number of words to include. Words are ranked
+            by how often they occur (in the training set) and only
+            the most frequent words are kept
+        skip_top: skip the top N most frequently occuring words
+            (which may not be informative).
+        maxlen: truncate sequences after this length.
+        test_split: Fraction of the dataset to be used as test data.
+        seed: random seed for sample shuffling.
+        start_char: The start of a sequence will be marked with this character.
+            Set to 1 because 0 is usually the padding character.
+        oov_char: words that were cut out because of the `nb_words`
+            or `skip_top` limit will be replaced with this character.
+        index_from: index actual words with this index and higher.
+
+    Note that the 'out of vocabulary' character is only used for
+    words that were present in the training set but are not included
+    because they're not making the `nb_words` cut here.
+    Words that were not seen in the trining set but are in the test set
+    have simply been skipped.
+    '''
 
     path = get_file(path, origin='https://s3.amazonaws.com/text-datasets/reuters.pkl')
     f = open(path, 'rb')

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -421,7 +421,7 @@ def generator_queue(generator, max_q_size=10,
         def data_generator_task():
             while not _stop.is_set():
                 try:
-                    if q.qsize() < max_q_size:
+                    if pickle_safe or q.qsize() < max_q_size:
                         try:
                             generator_output = next(generator)
                         except ValueError:


### PR DESCRIPTION
Changed the imbd dataset documentation to reflect all current options - most importantly the removal of the test_split option. I also included other options (oov_char, etc), though they are rather niche, so perhaps their lack of inclusion was intentional. I also added a docstring to reuters load_data for clarity.