### PR TITLE
Bypass shape inference in deconv2d and use the output shape provided by the user

### DIFF
--- a/examples/variational_autoencoder.py
+++ b/examples/variational_autoencoder.py
@@ -41,7 +41,7 @@ x_decoded_mean = decoder_mean(h_decoded)
 
 
 def vae_loss(x, x_decoded_mean):
-    xent_loss = objectives.binary_crossentropy(x, x_decoded_mean)
+    xent_loss = original_dim * objectives.binary_crossentropy(x, x_decoded_mean)
     kl_loss = - 0.5 * K.sum(1 + z_log_var - K.square(z_mean) - K.exp(z_log_var), axis=-1)
     return xent_loss + kl_loss
 
@@ -88,7 +88,7 @@ grid_y = np.linspace(-15, 15, n)
 
 for i, yi in enumerate(grid_x):
     for j, xi in enumerate(grid_y):
-        z_sample = np.array([[xi, yi]]) * 0.01
+        z_sample = np.array([[xi, yi]])
         x_decoded = generator.predict(z_sample)
         digit = x_decoded[0].reshape(digit_size, digit_size)
         figure[i * digit_size: (i + 1) * digit_size,

--- a/examples/variational_autoencoder.py
+++ b/examples/variational_autoencoder.py
@@ -26,7 +26,7 @@ z_log_var = Dense(latent_dim)(h)
 
 def sampling(args):
     z_mean, z_log_var = args
-    epsilon = K.random_normal(shape=(batch_size, latent_dim), mean=0.
+    epsilon = K.random_normal(shape=(batch_size, latent_dim), mean=0.,
                               std=epsilon_std)
     return z_mean + K.exp(z_log_var / 2) * epsilon
 

--- a/examples/variational_autoencoder_deconv.py
+++ b/examples/variational_autoencoder_deconv.py
@@ -74,7 +74,7 @@ decoder_mean = Deconvolution2D(nb_filters, 2, 2,
                                border_mode='valid',
                                subsample=(2, 2),
                                activation='relu')
-decoder_mean_c = Convolution2D(img_chns, 2, 2, border_mode='valid', activation='relu')
+decoder_mean_c = Convolution2D(img_chns, 2, 2, border_mode='valid', activation='sigmoid')
 
 h_decoded = decoder_h(z)
 f_decoded = decoder_f(h_decoded)
@@ -88,7 +88,7 @@ def vae_loss(x, x_decoded_mean):
     # NOTE: binary_crossentropy expects a batch_size by dim for x and x_decoded_mean, so we MUST flatten these!
     x = K.flatten(x)
     x_decoded_mean = K.flatten(x_decoded_mean)
-    xent_loss = objectives.binary_crossentropy(x, x_decoded_mean)
+    xent_loss = 28 * 28 * objectives.binary_crossentropy(x, x_decoded_mean)
     kl_loss = - 0.5 * K.mean(1 + z_log_var - K.square(z_mean) - K.exp(z_log_var), axis=-1)
     return xent_loss + kl_loss
 
@@ -151,7 +151,7 @@ grid_y = np.linspace(-15, 15, n)
 
 for i, yi in enumerate(grid_x):
     for j, xi in enumerate(grid_y):
-        z_sample = np.array([[xi, yi]]) * 0.01
+        z_sample = np.array([[xi, yi]])
         z_sample = np.tile(z_sample, batch_size).reshape(batch_size, 2)
         x_decoded = generator.predict(z_sample, batch_size=batch_size)
         digit = x_decoded[0].reshape(digit_size, digit_size)

--- a/examples/variational_autoencoder_deconv.py
+++ b/examples/variational_autoencoder_deconv.py
@@ -30,14 +30,14 @@ nb_epoch = 5
 x = Input(batch_shape=(batch_size,) + original_dim)
 conv_1 = Convolution2D(img_chns, 2, 2, border_mode='same', activation='relu')(x)
 conv_2 = Convolution2D(nb_filters, 2, 2,
-                    border_mode='same', activation='relu',
-                    subsample=(2, 2))(conv_1)
+                       border_mode='same', activation='relu',
+                       subsample=(2, 2))(conv_1)
 conv_3 = Convolution2D(nb_filters, nb_conv, nb_conv,
-                    border_mode='same', activation='relu',
-                    subsample=(1, 1))(conv_2)
+                       border_mode='same', activation='relu',
+                       subsample=(1, 1))(conv_2)
 conv_4 = Convolution2D(nb_filters, nb_conv, nb_conv,
-                    border_mode='same', activation='relu',
-                    subsample=(1, 1))(conv_3)
+                       border_mode='same', activation='relu',
+                       subsample=(1, 1))(conv_3)
 flat = Flatten()(conv_4)
 hidden = Dense(intermediate_dim, activation='relu')(flat)
 
