### PR TITLE
allow output size different from state size

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1185,10 +1185,8 @@ def rnn(step_function, inputs, initial_states,
                     new_state = tf.concat(1, new_states)
                 return output, new_state
 
-        # state size is assumed to be the same as output size
-        # (always the case)
         _step.state_size = state_size * nb_states
-        _step.output_size = state_size
+        _step.output_size = int(_step(tf.unpack(inputs)[0], state)[0].get_shape()[-1])
 
         (outputs, final_state) = _dynamic_rnn_loop(
             _step,


### PR DESCRIPTION
there seems no reason to assume the output size of rnn should be the same as the state size. 