### PR TITLE
Reference for VGG16 Model

### DIFF
--- a/examples/deep_dream.py
+++ b/examples/deep_dream.py
@@ -74,7 +74,7 @@ def deprocess_image(x):
     x = np.clip(x, 0, 255).astype('uint8')
     return x
 
-# build the VGG16 network
+# build the VGG16 network (reference: http://arxiv.org/pdf/1409.1556.pdf)
 model = Sequential()
 model.add(ZeroPadding2D((1, 1), batch_input_shape=(1, 3, img_width, img_height)))
 first_layer = model.layers[-1]


### PR DESCRIPTION
From the Visual Geometry Group site: 

"We release our two best-performing models, with 16 and 19 weight layers (denoted as configurations D and E in the techincal report). The models are released under Creative Commons Attribution License. Please cite our technical report if you use the models."

Added link to technical report pdf in line 77.