### PR TITLE
Fix TensorFlow RNN backwards support

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1136,7 +1136,7 @@ def rnn(step_function, inputs, initial_states,
 
         if mask is not None:
             if go_backwards:
-                mask = tf.reverse(mask, [True] + [False] * (ndim - 1))
+                mask = tf.reverse(mask, [True] + [False] * (ndim - 2))
 
             # Transpose not supported by bool tensor types, hence round-trip to uint8.
             mask = tf.cast(mask, tf.uint8)


### PR DESCRIPTION
With TF dynamic RNN support in Keras 1.0.8 a bug was introduced when using `go_backwards=True` and masking. Mask has one less dimension than input.

Example code (should we add a unit test?):

```python
import numpy as np
from keras.layers import Input, Embedding, Dense, GRU
from keras.models import Model

data_in = np.random.randint(2, size=(5, 10))
data_out = data_in[:, 0].astype(np.float32)

x_in = Input(shape=(10,), dtype='int32', name='x_in')
x = Embedding(2, 10, mask_zero=True)(x_in)

x = GRU(10, return_sequences=False, go_backwards=True)(x)

y_out = Dense(1, activation='softmax', name="y_out")(x)

model = Model(input=[x_in], output=[y_out])
model.compile(optimizer='adam', loss='mse')
model.fit([data_in], [data_out], nb_epoch=10)
```

```
Traceback (most recent call last):
  File "test_rnn_backwards.py", line 22, in <module>
    x = GRU(10, return_sequences=False, go_backwards=True)(x)
  File "/usr/local/lib/python2.7/dist-packages/keras/engine/topology.py", line 515, in __call__
    self.add_inbound_node(inbound_layers, node_indices, tensor_indices)
  File "/usr/local/lib/python2.7/dist-packages/keras/engine/topology.py", line 573, in add_inbound_node
    Node.create_node(self, inbound_layers, node_indices, tensor_indices)
  File "/usr/local/lib/python2.7/dist-packages/keras/engine/topology.py", line 150, in create_node
    output_tensors = to_list(outbound_layer.call(input_tensors[0], mask=input_masks[0]))
  File "/usr/local/lib/python2.7/dist-packages/keras/layers/recurrent.py", line 213, in call
    input_length=input_shape[1])
  File "/usr/local/lib/python2.7/dist-packages/keras/backend/tensorflow_backend.py", line 1139, in rnn
    mask = tf.reverse(mask, [True] + [False] * (ndim - 1))
  File "/usr/local/lib/python2.7/dist-packages/tensorflow/python/ops/gen_array_ops.py", line 1448, in reverse
    name=name)
  File "/usr/local/lib/python2.7/dist-packages/tensorflow/python/ops/op_def_library.py", line 704, in apply_op
    op_def=op_def)
  File "/usr/local/lib/python2.7/dist-packages/tensorflow/python/framework/ops.py", line 2262, in create_op
    set_shapes_for_outputs(ret)
  File "/usr/local/lib/python2.7/dist-packages/tensorflow/python/framework/ops.py", line 1702, in set_shapes_for_outputs
    shapes = shape_func(op)
  File "/usr/local/lib/python2.7/dist-packages/tensorflow/python/ops/array_ops.py", line 662, in _ReverseShape
    input_shape = op.inputs[0].get_shape().with_rank(dims_shape[0])
  File "/usr/local/lib/python2.7/dist-packages/tensorflow/python/framework/tensor_shape.py", line 641, in with_rank
    raise ValueError("Shape %s must have rank %d" % (self, rank))
ValueError: Shape (?, 10) must have rank 3
```