### PR TITLE
unbreak timedistributed conv with new TF rnn

### DIFF
--- a/keras/layers/wrappers.py
+++ b/keras/layers/wrappers.py
@@ -86,7 +86,8 @@ class TimeDistributed(Wrapper):
     # Arguments
         layer: a layer instance.
     """
-    def __init__(self, layer, **kwargs):
+    def __init__(self, layer, unroll=True, **kwargs):
+        self.unroll = unroll
         self.supports_masking = True
         super(TimeDistributed, self).__init__(layer, **kwargs)
 
@@ -114,6 +115,7 @@ class TimeDistributed(Wrapper):
                 return output, []
 
             last_output, outputs, states = K.rnn(step, X,
+                                                 unroll=self.unroll,
                                                  initial_states=[])
             y = outputs
         else:

--- a/tests/keras/layers/test_wrappers.py
+++ b/tests/keras/layers/test_wrappers.py
@@ -51,6 +51,11 @@ def test_TimeDistributed():
     model = model_from_json(model.to_json())
     model.summary()
 
+    # test with Convolution2D and functional API
+    layer = wrappers.TimeDistributed(convolutional.Convolution2D(5, 3, 3, border_mode='same'))
+    input_ = Input(batch_shape=(32, 10, 16, 16, 3))
+    layer(input_)
+
     # test stacked layers
     model = Sequential()
     model.add(wrappers.TimeDistributed(core.Dense(2), input_shape=(3, 4)))


### PR DESCRIPTION
is this only me or timedistributed(conv) was broken when using funcitonal api?
In any case setting unroll=True fixes it
the test I added is how to reproduce my bug