### PR TITLE
Fixed dead link in batch norm documentation

### DIFF
--- a/keras/layers/normalization.py
+++ b/keras/layers/normalization.py
@@ -58,7 +58,7 @@ class BatchNormalization(Layer):
         Same shape as input.
 
     # References
-        - [Batch Normalization: Accelerating Deep Network Training by Reducing Internal Covariate Shift](http://jmlr.org/proceedings/papers/v37/ioffe15.html)
+        - [Batch Normalization: Accelerating Deep Network Training by Reducing Internal Covariate Shift](http://jmlr.org/proceedings/papers/v37/ioffe15.pdf)
     '''
     def __init__(self, epsilon=1e-5, mode=0, axis=-1, momentum=0.99,
                  weights=None, beta_init='zero', gamma_init='one',


### PR DESCRIPTION
Fixed dead link for the references in the Batch Normalization documentation