### PR TITLE
add rational activation function

### DIFF
--- a/keras/activations.py
+++ b/keras/activations.py
@@ -35,6 +35,10 @@ def sigmoid(x):
     return K.sigmoid(x)
 
 
+def rational(x):
+    return x/(K.abs(x)+1)
+
+
 def hard_sigmoid(x):
     return K.hard_sigmoid(x)
 


### PR DESCRIPTION
I made a new activation function named "rational" into keras.

This activation function looks similar to sigmoid. (see https://c.mql5.com/18/20/af__1.gif)
However this doesn't include exponential calculation which has expensive complexity.

When the absolute value of input is bigger than about 3~4, the gradient of this activation function is higher than sigmoid or tanh function.
Therefore I think it will prevent gradient vanishing problem.