### PR TITLE
Matthews Correlation Fix & Binary helpers

### DIFF
--- a/keras/backend/common.py
+++ b/keras/backend/common.py
@@ -87,19 +87,3 @@ def set_legacy_weight_ordering(value):
 
 def legacy_weight_ordering():
     return _LEGACY_WEIGHT_ORDERING
-
-def binarize(x):
-    return K.round(K.clip(x, 0, 1))
-    
-def not(x):
-    return 1 - x
-    
-def logical_and(x, y):
-    return K.clip(x + y - 1, 0, 1)
-    
-def logical_or(x, y):
-    return K.clip(x + y, 0, 1)
-    
-def logical_xor(x, y):
-    return ((x + y) == 1)
-    

--- a/keras/backend/common.py
+++ b/keras/backend/common.py
@@ -87,3 +87,19 @@ def set_legacy_weight_ordering(value):
 
 def legacy_weight_ordering():
     return _LEGACY_WEIGHT_ORDERING
+
+def binarize(x):
+    return K.round(K.clip(x, 0, 1))
+    
+def not(x):
+    return 1 - x
+    
+def logical_and(x, y):
+    return K.clip(x + y - 1, 0, 1)
+    
+def logical_or(x, y):
+    return K.clip(x + y, 0, 1)
+    
+def logical_xor(x, y):
+    return ((x + y) == 1)
+    

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -519,20 +519,20 @@ def binarize(x):
     return round(clip(x, 0, 1))
 
 
-def logical_not(x, name=None):
-    return tf.logical_not(x, name=name)
+def logical_not(x):
+    return 1 - x
 
 
-def logical_and(x, y, name=None):
-    return tf.logical_and(x, y, name=name)
+def logical_and(x, y):
+    return clip(x + y - 1, 0, 1)
 
 
-def logical_or(x, y, name=None):
-    return tf.logical_or(x, y, name=name)
+def logical_or(x, y):
+    return clip(x + y, 0, 1)
 
 
-def logical_xor(x, y, name=None):
-    return tf.logical_xor(x, y, name=name)
+def logical_xor(x, y):
+    return ((x + y) == 1) * 1.0
 
 
 def argmax(x, axis=-1):

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -515,6 +515,26 @@ def all(x, axis=None, keepdims=False):
     return tf.cast(x, tf.uint8)
 
 
