### PR TITLE
Tokenizer improvements

### DIFF
--- a/keras/preprocessing/text.py
+++ b/keras/preprocessing/text.py
@@ -10,6 +10,7 @@ import sys
 import numpy as np
 from six.moves import range
 from six.moves import zip
+from collections import Counter
 
 if sys.version_info < (3,):
     maketrans = string.maketrans
@@ -81,44 +82,29 @@ class Tokenizer(object):
             texts: can be a list of strings,
                 or a generator of strings (for memory-efficiency)
         '''
-        self.document_count = 0
+        self.word_counter = Counter()
         for text in texts:
             self.document_count += 1
             seq = text if self.char_level else text_to_word_sequence(text, self.filters, self.lower, self.split)
-            for w in seq:
-                if w in self.word_counts:
-                    self.word_counts[w] += 1
-                else:
-                    self.word_counts[w] = 1
-            for w in set(seq):
-                if w in self.word_docs:
-                    self.word_docs[w] += 1
-                else:
-                    self.word_docs[w] = 1
+            self.word_counter.update(seq)
 
-        wcounts = list(self.word_counts.items())
-        wcounts.sort(key=lambda x: x[1], reverse=True)
-        sorted_voc = [wc[0] for wc in wcounts]
-        # note that index 0 is reserved, never assigned to an existing word
-        self.word_index = dict(list(zip(sorted_voc, list(range(1, len(sorted_voc) + 1)))))
-
-        self.index_docs = {}
-        for w, c in list(self.word_docs.items()):
-            self.index_docs[self.word_index[w]] = c
+        words = [w[0] for w in self.word_counter.most_common(self.nb_words - 1)] if self.nb_words is not None else self.word_counter.keys()
+        
+        self.word_index = dict(list(zip(words, list(range(1, len(words) + 1)))))
 
     def fit_on_sequences(self, sequences):
         '''Required before using sequences_to_matrix
         (if fit_on_texts was never called)
         '''
-        self.document_count = len(sequences)
-        self.index_docs = {}
+        self.word_counter = Counter()
+
         for seq in sequences:
-            seq = set(seq)
-            for i in seq:
-                if i not in self.index_docs:
-                    self.index_docs[i] = 1
-                else:
-                    self.index_docs[i] += 1
+            self.document_count += 1
+            self.word_counter.update(seq)
+
+        words = [w[0] for w in self.word_counter.most_common(self.nb_words - 1)] if self.nb_words is not None else self.word_counter.keys()
+
+        self.word_index = dict(list(zip(words, list(range(1, len(words) + 1)))))
 
     def texts_to_sequences(self, texts):
         '''Transforms each text in texts in a sequence of integers.
@@ -148,11 +134,9 @@ class Tokenizer(object):
             vect = []
             for w in seq:
                 i = self.word_index.get(w)
+
                 if i is not None:
-                    if nb_words and i >= nb_words:
-                        continue
-                    else:
-                        vect.append(i)
+                    vect.append(i)
             yield vect
 
     def texts_to_matrix(self, texts, mode='binary'):
@@ -211,7 +195,7 @@ class Tokenizer(object):
                     # Use weighting scheme 2 in
                     #   https://en.wikipedia.org/wiki/Tf%E2%80%93idf
                     tf = 1 + np.log(c)
-                    idf = np.log(1 + self.document_count / (1 + self.index_docs.get(j, 0)))
+                    idf = np.log(1 + self.document_count / (1 + self.word_counter.get(j, 0)))
                     X[i][j] = tf * idf
                 else:
                     raise Exception('Unknown vectorization mode: ' + str(mode))


### PR DESCRIPTION
These are a few improvements I made (I added no features):

* Use `Counter` under the hood
* Avoid sorting when `nb_words=None`
* Do not store unused words in word_index (and skip check)
* Use `most_common` instead of manual sort (will be faster when `nb_words` is low)
* Do not use `len` in `fit_on_sequences` so you can use an iterator for this function as well.