### PR TITLE
Python3 fix for deserialization of closures

### DIFF
--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -66,7 +66,7 @@ def func_reconstruct_closure(values):
     src += ["  return lambda:(%s)" % ','.join(["_%d" % n for n in nums]), ""]
     src = '\n'.join(src)
     try:
-        exec(src)
+        exec(src, globals())
     except:
         raise SyntaxError(src)
     return func(values).__closure__


### PR DESCRIPTION
From what I can see this fix for #3897 works for both Python 2 and 3.