### PR TITLE
Fix ValueError(ndim of gamma and beta) of batch normalization when using Theano

### DIFF
--- a/keras/layers/normalization.py
+++ b/keras/layers/normalization.py
@@ -140,7 +140,7 @@ class BatchNormalization(Layer):
                 self.updates = [K.moving_average_update(self.running_mean, mean, self.momentum),
                                 K.moving_average_update(self.running_std, std, self.momentum)]
 
-                if K._BACKEND == 'tensorflow' and sorted(reduction_axes) == range(K.ndim(x))[:-1]:
+                if K.backend() == 'tensorflow' and sorted(reduction_axes) == range(K.ndim(x))[:-1]:
                     x_normed_running = K.batch_normalization(
                         x, self.running_mean, self.running_std,
                         self.beta, self.gamma,

--- a/keras/layers/normalization.py
+++ b/keras/layers/normalization.py
@@ -140,7 +140,7 @@ class BatchNormalization(Layer):
                 self.updates = [K.moving_average_update(self.running_mean, mean, self.momentum),
                                 K.moving_average_update(self.running_std, std, self.momentum)]
 
-                if sorted(reduction_axes) == range(K.ndim(x))[:-1]:
+                if K._BACKEND == 'tensorflow' and sorted(reduction_axes) == range(K.ndim(x))[:-1]:
                     x_normed_running = K.batch_normalization(
                         x, self.running_mean, self.running_std,
                         self.beta, self.gamma,


### PR DESCRIPTION
I am using the latest version of theano and keras, and ValueError same as #3667 occurs when using batch normalization. The error is caused by theano's batch normalization methods, which require the exactly same ndim as input. So, in all cases gamma and beta must be reshaped when using theano.