+def binarize(x):
+    return round(clip(x, 0, 1))
+
+
+def logical_not(x):
+    return 1 - x
+
+
+def logical_and(x, y):
+    return clip(x + y - 1, 0, 1)
+
+
+def logical_or(x, y):
+    return clip(x + y, 0, 1)
+
+
+def logical_xor(x, y):
+    return ((x + y) == 1)
+
+
 def argmax(x, axis=-1):
     '''Returns the index of the maximum value
     along a tensor axis.

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -532,7 +532,7 @@ def logical_or(x, y):
 
 
 def logical_xor(x, y):
-    return ((x + y) == 1) * 1.0
+    return 1 - abs(x + y - 1)
 
 
 def argmax(x, axis=-1):

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -519,20 +519,20 @@ def binarize(x):
     return round(clip(x, 0, 1))
 
 
-def logical_not(x):
-    return 1 - x
+def logical_not(x, name=None):
+    return tf.logical_not(x, name=name)
 
 
-def logical_and(x, y):
-    return clip(x + y - 1, 0, 1)
+def logical_and(x, y, name=None):
+    return tf.logical_and(x, y, name=name)
 
 
-def logical_or(x, y):
-    return clip(x + y, 0, 1)
+def logical_or(x, y, name=None):
+    return tf.logical_or(x, y, name=name)
 
 
-def logical_xor(x, y):
-    return ((x + y) == 1)
+def logical_xor(x, y, name=None):
+    return tf.logical_xor(x, y, name=name)
 
 
 def argmax(x, axis=-1):

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -321,7 +321,7 @@ def logical_or(x, y):
 
 
 def logical_xor(x, y):
-    return ((x + y) == 1) * 1.0
+    return 1 - abs(x + y - 1)
 
 
 def argmax(x, axis=-1):

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -321,7 +321,7 @@ def logical_or(x, y):
 
 
 def logical_xor(x, y):
-    return ((x + y) == 1)
+    return ((x + y) == 1) * 1.0
 
 
 def argmax(x, axis=-1):

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -304,6 +304,26 @@ def all(x, axis=None, keepdims=False):
     return T.all(x, axis=axis, keepdims=keepdims)
 
 
+def binarize(x):
+    return round(clip(x, 0, 1))
+
+
+def logical_not(x):
+    return 1 - x
+
+
+def logical_and(x, y):
+    return clip(x + y - 1, 0, 1)
+
+
+def logical_or(x, y):
+    return clip(x + y, 0, 1)
+
+
+def logical_xor(x, y):
+    return ((x + y) == 1)
+
+
 def argmax(x, axis=-1):
     return T.argmax(x, axis=axis, keepdims=False)
 

--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -85,7 +85,7 @@ def matthews_correlation(y_true, y_pred):
 
     fp = K.sum(K.logical_and(y_true_neg, y_pred_pos))
     fn = K.sum(K.logical_and(y_true_pos, y_pred_neg))
-    
+
     numerator = (tp * tn - fp * fn)
     denominator = K.sqrt((tp + fp) * (tp + fn) * (tn + fp) * (tn + fn))
 

--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -74,17 +74,17 @@ def cosine_proximity(y_true, y_pred):
 def matthews_correlation(y_true, y_pred):
     ''' Matthews correlation coefficient
     '''
-    y_pred_pos = K.round(K.clip(y_pred, 0, 1))
-    y_pred_neg = 1 - y_pred_pos
+    y_pred_pos = K.binarize(y_pred)
+    y_pred_neg = K.not(y_pred_pos)
 
-    y_pos = K.round(K.clip(y_true, 0, 1))
-    y_neg = 1 - y_pos
+    y_true_pos = K.binarize(y_true)
+    y_true_neg = K.not(y_true_pos)
 
-    tp = K.sum(y_pos * y_pred_pos)
-    tn = K.sum(y_neg * y_pred_neg)
+    tp = K.sum(K.logical_and(y_true_pos, y_pred_pos))
+    tn = K.sum(K.logical_and(y_true_neg, y_pred_neg))
 
-    fp = K.sum(1 - y_neg * y_pred_pos)
-    fn = K.sum(1 - y_pos * y_pred_neg)
+    fp = K.sum(K.logical_and(y_true_neg, y_pred_pos))
+    fn = K.sum(K.logical_and(y_true_pos, y_pred_neg))
     
     numerator = (tp * tn - fp * fn)
     denominator = K.sqrt((tp + fp) * (tp + fn) * (tn + fp) * (tn + fn))

--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -75,10 +75,10 @@ def matthews_correlation(y_true, y_pred):
     ''' Matthews correlation coefficient
     '''
     y_pred_pos = K.binarize(y_pred)
-    y_pred_neg = K.not(y_pred_pos)
+    y_pred_neg = K.logical_not(y_pred_pos)
 
     y_true_pos = K.binarize(y_true)
-    y_true_neg = K.not(y_true_pos)
+    y_true_neg = K.logical_not(y_true_pos)
 
     tp = K.sum(K.logical_and(y_true_pos, y_pred_pos))
     tn = K.sum(K.logical_and(y_true_neg, y_pred_neg))

--- a/tests/keras/backend/test_backends.py
+++ b/tests/keras/backend/test_backends.py
@@ -9,10 +9,15 @@ from keras.backend import tensorflow_backend as KTF
 from keras.utils.np_utils import convert_kernel
 
 
-def check_single_tensor_operation(function_name, input_shape, **kwargs):
+def check_single_tensor_operation(function_name, input_shape, binary=False, **kwargs):
     val = np.random.random(input_shape) - 0.5
+
     xth = KTH.variable(val)
     xtf = KTF.variable(val)
+
+    if binary:
+        xth = K.binarize(xth)
+        xtf = K.binarize(xtf)
 
     zth = KTH.eval(getattr(KTH, function_name)(xth, **kwargs))
     ztf = KTF.eval(getattr(KTF, function_name)(xtf, **kwargs))
@@ -22,11 +27,15 @@ def check_single_tensor_operation(function_name, input_shape, **kwargs):
 
 
 def check_two_tensor_operation(function_name, x_input_shape,
-                               y_input_shape, **kwargs):
+                               y_input_shape, binary=False, **kwargs):
     xval = np.random.random(x_input_shape) - 0.5
 
     xth = KTH.variable(xval)
     xtf = KTF.variable(xval)
+
+    if binary:
+        xth = K.binarize(xth)
+        xtf = K.binarize(xtf)
 
     yval = np.random.random(y_input_shape) - 0.5
 
@@ -73,6 +82,13 @@ class TestBackend(object):
         check_single_tensor_operation('transpose', (4, 2))
         check_single_tensor_operation('reverse', (4, 3, 2), axes=1)
         check_single_tensor_operation('reverse', (4, 3, 2), axes=(1, 2))
+
+    def test_logical_operations(self):
+        check_single_tensor_operation('logical_not', (4, 2))
+
+        check_two_tensor_operation('logical_and', (4, 3), (4, 3))
+        check_two_tensor_operation('logical_or', (4, 3), (4, 3))
+        check_two_tensor_operation('logical_xor', (4, 3), (4, 3))
 
     def test_shape_operations(self):
         # concatenate

--- a/tests/keras/test_metrics.py
+++ b/tests/keras/test_metrics.py
@@ -33,6 +33,16 @@ def test_metrics():
         output = metric(y_a, y_b)
         assert K.eval(output).shape == ()
 
+def test_matthews_correlation():
+    y_true = K.variable(np.array([0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 1, 0, 0]))
+    y_pred = K.variable(np.array([1, 0, 1, 0, 1, 0, 0, 1, 0, 0, 0, 0, 1, 0]))
+
+    #Calculated using sklearn.metrics.matthews_corrcoef
+    actual = -0.14907119849998601
+    
+    calc = K.eval(metrics.matthews_correlation(y_true, y_pred))
+    epsilon = 1e-05
+    assert actual - epsilon <= calc <= actual + epsilon
 
 def test_sparse_metrics():
     for metric in all_sparse_metrics:

--- a/tests/keras/test_metrics.py
+++ b/tests/keras/test_metrics.py
@@ -33,16 +33,18 @@ def test_metrics():
         output = metric(y_a, y_b)
         assert K.eval(output).shape == ()
 
+
 def test_matthews_correlation():
     y_true = K.variable(np.array([0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 1, 0, 0]))
     y_pred = K.variable(np.array([1, 0, 1, 0, 1, 0, 0, 1, 0, 0, 0, 0, 1, 0]))
 
-    #Calculated using sklearn.metrics.matthews_corrcoef
+    # Calculated using sklearn.metrics.matthews_corrcoef
     actual = -0.14907119849998601
-    
+
     calc = K.eval(metrics.matthews_correlation(y_true, y_pred))
     epsilon = 1e-05
     assert actual - epsilon <= calc <= actual + epsilon
+
 
 def test_sparse_metrics():
     for metric in all_sparse_metrics:


### PR DESCRIPTION
I added some extra functions to the backend for logical operations.

Originally I had these just based on existing backend functions (as in the Theano implementation) and thought they could just be helpers in common or something, but it seems Tensorflow has built-in operations for this already.

While rewriting the matthews correlation metric with this I noticed it was buggy, so I fixed that and added tests for the metric and the new backend functions.

I haven't benchmarked the Theano backend to see if this is an ideal implementation, but it at the very least seems consistent with tensorflow, so at least they're accurate.

[EDIT]: Actually, the backend tests are failing on my machine since it seems like the CTC bits are incompatible with TF 0.10.0rc0 so I couldn't check if the backend test works, so hopefully CI can verify this. Metric test passes though.