### PR TITLE
Make ZeroPadding2D optionally asymmetric

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -844,6 +844,14 @@ def temporal_padding(x, padding=1):
     return tf.pad(x, pattern)
 
 
+def asymmetric_temporal_padding(x, left_pad=1, right_pad=1):
+    '''Pad the middle dimension of a 3D tensor
+    with "left_pad" zeros left and "right_pad" right.
+    '''
+    pattern = [[0, 0], [left_pad, right_pad], [0, 0]]
+    return tf.pad(x, pattern)
+
+
 def spatial_2d_padding(x, padding=(1, 1), dim_ordering=_IMAGE_DIM_ORDERING):
     '''Pads the 2nd and 3rd dimensions of a 4D tensor
     with "padding[0]" and "padding[1]" (resp.) zeros left and right.
@@ -854,6 +862,23 @@ def spatial_2d_padding(x, padding=(1, 1), dim_ordering=_IMAGE_DIM_ORDERING):
     else:
         pattern = [[0, 0],
                    [padding[0], padding[0]], [padding[1], padding[1]],
+                   [0, 0]]
+    return tf.pad(x, pattern)
+
+
+def asymmetric_spatial_2d_padding(x, top_pad=1, bottom_pad=1, left_pad=1, right_pad=1, dim_ordering=_IMAGE_DIM_ORDERING):
+    '''Pad the rows and columns of a 4D tensor
+    with "top_pad", "bottom_pad", "left_pad", "right_pad"  (resp.) zeros rows on top, bottom; cols on left, right.
+    '''
+    if dim_ordering == 'th':
+        pattern = [[0, 0],
+                   [0, 0],
+                   [top_pad, bottom_pad],
+                   [left_pad, right_pad]]
+    else:
+        pattern = [[0, 0],
+                   [top_pad, bottom_pad],
+                   [left_pad, right_pad],
                    [0, 0]]
     return tf.pad(x, pattern)
 

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -623,9 +623,6 @@ def asymmetric_spatial_2d_padding(x, top_pad=1, bottom_pad=1, left_pad=1, right_
     '''Pad the rows and columns of a 4D tensor
     with "top_pad", "bottom_pad", "left_pad", "right_pad"  (resp.) zeros rows on top, bottom; cols on left, right.
     '''
-    from theano import tensor as T
-    import sys
-
     input_shape = x.shape
     if dim_ordering == 'th':
         output_shape = (input_shape[0],

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -573,6 +573,21 @@ def temporal_padding(x, padding=1):
     return T.set_subtensor(output[:, padding:x.shape[1] + padding, :], x)
 
 
+def asymmetric_temporal_padding(x, left_pad=1, right_pad=1):
+    '''Pad the middle dimension of a 3D tensor
+    with "left_pad" zeros left and "right_pad" right.
+
+    Apologies for the inane API, but Theano makes this
+    really hard.
+    '''
+    input_shape = x.shape
+    output_shape = (input_shape[0],
+                    input_shape[1] + left_pad + right_pad,
+                    input_shape[2])
+    output = T.zeros(output_shape)
+    return T.set_subtensor(output[:, left_pad:x.shape[1] + left_pad, :], x)
+
+
 def spatial_2d_padding(x, padding=(1, 1), dim_ordering=_IMAGE_DIM_ORDERING):
     '''Pad the 2nd and 3rd dimensions of a 4D tensor
     with "padding[0]" and "padding[1]" (resp.) zeros left and right.
