### PR TITLE
Bug fix, batch_size set instead of default one

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1471,6 +1471,7 @@ class Model(Container):
                         # no need for try/except because
                         # data has already been validated
                         val_outs = self.evaluate(val_x, val_y,
+                                                 batch_size=batch_size,
                                                  sample_weight=val_sample_weights,
                                                  verbose=0)
                     if type(val_outs) is not list:


### PR DESCRIPTION
The evaluate function was called with the default batch_size (32).
So it doesn't work when your GPU does not handle a batch_size of 32.