### PR TITLE
Fixing NaN caused by batch-norm for theano Update theano_backend.py

### DIFF
--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -392,7 +392,7 @@ def batch_normalization(x, mean, var, beta, gamma, epsilon=0.0001):
                                                                         'spatial', epsilon)
         except AttributeError:
             pass
-    return T.nnet.bn.batch_normalization(x, gamma, beta, mean, sqrt(var) + epsilon,
+    return T.nnet.bn.batch_normalization(x, gamma, beta, mean, sqrt(var + epsilon),
                                          mode='high_mem')
 
 


### PR DESCRIPTION
fix batch norm causing NaN for many datasets, fixes issue #3475 