@@ -598,6 +613,41 @@ def spatial_2d_padding(x, padding=(1, 1), dim_ordering=_IMAGE_DIM_ORDERING):
         indices = (slice(None),
                    slice(padding[0], input_shape[1] + padding[0]),
                    slice(padding[1], input_shape[2] + padding[1]),
+                   slice(None))
+    else:
+        raise Exception('Invalid dim_ordering: ' + dim_ordering)
+    return T.set_subtensor(output[indices], x)
+
+
+def asymmetric_spatial_2d_padding(x, top_pad=1, bottom_pad=1, left_pad=1, right_pad=1, dim_ordering=_IMAGE_DIM_ORDERING):
+    '''Pad the rows and columns of a 4D tensor
+    with "top_pad", "bottom_pad", "left_pad", "right_pad"  (resp.) zeros rows on top, bottom; cols on left, right.
+    '''
+    from theano import tensor as T
+    import sys
+
+    input_shape = x.shape
+    if dim_ordering == 'th':
+        output_shape = (input_shape[0],
+                        input_shape[1],
+                        input_shape[2] + top_pad + bottom_pad,
+                        input_shape[3] + left_pad + right_pad)
+        output = T.zeros(output_shape)
+        indices = (slice(None),
+                   slice(None),
+                   slice(top_pad, input_shape[2] + top_pad),
+                   slice(left_pad, input_shape[3] + left_pad))
+
+    elif dim_ordering == 'tf':
+        output_shape = (input_shape[0],
+                        input_shape[1] + top_pad + bottom_pad,
+                        input_shape[2] + left_pad + right_pad,
+                        input_shape[3])
+        print(output_shape)
+        output = T.zeros(output_shape)
+        indices = (slice(None),
+                   slice(top_pad, input_shape[1] + top_pad),
+                   slice(left_pad, input_shape[2] + left_pad),
                    slice(None))
     else:
         raise Exception('Invalid dim_ordering: ' + dim_ordering)

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -1418,9 +1418,9 @@ class ZeroPadding1D(Layer):
             the padding dimension (axis 1).
             For asymmetric padding: tuple of int (length 2)
             How many zeros to add at the beginning and at the end of
-            the padding dimension (left_pad, right_pad) or
-            {'left_pad': left_pad, 'right_pad': right_pad}.
-            If any key is missing, default value of 1 will be used for the missing key.
+            the padding dimension '(left_pad, right_pad)' or
+            '{'left_pad': left_pad, 'right_pad': right_pad}'.
+            If any key is missing, default value of 0 will be used for the missing key.
 
     # Input shape
         3D tensor with shape (samples, axis_to_pad, features)
@@ -1437,8 +1437,12 @@ class ZeroPadding1D(Layer):
             self.left_pad = padding
             self.right_pad = padding
         elif isinstance(padding, dict):
-            self.left_pad = padding.get('left_pad', 1)
-            self.right_pad = padding.get('right_pad', 1)
+            if set(padding.keys()) <= {'left_pad', 'right_pad'}:
+                self.left_pad = padding.get('left_pad', 0)
+                self.right_pad = padding.get('right_pad', 0)
+            else:
+                raise ValueError('Unexpected key is found in the padding argument. '
+                                 'Keys have to be in {"left_pad", "right_pad"}')
         else:
             padding = tuple(padding)
             self.left_pad = padding[0]
@@ -1471,9 +1475,9 @@ class ZeroPadding2D(Layer):
             For asymmetric padding tuple of int (length 4)
             How many zeros to add at the beginning and at the end of
             the 2 padding dimensions (rows and cols).
-            (top_pad, bottom_pad, left_pad, right_pad) or
-            {'top_pad': top_pad, 'bottom_pad': bottom_pad, 'left_pad': left_pad, 'right_pad': right_pad}
-            If any key is missing, default value of 1 will be used for the missing key.
+            '(top_pad, bottom_pad, left_pad, right_pad)' or
+            '{'top_pad': top_pad, 'bottom_pad': bottom_pad, 'left_pad': left_pad, 'right_pad': right_pad}'
+            If any key is missing, default value of 0 will be used for the missing key.
         dim_ordering: 'th' or 'tf'.
             In 'th' mode, the channels dimension (the depth)
             is at index 1, in 'tf' mode is it at index 3.
@@ -1504,10 +1508,14 @@ class ZeroPadding2D(Layer):
 
         self.padding = padding
         try:
