### PR TITLE
Multi-GPU Support

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -11,7 +11,7 @@ from .common import _FLOATX, _EPSILON, _IMAGE_DIM_ORDERING, reset_uids
 _SESSION = None
 _LEARNING_PHASE = tf.placeholder(dtype='uint8', name='keras_learning_phase')  # 0 = test, 1 = train
 _MANUAL_VAR_INIT = False
-
+_DEVICE = None
 
 def clear_session():
     global _SESSION
@@ -124,7 +124,11 @@ def variable(value, dtype=_FLOATX, name=None):
     # Returns
         Tensor variable instance.
     '''
-    v = tf.Variable(value, dtype=_convert_string_dtype(dtype), name=name)
+    if _DEVICE is None:
+        v = tf.Variable(value, dtype=_convert_string_dtype(dtype), name=name)
+    else:
+        with tf.device(_get_tf_device_name(_DEVICE)):
+            v = tf.Variable(value, dtype=_convert_string_dtype(dtype), name=name)   
     if _MANUAL_VAR_INIT:
         return v
     if tf.get_default_graph() is get_session().graph:
@@ -1808,3 +1812,35 @@ def ctc_decode(y_pred, input_length, greedy=True, beam_width=None,
                      for st in decoded]
 
     return (decoded_dense, log_prob)
+
+
+# MULTI GPU
+
+def set_device(dev):
+    _DEVICE = dev
+
+
+def get_device():
+    return _DEVICE
+
+
+def _get_tf_device_name(device):
+    return '/' + device[:3] + ':' + device[3:]
+
+
+class device:
+
+    def __init__(self, name):
+        self.name = name
+
+    def __enter__(self):
+        set_device(self.name)
+
+    def __exit__(self, type, value, traceback):
+        set_device(None)
+
+
+def run_on_device(function, inputs):
+    with tf.device(_get_tf_device_name(_DEVICE)):
+        y = function(*inputs)
+    return y

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1817,6 +1817,7 @@ def ctc_decode(y_pred, input_length, greedy=True, beam_width=None,
 # MULTI GPU
 
 def set_device(dev):
+    global _DEVICE
     _DEVICE = dev
 
 

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1841,6 +1841,9 @@ class device:
 
 
 def run_on_device(function, inputs):
-    with tf.device(_get_tf_device_name(_DEVICE)):
+    if _DEVICE is None:
         y = function(*inputs)
+    else:
+        with tf.device(_get_tf_device_name(_DEVICE)):
+            y = function(*inputs)
     return y

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1829,7 +1829,7 @@ def _get_tf_device_name(device):
     return '/' + device[:3] + ':' + device[3:]
 
 
-class device:
+class device(object):
 
     def __init__(self, name):
         self.name = name

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1455,7 +1455,7 @@ def get_device():
     return _DEVICE
 
 
-class device:
+class device(object):
 
     def __init__(self, name):
         self.name = name

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1473,5 +1473,10 @@ def run_on_device(function, inputs):
     else:
         for i in range(len(inputs)):
             if hasattr(inputs[i], 'transfer'):
-                inputs[i] = inputs[i].transfer(_DEVICE)
+                new_input = inputs[i].transfer(_DEVICE)
+                # If keras tensor, copy keras topology and shape information.
+                if hasattr(inputs[i], '_keras_shape'):
+                    new_input._keras_shape = inputs[i]._keras_shape
+                    new_input._keras_history = inputs[i]._keras_history
+                inputs[i] = new_input
         return function(*inputs)

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -1314,7 +1314,6 @@ class Merge(Layer):
                 return self.__call__(inputs[:-1], inputs[-1])
             return K.run_on_device(_call, inputs + [mask])
 
-
         if type(inputs) is not list:
             raise Exception('Merge can only be called on a list of tensors, '
                             'not a single tensor. Received: ' + str(inputs))

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -466,13 +466,14 @@ class Layer(object):
             mask: tensor or list/tuple of tensors.
         '''
         # place the op on the right device:
