### PR TITLE
fix bug in neural_style_transfer example for image_dim_ordering=tf

### DIFF
--- a/examples/neural_style_transfer.py
+++ b/examples/neural_style_transfer.py
@@ -128,7 +128,10 @@ outputs_dict = dict([(layer.name, layer.output) for layer in model.layers])
 # the gram matrix of an image tensor (feature-wise outer product)
 def gram_matrix(x):
     assert K.ndim(x) == 3
-    features = K.batch_flatten(x)
+    if K.image_dim_ordering() == 'th':
+    	features = K.batch_flatten(x)
+    else:
+    	features = K.batch_flatten(K.permute_dimensions(x, (2, 0, 1)))
     gram = K.dot(features, K.transpose(features))
     return gram
 

--- a/examples/neural_style_transfer.py
+++ b/examples/neural_style_transfer.py
@@ -129,9 +129,9 @@ outputs_dict = dict([(layer.name, layer.output) for layer in model.layers])
 def gram_matrix(x):
     assert K.ndim(x) == 3
     if K.image_dim_ordering() == 'th':
-    	features = K.batch_flatten(x)
+        features = K.batch_flatten(x)
     else:
-    	features = K.batch_flatten(K.permute_dimensions(x, (2, 0, 1)))
+        features = K.batch_flatten(K.permute_dimensions(x, (2, 0, 1)))
     gram = K.dot(features, K.transpose(features))
     return gram
 


### PR DESCRIPTION
When image_dim_ordering = 'tf', the output_shape of layers in vgg model will be `(batch_size, nrows, ncols, nchannels)` rather than `(batch_size, nchannels, nrows, ncols)`.

Thus the `batch_flatten` line in `gram_matrix` will only work with 'th' ordering. As a result,  the color of the generated images will be screwed up for 'tf' ordering. This ordering difference only affects `style_loss` and `total_variation_loss`, but not `content_loss` .
 
The PR fixes this bug - tested for [sample images](https://github.com/DmitryUlyanov/fast-neural-doodle/tree/master/data) for both 'th' and 'tf' ordering.

Now it seems to be a pain point to repeat these image_dim_ordering() tests. Would there be a better way?