### PR TITLE
Support sparse labels and squeeze prediction outputs in sklearn wrapper (bugfix)

### DIFF
--- a/keras/wrappers/scikit_learn.py
+++ b/keras/wrappers/scikit_learn.py
@@ -234,6 +234,13 @@ class KerasClassifier(BaseWrapper):
                 Mean accuracy of predictions on X wrt. y.
         '''
         kwargs = self.filter_sk_params(Sequential.evaluate, kwargs)
+
+        loss_name = self.model.loss
+        if hasattr(loss_name, '__name__'):
+            loss_name = loss_name.__name__
+        if loss_name == 'categorical_crossentropy' and len(y.shape) != 2:
+            y = to_categorical(y)
+
         outputs = self.model.evaluate(X, y, **kwargs)
         if type(outputs) is not list:
             outputs = [outputs]
@@ -263,7 +270,7 @@ class KerasRegressor(BaseWrapper):
                 Predictions.
         '''
         kwargs = self.filter_sk_params(Sequential.predict, kwargs)
-        return self.model.predict(X, **kwargs)
+        return np.squeeze(self.model.predict(X, **kwargs))
 
     def score(self, X, y, **kwargs):
         '''Returns the mean loss on the given test data and labels.


### PR DESCRIPTION
This PR proposes two small changes to `keras/wrappers/scikit_learn.py`

## Add support for sparse labels in KerasClassifier.score(X,y)

According to the documentation, the sklearn classification wrapper `KerasClassifier` should accept labels for the `fit` and `score` methods in the following two formats:
1. (n_samples,)
2. (n_samples, n_outputs)

In `fit`, the 1. format is transformed to the 2. with the following code:
```python
loss_name = self.model.loss
if hasattr(loss_name, '__name__'):
    loss_name = loss_name.__name__
if loss_name == 'categorical_crossentropy' and len(y.shape) != 2:
    y = to_categorical(y)
```

The same code should be in `score` but is currently missing. I have added the code.

## Squeeze output of KerasClassifier.predict(X)

According to the documentation (and sklearn standards), the `predict` method of a regressor returns an array of shape `(n_samples,)`.  `KerasClassifier.predict(X)` though seems to return an array of shape `(n_samples,1)`. I've added a `np.squeeze` to make it match the output format.

## Tests

I noticed that the wrapper tests are not executed (methods not prefixed with "test_"?), so  I've changed the tests a bit and now `py.test tests/` seems to pick them up. First time I've used py.test, so if what I did violates any standards, please let me know!