@@ -60,20 +60,20 @@ decoder_hid = Dense(intermediate_dim, activation='relu')
 decoder_upsample = Dense(nb_filters * 14 * 14, activation='relu')
 decoder_reshape = Reshape((nb_filters, 14, 14))
 decoder_deconv_1 = Deconvolution2D(nb_filters, nb_conv, nb_conv,
-                              (batch_size, nb_filters, 14, 14),
-                              border_mode='same',
-                              subsample=(1, 1),
-                              activation='relu')
+                                   (batch_size, nb_filters, 14, 14),
+                                   border_mode='same',
+                                   subsample=(1, 1),
+                                   activation='relu')
 decoder_deconv_2 = Deconvolution2D(nb_filters, nb_conv, nb_conv,
-                              (batch_size, nb_filters, 14, 14),
-                              border_mode='same',
-                              subsample=(1, 1),
-                              activation='relu')
+                                   (batch_size, nb_filters, 14, 14),
+                                   border_mode='same',
+                                   subsample=(1, 1),
+                                   activation='relu')
 decoder_deconv_3_upsamp = Deconvolution2D(nb_filters, 2, 2,
-                               (batch_size, nb_filters, 29, 29),
-                               border_mode='valid',
-                               subsample=(2, 2),
-                               activation='relu')
+                                          (batch_size, nb_filters, 29, 29),
+                                          border_mode='valid',
+                                          subsample=(2, 2),
+                                          activation='relu')
 decoder_mean_squash = Convolution2D(img_chns, 2, 2, border_mode='valid', activation='sigmoid')
 
 hid_decoded = decoder_hid(z)

--- a/examples/variational_autoencoder_deconv.py
+++ b/examples/variational_autoencoder_deconv.py
@@ -6,7 +6,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 from keras.layers import Input, Dense, Lambda, Flatten, Reshape
-from keras.layers import Convolution2D, Deconvolution2D, MaxPooling2D
+from keras.layers import Convolution2D, MaxPooling2D
 from keras.models import Model
 from keras import backend as K
 from keras import objectives
@@ -15,21 +15,30 @@ from keras.datasets import mnist
 # input image dimensions
 img_rows, img_cols, img_chns = 28, 28, 1
 # number of convolutional filters to use
-nb_filters = 32
+nb_filters = 64
 # convolution kernel size
 nb_conv = 3
 
-batch_size = 16
+batch_size = 128
 original_dim = (img_chns, img_rows, img_cols)
 latent_dim = 2
 intermediate_dim = 128
-epsilon_std = 0.01
+epsilon_std = 1.0
 nb_epoch = 5
 
 
 x = Input(batch_shape=(batch_size,) + original_dim)
-c = Convolution2D(nb_filters, nb_conv, nb_conv, border_mode='same', activation='relu')(x)
-f = Flatten()(c)
+c_1 = Convolution2D(img_chns, 2, 2, border_mode='same', activation='relu')(x)
+c_2 = Convolution2D(nb_filters, 2, 2,
+                    border_mode='same', activation='relu',
+                    subsample=(2, 2))(c_1)
+c_3 = Convolution2D(nb_filters, nb_conv, nb_conv,
+                    border_mode='same', activation='relu',
+                    subsample=(1, 1))(c_2)
+c_4 = Convolution2D(nb_filters, nb_conv, nb_conv,
+                    border_mode='same', activation='relu',
+                    subsample=(1, 1))(c_3)
+f = Flatten()(c_4)
 h = Dense(intermediate_dim, activation='relu')(f)
 
 z_mean = Dense(latent_dim)(h)
