### PR TITLE
Remove a print message when using global pooling

### DIFF
--- a/keras/layers/pooling.py
+++ b/keras/layers/pooling.py
@@ -447,7 +447,6 @@ class _GlobalPooling2D(Layer):
         super(_GlobalPooling2D, self).__init__(**kwargs)
         if dim_ordering == 'default':
             dim_ordering = K.image_dim_ordering()
-        print(dim_ordering)
         self.dim_ordering = dim_ordering
         self.input_spec = [InputSpec(ndim=4)]
 


### PR DESCRIPTION
It seems to be a mistake and might be unnecessary.