-            self.top_pad = padding.get('top_pad', 1)
-            self.bottom_pad = padding.get('bottom_pad', 1)
-            self.left_pad = padding.get('left_pad', 1)
-            self.right_pad = padding.get('right_pad', 1)
+            if set(padding.keys()) <= {'top_pad', 'bottom_pad', 'left_pad', 'right_pad'}:
+                self.top_pad = padding.get('top_pad', 0)
+                self.bottom_pad = padding.get('bottom_pad', 0)
+                self.left_pad = padding.get('left_pad', 0)
+                self.right_pad = padding.get('right_pad', 0)
+            else:
+                raise ValueError('Unexpected key is found in the padding argument. '
+                                 'Keys have to be in {"top_pad", "bottom_pad", "left_pad", "right_pad"}')
         except AttributeError:
             padding = tuple(padding)
             if len(padding) == 2:

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -1414,7 +1414,15 @@ class ZeroPadding1D(Layer):
     # Arguments
         padding: int
             How many zeros to add at the beginning and end of
-            the padding dimension (axis 1).
+            the padding dimension (axis 1) symmetrically.
+            Setting padding to the value different from 1
+            overrides left_pad, right_pad arguments.
+        left_pad:
+            How many zeros to add at the beginning of
+            the padding dimension.
+        right_pad:
+            How many zeros to add at the end of
+            the padding dimension.
 
     # Input shape
         3D tensor with shape (samples, axis_to_pad, features)
@@ -1423,22 +1431,29 @@ class ZeroPadding1D(Layer):
         3D tensor with shape (samples, padded_axis, features)
     '''
 
-    def __init__(self, padding=1, **kwargs):
+    def __init__(self, padding=1, left_pad=1, right_pad=1, **kwargs):
         super(ZeroPadding1D, self).__init__(**kwargs)
         self.padding = padding
+        self.left_pad = left_pad
+        self.right_pad = right_pad
+        if self.padding != 1:
+            self.left_pad = self.padding
+            self.right_pad = self.padding
         self.input_spec = [InputSpec(ndim=3)]
 
     def get_output_shape_for(self, input_shape):
-        length = input_shape[1] + self.padding * 2 if input_shape[1] is not None else None
+        length = input_shape[1] + self.left_pad + self.right_pad if input_shape[1] is not None else None
         return (input_shape[0],
                 length,
                 input_shape[2])
 
     def call(self, x, mask=None):
-        return K.temporal_padding(x, padding=self.padding)
+        return K.asymmetric_temporal_padding(x, left_pad=self.left_pad, right_pad=self.right_pad)
 
     def get_config(self):
-        config = {'padding': self.padding}
+        config = {'padding': self.padding,
+                  'left_pad': self.left_pad,
+                  'right_pad': self.right_pad}
         base_config = super(ZeroPadding1D, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
 
@@ -1449,7 +1464,17 @@ class ZeroPadding2D(Layer):
     # Arguments
         padding: tuple of int (length 2)
             How many zeros to add at the beginning and end of
-            the 2 padding dimensions (axis 3 and 4).
+            the 2 padding dimensions (rows and cols) symmetrically.
+            Setting padding to the values different from (1, 1)
+            overrides top_pad, bottom_pad; and left_pad, right_pad arguments.
+        top_pad: int
+            How many zeros to add to the top of the rows.
+        bottom_pad: int
+            How many zeros to add at the bottom of the rows.
+        left_pad:
+            How many zeros to add to the left of the cols.
+        right_pad:
+            How many zeros to add to the right of the cols.
         dim_ordering: 'th' or 'tf'.
             In 'th' mode, the channels dimension (the depth)
             is at index 1, in 'tf' mode is it at index 3.
@@ -1459,46 +1484,79 @@ class ZeroPadding2D(Layer):
 
     # Input shape
         4D tensor with shape:
-        (samples, depth, first_axis_to_pad, second_axis_to_pad)
+        `(samples, channels, rows, cols)` if dim_ordering='th'
+        or 4D tensor with shape:
+        `(samples, rows, cols, channels)` if dim_ordering='tf'.
 
     # Output shape
         4D tensor with shape:
-        (samples, depth, first_padded_axis, second_padded_axis)
+        `(samples, channels, padded_rows, padded_cols)` if dim_ordering='th'
+        or 4D tensor with shape:
+        `(samples, padded_rows, padded_cols, channels)` if dim_ordering='tf'.
     '''
 
