### PR TITLE
Add pydot-ng dependency to extras_require for visualize_util

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,5 +13,6 @@ setup(name='Keras',
       install_requires=['theano', 'pyyaml', 'six'],
       extras_require={
           'h5py': ['h5py'],
+          'visualize': ['pydot-ng'],
       },
       packages=find_packages())


### PR DESCRIPTION
`visualize_util.plot` requires pydot-ng. Added it to extras_require.