### PR TITLE
Fixed crash when using advanced activations in wrapped layers

### DIFF
--- a/docs/templates/activations.md
+++ b/docs/templates/activations.md
@@ -39,4 +39,15 @@ model.add(Activation(tanh))
 
 ## On Advanced Activations
 
-Activations that are more complex than a simple Theano/TensorFlow function (eg. learnable activations, configurable activations, etc.) are available as [Advanced Activation layers](layers/advanced-activations.md), and can be found in the module `keras.layers.advanced_activations`. These include PReLU and LeakyReLU.
+Activations that are more complex than a simple Theano/TensorFlow function (eg. learnable activations, configurable activations, etc.) are available as [Advanced Activation layers](layers/advanced-activations.md), and can be found in the module `keras.layers.advanced_activations`. These include:
+ - __ELU__
+ - __LeakyReLU__
+ - __ThresholdedReLU__
+ - __PReLU__
+ - __SReLU__
+ - __ParametricSoftplus__
+
+
+### Important
+
+Advanced activations with non-default parameters **don't work correctly** with wrapper layers

--- a/keras/activations.py
+++ b/keras/activations.py
@@ -1,4 +1,7 @@
 from __future__ import absolute_import
+
+from keras.layers import advanced_activations
+
 from . import backend as K
 
 
@@ -50,4 +53,9 @@ from .utils.generic_utils import get_from_module
 def get(identifier):
     if identifier is None:
         return linear
-    return get_from_module(identifier, globals(), 'activation function')
+    try:
+        return get_from_module(identifier, globals(), 'activation function')
+    except LookupError:
+        advanced = advanced_activations.get(identifier)
+        # TODO: figure how to pass parameters when cloning in wrappers
+        return advanced()

--- a/keras/layers/advanced_activations.py
+++ b/keras/layers/advanced_activations.py
@@ -4,7 +4,16 @@ from .. import backend as K
 import numpy as np
 
 
-class LeakyReLU(Layer):
+class AdvancedActivation(Layer):
+    '''
+    Base class for all advanced activation layers
+    '''
+    def __init__(self, **kwargs):
+        self.__name__ = self.__class__.__name__
+        super(AdvancedActivation, self).__init__(**kwargs)
+
+
+class LeakyReLU(AdvancedActivation):
     '''Special version of a Rectified Linear Unit
     that allows a small gradient when the unit is not active:
     `f(x) = alpha * x for x < 0`,
@@ -35,7 +44,7 @@ class LeakyReLU(Layer):
         return dict(list(base_config.items()) + list(config.items()))
 
 
-class PReLU(Layer):
+class PReLU(AdvancedActivation):
     '''Parametric Rectified Linear Unit:
     `f(x) = alphas * x for x < 0`,
     `f(x) = x for x >= 0`,
@@ -82,7 +91,7 @@ class PReLU(Layer):
         return dict(list(base_config.items()) + list(config.items()))
 
 
-class ELU(Layer):
+class ELU(AdvancedActivation):
     '''Exponential Linear Unit:
     `f(x) =  alpha * (exp(x) - 1.) for x < 0`,
     `f(x) = x for x >= 0`.
@@ -117,7 +126,7 @@ class ELU(Layer):
         return dict(list(base_config.items()) + list(config.items()))
 
 
-class ParametricSoftplus(Layer):
+class ParametricSoftplus(AdvancedActivation):
     '''Parametric Softplus:
     `alpha * log(1 + exp(beta * x))`
 
@@ -167,7 +176,7 @@ class ParametricSoftplus(Layer):
         return dict(list(base_config.items()) + list(config.items()))
 
 
-class ThresholdedReLU(Layer):
+class ThresholdedReLU(AdvancedActivation):
     '''Thresholded Rectified Linear Unit:
     `f(x) = x for x > theta`
     `f(x) = 0 otherwise`.
@@ -200,7 +209,7 @@ class ThresholdedReLU(Layer):
         return dict(list(base_config.items()) + list(config.items()))
 
 
-class SReLU(Layer):
+class SReLU(AdvancedActivation):
     '''S-shaped Rectified Linear Unit.
 
     # Input shape
@@ -264,3 +273,8 @@ class SReLU(Layer):
                   'a_right_init': self.a_right_init}
         base_config = super(SReLU, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
+
+
+from ..utils.generic_utils import get_from_module
+def get(identifier):
+    return get_from_module(identifier, globals(), 'activation function')

--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -12,8 +12,8 @@ def get_from_module(identifier, module_params, module_name,
     if isinstance(identifier, six.string_types):
         res = module_params.get(identifier)
         if not res:
-            raise Exception('Invalid ' + str(module_name) + ': ' +
-                            str(identifier))
+            raise LookupError('Invalid ' + str(module_name) + ': ' +
+                              str(identifier))
         if instantiate and not kwargs:
             return res()
         elif instantiate and kwargs:
@@ -26,8 +26,8 @@ def get_from_module(identifier, module_params, module_name,
         if res:
             return res(**identifier)
         else:
-            raise Exception('Invalid ' + str(module_name) + ': ' +
-                            str(identifier))
+            raise LookupError('Invalid ' + str(module_name) + ': ' +
+                              str(identifier))
     return identifier
 
 

--- a/tests/keras/layers/test_wrappers.py
+++ b/tests/keras/layers/test_wrappers.py
@@ -2,7 +2,7 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 from keras.utils.test_utils import keras_test
-from keras.layers import wrappers, Input
+from keras.layers import wrappers, Input, ELU
 from keras.layers import core, convolutional, recurrent
 from keras.models import Sequential, Model, model_from_json
 
@@ -112,6 +112,14 @@ def test_Bidirectional():
         input = Input((timesteps, dim))
         output = wrappers.Bidirectional(rnn(output_dim), merge_mode=mode)(input)
         model = Model(input, output)
+        model.compile(loss='mse', optimizer='sgd')
+        model.fit(x, y, nb_epoch=1, batch_size=1)
+
+        # test with advanced activation
+        model = Sequential()
+        model.add(wrappers.Bidirectional(rnn(output_dim, activation=ELU()),
+                                         merge_mode=mode,
+                                         input_shape=(timesteps, dim)))
         model.compile(loss='mse', optimizer='sgd')
         model.fit(x, y, nb_epoch=1, batch_size=1)
 

--- a/tests/keras/test_activations.py
+++ b/tests/keras/test_activations.py
@@ -153,5 +153,18 @@ def test_linear():
         assert(x == activations.linear(x))
 
 
+def test_can_get_advanced_activation():
+    for activation in [
+        "ELU",
+        "LeakyReLU",
+        "ThresholdedReLU",
+        "PReLU",
+        "SReLU",
+        "ParametricSoftplus"
+    ]:
+        tensor = K.zeros((3, 4))
+        activations.get(activation)(tensor)
+
+
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
Wrapped activations still won't clone parameters correctly, but will instead use default parameters.