-    def __init__(self, padding=(1, 1), dim_ordering='default', **kwargs):
+    def __init__(self,
+                 padding=(1, 1),
+                 top_pad=1,
+                 bottom_pad=1,
+                 left_pad=1,
+                 right_pad=1,
+                 dim_ordering='default',
+                 **kwargs):
+        import sys
         super(ZeroPadding2D, self).__init__(**kwargs)
         if dim_ordering == 'default':
             dim_ordering = K.image_dim_ordering()
-        self.padding = tuple(padding)
+
+        self.padding = padding
+        self.top_pad = top_pad
+        self.bottom_pad = bottom_pad
+        self.left_pad = left_pad
+        self.right_pad = right_pad
+
+        if padding[0] != 1:
+            self.top_pad = self.padding[0]
+            self.bottom_pad = self.padding[0]
+        if padding[1] != 1:
+            self.left_pad = self.padding[1]
+            self.right_pad = self.padding[1]
+
         assert dim_ordering in {'tf', 'th'}, 'dim_ordering must be in {tf, th}'
         self.dim_ordering = dim_ordering
         self.input_spec = [InputSpec(ndim=4)]
 
     def get_output_shape_for(self, input_shape):
         if self.dim_ordering == 'th':
-            width = input_shape[2] + 2 * self.padding[0] if input_shape[2] is not None else None
-            height = input_shape[3] + 2 * self.padding[1] if input_shape[3] is not None else None
+            rows = input_shape[2] + self.top_pad + self.bottom_pad if input_shape[2] is not None else None
+            cols = input_shape[3] + self.left_pad + self.right_pad if input_shape[3] is not None else None
             return (input_shape[0],
                     input_shape[1],
-                    width,
-                    height)
+                    rows,
+                    cols)
         elif self.dim_ordering == 'tf':
-            width = input_shape[1] + 2 * self.padding[0] if input_shape[1] is not None else None
-            height = input_shape[2] + 2 * self.padding[1] if input_shape[2] is not None else None
+            rows = input_shape[1] + self.top_pad + self.bottom_pad if input_shape[1] is not None else None
+            cols = input_shape[2] + self.left_pad + self.right_pad if input_shape[2] is not None else None
             return (input_shape[0],
-                    width,
-                    height,
+                    rows,
+                    cols,
                     input_shape[3])
         else:
             raise Exception('Invalid dim_ordering: ' + self.dim_ordering)
 
     def call(self, x, mask=None):
-        return K.spatial_2d_padding(x, padding=self.padding,
-                                    dim_ordering=self.dim_ordering)
+        return K.asymmetric_spatial_2d_padding(x,
+                                               top_pad=self.top_pad,
+                                               bottom_pad=self.bottom_pad,
+                                               left_pad=self.left_pad,
+                                               right_pad=self.right_pad,
+                                               dim_ordering=self.dim_ordering)
 
     def get_config(self):
