### PR TITLE
Fixing #3493: Stop ignoring ValueErrors in fit_generator

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -413,19 +413,20 @@ def generator_queue(generator, max_q_size=10,
     if pickle_safe:
         q = multiprocessing.Queue(maxsize=max_q_size)
         _stop = multiprocessing.Event()
+        lock = multiprocessing.Lock()
     else:
         q = queue.Queue()
         _stop = threading.Event()
+        lock = threading.Lock()
 
     try:
         def data_generator_task():
             while not _stop.is_set():
                 try:
                     if pickle_safe or q.qsize() < max_q_size:
-                        try:
-                            generator_output = next(generator)
-                        except ValueError:
-                            continue
+                        lock.acquire()
+                        generator_output = next(generator)
+                        lock.release()
                         q.put(generator_output)
                     else:
                         time.sleep(wait_time)


### PR DESCRIPTION
As discussed in #3493, fit_generator could use locks for thread safety.