@@ -48,23 +57,35 @@ z = Lambda(sampling, output_shape=(latent_dim,))([z_mean, z_log_var])
 
 # we instantiate these layers separately so as to reuse them later
 decoder_h = Dense(intermediate_dim, activation='relu')
-decoder_f = Dense(nb_filters*img_rows*img_cols, activation='relu')
-decoder_c = Reshape((nb_filters, img_rows, img_cols))
-decoder_mean = Deconvolution2D(img_chns, nb_conv, nb_conv,
-                               (batch_size, img_chns, img_rows, img_cols),
-                               border_mode='same')
+decoder_f = Dense(nb_filters*14*14, activation='relu')
+decoder_c_1 = Reshape((nb_filters, 14, 14))
+decoder_c_2 = Deconvolution2D(nb_filters, nb_conv, nb_conv,
+                              (batch_size, nb_filters, 14, 14),
+                              border_mode='same',
+                              subsample=(1, 1))
+decoder_c_3 = Deconvolution2D(nb_filters, nb_conv, nb_conv,
+                              (batch_size, nb_filters, 14, 14),
+                              border_mode='same',
+                              subsample=(1, 1))
+decoder_mean = Deconvolution2D(nb_filters, 2, 2,
+                               (batch_size, nb_filters, 29, 29),
+                               border_mode='valid',
+                               subsample=(2, 2))
+decoder_mean_c = Convolution2D(img_chns, 2, 2, border_mode='valid', activation='relu')
 
 h_decoded = decoder_h(z)
 f_decoded = decoder_f(h_decoded)
-c_decoded = decoder_c(f_decoded)
-x_decoded_mean = decoder_mean(c_decoded)
-
+c_1_decoded = decoder_c_1(f_decoded)
+c_2_decoded = decoder_c_2(c_1_decoded)
+c_3_decoded = decoder_c_3(c_2_decoded)
+x_decoded_mean = decoder_mean(c_3_decoded)
+x_decoded_mean = decoder_mean_c(x_decoded_mean)
 
 def vae_loss(x, x_decoded_mean):
     # NOTE: binary_crossentropy expects a batch_size by dim for x and x_decoded_mean, so we MUST flatten these!
     x = K.flatten(x)
     x_decoded_mean = K.flatten(x_decoded_mean)
-    xent_loss = objectives.binary_crossentropy(x, x_decoded_mean)
+    xent_loss = 28 * 28 * objectives.binary_crossentropy(x, x_decoded_mean)
     kl_loss = - 0.5 * K.mean(1 + z_log_var - K.square(z_mean) - K.exp(z_log_var), axis=-1)
     return xent_loss + kl_loss
 
@@ -77,6 +98,17 @@ vae.summary()
 
 x_train = x_train.astype('float32')[:, None, :, :] / 255.
 x_test = x_test.astype('float32')[:, None, :, :] / 255.