-        if type(x) == list and not hasattr(x[0], '_keras_on_device'):
+        if type(x) in [list, tuple] and not hasattr(x[0], '_keras_on_device'):
             x[0]._keras_on_device = True
 
             def _call(*inputs):
-                return self.__call__(inputs[:-1], inputs[-1])
-            return K.run_on_device(_call, x + [mask])
-        elif not hasattr(x, '_keras_on_device'):
+                assert hasattr(inputs[0], '_keras_on_device')
+                return self.__call__(list(inputs[:-1]), inputs[-1])
+            return K.run_on_device(_call, list(x) + [mask])
+        elif type(x) not in [list, tuple] and not hasattr(x, '_keras_on_device'):
             x._keras_on_device = True
             return K.run_on_device(self.__call__, [x, mask])
         if not self.built:
@@ -1317,7 +1318,7 @@ class Merge(Layer):
             inputs[0]._keras_on_device = True
 
             def _call(*inputs):
-                return self.__call__(inputs[:-1], inputs[-1])
+                return self.__call__(list(inputs[:-1]), inputs[-1])
             return K.run_on_device(_call, inputs + [mask])
 
         if type(inputs) is not list:

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -1312,7 +1312,7 @@ class Merge(Layer):
 
             def _call(inputs):
                 return self.__call__(inputs[:-1], inputs[-1])
-            return run_on_device(_call, inputs + [mask])
+            return K.run_on_device(_call, inputs + [mask])
 
 
         if type(inputs) is not list:

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -466,7 +466,13 @@ class Layer(object):
             mask: tensor or list/tuple of tensors.
         '''
         # place the op on the right device:
-        if not hasattr(x, '_keras_on_device'):
+        if type(x) == list and not hasattr(x[0], '_keras_on_device'):
+            x[0]._keras_on_device = True
+
+            def _call(inputs):
+                return self.__call__(inputs[:-1], inputs[-1])
+            return K.run_on_device(_call, x + [mask])
+        elif not hasattr(x, '_keras_on_device'):
             x._keras_on_device = True
             return K.run_on_device(self.__call__, [x, mask])
         if not self.built:

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -469,7 +469,7 @@ class Layer(object):
         if type(x) == list and not hasattr(x[0], '_keras_on_device'):
             x[0]._keras_on_device = True
 
-            def _call(inputs):
+            def _call(*inputs):
                 return self.__call__(inputs[:-1], inputs[-1])
             return K.run_on_device(_call, x + [mask])
         elif not hasattr(x, '_keras_on_device'):
@@ -1316,7 +1316,7 @@ class Merge(Layer):
         if not hasattr(inputs[0], '_keras_on_device'):
             inputs[0]._keras_on_device = True
 
-            def _call(inputs):
+            def _call(*inputs):
                 return self.__call__(inputs[:-1], inputs[-1])
             return K.run_on_device(_call, inputs + [mask])
 


### PR DESCRIPTION
- API similar to that of TF:

Example:

``` python

# We create a siamese model, each leg in a difference GPU

from keras.models import*
from keras.layers import*
from keras import backend as K

with K.device('gpu0'):
    left_input = Input((10,))
    left = Dense(10)(left_input)
    left = Dense(10)(left)

with K.device('gpu1'):
    right_input = Input((10,))
    right = Dense(10)(right_input)
    right = Dense(10)(right)

# Use default gpu
output = merge([left, right], 'sum')
model = Model([left_input, right_input], output)
model.compile(loss='mse', optimizer='sgd')

```

For better control you can also use the `K.set_device()` function (accompanied by `K.get_device()`):

``` python
K.set_device('gpu1')
model = Sequential()
model.add(Dense(10, input_dim=20)) # The layer weights W and b will reside in gpu1's memory. The dot operation will also be done by gpu1 
```

When using `set_device()`, you can go back to your default device(decided by your backend) by:

``` python
K.set_device(None)
```
