### PR TITLE
add cropping1d/2d/3d layers

### DIFF
--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -1407,6 +1407,20 @@ class Cropping2D(Layer):
     # Output shape
         4D tensor with shape:
         (samples, depth, first_cropped_axis, second_cropped_axis)
+
+    # Examples
+
+    ```python
+        # crop the input image and feature meps
+        model = Sequential()
+        model.add(Cropping2D(cropping=((2, 2), (4, 4)), input_shape=(3, 28, 28)))
+        # now model.output_shape == (None, 3, 24, 20)
+        model.add(Convolution2D(64, 3, 3, border_mode='same))
+        model.add(Cropping2D(cropping=((2, 2), (2, 2))))
+        # now model.output_shape == (None, 64, 20, 16)
+
+    ```
+
     '''
 
     def __init__(self, cropping=((0, 0), (0, 0)), dim_ordering='default', **kwargs):

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -1352,7 +1352,7 @@ class Cropping1D(Layer):
 
     # Arguments
         cropping: tuple of int (length 2)
-            How many should be trimmed off at the beginning and end of
+            How many units should be trimmed off at the beginning and end of
             the cropping dimension (axis 1).
 
     # Input shape
@@ -1364,7 +1364,8 @@ class Cropping1D(Layer):
 
     def __init__(self, cropping=(1, 1), **kwargs):
         super(Cropping1D, self).__init__(**kwargs)
-        self.cropping = cropping
+        self.cropping = tuple(cropping)
+        assert len(self.cropping) == 2, 'cropping must be a tuple length of 2'
         self.input_spec = [InputSpec(ndim=3)] # redundant due to build()?       
 
     def build(self, input_shape):
@@ -1391,7 +1392,7 @@ class Cropping2D(Layer):
 
     # Arguments
         cropping: tuple of tuple of int (length 2)
-            How many should be trimmed off at the beginning and end of
+            How many units should be trimmed off at the beginning and end of
             the 2 cropping dimensions (width, height).
         dim_ordering: 'th' or 'tf'.
             In 'th' mode, the channels dimension (the depth)
@@ -1411,7 +1412,7 @@ class Cropping2D(Layer):
     # Examples
 
     ```python
-        # crop the input image and feature meps
+        # Crop the input 2D images or feature maps
         model = Sequential()
         model.add(Cropping2D(cropping=((2, 2), (4, 4)), input_shape=(3, 28, 28)))
         # now model.output_shape == (None, 3, 24, 20)
@@ -1428,6 +1429,9 @@ class Cropping2D(Layer):
         if dim_ordering == 'default':
             dim_ordering = K.image_dim_ordering()
         self.cropping = tuple(cropping)
+        assert len(self.cropping) == 2, 'cropping must be a tuple length of 2'
+        assert len(self.cropping[0]) == 2, 'cropping[0] must be a tuple length of 2'
+        assert len(self.cropping[1]) == 2, 'cropping[1] must be a tuple length of 2'
         assert dim_ordering in {'tf', 'th'}, 'dim_ordering must be in {tf, th}'
         self.dim_ordering = dim_ordering
         self.input_spec = [InputSpec(ndim=4)]        
@@ -1472,7 +1476,7 @@ class Cropping3D(Layer):
 
     # Arguments
         cropping: tuple of tuple of int (length 3)
-            How many should be trimmed off at the beginning and end of
+            How many units should be trimmed off at the beginning and end of
             the 3 cropping dimensions (kernel_dim1, kernel_dim2, kernerl_dim3).
         dim_ordering: 'th' or 'tf'.
             In 'th' mode, the channels dimension (the depth)
@@ -1496,6 +1500,10 @@ class Cropping3D(Layer):
         if dim_ordering == 'default':
             dim_ordering = K.image_dim_ordering()
         self.cropping = tuple(cropping)
+        assert len(self.cropping) == 3, 'cropping must be a tuple length of 3'
+        assert len(self.cropping[0]) == 2, 'cropping[0] must be a tuple length of 2'
+        assert len(self.cropping[1]) == 2, 'cropping[1] must be a tuple length of 2'
+        assert len(self.cropping[2]) == 2, 'cropping[2] must be a tuple length of 2'
         assert dim_ordering in {'tf', 'th'}, 'dim_ordering must be in {tf, th}'
         self.dim_ordering = dim_ordering
         self.input_spec = [InputSpec(ndim=4)]        

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -1452,9 +1452,15 @@ class Cropping2D(Layer):
     def call(self, x, mask=None):
         input_shape = self.input_spec[0].shape
         if self.dim_ordering == 'th':
-            return x[:, :, self.cropping[0][0]:input_shape[2]-self.cropping[0][1], self.cropping[1][0]:input_shape[3]-self.cropping[1][1]]
+            return x[:, 
+                     :, 
+                     self.cropping[0][0] : input_shape[2]-self.cropping[0][1],
+                     self.cropping[1][0] : input_shape[3]-self.cropping[1][1]]
         elif self.dim_ordering == 'tf':
-            return x[:, self.cropping[0][0]:input_shape[1]-self.cropping[0][1], self.cropping[1][0]:input_shape[2]-self.cropping[1][1], :]
+            return x[:, 
+                     self.cropping[0][0] : input_shape[1]-self.cropping[0][1], 
+                     self.cropping[1][0] : input_shape[2]-self.cropping[1][1],
+                     :]
 
     def get_config(self):
         config = {'cropping': self.cropping}
@@ -1522,9 +1528,17 @@ class Cropping3D(Layer):
     def call(self, x, mask=None):
         input_shape = self.input_spec[0].shape
         if self.dim_ordering == 'th':
-            return x[:, :, self.cropping[0][0]:input_shape[2]-self.cropping[0][1], self.cropping[1][0]:input_shape[3]-self.cropping[1][1], self.cropping[2][0]:input_shape[4]-self.cropping[2][1]]
+            return x[:, 
+                     :, 
+                     self.cropping[0][0] : input_shape[2]-self.cropping[0][1], 
+                     self.cropping[1][0] : input_shape[3]-self.cropping[1][1], 
+                     self.cropping[2][0] : input_shape[4]-self.cropping[2][1]]
         elif self.dim_ordering == 'tf':
-            return x[:, self.cropping[0][0]:input_shape[1]-self.cropping[0][1], self.cropping[1][0]:input_shape[2]-self.cropping[1][1], self.cropping[2][0]:input_shape[3]-self.cropping[2][1], :]
+            return x[:, 
+                     self.cropping[0][0] : input_shape[1]-self.cropping[0][1], 
+                     self.cropping[1][0] : input_shape[2]-self.cropping[1][1], 
+                     self.cropping[2][0] : input_shape[3]-self.cropping[2][1], 
+                     :]
 
     def get_config(self):
         config = {'cropping': self.cropping}

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -1454,12 +1454,12 @@ class Cropping2D(Layer):
         if self.dim_ordering == 'th':
             return x[:, 
                      :, 
-                     self.cropping[0][0] : input_shape[2]-self.cropping[0][1],
-                     self.cropping[1][0] : input_shape[3]-self.cropping[1][1]]
+                     self.cropping[0][0]:input_shape[2]-self.cropping[0][1],
+                     self.cropping[1][0]:input_shape[3]-self.cropping[1][1]]
         elif self.dim_ordering == 'tf':
             return x[:, 
-                     self.cropping[0][0] : input_shape[1]-self.cropping[0][1], 
-                     self.cropping[1][0] : input_shape[2]-self.cropping[1][1],
+                     self.cropping[0][0]:input_shape[1]-self.cropping[0][1], 
+                     self.cropping[1][0]:input_shape[2]-self.cropping[1][1],
                      :]
 
     def get_config(self):
@@ -1530,14 +1530,14 @@ class Cropping3D(Layer):
         if self.dim_ordering == 'th':
             return x[:, 
                      :, 
-                     self.cropping[0][0] : input_shape[2]-self.cropping[0][1], 
-                     self.cropping[1][0] : input_shape[3]-self.cropping[1][1], 
-                     self.cropping[2][0] : input_shape[4]-self.cropping[2][1]]
+                     self.cropping[0][0]:input_shape[2]-self.cropping[0][1], 
+                     self.cropping[1][0]:input_shape[3]-self.cropping[1][1], 
+                     self.cropping[2][0]:input_shape[4]-self.cropping[2][1]]
         elif self.dim_ordering == 'tf':
             return x[:, 
-                     self.cropping[0][0] : input_shape[1]-self.cropping[0][1], 
-                     self.cropping[1][0] : input_shape[2]-self.cropping[1][1], 
-                     self.cropping[2][0] : input_shape[3]-self.cropping[2][1], 
+                     self.cropping[0][0]:input_shape[1]-self.cropping[0][1], 
+                     self.cropping[1][0]:input_shape[2]-self.cropping[1][1], 
+                     self.cropping[2][0]:input_shape[3]-self.cropping[2][1], 
                      :]
 
     def get_config(self):

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -1359,11 +1359,11 @@ class Cropping1D(Layer):
         3D tensor with shape (samples, axis_to_crop, features)
 
     # Output shape
-       3D tensor with shape (samples, cropped_axis, features)
+        3D tensor with shape (samples, cropped_axis, features)
     '''
 
     def __init__(self, cropping=(1, 1), **kwargs):
