### PR TITLE
Fix Batch Norm compatibility with 3D inputs

### DIFF
--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -386,7 +386,10 @@ def normalize_batch_in_training(x, gamma, beta,
 def batch_normalization(x, mean, var, beta, gamma, epsilon=0.0001):
     '''Apply batch normalization on x given mean, var, beta and gamma.
     '''
-    if x.ndim < 5 and (theano.config.device.startswith('cuda') or theano.config.device.startswith('gpu')):
+    ndim = x.ndim
+    dev = theano.config.device
+    use_cudnn = ndim < 5 and (dev.startswith('cuda') or dev.startswith('gpu'))
+    if use_cudnn:
         try:
             return theano.sandbox.cuda.dnn.dnn_batch_normalization_test(x, gamma, beta, mean, var,
                                                                         'spatial', epsilon)

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -386,7 +386,7 @@ def normalize_batch_in_training(x, gamma, beta,
 def batch_normalization(x, mean, var, beta, gamma, epsilon=0.0001):
     '''Apply batch normalization on x given mean, var, beta and gamma.
     '''
-    if theano.config.device.startswith('cuda') or theano.config.device.startswith('gpu'):
+    if x.ndim < 5 and (theano.config.device.startswith('cuda') or theano.config.device.startswith('gpu')):
         try:
             return theano.sandbox.cuda.dnn.dnn_batch_normalization_test(x, gamma, beta, mean, var,
                                                                         'spatial', epsilon)


### PR DESCRIPTION
the theano backend now uses dnn_batch_normalization which only supports
up to 4-dimensional input. This breaks any 5-d layers such as 3D
convolutions.