-        config = {'padding': self.padding}
+        config = {'padding': self.padding,
+                  'top_pad': self.top_pad,
+                  'bottom_pad': self.bottom_pad,
+                  'left_pad': self.left_pad,
+                  'right_pad': self.right_pad}
         base_config = super(ZeroPadding2D, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
 

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -1441,14 +1441,13 @@ class ZeroPadding1D(Layer):
         if isinstance(padding, int):
             self.left_pad = padding
             self.right_pad = padding
-        elif isinstance(padding, tuple):
-            self.left_pad = padding[0]
-            self.right_pad = padding[1]
         elif isinstance(padding, dict):
             self.left_pad = padding.get('left_pad', 1)
             self.right_pad = padding.get('right_pad', 1)
         else:
-            raise TypeError('padding should be int or tuple of int of length 2 or dict')
+            padding = tuple(padding)
+            self.left_pad = padding[0]
+            self.right_pad = padding[1]
         self.input_spec = [InputSpec(ndim=3)]
 
     def get_output_shape_for(self, input_shape):
@@ -1519,7 +1518,13 @@ class ZeroPadding2D(Layer):
             dim_ordering = K.image_dim_ordering()
 
         self.padding = padding
-        if isinstance(padding, tuple):
+        try:
+            self.top_pad = padding.get('top_pad', 1)
+            self.bottom_pad = padding.get('bottom_pad', 1)
+            self.left_pad = padding.get('left_pad', 1)
+            self.right_pad = padding.get('right_pad', 1)
+        except AttributeError:
+            padding = tuple(padding)
             if len(padding) == 2:
                 self.top_pad = padding[0]
                 self.bottom_pad = padding[0]
@@ -1532,13 +1537,6 @@ class ZeroPadding2D(Layer):
                 self.right_pad = padding[3]
             else:
                 raise TypeError('padding should be tuple of int of length 2 or 4, or dict')
-        elif isinstance(padding, dict):
-            self.top_pad = padding.get('top_pad', 1)
-            self.bottom_pad = padding.get('bottom_pad', 1)
-            self.left_pad = padding.get('left_pad', 1)
-            self.right_pad = padding.get('right_pad', 1)
-        else:
-            raise TypeError('padding should be tuple of int of length 2 or 4, or dict')
 
         assert dim_ordering in {'tf', 'th'}, 'dim_ordering must be in {tf, th}'
         self.dim_ordering = dim_ordering

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -1434,14 +1434,9 @@ class ZeroPadding1D(Layer):
         3D tensor with shape (samples, padded_axis, features)
     '''
 
-    def __init__(self, padding=1, left_pad=1, right_pad=1, **kwargs):
+    def __init__(self, padding=1, **kwargs):
         super(ZeroPadding1D, self).__init__(**kwargs)
         self.padding = padding
-        self.left_pad = left_pad
-        self.right_pad = right_pad
-        if self.padding != 1:
-            self.left_pad = self.padding
-            self.right_pad = self.padding
 
         if isinstance(padding, int):
             self.left_pad = padding
@@ -1523,6 +1518,7 @@ class ZeroPadding2D(Layer):
         if dim_ordering == 'default':
             dim_ordering = K.image_dim_ordering()
 
+        self.padding = padding
         if isinstance(padding, tuple):
             if len(padding) == 2:
                 self.top_pad = padding[0]

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -1413,19 +1413,14 @@ class ZeroPadding1D(Layer):
 
     # Arguments
         padding: int or tuple of int (length 2) or dictionary
-            If int then defines how many zeros to add at the beginning and end of
-            the padding dimension (axis 1) symmetrically.
-            If tuple of int (length 2) then:
-            left_pad = padding[0],
-            right_pad = padding[1]
-            If 'padding' is a dictionary then it should have keys 'left_pad', 'right_pad'.
+            For symmetric padding: int
+            How many zeros to add at the beginning and end of
+            the padding dimension (axis 1).
+            For asymmetric padding: tuple of int (length 2)
+            How many zeros to add at the beginning and at the end of
+            the padding dimension (left_pad, right_pad) or
+            {'left_pad': left_pad, 'right_pad': right_pad}.
             If any key is missing, default value of 1 will be used for the missing key.
-        left_pad:
-            How many zeros to add at the beginning of
-            the padding dimension.
-        right_pad:
-            How many zeros to add at the end of
-            the padding dimension.
 
     # Input shape
         3D tensor with shape (samples, axis_to_pad, features)
@@ -1470,25 +1465,15 @@ class ZeroPadding2D(Layer):
 
     # Arguments
         padding: tuple of int (length 2) or tuple of int (length 4) or dictionary
-            If tuple of int (length 2) then defines
-            how many zeros to add at the beginning and end of
-            the 2 padding dimensions (rows and cols) symmetrically.
-            If tuple of int (length 2) then:
-            top_pad = padding[0],
-            bottom_pad = padding[1],
-            left_pad = padding[2],
-            right_pad = padding[3]
-            If 'padding' is a dictionary then it should have keys
-            'top_pad', 'bottom_pad', 'left_pad', 'right_pad'.
+            For symmetric padding tuple of int (length 2)
+            How many zeros to add at the beginning and end of
+            the 2 padding dimensions (rows and cols).
+            For asymmetric padding tuple of int (length 4)
+            How many zeros to add at the beginning and at the end of
+            the 2 padding dimensions (rows and cols).
+            (top_pad, bottom_pad, left_pad, right_pad) or
+            {'top_pad': top_pad, 'bottom_pad': bottom_pad, 'left_pad': left_pad, 'right_pad': right_pad}
             If any key is missing, default value of 1 will be used for the missing key.
-        top_pad: int
-            How many zeros to add to the top of the rows.
-        bottom_pad: int
-            How many zeros to add at the bottom of the rows.
-        left_pad:
-            How many zeros to add to the left of the cols.
-        right_pad:
-            How many zeros to add to the right of the cols.
         dim_ordering: 'th' or 'tf'.
             In 'th' mode, the channels dimension (the depth)
             is at index 1, in 'tf' mode is it at index 3.

--- a/tests/keras/layers/test_convolutional.py
+++ b/tests/keras/layers/test_convolutional.py
@@ -369,8 +369,14 @@ def test_zero_padding_2d():
     stack_size = 2
     input_nb_row = 11
     input_nb_col = 12
+    dim_ordering = K.image_dim_ordering()
+    print("Dim ordering: {}".format(dim_ordering))
+    assert dim_ordering in {'tf', 'th'}, 'dim_ordering must be in {tf, th}'
 
-    input = np.ones((nb_samples, input_nb_row, input_nb_col, stack_size))
+    if dim_ordering == 'tf':
+        input = np.ones((nb_samples, input_nb_row, input_nb_col, stack_size))
+    elif dim_ordering == 'th':
+        input = np.ones((nb_samples, stack_size, input_nb_row, input_nb_col))
 
     # basic test
     layer_test(convolutional.ZeroPadding2D,
@@ -382,10 +388,16 @@ def test_zero_padding_2d():
     layer.set_input(K.variable(input), shape=input.shape)
 
     out = K.eval(layer.output)
-    for offset in [0, 1, -1, -2]:
-        assert_allclose(out[:, offset, :, :], 0.)
-        assert_allclose(out[:, :, offset, :], 0.)
-    assert_allclose(out[:, 2:-2, 2:-2, :], 1.)
+    if dim_ordering == 'tf':
+        for offset in [0, 1, -1, -2]:
+            assert_allclose(out[:, offset, :, :], 0.)
+            assert_allclose(out[:, :, offset, :], 0.)
+        assert_allclose(out[:, 2:-2, 2:-2, :], 1.)
+    elif dim_ordering == 'th':
+        for offset in [0, 1, -1, -2]:
+            assert_allclose(out[:, :, offset, :], 0.)
+            assert_allclose(out[:, :, :, offset], 0.)
+        assert_allclose(out[:, 2:-2, 2:-2, :], 1.)
     layer.get_config()
 
 

--- a/tests/keras/layers/test_convolutional.py
+++ b/tests/keras/layers/test_convolutional.py
@@ -364,6 +364,45 @@ def test_averagepooling_3d():
 
 
 @keras_test
+def test_zero_padding_1d():
+    nb_samples = 2
+    input_dim = 2
+    nb_steps = 11
+    input = np.ones((nb_samples, nb_steps, input_dim))
+
+    # basic test
+    layer_test(convolutional.ZeroPadding1D,
+               kwargs={'padding': 2},
+               input_shape=input.shape)
+    layer_test(convolutional.ZeroPadding1D,
+               kwargs={'padding': (1, 2)},
+               input_shape=input.shape)
+    layer_test(convolutional.ZeroPadding1D,
+               kwargs={'padding': {'left_pad': 1, 'right_pad': 2}},
+               input_shape=input.shape)
+
+    # correctness test
+    layer = convolutional.ZeroPadding1D(padding=2)
+    layer.set_input(K.variable(input), shape=input.shape)
+
+    out = K.eval(layer.output)
+    for offset in [0, 1, -1, -2]:
+        assert_allclose(out[:, offset, :], 0.)
+    assert_allclose(out[:, 2:-2, :], 1.)
+
+    layer = convolutional.ZeroPadding1D(padding=(1, 2))
+    layer.set_input(K.variable(input), shape=input.shape)
+
+    out = K.eval(layer.output)
+    for left_offset in [0]:
+        assert_allclose(out[:, left_offset, :], 0.)
+    for right_offset in [-1, -2]:
+        assert_allclose(out[:, right_offset, :], 0.)
+    assert_allclose(out[:, 1:-2, :], 1.)
+    layer.get_config()
+
+
+@keras_test
 def test_zero_padding_2d():
     nb_samples = 2
     stack_size = 2

--- a/tests/keras/layers/test_convolutional.py
+++ b/tests/keras/layers/test_convolutional.py
@@ -370,7 +370,6 @@ def test_zero_padding_2d():
     input_nb_row = 11
     input_nb_col = 12
     dim_ordering = K.image_dim_ordering()
-    print("Dim ordering: {}".format(dim_ordering))
     assert dim_ordering in {'tf', 'th'}, 'dim_ordering must be in {tf, th}'
 
     if dim_ordering == 'tf':
@@ -381,6 +380,12 @@ def test_zero_padding_2d():
     # basic test
     layer_test(convolutional.ZeroPadding2D,
                kwargs={'padding': (2, 2)},
+               input_shape=input.shape)
+    layer_test(convolutional.ZeroPadding2D,
+               kwargs={'padding': (1, 2, 3, 4)},
+               input_shape=input.shape)
+    layer_test(convolutional.ZeroPadding2D,
+               kwargs={'padding': {'top_pad': 1, 'bottom_pad': 2, 'left_pad': 3, 'right_pad': 4}},
                input_shape=input.shape)
 
     # correctness test
@@ -398,6 +403,31 @@ def test_zero_padding_2d():
             assert_allclose(out[:, :, offset, :], 0.)
             assert_allclose(out[:, :, :, offset], 0.)
         assert_allclose(out[:, 2:-2, 2:-2, :], 1.)
+
+    layer = convolutional.ZeroPadding2D(padding=(1, 2, 3, 4))
+    layer.set_input(K.variable(input), shape=input.shape)
+
+    out = K.eval(layer.output)
+    if dim_ordering == 'tf':
+        for top_offset in [0]:
+            assert_allclose(out[:, top_offset, :, :], 0.)
+        for bottom_offset in [-1, -2]:
+            assert_allclose(out[:, bottom_offset, :, :], 0.)
+        for left_offset in [0, 1, 2]:
+            assert_allclose(out[:, :, left_offset, :], 0.)
+        for right_offset in [-1, -2, -3, -4]:
+            assert_allclose(out[:, :, right_offset, :], 0.)
+        assert_allclose(out[:, 1:-2, 3:-4, :], 1.)
+    elif dim_ordering == 'th':
+        for top_offset in [0]:
+            assert_allclose(out[:, :, top_offset, :], 0.)
+        for bottom_offset in [-1, -2]:
+            assert_allclose(out[:, :, bottom_offset, :], 0.)
+        for left_offset in [0, 1, 2]:
+            assert_allclose(out[:, :, :, left_offset], 0.)
+        for right_offset in [-1, -2, -3, -4]:
+            assert_allclose(out[:, :, :, right_offset], 0.)
+        assert_allclose(out[:, :, 1:-2, 3:-4], 1.)
     layer.get_config()
 
 


### PR DESCRIPTION
I propose to implement an asymmetric padding as an option in the ZeroPadding2D.

Reasons:
- From my experience it could be definitely useful when using convolutional layers for the time series data. At some degree it's covered in #531.
- Probably it could also be useful for the image processing, but I cannot offer an example.

Open questions:
- May be it's better to add a separate layer for asymmetric zero padding instead of changing the existing ZeroPadding2D?
- There's a possible confusion in the existing ZeroPadding2D (see https://github.com/fchollet/keras/blob/master/keras/layers/convolutional.py#L1345-L1346) - dimensions are called width and height, respectively, but in all convolutional layers respective dimensions are rows, cols (vice versa). Should I leave the as is or change?
- May be it makes sense to do the same thing for ZeroPadding1D simultaneously? The reason why I've started with 2D is that 1D convolution is a kind of not 1st class citizen - e.g. it lacks Deconvolution, AtrousConvolution implementations, etc.