### PR TITLE
Add HDF5Matrix documentation

### DIFF
--- a/docs/autogen.py
+++ b/docs/autogen.py
@@ -83,6 +83,7 @@ from keras import backend
 from keras import constraints
 from keras import activations
 from keras import regularizers
+from keras.utils import io_utils
 
 
 EXCLUDE = {
@@ -236,6 +237,12 @@ PAGES = [
     {
         'page': 'backend.md',
         'all_module_functions': [backend],
+    },
+    {
+        'page': 'io_utils.md',
+        'classes': [
+            io_utils.HDF5Matrix
+        ],
     },
 ]
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -49,6 +49,8 @@ pages:
 - Constraints: constraints.md
 - Visualization: visualization.md
 - Scikit-learn API: scikit-learn-api.md
+- Utils:
+  - I/O Utils: io_utils.md
 
 
 

--- a/keras/utils/io_utils.py
+++ b/keras/utils/io_utils.py
@@ -6,6 +6,30 @@ from collections import defaultdict
 
 
 class HDF5Matrix():
+    '''Representation of HDF5 dataset which can be used instead of a
+    Numpy array.
+
+    # Example
+
+    ```python
+        X_data = HDF5Matrix('input/file.hdf5', 'data')
+        model.predict(X_data)
+    ```
+
+    Providing start and end allows use of a slice of the dataset.
+
+    Optionally, a normalizer function (or lambda) can be given. This will
+    be called on every slice of data retrieved.
+
+    # Arguments
+        datapath: string, path to a HDF5 file
+        dataset: string, name of the HDF5 dataset in the file specified
+            in datapath
+        start: int, start of desired slice of the specified dataset
+        end: int, end of desired slice of the specified dataset
+        normalizer: function to be called on data when retrieved
+
+    '''
     refs = defaultdict(int)
 
     def __init__(self, datapath, dataset, start, end, normalizer=None):


### PR DESCRIPTION
Documentation for the HDF5Matrix class. See #2674.

Wasn't quite sure about where to actually put the documentation though. None of the other utils are actually documented either.