### PR TITLE
Added: Ability to get top-n predictions from the classifiers

### DIFF
--- a/keras/applications/imagenet_utils.py
+++ b/keras/applications/imagenet_utils.py
@@ -28,7 +28,7 @@ def preprocess_input(x, dim_ordering='default'):
     return x
 
 
-def decode_predictions(preds):
+def decode_predictions(preds, top_preds=1):
     global CLASS_INDEX
     assert len(preds.shape) == 2 and preds.shape[1] == 1000
     if CLASS_INDEX is None:
@@ -36,8 +36,12 @@ def decode_predictions(preds):
                          CLASS_INDEX_PATH,
                          cache_subdir='models')
         CLASS_INDEX = json.load(open(fpath))
-    indices = np.argmax(preds, axis=-1)
+    
+    top = top_preds
+    indices = np.argpartition(preds,-top)[-top:]
+    tpreds = indices[0,-top:]
+    
     results = []
-    for i in indices:
+    for i in tpreds:
         results.append(CLASS_INDEX[str(i)])
     return results

--- a/keras/applications/imagenet_utils.py
+++ b/keras/applications/imagenet_utils.py
@@ -41,7 +41,7 @@ def decode_predictions(preds, top=1):
         indices = (-preds).argsort()[:top]
         top_preds = indices[0, :top]
     else:
-        top_preds = np.argmax(preds)
+        top_preds = np.argmax(preds, axis=-1)
     
     results = []
     for i in top_preds:

--- a/keras/applications/imagenet_utils.py
+++ b/keras/applications/imagenet_utils.py
@@ -37,8 +37,11 @@ def decode_predictions(preds, top=1):
                          cache_subdir='models')
         CLASS_INDEX = json.load(open(fpath))
     
-    indices = np.argpartition(preds, -top)[-top:]
-    top_preds = indices[0, -top:]
+    if top > 1:
+        indices = (-preds).argsort()[:top]
+        top_preds = indices[0, :top]
+    else:
+        top_preds = np.argmax(preds)
     
     results = []
     for i in top_preds:

--- a/keras/applications/imagenet_utils.py
+++ b/keras/applications/imagenet_utils.py
@@ -28,7 +28,7 @@ def preprocess_input(x, dim_ordering='default'):
     return x
 
 
-def decode_predictions(preds, top_preds=1):
+def decode_predictions(preds, top=1):
     global CLASS_INDEX
     assert len(preds.shape) == 2 and preds.shape[1] == 1000
     if CLASS_INDEX is None:
@@ -37,11 +37,10 @@ def decode_predictions(preds, top_preds=1):
                          cache_subdir='models')
         CLASS_INDEX = json.load(open(fpath))
     
-    top = top_preds
     indices = np.argpartition(preds, -top)[-top:]
-    tpreds = indices[0, -top:]
+    top_preds = indices[0, -top:]
     
     results = []
-    for i in tpreds:
+    for i in top_preds:
         results.append(CLASS_INDEX[str(i)])
     return results

--- a/keras/applications/imagenet_utils.py
+++ b/keras/applications/imagenet_utils.py
@@ -38,8 +38,8 @@ def decode_predictions(preds, top_preds=1):
         CLASS_INDEX = json.load(open(fpath))
     
     top = top_preds
-    indices = np.argpartition(preds,-top)[-top:]
-    tpreds = indices[0,-top:]
+    indices = np.argpartition(preds, -top)[-top:]
+    tpreds = indices[0, -top:]
     
     results = []
     for i in tpreds:


### PR DESCRIPTION
* Replaced argmax with argpartition with default = 1 for Top-1 prediction.
* Added top_preds optional argument to get top-n predictions.

Example usage: 

```
preds = model.predict(x)
top = 5   # Specify the Top-n predictions for the model to return
print('Top ' + str(top) + ' predictions: ', decode_predictions(preds, top))
```