### PR TITLE
update pytest config for pep8 tests (#3617)

### DIFF
--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -1388,7 +1388,7 @@ class Merge(Layer):
             masks = [K.expand_dims(m, 0) for m in mask if m is not None]
             return K.all(K.concatenate(masks, axis=0), axis=0, keepdims=False)
         elif self.mode == 'concat':
-            # Make a list of masks while making sure the dimensionality of each mask 
+            # Make a list of masks while making sure the dimensionality of each mask
             # is the same as the corresponding input.
             masks = []
             for input_i, mask_i in zip(inputs, mask):

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -517,7 +517,7 @@ class Deconvolution2D(Convolution2D):
             raise Exception('Invalid dim_ordering: ' + self.dim_ordering)
 
     def call(self, x, mask=None):
-        output = K.deconv2d(x, self.W, self.output_shape_, 
+        output = K.deconv2d(x, self.W, self.output_shape_,
                             strides=self.subsample,
                             border_mode=self.border_mode,
                             dim_ordering=self.dim_ordering,
@@ -1544,13 +1544,13 @@ class Cropping2D(Layer):
     def call(self, x, mask=None):
         input_shape = self.input_spec[0].shape
         if self.dim_ordering == 'th':
-            return x[:, 
-                     :, 
+            return x[:,
+                     :,
                      self.cropping[0][0]:input_shape[2]-self.cropping[0][1],
                      self.cropping[1][0]:input_shape[3]-self.cropping[1][1]]
         elif self.dim_ordering == 'tf':
-            return x[:, 
-                     self.cropping[0][0]:input_shape[1]-self.cropping[0][1], 
+            return x[:,
+                     self.cropping[0][0]:input_shape[1]-self.cropping[0][1],
                      self.cropping[1][0]:input_shape[2]-self.cropping[1][1],
                      :]
 
@@ -1624,16 +1624,16 @@ class Cropping3D(Layer):
     def call(self, x, mask=None):
         input_shape = self.input_spec[0].shape
         if self.dim_ordering == 'th':
-            return x[:, 
-                     :, 
-                     self.cropping[0][0]:input_shape[2]-self.cropping[0][1], 
-                     self.cropping[1][0]:input_shape[3]-self.cropping[1][1], 
+            return x[:,
+                     :,
+                     self.cropping[0][0]:input_shape[2]-self.cropping[0][1],
+                     self.cropping[1][0]:input_shape[3]-self.cropping[1][1],
                      self.cropping[2][0]:input_shape[4]-self.cropping[2][1]]
         elif self.dim_ordering == 'tf':
-            return x[:, 
-                     self.cropping[0][0]:input_shape[1]-self.cropping[0][1], 
-                     self.cropping[1][0]:input_shape[2]-self.cropping[1][1], 
-                     self.cropping[2][0]:input_shape[3]-self.cropping[2][1], 
+            return x[:,
+                     self.cropping[0][0]:input_shape[1]-self.cropping[0][1],
+                     self.cropping[1][0]:input_shape[2]-self.cropping[1][1],
+                     self.cropping[2][0]:input_shape[3]-self.cropping[2][1],
                      :]
 
     def get_config(self):

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -487,13 +487,13 @@ class Lambda(Layer):
             Takes one argument: the output of previous layer
         output_shape: Expected output shape from function.
             Can be a tuple or function.
-            If a tuple, it only specifies the first dimension onward; 
+            If a tuple, it only specifies the first dimension onward;
                  sample dimension is assumed either the same as the input:
                  `output_shape = (input_shape[0], ) + output_shape`
                  or, the input is `None` and the sample dimension is also `None`:
                  `output_shape = (None, ) + output_shape`
-            If a function, it specifies the entire shape as a function of 
-                 the input shape: `output_shape = f(input_shape)`
+            If a function, it specifies the entire shape as a function of the
+            input shape: `output_shape = f(input_shape)`
         arguments: optional dictionary of keyword arguments to be passed
             to the function.
 

--- a/keras/preprocessing/sequence.py
+++ b/keras/preprocessing/sequence.py
@@ -138,7 +138,7 @@ def skipgrams(sequence, vocabulary_size,
                     continue
                 couples.append([wi, wj])
                 if categorical:
-                    labels.append([0,1])
+                    labels.append([0, 1])
                 else:
                     labels.append(1)
 
@@ -149,12 +149,12 @@ def skipgrams(sequence, vocabulary_size,
 
         couples += [[words[i %len(words)], random.randint(1, vocabulary_size-1)] for i in range(nb_negative_samples)]
         if categorical:
-            labels += [[1,0]]*nb_negative_samples
+            labels += [[1, 0]]*nb_negative_samples
         else:
             labels += [0]*nb_negative_samples
 
     if shuffle:
-        seed = random.randint(0,10e6)
+        seed = random.randint(0, 10e6)
         random.seed(seed)
         random.shuffle(couples)
         random.seed(seed)

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -65,7 +65,7 @@ def get_file(fname, origin, untar=False,
         download = True
 
     if download:
-        print('Downloading data from',  origin)
+        print('Downloading data from', origin)
         global progbar
         progbar = None
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -13,26 +13,20 @@ norecursedirs= build
 # E251 unexpected spaces around keyword / parameter equals
 # E225 missing whitespace around operator
 # E226 missing whitespace around arithmetic operator
-# W291 trailing whitespace
 # W293 blank line contains whitespace
 # E501 line too long (82 > 79 characters)
 # E402 module level import not at top of file - temporary measure to coninue adding ros python packaged in sys.path
 # E731 do not assign a lambda expression, use a def
 # E302 two blank lines between the functions
-# E231 missing whitespace after ,
-# E241 multiple spaces after ','
 # E261 at least two spaces before inline comment
 
 
 pep8ignore=* E251 \
            * E225 \
            * E226 \
-           * W291 \
            * W293 \
            * E501 \
            * E402 \
            * E731 \
            * E302 \
-           * E231 \
-           * E241 \
            * E261

--- a/tests/keras/preprocessing/test_sequence.py
+++ b/tests/keras/preprocessing/test_sequence.py
@@ -63,7 +63,7 @@ def test_pad_sequences_vector():
 
 def test_make_sampling_table():
     a = make_sampling_table(3)
-    assert_allclose(a, np.asarray([0.00315225,  0.00315225,  0.00547597]),
+    assert_allclose(a, np.asarray([0.00315225, 0.00315225, 0.00547597]),
                     rtol=.1)
 
 

--- a/tests/keras/test_activations.py
+++ b/tests/keras/test_activations.py
@@ -48,7 +48,7 @@ def test_softplus():
         return np.log(np.ones_like(x) + np.exp(x))
 
     x = K.placeholder(ndim=2)
-    f = K.function([x],  [activations.softplus(x)])
+    f = K.function([x], [activations.softplus(x)])
     test_values = get_standard_values()
 
     result = f([test_values])[0]
@@ -64,7 +64,7 @@ def test_softsign():
         return np.divide(x, np.ones_like(x) + np.absolute(x))
 
     x = K.placeholder(ndim=2)
-    f = K.function([x],  [activations.softsign(x)])
+    f = K.function([x], [activations.softsign(x)])
     test_values = get_standard_values()
 
     result = f([test_values])[0]
@@ -85,7 +85,7 @@ def test_sigmoid():
     sigmoid = np.vectorize(ref_sigmoid)
 
     x = K.placeholder(ndim=2)
-    f = K.function([x],  [activations.sigmoid(x)])
+    f = K.function([x], [activations.sigmoid(x)])
     test_values = get_standard_values()
 
     result = f([test_values])[0]
@@ -108,7 +108,7 @@ def test_hard_sigmoid():
     hard_sigmoid = np.vectorize(ref_hard_sigmoid)
 
     x = K.placeholder(ndim=2)
-    f = K.function([x],  [activations.hard_sigmoid(x)])
+    f = K.function([x], [activations.hard_sigmoid(x)])
     test_values = get_standard_values()
 
     result = f([test_values])[0]


### PR DESCRIPTION
> Test improvements: stricter PEP8 checks in our PEP8 test. That's an easy one. In particular, we need to check for missing spaces after commas, trailing spaces, this kind of thing.

I removed trailing whitespace, missing whitespace after, and multiple spaces after from the ignored list of pep8 rules. 

There are a few more rules in regards to whitespace around operators but wasn't sure whether to remove those from the ignore list as well. 