-        super(Cropping2D, self).__init__(**kwargs)
+        super(Cropping1D, self).__init__(**kwargs)
         self.cropping = cropping
         self.input_spec = [InputSpec(ndim=3)] # redundant due to build()?       
 
@@ -1371,18 +1371,18 @@ class Cropping1D(Layer):
         self.input_spec = [InputSpec(shape=input_shape)]
 
     def get_output_shape_for(self, input_shape):
-        length = input_shape[1] - self.cropping[0][0] - self.cropping[0][1] if input_shape[1] is not None else None
+        length = input_shape[1] - self.cropping[0] - self.cropping[1] if input_shape[1] is not None else None
         return (input_shape[0],
                 length,
                 input_shape[2])
 
     def call(self, x, mask=None):
         input_shape = self.input_spec[0].shape
-        return x[:, self.cropping[0][0]:input_shape[1]-self.cropping[0][1], :]
+        return x[:, self.cropping[0]:input_shape[1]-self.cropping[1], :]
 
     def get_config(self):
         config = {'cropping': self.cropping}
-        base_config = super(Cropping2D, self).get_config()
+        base_config = super(Cropping1D, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
 
 class Cropping2D(Layer):
@@ -1451,7 +1451,10 @@ class Cropping2D(Layer):
 
     def call(self, x, mask=None):
         input_shape = self.input_spec[0].shape
-        return x[:, :, self.cropping[0][0]:input_shape[2]-self.cropping[0][1], self.cropping[1][0]:input_shape[3]-self.cropping[1][1]]
+        if self.dim_ordering == 'th':
+            return x[:, :, self.cropping[0][0]:input_shape[2]-self.cropping[0][1], self.cropping[1][0]:input_shape[3]-self.cropping[1][1]]
+        elif self.dim_ordering == 'tf':
+            return x[:, self.cropping[0][0]:input_shape[1]-self.cropping[0][1], self.cropping[1][0]:input_shape[2]-self.cropping[1][1], :]
 
     def get_config(self):
         config = {'cropping': self.cropping}
@@ -1483,7 +1486,7 @@ class Cropping3D(Layer):
     '''
 
     def __init__(self, cropping=((1, 1), (1, 1), (1, 1)), dim_ordering='default', **kwargs):
-        super(Cropping2D, self).__init__(**kwargs)
+        super(Cropping3D, self).__init__(**kwargs)
         if dim_ordering == 'default':
             dim_ordering = K.image_dim_ordering()
         self.cropping = tuple(cropping)
@@ -1525,7 +1528,7 @@ class Cropping3D(Layer):
 
     def get_config(self):
         config = {'cropping': self.cropping}
-        base_config = super(Cropping2D, self).get_config()
+        base_config = super(Cropping3D, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
 
 

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -1346,6 +1346,173 @@ class ZeroPadding3D(Layer):
         base_config = super(ZeroPadding3D, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
 
+class Cropping1D(Layer):
+    '''Cropping layer for 1D input (e.g. temporal sequence).
+
+    # Arguments
+        cropping: tuple of int (length 2)
+            How many should be trimmed off at the beginning and end of
+            the cropping dimension (axis 1).
+
+    # Input shape
+        3D tensor with shape (samples, axis_to_crop, features)
+
+    # Output shape
+       3D tensor with shape (samples, cropped_axis, features)
+    '''
+
+    def __init__(self, cropping=(1,1), **kwargs):
+        super(Cropping2D, self).__init__(**kwargs)
+        self.cropping = cropping
+        self.input_spec = [InputSpec(ndim=3)] # redundant due to build()?       
+
+    def build(self, input_shape):
+        self.input_spec = [InputSpec(shape=input_shape)]
+
+    def get_output_shape_for(self, input_shape):
+        length = input_shape[1] - self.cropping[0][0] - self.cropping[0][1] if input_shape[1] is not None else None
+        return (input_shape[0],
+                length,
+                input_shape[2])
+
+    def call(self, x, mask=None):
+        input_shape = self.input_spec[0].shape
+        return x[:, self.cropping[0][0]:input_shape[1]-self.cropping[0][1], :]
+
+    def get_config(self):
+        config = {'cropping': self.padding}
+        base_config = super(Cropping2D, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))
+
+class Cropping2D(Layer):
+    '''Cropping layer for 2D input (e.g. picture).
+
+    # Arguments
+        padding: tuple of tuple of int (length 2)
+            How many should be trimmed off at the beginning and end of
+            the 2 padding dimensions (axis 3 and 4).
+        dim_ordering: 'th' or 'tf'.
+            In 'th' mode, the channels dimension (the depth)
+            is at index 1, in 'tf' mode is it at index 3.
+            It defaults to the `image_dim_ordering` value found in your
+            Keras config file at `~/.keras/keras.json`.
+            If you never set it, then it will be "th".
+
+    # Input shape
+        4D tensor with shape:
+        (samples, depth, first_axis_to_crop, second_axis_to_crop)
+
+    # Output shape
+        4D tensor with shape:
+        (samples, depth, first_cropped_axis, second_cropped_axis)
+    '''
+
+    def __init__(self, cropping=((0,0),(0,0)), dim_ordering='default', **kwargs):
+        super(Cropping2D, self).__init__(**kwargs)
+        if dim_ordering == 'default':
+            dim_ordering = K.image_dim_ordering()
+        self.cropping = tuple(cropping)
+        assert dim_ordering in {'tf', 'th'}, 'dim_ordering must be in {tf, th}'
+        self.dim_ordering = dim_ordering
+        self.input_spec = [InputSpec(ndim=4)]        
+
+    def build(self, input_shape):
+        self.input_spec = [InputSpec(shape=input_shape)]
+
+    def get_output_shape_for(self, input_shape):
+        if self.dim_ordering == 'th':
+            
+            return (input_shape[0],
+                    input_shape[1],
+                    input_shape[2] - self.cropping[0][0] - self.cropping[0][1],
+                    input_shape[3] - self.cropping[1][0] - self.cropping[1][1])
+        elif self.dim_ordering == 'tf':
+            return (input_shape[0],
+                    input_shape[1] - self.cropping[0][0] - self.cropping[0][1],
+                    input_shape[2] - self.cropping[1][0] - self.cropping[1][1],
+                    input_shape[3])
+        else:
+            raise Exception('Invalid dim_ordering: ' + self.dim_ordering)
+
+    def call(self, x, mask=None):
+        input_shape = self.input_spec[0].shape
+        return x[:, :, self.cropping[0][0]:input_shape[2]-self.cropping[0][1], self.cropping[1][0]:input_shape[3]-self.cropping[1][1]]
+
+    def get_config(self):
+        config = {'cropping': self.padding}
+        base_config = super(Cropping2D, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))
+
+class Cropping3D(Layer):
+    '''Cropping layer for 2D input (e.g. picture).
+
+    # Arguments
+        padding: tuple of tuple of int (length 2)
+            How many should be trimmed off at the beginning and end of
+            the 2 padding dimensions (axis 3 and 4).
+        dim_ordering: 'th' or 'tf'.
+            In 'th' mode, the channels dimension (the depth)
+            is at index 1, in 'tf' mode is it at index 4.
+            It defaults to the `image_dim_ordering` value found in your
+            Keras config file at `~/.keras/keras.json`.
+            If you never set it, then it will be "th".
+
+    # Input shape
+        5D tensor with shape:
+        (samples, depth, first_axis_to_crop, second_axis_to_crop, third_axis_to_crop)
+
+    # Output shape
+        5D tensor with shape:
+        (samples, depth, first_cropped_axis, second_cropped_axis, third_cropped_axis)
+    
+    '''
+
+    def __init__(self, cropping=((1,1),(1,1),(1,1)), dim_ordering='default', **kwargs):
+        super(Cropping2D, self).__init__(**kwargs)
+        if dim_ordering == 'default':
+            dim_ordering = K.image_dim_ordering()
+        self.cropping = tuple(cropping)
+        assert dim_ordering in {'tf', 'th'}, 'dim_ordering must be in {tf, th}'
+        self.dim_ordering = dim_ordering
+        self.input_spec = [InputSpec(ndim=4)]        
+
+    def build(self, input_shape):
+        self.input_spec = [InputSpec(shape=input_shape)]
+
+    def get_output_shape_for(self, input_shape):
+        if self.dim_ordering == 'th':
+            dim1 = input_shape[2] - self.cropping[0][0] - self.cropping[0][1] if input_shape[2] is not None else None
+            dim2 = input_shape[3] - self.cropping[1][0] - self.cropping[1][1] if input_shape[3] is not None else None
+            dim3 = input_shape[4] - self.cropping[2][0] - self.cropping[2][1] if input_shape[4] is not None else None
+            return (input_shape[0],
+                    input_shape[1],
+                    dim1,
+                    dim2,
+                    dim3)
+        elif self.dim_ordering == 'tf':
+            dim1 = input_shape[1] - self.cropping[0][0] - self.cropping[0][1] if input_shape[1] is not None else None
+            dim2 = input_shape[2] - self.cropping[1][0] - self.cropping[1][1] if input_shape[2] is not None else None
+            dim3 = input_shape[3] - self.cropping[2][0] - self.cropping[2][1] if input_shape[3] is not None else None
+            return (input_shape[0],
+                    dim1,
+                    dim2,
+                    dim3,
+                    input_shape[4])
+        else:
+            raise Exception('Invalid dim_ordering: ' + self.dim_ordering)
+
+    def call(self, x, mask=None):
+        input_shape = self.input_spec[0].shape
+        if self.dim_ordering == 'th':
+            return x[:, :, self.cropping[0][0]:input_shape[2]-self.cropping[0][1], self.cropping[1][0]:input_shape[3]-self.cropping[1][1], self.cropping[2][0]:input_shape[4]-self.cropping[2][1]]
+        elif self.dim_ordering == 'tf':
+            return x[:, self.cropping[0][0]:input_shape[1]-self.cropping[0][1], self.cropping[1][0]:input_shape[2]-self.cropping[1][1], self.cropping[2][0]:input_shape[3]-self.cropping[2][1], :]
+
+    def get_config(self):
+        config = {'cropping': self.padding}
+        base_config = super(Cropping2D, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))
+
 
 # Aliases
 

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -1348,6 +1348,7 @@ class ZeroPadding3D(Layer):
 
 class Cropping1D(Layer):
     '''Cropping layer for 1D input (e.g. temporal sequence).
+    It crops along the time dimension (axis 1).
 
     # Arguments
         cropping: tuple of int (length 2)
@@ -1361,7 +1362,7 @@ class Cropping1D(Layer):
        3D tensor with shape (samples, cropped_axis, features)
     '''
 
-    def __init__(self, cropping=(1,1), **kwargs):
+    def __init__(self, cropping=(1, 1), **kwargs):
         super(Cropping2D, self).__init__(**kwargs)
         self.cropping = cropping
         self.input_spec = [InputSpec(ndim=3)] # redundant due to build()?       
@@ -1380,17 +1381,18 @@ class Cropping1D(Layer):
         return x[:, self.cropping[0][0]:input_shape[1]-self.cropping[0][1], :]
 
     def get_config(self):
-        config = {'cropping': self.padding}
+        config = {'cropping': self.cropping}
         base_config = super(Cropping2D, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
 
 class Cropping2D(Layer):
     '''Cropping layer for 2D input (e.g. picture).
+    It crops along spatial dimensions, i.e. width and height.
 
     # Arguments
-        padding: tuple of tuple of int (length 2)
+        cropping: tuple of tuple of int (length 2)
             How many should be trimmed off at the beginning and end of
-            the 2 padding dimensions (axis 3 and 4).
+            the 2 cropping dimensions (width, height).
         dim_ordering: 'th' or 'tf'.
             In 'th' mode, the channels dimension (the depth)
             is at index 1, in 'tf' mode is it at index 3.
@@ -1407,7 +1409,7 @@ class Cropping2D(Layer):
         (samples, depth, first_cropped_axis, second_cropped_axis)
     '''
 
-    def __init__(self, cropping=((0,0),(0,0)), dim_ordering='default', **kwargs):
+    def __init__(self, cropping=((0, 0), (0, 0)), dim_ordering='default', **kwargs):
         super(Cropping2D, self).__init__(**kwargs)
         if dim_ordering == 'default':
             dim_ordering = K.image_dim_ordering()
@@ -1421,7 +1423,6 @@ class Cropping2D(Layer):
 
     def get_output_shape_for(self, input_shape):
         if self.dim_ordering == 'th':
-            
             return (input_shape[0],
                     input_shape[1],
                     input_shape[2] - self.cropping[0][0] - self.cropping[0][1],
@@ -1439,7 +1440,7 @@ class Cropping2D(Layer):
         return x[:, :, self.cropping[0][0]:input_shape[2]-self.cropping[0][1], self.cropping[1][0]:input_shape[3]-self.cropping[1][1]]
 
     def get_config(self):
-        config = {'cropping': self.padding}
+        config = {'cropping': self.cropping}
         base_config = super(Cropping2D, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
 
@@ -1447,9 +1448,9 @@ class Cropping3D(Layer):
     '''Cropping layer for 2D input (e.g. picture).
 
     # Arguments
-        padding: tuple of tuple of int (length 2)
+        cropping: tuple of tuple of int (length 3)
             How many should be trimmed off at the beginning and end of
-            the 2 padding dimensions (axis 3 and 4).
+            the 3 cropping dimensions (kernel_dim1, kernel_dim2, kernerl_dim3).
         dim_ordering: 'th' or 'tf'.
             In 'th' mode, the channels dimension (the depth)
             is at index 1, in 'tf' mode is it at index 4.
@@ -1467,7 +1468,7 @@ class Cropping3D(Layer):
     
     '''
 
-    def __init__(self, cropping=((1,1),(1,1),(1,1)), dim_ordering='default', **kwargs):
+    def __init__(self, cropping=((1, 1), (1, 1), (1, 1)), dim_ordering='default', **kwargs):
         super(Cropping2D, self).__init__(**kwargs)
         if dim_ordering == 'default':
             dim_ordering = K.image_dim_ordering()
@@ -1509,7 +1510,7 @@ class Cropping3D(Layer):
             return x[:, self.cropping[0][0]:input_shape[1]-self.cropping[0][1], self.cropping[1][0]:input_shape[2]-self.cropping[1][1], self.cropping[2][0]:input_shape[3]-self.cropping[2][1], :]
 
     def get_config(self):
-        config = {'cropping': self.padding}
+        config = {'cropping': self.cropping}
         base_config = super(Cropping2D, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
 

--- a/tests/keras/layers/test_convolutional.py
+++ b/tests/keras/layers/test_convolutional.py
@@ -461,36 +461,37 @@ def test_cropping_2d():
     input_len_dim1 = 10
     input_len_dim2 = 20
     cropping = ((2, 2), (3, 3))
-    for dim_ordering in ['th', 'tf']:
-        if dim_ordering == 'th':
-            input = np.random.rand(nb_samples, stack_size, input_len_dim1, input_len_dim2)
-        else:
-            input = np.random.rand(nb_samples, input_len_dim1, input_len_dim2, stack_size)
-        # basic test        
-        layer_test(convolutional.Cropping2D,
-                   kwargs={'cropping': cropping,
-                           'dim_ordering': dim_ordering},
-                   input_shape=input.shape)
-        # correctness test
-        layer = convolutional.Cropping2D(
-                            cropping=cropping,
-                            dim_ordering=dim_ordering)
-        layer.set_input(K.variable(input), shape=input.shape)
+    dim_ordering = K.image_dim_ordering()
+    
+    if dim_ordering == 'th':
+        input = np.random.rand(nb_samples, stack_size, input_len_dim1, input_len_dim2)
+    else:
+        input = np.random.rand(nb_samples, input_len_dim1, input_len_dim2, stack_size)
+    # basic test        
+    layer_test(convolutional.Cropping2D,
+               kwargs={'cropping': cropping,
+                       'dim_ordering': dim_ordering},
+               input_shape=input.shape)
+    # correctness test
+    layer = convolutional.Cropping2D(
+      cropping=cropping,
+      dim_ordering=dim_ordering)
+    layer.set_input(K.variable(input), shape=input.shape)
 
-        out = K.eval(layer.output)
-        # compare with numpy
-        if dim_ordering == 'th':
-            expected_out = input[:, 
-                                 :, 
-                                 cropping[0][0] : -cropping[0][1], 
-                                 cropping[1][0] : -cropping[1][1]]
-        else:
-            expected_out = input[:, 
-                                 cropping[0][0] : -cropping[0][1], 
-                                 cropping[1][0] : -cropping[1][1], 
-                                 :]
+    out = K.eval(layer.output)
+    # compare with numpy
+    if dim_ordering == 'th':
+        expected_out = input[:, 
+                             :, 
+                             cropping[0][0]:-cropping[0][1], 
+                             cropping[1][0]:-cropping[1][1]]
+    else:
+        expected_out = input[:, 
+                             cropping[0][0]:-cropping[0][1], 
+                             cropping[1][0]:-cropping[1][1], 
+                             :]
 
-        assert_allclose(out, expected_out)
+    assert_allclose(out, expected_out)
 
 
 def test_cropping_3d():
@@ -500,38 +501,39 @@ def test_cropping_3d():
     input_len_dim2 = 20
     input_len_dim3 = 30
     cropping = ((2, 2), (3, 3), (2, 3))
-    for dim_ordering in ['th', 'tf']:
-        if dim_ordering == 'th':
-            input = np.random.rand(nb_samples, stack_size, input_len_dim1, input_len_dim2, input_len_dim3)
-        else:
-            input = np.random.rand(nb_samples, input_len_dim1, input_len_dim2, input_len_dim3, stack_size)
-        # basic test        
-        layer_test(convolutional.Cropping3D,
-                   kwargs={'cropping': cropping,
-                           'dim_ordering': dim_ordering},
-                   input_shape=input.shape)
-        # correctness test
-        layer = convolutional.Cropping3D(
-                        cropping=cropping,
-                        dim_ordering=dim_ordering)
-        layer.set_input(K.variable(input), shape=input.shape)
+    dim_ordering = K.image_dim_ordering()
+    
+    if dim_ordering == 'th':
+        input = np.random.rand(nb_samples, stack_size, input_len_dim1, input_len_dim2, input_len_dim3)
+    else:
+        input = np.random.rand(nb_samples, input_len_dim1, input_len_dim2, input_len_dim3, stack_size)
+    # basic test        
+    layer_test(convolutional.Cropping3D,
+               kwargs={'cropping': cropping,
+                       'dim_ordering': dim_ordering},
+               input_shape=input.shape)
+    # correctness test
+    layer = convolutional.Cropping3D(
+      cropping=cropping,
+      dim_ordering=dim_ordering)
+    layer.set_input(K.variable(input), shape=input.shape)
 
-        out = K.eval(layer.output)
-        # compare with numpy
-        if dim_ordering == 'th':
-            expected_out = input[:, 
-                                 :, 
-                                 cropping[0][0] : -cropping[0][1], 
-                                 cropping[1][0] : -cropping[1][1], 
-                                 cropping[2][0] : -cropping[2][1]]
-        else:
-            expected_out = input[:, 
-                                 cropping[0][0] : -cropping[0][1], 
-                                 cropping[1][0] : -cropping[1][1], 
-                                 cropping[2][0] : -cropping[2][1], 
-                                 :]
+    out = K.eval(layer.output)
+    # compare with numpy
+    if dim_ordering == 'th':
+        expected_out = input[:, 
+                             :, 
+                             cropping[0][0]:-cropping[0][1], 
+                             cropping[1][0]:-cropping[1][1], 
+                             cropping[2][0]:-cropping[2][1]]
+    else:
+        expected_out = input[:, 
+                             cropping[0][0]:-cropping[0][1], 
+                             cropping[1][0]:-cropping[1][1], 
+                             cropping[2][0]:-cropping[2][1], 
+                             :]
 
-        assert_allclose(out, expected_out)
+    assert_allclose(out, expected_out)
 
 
 def test_cropping_3d():

--- a/tests/keras/layers/test_convolutional.py
+++ b/tests/keras/layers/test_convolutional.py
@@ -459,7 +459,7 @@ def test_cropping_2d():
     nb_samples = 2
     stack_size = 2
     input_len_dim1 = 10
-    input_len_dim2 = 10
+    input_len_dim2 = 20
     cropping = ((2, 2), (3, 3))
     for dim_ordering in ['th', 'tf']:
         if dim_ordering == 'th':
@@ -468,8 +468,9 @@ def test_cropping_2d():
             input = np.random.rand(nb_samples, input_len_dim1, input_len_dim2, stack_size)
         # basic test        
         layer_test(convolutional.Cropping2D,
-                       kwargs={'cropping': cropping},
-                       input_shape=input.shape)
+                   kwargs={'cropping': cropping,
+                           'dim_ordering': dim_ordering},
+                   input_shape=input.shape)
         # correctness test
         layer = convolutional.Cropping2D(
                             cropping=cropping,
@@ -479,9 +480,15 @@ def test_cropping_2d():
         out = K.eval(layer.output)
         # compare with numpy
         if dim_ordering == 'th':
-            expected_out = input[:, :, cropping[0][0]:-cropping[0][1], cropping[1][0]:-cropping[1][1]]
+            expected_out = input[:, 
+                                 :, 
+                                 cropping[0][0] : -cropping[0][1], 
+                                 cropping[1][0] : -cropping[1][1]]
         else:
-            expected_out = input[:, cropping[0][0]:-cropping[0][1], cropping[1][0]:-cropping[1][1], :]
+            expected_out = input[:, 
+                                 cropping[0][0] : -cropping[0][1], 
+                                 cropping[1][0] : -cropping[1][1], 
+                                 :]
 
         assert_allclose(out, expected_out)
 
@@ -490,8 +497,8 @@ def test_cropping_3d():
     nb_samples = 2
     stack_size = 2
     input_len_dim1 = 10
-    input_len_dim2 = 10
-    input_len_dim3 = 10
+    input_len_dim2 = 20
+    input_len_dim3 = 30
     cropping = ((2, 2), (3, 3), (2, 3))
     for dim_ordering in ['th', 'tf']:
         if dim_ordering == 'th':
@@ -500,7 +507,8 @@ def test_cropping_3d():
             input = np.random.rand(nb_samples, input_len_dim1, input_len_dim2, input_len_dim3, stack_size)
         # basic test        
         layer_test(convolutional.Cropping3D,
-                   kwargs={'cropping': cropping},
+                   kwargs={'cropping': cropping,
+                           'dim_ordering': dim_ordering},
                    input_shape=input.shape)
         # correctness test
         layer = convolutional.Cropping3D(
@@ -511,9 +519,17 @@ def test_cropping_3d():
         out = K.eval(layer.output)
         # compare with numpy
         if dim_ordering == 'th':
-            expected_out = input[:, :, cropping[0][0]:-cropping[0][1], cropping[1][0]:-cropping[1][1], cropping[2][0]:-cropping[2][1]]
+            expected_out = input[:, 
+                                 :, 
+                                 cropping[0][0] : -cropping[0][1], 
+                                 cropping[1][0] : -cropping[1][1], 
+                                 cropping[2][0] : -cropping[2][1]]
         else:
-            expected_out = input[:, cropping[0][0]:-cropping[0][1], cropping[1][0]:-cropping[1][1], cropping[2][0]:-cropping[2][1], :]
+            expected_out = input[:, 
+                                 cropping[0][0] : -cropping[0][1], 
+                                 cropping[1][0] : -cropping[1][1], 
+                                 cropping[2][0] : -cropping[2][1], 
+                                 :]
 
         assert_allclose(out, expected_out)
 

--- a/tests/keras/layers/test_convolutional.py
+++ b/tests/keras/layers/test_convolutional.py
@@ -444,5 +444,81 @@ def test_upsampling_3d():
                     assert_allclose(out, expected_out)
 
 
+@keras_test
+def test_cropping_1d():
+    nb_samples = 2
+    time_length = 10
+    input_len_dim1 = 2
+    input = np.random.rand(nb_samples, time_length, input_len_dim1)
+
+    layer_test(convolutional.Cropping1D,
+               kwargs={'cropping': (2, 2)},
+               input_shape=input.shape)
+
+def test_cropping_2d():
+    nb_samples = 2
+    stack_size = 2
+    input_len_dim1 = 10
+    input_len_dim2 = 10
+    cropping = ((2, 2), (3, 3))
+    for dim_ordering in ['th', 'tf']:
+        if dim_ordering == 'th':
+            input = np.random.rand(nb_samples, stack_size, input_len_dim1, input_len_dim2)
+        else:
+            input = np.random.rand(nb_samples, input_len_dim1, input_len_dim2, stack_size)
+        # basic test        
+        layer_test(convolutional.Cropping2D,
+                       kwargs={'cropping': cropping},
+                       input_shape=input.shape)
+        # correctness test
+        layer = convolutional.Cropping2D(
+                            cropping=cropping,
+                            dim_ordering=dim_ordering)
+        layer.set_input(K.variable(input), shape=input.shape)
+
+        out = K.eval(layer.output)
+        # compare with numpy
+        if dim_ordering == 'th':
+            expected_out = input[:, :, cropping[0][0]:-cropping[0][1], cropping[1][0]:-cropping[1][1]]
+        else:
+            expected_out = input[:, cropping[0][0]:-cropping[0][1], cropping[1][0]:-cropping[1][1], :]
+
+        assert_allclose(out, expected_out)
+
+
+def test_cropping_3d():
+    nb_samples = 2
+    stack_size = 2
+    input_len_dim1 = 10
+    input_len_dim2 = 10
+    input_len_dim3 = 10
+    cropping = ((2, 2), (3, 3), (2, 3))
+    for dim_ordering in ['th', 'tf']:
+        if dim_ordering == 'th':
+            input = np.random.rand(nb_samples, stack_size, input_len_dim1, input_len_dim2, input_len_dim3)
+        else:
+            input = np.random.rand(nb_samples, input_len_dim1, input_len_dim2, input_len_dim3, stack_size)
+        # basic test        
+        layer_test(convolutional.Cropping3D,
+                   kwargs={'cropping': cropping},
+                   input_shape=input.shape)
+        # correctness test
+        layer = convolutional.Cropping3D(
+                        cropping=cropping,
+                        dim_ordering=dim_ordering)
+        layer.set_input(K.variable(input), shape=input.shape)
+
+        out = K.eval(layer.output)
+        # compare with numpy
+        if dim_ordering == 'th':
+            expected_out = input[:, :, cropping[0][0]:-cropping[0][1], cropping[1][0]:-cropping[1][1], cropping[2][0]:-cropping[2][1]]
+        else:
+            expected_out = input[:, cropping[0][0]:-cropping[0][1], cropping[1][0]:-cropping[1][1], cropping[2][0]:-cropping[2][1], :]
+
+        assert_allclose(out, expected_out)
+
+
+def test_cropping_3d():
+    pass
 if __name__ == '__main__':
     pytest.main([__file__])

--- a/tests/keras/layers/test_convolutional.py
+++ b/tests/keras/layers/test_convolutional.py
@@ -473,9 +473,7 @@ def test_cropping_2d():
                        'dim_ordering': dim_ordering},
                input_shape=input.shape)
     # correctness test
-    layer = convolutional.Cropping2D(
-      cropping=cropping,
-      dim_ordering=dim_ordering)
+    layer = convolutional.Cropping2D(cropping=cropping, dim_ordering=dim_ordering)
     layer.set_input(K.variable(input), shape=input.shape)
 
     out = K.eval(layer.output)
@@ -513,9 +511,7 @@ def test_cropping_3d():
                        'dim_ordering': dim_ordering},
                input_shape=input.shape)
     # correctness test
-    layer = convolutional.Cropping3D(
-      cropping=cropping,
-      dim_ordering=dim_ordering)
+    layer = convolutional.Cropping3D(cropping=cropping, dim_ordering=dim_ordering)
     layer.set_input(K.variable(input), shape=input.shape)
 
     out = K.eval(layer.output)


### PR DESCRIPTION
This is a new feature that is being discussed in https://github.com/fchollet/keras/issues/3162. In this repo, https://github.com/keunwoochoi/keras_cropping_layer, I uploaded example code. I tested Cropping2D on theano/tensorflow, I haven't tested it on `Cropping1D/3D` yet. I would like to know if it makes sense to add this feature first before testing 1D/3D cases. 

Some questions are: 
 * Is the API okay? I think there should be some non-symmetric cropping cases. (At least I need it but I am not working on image, so..)
 * In `Cropping1D`, `self.input_spec = [InputSpec(ndim=3)]` exists in `__init__()`, but it seems like this layer needs overriding `build()`as below:
```python
def build(self, input_shape):
        self.input_spec = [InputSpec(shape=input_shape)]
```
 Does it mean that the line in `__init__()` should be removed?

