### PR TITLE
Fix crash on RNN with non-fixed time dimesion

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1238,7 +1238,7 @@ def rnn(step_function, inputs, initial_states,
                 return output, new_state
 
         _step.state_size = state_size * nb_states
-        _step.output_size = int(_step(tf.unpack(inputs)[0], state)[0].get_shape()[-1])
+        _step.output_size = int(_step(inputs[0], state)[0].get_shape()[-1])
 
         (outputs, final_state) = _dynamic_rnn_loop(
             _step,

--- a/tests/keras/layers/test_recurrent.py
+++ b/tests/keras/layers/test_recurrent.py
@@ -105,6 +105,13 @@ def _runner(layer_class):
                     shape=shape)
     K.eval(layer.output)
 
+    # check unknown time dimension
+
+    model = Sequential()
+    layer = layer_class(output_dim, batch_input_shape=(nb_samples, None, embedding_dim))
+
+    model.add(layer)
+
 
 @keras_test
 def test_SimpleRNN():


### PR DESCRIPTION
Fixes #3810 

`inputs` has shape (?, ?, num) and fails with `tf.unpack`