+
+end = len(x_test) - len(x_test) % batch_size
+x_test = x_test[:end]
+
+end = len(x_train) - len(x_train) % batch_size
+x_train = x_train[:end]
+
+end = len(y_test) - len(y_test) % batch_size
+y_test = y_test[:end]
+
+print(x_train.shape)
 
 vae.fit(x_train, x_train,
         shuffle=True,
@@ -99,9 +131,12 @@ plt.show()
 decoder_input = Input(shape=(latent_dim,))
 _h_decoded = decoder_h(decoder_input)
 _f_decoded = decoder_f(_h_decoded)
-_c_decoded = decoder_c(_f_decoded)
-_x_decoded_mean = decoder_mean(_c_decoded)
-generator = Model(decoder_input, _x_decoded_mean)
+_c_1_decoded = decoder_c_1(_f_decoded)
+_c_2_decoded = decoder_c_2(_c_1_decoded)
+_c_3_decoded = decoder_c_3(_c_2_decoded)
+_x_decoded_mean = decoder_mean(_c_3_decoded)
+_x_decoded_mean_c = decoder_mean_c(_x_decoded_mean)
+generator = Model(decoder_input, _x_decoded_mean_c)
 
 # display a 2D manifold of the digits
 n = 15  # figure with 15x15 digits
@@ -114,7 +149,8 @@ grid_y = np.linspace(-15, 15, n)
 for i, yi in enumerate(grid_x):
     for j, xi in enumerate(grid_y):
         z_sample = np.array([[xi, yi]])
-        x_decoded = generator.predict(z_sample)
+        z_sample = np.tile(z_sample, batch_size).reshape(batch_size, 2)
+        x_decoded = generator.predict(z_sample, batch_size=batch_size)
         digit = x_decoded[0].reshape(digit_size, digit_size)
         figure[i * digit_size: (i + 1) * digit_size,
                j * digit_size: (j + 1) * digit_size] = digit

--- a/examples/variational_autoencoder_deconv.py
+++ b/examples/variational_autoencoder_deconv.py
@@ -28,21 +28,21 @@ nb_epoch = 5
 
 
 x = Input(batch_shape=(batch_size,) + original_dim)
-c_1 = Convolution2D(img_chns, 2, 2, border_mode='same', activation='relu')(x)
-c_2 = Convolution2D(nb_filters, 2, 2,
+conv_1 = Convolution2D(img_chns, 2, 2, border_mode='same', activation='relu')(x)
+conv_2 = Convolution2D(nb_filters, 2, 2,
                     border_mode='same', activation='relu',
-                    subsample=(2, 2))(c_1)
-c_3 = Convolution2D(nb_filters, nb_conv, nb_conv,
+                    subsample=(2, 2))(conv_1)
+conv_3 = Convolution2D(nb_filters, nb_conv, nb_conv,
                     border_mode='same', activation='relu',
-                    subsample=(1, 1))(c_2)
-c_4 = Convolution2D(nb_filters, nb_conv, nb_conv,
+                    subsample=(1, 1))(conv_2)
+conv_4 = Convolution2D(nb_filters, nb_conv, nb_conv,
                     border_mode='same', activation='relu',
-                    subsample=(1, 1))(c_3)
-f = Flatten()(c_4)
-h = Dense(intermediate_dim, activation='relu')(f)
+                    subsample=(1, 1))(conv_3)
+flat = Flatten()(conv_4)
+hidden = Dense(intermediate_dim, activation='relu')(flat)
 
-z_mean = Dense(latent_dim)(h)
-z_log_var = Dense(latent_dim)(h)
+z_mean = Dense(latent_dim)(hidden)
+z_log_var = Dense(latent_dim)(hidden)
 
 
 def sampling(args):
@@ -56,43 +56,43 @@ def sampling(args):
 z = Lambda(sampling, output_shape=(latent_dim,))([z_mean, z_log_var])
 
 # we instantiate these layers separately so as to reuse them later
-decoder_h = Dense(intermediate_dim, activation='relu')
-decoder_f = Dense(nb_filters*14*14, activation='relu')
-decoder_c_1 = Reshape((nb_filters, 14, 14))
-decoder_c_2 = Deconvolution2D(nb_filters, nb_conv, nb_conv,
+decoder_hid = Dense(intermediate_dim, activation='relu')
+decoder_upsample = Dense(nb_filters * 14 * 14, activation='relu')
+decoder_reshape = Reshape((nb_filters, 14, 14))
+decoder_deconv_1 = Deconvolution2D(nb_filters, nb_conv, nb_conv,
                               (batch_size, nb_filters, 14, 14),
                               border_mode='same',
                               subsample=(1, 1),
                               activation='relu')
-decoder_c_3 = Deconvolution2D(nb_filters, nb_conv, nb_conv,
+decoder_deconv_2 = Deconvolution2D(nb_filters, nb_conv, nb_conv,
                               (batch_size, nb_filters, 14, 14),
                               border_mode='same',
                               subsample=(1, 1),
                               activation='relu')
-decoder_mean = Deconvolution2D(nb_filters, 2, 2,
+decoder_deconv_3_upsamp = Deconvolution2D(nb_filters, 2, 2,
                                (batch_size, nb_filters, 29, 29),
                                border_mode='valid',
                                subsample=(2, 2),
                                activation='relu')
-decoder_mean_c = Convolution2D(img_chns, 2, 2, border_mode='valid', activation='sigmoid')
+decoder_mean_squash = Convolution2D(img_chns, 2, 2, border_mode='valid', activation='sigmoid')
 
-h_decoded = decoder_h(z)
-f_decoded = decoder_f(h_decoded)
-c_1_decoded = decoder_c_1(f_decoded)
-c_2_decoded = decoder_c_2(c_1_decoded)
-c_3_decoded = decoder_c_3(c_2_decoded)
-x_decoded_mean = decoder_mean(c_3_decoded)
-x_decoded_mean = decoder_mean_c(x_decoded_mean)
+hid_decoded = decoder_hid(z)
+up_decoded = decoder_upsample(hid_decoded)
+reshape_decoded = decoder_reshape(up_decoded)
+deconv_1_decoded = decoder_deconv_1(reshape_decoded)
+deconv_2_decoded = decoder_deconv_2(deconv_1_decoded)
+x_decoded_relu = decoder_deconv_3_upsamp(deconv_2_decoded)
+x_decoded_mean_squash = decoder_mean_squash(x_decoded_relu)
 
 def vae_loss(x, x_decoded_mean):
     # NOTE: binary_crossentropy expects a batch_size by dim for x and x_decoded_mean, so we MUST flatten these!
     x = K.flatten(x)
     x_decoded_mean = K.flatten(x_decoded_mean)
-    xent_loss = 28 * 28 * objectives.binary_crossentropy(x, x_decoded_mean)
+    xent_loss = img_rows * img_cols * objectives.binary_crossentropy(x, x_decoded_mean)
     kl_loss = - 0.5 * K.mean(1 + z_log_var - K.square(z_mean) - K.exp(z_log_var), axis=-1)
     return xent_loss + kl_loss
 
-vae = Model(x, x_decoded_mean)
+vae = Model(x, x_decoded_mean_squash)
 vae.compile(optimizer='rmsprop', loss=vae_loss)
 vae.summary()
 
@@ -101,15 +101,6 @@ vae.summary()
 
 x_train = x_train.astype('float32')[:, None, :, :] / 255.
 x_test = x_test.astype('float32')[:, None, :, :] / 255.
-
-end = len(x_test) - len(x_test) % batch_size
-x_test = x_test[:end]
-
-end = len(x_train) - len(x_train) % batch_size
-x_train = x_train[:end]
-
-end = len(y_test) - len(y_test) % batch_size
-y_test = y_test[:end]
 
 print(x_train.shape)
 
@@ -132,14 +123,14 @@ plt.show()
 
 # build a digit generator that can sample from the learned distribution
 decoder_input = Input(shape=(latent_dim,))
-_h_decoded = decoder_h(decoder_input)
-_f_decoded = decoder_f(_h_decoded)
-_c_1_decoded = decoder_c_1(_f_decoded)
-_c_2_decoded = decoder_c_2(_c_1_decoded)
-_c_3_decoded = decoder_c_3(_c_2_decoded)
-_x_decoded_mean = decoder_mean(_c_3_decoded)
-_x_decoded_mean_c = decoder_mean_c(_x_decoded_mean)
-generator = Model(decoder_input, _x_decoded_mean_c)
+_hid_decoded = decoder_hid(decoder_input)
+_up_decoded = decoder_upsample(_hid_decoded)
+_reshape_decoded = decoder_reshape(_up_decoded)
+_deconv_1_decoded = decoder_deconv_1(_reshape_decoded)
+_deconv_2_decoded = decoder_deconv_2(_deconv_1_decoded)
+_x_decoded_relu = decoder_deconv_3_upsamp(_deconv_2_decoded)
+_x_decoded_mean_squash = decoder_mean_squash(_x_decoded_relu)
+generator = Model(decoder_input, _x_decoded_mean_squash)
 
 # display a 2D manifold of the digits
 n = 15  # figure with 15x15 digits

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -587,7 +587,7 @@ class Deconvolution2D(Convolution2D):
             (the depth) is at index 1, in 'tf' mode is it at index 3.
             It defaults to the `image_dim_ordering` value found in your
             Keras config file at `~/.keras/keras.json`.
-            If you never set it, then it will be "th".
+            If you never set it, then it will be "tf".
         bias: whether to include a bias (i.e. make the layer affine rather than linear).
 
     # Input shape

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -506,19 +506,39 @@ class Deconvolution2D(Convolution2D):
     (tuple of integers, does not include the sample axis),
     e.g. `input_shape=(3, 128, 128)` for 128x128 RGB pictures.
 
+    To pass the correct `output_shape` to this layer,
+    one could use a test model to predict and observe the actual output shape.
+
     # Examples
 
     ```python
         # apply a 3x3 transposed convolution with stride 1x1 and 3 output filters on a 12x12 image:
         model = Sequential()
         model.add(Deconvolution2D(3, 3, 3, output_shape=(None, 3, 14, 14), border_mode='valid', input_shape=(3, 12, 12)))
-        # output_shape will be (None, 3, 14, 14)
+        # Note that you will have to change the output_shape depending on the backend used.
+
+        # we can predict with the model and print the shape of the array.
+        dummy_input = np.ones((32, 3, 12, 12))
+        # For TensorFlow dummy_input = np.ones((32, 12, 12, 3))
+        preds = model.predict(dummy_input)
+        print(preds.shape)
+        # Theano GPU: (None, 3, 13, 13)
+        # Theano CPU: (None, 3, 14, 14)
+        # TensorFlow: (None, 14, 14, 3)
 
         # apply a 3x3 transposed convolution with stride 2x2 and 3 output filters on a 12x12 image:
         model = Sequential()
         model.add(Deconvolution2D(3, 3, 3, output_shape=(None, 3, 25, 25), subsample=(2, 2), border_mode='valid', input_shape=(3, 12, 12)))
         model.summary()
-        # output_shape will be (None, 3, 25, 25)
+
+        # we can predict with the model and print the shape of the array.
+        dummy_input = np.ones((32, 3, 12, 12))
+        # For TensorFlow dummy_input = np.ones((32, 12, 12, 3))
+        preds = model.predict(dummy_input)
+        print(preds.shape)
+        # Theano GPU: (None, 3, 25, 25)
+        # Theano CPU: (None, 3, 25, 25)
+        # TensorFlow: (None, 25, 25, 3)
     ```
 
     # Arguments
@@ -536,6 +556,9 @@ class Deconvolution2D(Convolution2D):
                     p - padding size,
                     a - user-specified quantity used to distinguish between
                         the s different possible output sizes.
+             Because a is not specified explicitely and Theano and Tensorflow
+             use different values, it is better to use a dummy input and observe
+             the actual output shape of a layer as specified in the examples.
         init: name of initialization function for the weights of the layer
             (see [initializations](../initializations.md)), or alternatively,
             Theano function to use for weights initialization.

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -556,7 +556,7 @@ class Deconvolution2D(Convolution2D):
                     p - padding size,
                     a - user-specified quantity used to distinguish between
                         the s different possible output sizes.
-             Because a is not specified explicitely and Theano and Tensorflow
+             Because a is not specified explicitly and Theano and Tensorflow
              use different values, it is better to use a dummy input and observe
              the actual output shape of a layer as specified in the examples.
         init: name of initialization function for the weights of the layer

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -610,18 +610,13 @@ class Deconvolution2D(Convolution2D):
 
     def get_output_shape_for(self, input_shape):
         if self.dim_ordering == 'th':
-            rows = input_shape[2]
-            cols = input_shape[3]
+            rows = self.output_shape_[2]
+            cols = self.output_shape_[3]
         elif self.dim_ordering == 'tf':
-            rows = input_shape[1]
-            cols = input_shape[2]
+            rows = self.output_shape_[1]
+            cols = self.output_shape_[2]
         else:
             raise Exception('Invalid dim_ordering: ' + self.dim_ordering)
-
-        rows = conv_input_length(rows, self.nb_row,
-                                 self.border_mode, self.subsample[0])
-        cols = conv_input_length(cols, self.nb_col,
-                                 self.border_mode, self.subsample[1])
 
         if self.dim_ordering == 'th':
             return (input_shape[0], self.nb_filter, rows, cols)


### PR DESCRIPTION
Following the discussions in #3540 and #3824 this pull request removes the shape inference part of the `Deconv2d` layer and use the output shape provided by the user.

Because the user must specify an output shape and the shape inference introduced does not work in all cases, the code is more concise and works in cases where the user wants to introduce operations where a precise output shape is needed.

@yaringal is this reasonnable?