### PR TITLE
Create Preprocessing Documentation for Labels (np_utils.to_categorical)

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -34,6 +34,7 @@ pages:
   - Layer wrappers: layers/wrappers.md
   - Writing your own Keras layers: layers/writing-your-own-keras-layers.md
 - Preprocessing:
+  - Labels Preprocessing: preprocessing/labels.md
   - Sequence Preprocessing: preprocessing/sequence.md
   - Text Preprocessing: preprocessing/text.md
   - Image Preprocessing: preprocessing/image.md

--- a/docs/templates/preprocessing/labels.md
+++ b/docs/templates/preprocessing/labels.md
@@ -1,0 +1,14 @@
+ 
+## to_categorical
+
+```python
+keras.utils.np_utils.to_categorical(labels, nb_classes=None)
+```
+
+Convert class vector (integers from 0 to nb_classes) to binary class matrix. For use with categorical_crossentropy.
+
+- __Return__: numpy array of shape `(len(labels), nb_classes)`.
+
+- __Arguments__:
+    - __labels__: list of labels.
+    - __nb_classes__: None or int. Maximum number of classes, this determines the number of columns in the returned matrix. Default: None, the number of columns defaults to the max integer in the labels array.


### PR DESCRIPTION
Includes useful documentation that was only found through an example in the sequential tutorial.

The use of `keras.utils.np_utils.to_categorical(labels, nb_classes` is hard to find in current documentation and is very useful for many categorical classification tasks that many students/beginners start out with.

`to_categorical` belongs to the `np_utils` file and not a preprocessing one so this addition could be misleading in terms of code structure but I believe it is useful to include in the current documentation.

Link to method documented: https://github.com/fchollet/keras/blob/master/keras/utils/np_utils.py

To test follow documentation: https://github.com/fchollet/keras/blob/master/docs/README.md