### PR TITLE
TensorBoard callback improvements

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -471,14 +471,6 @@ class TensorBoard(Callback):
         if self.histogram_freq and self.merged is None:
             for layer in self.model.layers:
 
-                W = None
-                if hasattr(layer, 'W'):
-                    W = layer.W
-
-                b = None
-                if hasattr(layer, 'b'):
-                    b = layer.b
-
                 weights = []
                 if hasattr(layer, 'trainable_weights'):
                     weights.extend(layer.trainable_weights)
@@ -486,34 +478,18 @@ class TensorBoard(Callback):
                     weights.extend(layer.non_trainable_weights)
 
                 for weight in weights:
-                    #Try and figure out a sensible name
-                    if weight == W:
-                        name = layer.name + '_W'
-                    elif weight == b:
-                        name = layer.name + '_b'
-                    else:
-                        if weight.name.startswith(layer.name):
-                            (_, _, suffix) = weight.name.partition(layer.name)
-                            name = layer.name + '_' + suffix
-                        else: 
-                            name = layer.name + '_' + weight.name
-
-                    #Add histogram summary
                     tf.histogram_summary(name, weight)
 
                     if self.write_images:
                         w_img = tf.squeeze(weight)
 
-                        #Using the shape feels unsafe, but is probably ok for weights
                         shape = w_img.get_shape()
                         if len(shape) > 1 and shape[0] > shape[1]:
                             w_img = tf.transpose(w_img)
 
-                        #Expand the tensor to a single row if we squeezed too hard...
                         if len(shape) == 1:
                             w_img = tf.expand_dims(w_img, 0)
 
-                        #Expand the tensor to 4d for plotting
                         w_img = tf.expand_dims(tf.expand_dims(w_img, 0), -1)
 
                         tf.image_summary(name, w_img)

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -471,13 +471,7 @@ class TensorBoard(Callback):
         if self.histogram_freq and self.merged is None:
             for layer in self.model.layers:
 
-                weights = []
-                if hasattr(layer, 'trainable_weights'):
-                    weights.extend(layer.trainable_weights)
-                if hasattr(layer, 'non_trainable_weights'):
-                    weights.extend(layer.non_trainable_weights)
-
-                for weight in weights:
+                for weight in layer.weights:
                     tf.histogram_summary(weight.name, weight)
 
                     if self.write_images:

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -478,7 +478,7 @@ class TensorBoard(Callback):
                     weights.extend(layer.non_trainable_weights)
 
                 for weight in weights:
-                    tf.histogram_summary(name, weight)
+                    tf.histogram_summary(weight.name, weight)
 
                     if self.write_images:
                         w_img = tf.squeeze(weight)
@@ -492,7 +492,7 @@ class TensorBoard(Callback):
 
                         w_img = tf.expand_dims(tf.expand_dims(w_img, 0), -1)
 
-                        tf.image_summary(name, w_img)
+                        tf.image_summary(weight.name, w_img)
 
                 if hasattr(layer, 'output'):
                     tf.histogram_summary('{}_out'.format(layer.name),


### PR DESCRIPTION
This PR modifies the TensorBoard callback to:

* Log histograms for all trainable & non-trainable weights; not just .W and .b
* Tries to provide good names for the weights even when they're not named well
* Generates image summaries for weights (behind a parameter since the value is questionable)