### PR TITLE
Add `AtrousConvolution1D` to convolutional layers

### DIFF
--- a/docs/autogen.py
+++ b/docs/autogen.py
@@ -152,6 +152,7 @@ PAGES = [
         'page': 'layers/convolutional.md',
         'classes': [
             convolutional.Convolution1D,
+            convolutional.AtrousConvolution1D,
             convolutional.Convolution2D,
             convolutional.AtrousConvolution2D,
             convolutional.SeparableConvolution2D,

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -183,6 +183,123 @@ class Convolution1D(Layer):
         return dict(list(base_config.items()) + list(config.items()))
 
 
+class AtrousConvolution1D(Convolution1D):
+    '''Atrous Convolution operator for filtering neighborhoods of one-dimensional inputs.
+    A.k.a dilated convolution or convolution with holes.
+    When using this layer as the first layer in a model,
+    either provide the keyword argument `input_dim`
+    (int, e.g. 128 for sequences of 128-dimensional vectors),
+    or `input_shape` (tuples of integers, e.g. (10, 128) for sequences
+    of 10 vectors of 128-dimensional vectors).
+
+    # Example
+
+    ```python
+        # apply an atrous convolution 1d with atrous rate 2 of length 3 to a sequence with 10 timesteps,
+        # with 64 output filters
+        model = Sequential()
+        model.add(AtrousConvolution1D(64, 3, atrous_rate=2, border_mode='same', input_shape=(10, 32)))
+        # now model.output_shape == (None, 10, 64)
+
+        # add a new atrous conv1d on top
+        model.add(AtrousConvolution1D(32, 3, atrous_rate=2, border_mode='same'))
+        # now model.output_shape == (None, 10, 32)
+    ```
+
+    # Arguments
+        nb_filter: Number of convolution kernels to use
+            (dimensionality of the output).
+        filter_length: The extension (spatial or temporal) of each filter.
+        init: name of initialization function for the weights of the layer
+            (see [initializations](../initializations.md)),
+            or alternatively, Theano function to use for weights initialization.
+            This parameter is only relevant if you don't pass a `weights` argument.
+        activation: name of activation function to use
+            (see [activations](../activations.md)),
+            or alternatively, elementwise Theano function.
+            If you don't specify anything, no activation is applied
+            (ie. "linear" activation: a(x) = x).
+        weights: list of numpy arrays to set as initial weights.
+        border_mode: 'valid' or 'same'.
+        subsample_length: factor by which to subsample output.
+        atrous_rate: Factor for kernel dilation. Also called filter_dilation
+            elsewhere.
+        W_regularizer: instance of [WeightRegularizer](../regularizers.md)
+            (eg. L1 or L2 regularization), applied to the main weights matrix.
+        b_regularizer: instance of [WeightRegularizer](../regularizers.md),
+            applied to the bias.
+        activity_regularizer: instance of [ActivityRegularizer](../regularizers.md),
+            applied to the network output.
+        W_constraint: instance of the [constraints](../constraints.md) module
+            (eg. maxnorm, nonneg), applied to the main weights matrix.
+        b_constraint: instance of the [constraints](../constraints.md) module,
+            applied to the bias.
+        bias: whether to include a bias
+            (i.e. make the layer affine rather than linear).
+        input_dim: Number of channels/dimensions in the input.
+            Either this argument or the keyword argument `input_shape`must be
+            provided when using this layer as the first layer in a model.
+        input_length: Length of input sequences, when it is constant.
+            This argument is required if you are going to connect
+            `Flatten` then `Dense` layers upstream
+            (without it, the shape of the dense outputs cannot be computed).
+
+    # Input shape
+        3D tensor with shape: `(samples, steps, input_dim)`.
+
+    # Output shape
+        3D tensor with shape: `(samples, new_steps, nb_filter)`.
+        `steps` value might have changed due to padding.
+    '''
+    def __init__(self, nb_filter, filter_length,
+                 init='uniform', activation='linear', weights=None,
+                 border_mode='valid', subsample_length=1, atrous_rate=1,
+                 W_regularizer=None, b_regularizer=None, activity_regularizer=None,
+                 W_constraint=None, b_constraint=None,
+                 bias=True, **kwargs):
+
+        if border_mode not in {'valid', 'same'}:
+            raise Exception('Invalid border mode for AtrousConv1D:', border_mode)
+
+        self.atrous_rate = int(atrous_rate)
+
+        super(AtrousConvolution1D, self).__init__(nb_filter, filter_length,
+                                                  init=init, activation=activation,
+                                                  weights=weights, border_mode=border_mode,
+                                                  subsample_length=subsample_length,
+                                                  W_regularizer=W_regularizer, b_regularizer=b_regularizer,
+                                                  activity_regularizer=activity_regularizer,
+                                                  W_constraint=W_constraint, b_constraint=b_constraint,
+                                                  bias=bias, **kwargs)
+
+    def get_output_shape_for(self, input_shape):
+        length = conv_output_length(input_shape[1],
+                                    self.filter_length,
+                                    self.border_mode,
+                                    self.subsample[0],
+                                    dilation=self.atrous_rate)
+        return (input_shape[0], length, self.nb_filter)
+
+    def call(self, x, mask=None):
+        x = K.expand_dims(x, -1) # add a dimension of the right
+        x = K.permute_dimensions(x, (0, 2, 1, 3))
+        output = K.conv2d(x, self.W, strides=self.subsample,
+                          border_mode=self.border_mode,
+                          dim_ordering='th',
+                          filter_dilation=(self.atrous_rate, self.atrous_rate))
+        if self.bias:
+            output += K.reshape(self.b, (1, self.nb_filter, 1, 1))
+        output = K.squeeze(output, 3) # remove the dummy 3rd dimension
+        output = K.permute_dimensions(output, (0, 2, 1))
+        output = self.activation(output)
+        return output
+
+    def get_config(self):
+        config = {'atrous_rate': self.atrous_rate}
+        base_config = super(AtrousConvolution1D, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))
+
+
 class Convolution2D(Layer):
     '''Convolution operator for filtering windows of two-dimensional inputs.
     When using this layer as the first layer in a model,
@@ -1648,5 +1765,6 @@ Conv1D = Convolution1D
 Conv2D = Convolution2D
 Conv3D = Convolution3D
 Deconv2D = Deconvolution2D
+AtrousConv1D = AtrousConvolution1D
 AtrousConv2D = AtrousConvolution2D
 SeparableConv2D = SeparableConvolution2D

--- a/tests/keras/layers/test_convolutional.py
+++ b/tests/keras/layers/test_convolutional.py
@@ -39,6 +39,42 @@ def test_convolution_1d():
 
 
 @keras_test
+def test_atrous_conv_1d():
+    nb_samples = 2
+    nb_steps = 8
+    input_dim = 2
+    filter_length = 3
+    nb_filter = 3
+
+    for border_mode in ['valid', 'same']:
+        for subsample_length in [1, 2]:
+            for atrous_rate in [1, 2]:
+                if border_mode == 'same' and subsample_length != 1:
+                    continue
+                if subsample_length != 1 and atrous_rate != 1:
+                    continue
+
+                layer_test(convolutional.AtrousConv1D,
+                           kwargs={'nb_filter': nb_filter,
+                                   'filter_length': filter_length,
+                                   'border_mode': border_mode,
+                                   'subsample_length': subsample_length,
+                                   'atrous_rate': atrous_rate},
+                           input_shape=(nb_samples, nb_steps, input_dim))
+
+                layer_test(convolutional.AtrousConv1D,
+                           kwargs={'nb_filter': nb_filter,
+                                   'filter_length': filter_length,
+                                   'border_mode': border_mode,
+                                   'W_regularizer': 'l2',
+                                   'b_regularizer': 'l2',
+                                   'activity_regularizer': 'activity_l2',
+                                   'subsample_length': subsample_length,
+                                   'atrous_rate': atrous_rate},
+                           input_shape=(nb_samples, nb_steps, input_dim))
+
+
+@keras_test
 def test_maxpooling_1d():
     for stride in [1, 2]:
         layer_test(convolutional.MaxPooling1D,


### PR DESCRIPTION
See issue #3762 for discussion. Adds dilated 1D convolutions as a new built-in layer.