### PR TITLE
Use Theano's CuDNN implementation of batch normalization

### DIFF
--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -386,10 +386,14 @@ def normalize_batch_in_training(x, gamma, beta,
 def batch_normalization(x, mean, var, beta, gamma, epsilon=0.0001):
     '''Apply batch normalization on x given mean, var, beta and gamma.
     '''
-    normed = T.nnet.bn.batch_normalization(x, gamma, beta, mean,
-                                           sqrt(var) + epsilon,
-                                           mode='high_mem')
-    return normed
+    if theano.config.device.startswith('cuda') or theano.config.device.startswith('gpu'):
+        try:
+            return theano.sandbox.cuda.dnn.dnn_batch_normalization_test(x, gamma, beta, mean, var,
+                                                                        'spatial', epsilon)
+        except AttributeError:
+            pass
+    return T.nnet.bn.batch_normalization(x, gamma, beta, mean, sqrt(var) + epsilon,
+                                         mode='high_mem')
 
 
 # SHAPE OPERATIONS

--- a/keras/layers/normalization.py
+++ b/keras/layers/normalization.py
@@ -56,7 +56,7 @@ class BatchNormalization(Layer):
     # References
         - [Batch Normalization: Accelerating Deep Network Training by Reducing Internal Covariate Shift](http://jmlr.org/proceedings/papers/v37/ioffe15.html)
     '''
-    def __init__(self, epsilon=1e-6, mode=0, axis=-1, momentum=0.99,
+    def __init__(self, epsilon=1e-5, mode=0, axis=-1, momentum=0.99,
                  weights=None, beta_init='zero', gamma_init='one', **kwargs):
         self.supports_masking = True
         self.beta_init = initializations.get(beta_init)


### PR DESCRIPTION
Following on from https://github.com/fchollet/keras/pull/3260, use Theano's new CuDNN implementation of batch normalization, falling back if it is unavailable or we are not running on a GPU.