### PR TITLE
make ImageDataGenerator behaviour fully seedable/repeatable

### DIFF
--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -390,6 +390,9 @@ class ImageDataGenerator(object):
                 how many augmentation passes to do over the data
             seed: random seed.
         '''
+        if seed is not None:
+            np.random.seed(seed)
+
         X = np.copy(X)
         if augment:
             aX = np.zeros(tuple([rounds * X.shape[0]] + list(X.shape)[1:]))
@@ -431,11 +434,11 @@ class Iterator(object):
         # ensure self.batch_index is 0
         self.reset()
         while 1:
+            if seed is not None:
+                np.random.seed(seed + self.total_batches_seen)
             if self.batch_index == 0:
                 index_array = np.arange(N)
                 if shuffle:
-                    if seed is not None:
-                        np.random.seed(seed + self.total_batches_seen)
                     index_array = np.random.permutation(N)
 
             current_index = (self.batch_index * batch_size) % N

--- a/tests/keras/preprocessing/test_image.py
+++ b/tests/keras/preprocessing/test_image.py
@@ -90,55 +90,6 @@ class TestImage:
                 assert ((potentially_flipped_x == x).all() or
                         (potentially_flipped_x == flip_axis(x, col_index)).all())
 
-    def test_dual_generators(self):
-        '''
-        Should be able to run ImageDataGenerator on multiple arrays of images
-        and get identical transforms (as long as we provide the same seed).
-        This lets us transform images and masks together or other use cases.
-        '''
-        for test_images in self.all_test_images:
-            img_list = []
-            for im in test_images:
-                img_list.append(img_to_array(im)[None, ...])
-
-            X = np.vstack(img_list)
-            y = np.arange(X.shape[0])
-
-            seed = 1
-            batch_size = 2
-            data_gen_args = dict(
-                featurewise_center=True,
-                samplewise_center=True,
-                featurewise_std_normalization=True,
-                samplewise_std_normalization=True,
-                zca_whitening=True,
-                rotation_range=90.,
-                width_shift_range=0.1,
-                height_shift_range=0.1,
-                shear_range=0.5,
-                zoom_range=0.2,
-                channel_shift_range=0.01,
-                fill_mode='nearest',
-                cval=0.5,
-                horizontal_flip=True,
-                vertical_flip=True)
-
-            generator1 = ImageDataGenerator(**data_gen_args)
-            generator2 = ImageDataGenerator(**data_gen_args)
-
-            generator1.fit(X, augment=True, seed=seed)
-            generator2.fit(X, augment=True, seed=seed)
-
-            flow1 = generator1.flow(X, y, batch_size=batch_size, seed=seed)
-            flow2 = generator2.flow(X, y, batch_size=batch_size, seed=seed)
-
-            for i in range(10):
-                X1, y1 = next(flow1)
-                X2, y2 = next(flow2)
-                for b in range(batch_size):
-                    assert (X1 == X2).all()
-                    assert (y1 == y2).all()
-
 
 if __name__ == '__main__':
     pytest.main([__file__])

--- a/tests/keras/preprocessing/test_image.py
+++ b/tests/keras/preprocessing/test_image.py
@@ -90,6 +90,55 @@ class TestImage:
                 assert ((potentially_flipped_x == x).all() or
                         (potentially_flipped_x == flip_axis(x, col_index)).all())
 
+    def test_dual_generators(self):
+        '''
+        Should be able to run ImageDataGenerator on multiple arrays of images
+        and get identical transforms (as long as we provide the same seed).
+        This lets us transform images and masks together or other use cases.
+        '''
+        for test_images in self.all_test_images:
+            img_list = []
+            for im in test_images:
+                img_list.append(img_to_array(im)[None, ...])
+
+            X = np.vstack(img_list)
+            y = np.arange(X.shape[0])
+
+            seed = 1
+            batch_size = 2
+            data_gen_args = dict(
+                featurewise_center=True,
+                samplewise_center=True,
+                featurewise_std_normalization=True,
+                samplewise_std_normalization=True,
+                zca_whitening=True,
+                rotation_range=90.,
+                width_shift_range=0.1,
+                height_shift_range=0.1,
+                shear_range=0.5,
+                zoom_range=0.2,
+                channel_shift_range=0.01,
+                fill_mode='nearest',
+                cval=0.5,
+                horizontal_flip=True,
+                vertical_flip=True)
+
+            generator1 = ImageDataGenerator(**data_gen_args)
+            generator2 = ImageDataGenerator(**data_gen_args)
+
+            generator1.fit(X, augment=True, seed=seed)
+            generator2.fit(X, augment=True, seed=seed)
+
+            flow1 = generator1.flow(X, y, batch_size=batch_size, seed=seed)
+            flow2 = generator2.flow(X, y, batch_size=batch_size, seed=seed)
+
+            for i in range(10):
+                X1, y1 = next(flow1)
+                X2, y2 = next(flow2)
+                for b in range(batch_size):
+                    assert (X1 == X2).all()
+                    assert (y1 == y2).all()
+
 
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
This makes ImageDataGenerator fully seedable with minimal changes.
- the seed argument in fit is now used
- the seed argument in flow and flow_from_directory now affects
transforms
- added example to docs of transforming images and masks together
- added test of using two seeded streams to get the same result

Related issue: [3059](https://github.com/fchollet/keras/issues/3059)

Use cases: 
- Needing repeatable behaviour from ImageDataGenerator
- Wanting to transform images and masks at the same time, e.g. kaggle ultrasound nerve segmentation challenge


- [x] Tests pass in python2.7 with tensorflow and theano and python3.4 with theano
- [x] pep8 passes
- [x] docs updated
