### PR TITLE
Fix Theano Cudnn BatchNorm when axis!=1

### DIFF
--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -435,7 +435,7 @@ def batch_normalization(x, mean, var, beta, gamma, epsilon=0.0001):
                 beta = beta.dimshuffle(shuffle_pattern)
                 gamma = gamma.dimshuffle(shuffle_pattern)
             normed = theano.sandbox.cuda.dnn.dnn_batch_normalization_test(x, gamma, beta, mean, var,
-                                                                        'spatial', epsilon)
+                                                                          'spatial', epsilon)
             if axis != 1:
                 normed = normed.dimshuffle(shuffle_pattern)
             return normed

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -441,6 +441,8 @@ def batch_normalization(x, mean, var, beta, gamma, epsilon=0.0001):
             return normed
         except AttributeError:
             pass
+        except ValueError:
+            pass
     return T.nnet.bn.batch_normalization(x, gamma, beta, mean, sqrt(var + epsilon),
                                          mode='high_mem')
 

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -424,8 +424,21 @@ def batch_normalization(x, mean, var, beta, gamma, epsilon=0.0001):
     use_cudnn = ndim < 5 and (dev.startswith('cuda') or dev.startswith('gpu'))
     if use_cudnn:
         try:
-            return theano.sandbox.cuda.dnn.dnn_batch_normalization_test(x, gamma, beta, mean, var,
+            axis = mean.broadcastable.index(False)
+            if axis != 1:
+                shuffle_pattern = list(range(ndim))
+                shuffle_pattern[1] = shuffle_pattern[axis]
+                shuffle_pattern[axis] = 1
+                x = x.dimshuffle(shuffle_pattern)
+                mean = mean.dimshuffle(shuffle_pattern)
+                var = var.dimshuffle(shuffle_pattern)
+                beta = beta.dimshuffle(shuffle_pattern)
+                gamma = gamma.dimshuffle(shuffle_pattern)
+            normed = theano.sandbox.cuda.dnn.dnn_batch_normalization_test(x, gamma, beta, mean, var,
                                                                         'spatial', epsilon)
+            if axis != 1:
+                normed = normed.dimshuffle(shuffle_pattern)
+            return normed
         except AttributeError:
             pass
     return T.nnet.bn.batch_normalization(x, gamma, beta, mean, sqrt(var + epsilon),

--- a/keras/layers/normalization.py
+++ b/keras/layers/normalization.py
@@ -117,11 +117,11 @@ class BatchNormalization(Layer):
             shuffle_pattern = list(range(len(input_shape)))
             shuffle_pattern[1] = shuffle_pattern[self.axis]
             shuffle_pattern[self.axis] = 1
-            
+
             reduction_axes = list(range(len(input_shape)))
             del reduction_axes[1]
 
-            x = x.dimshuffle(shuffle_pattern)
+            x = K.permute_dimensions(x, shuffle_pattern)
 
             if self.mode == 2:
                 x_normed, mean, std = K.normalize_batch_in_training(
@@ -154,10 +154,10 @@ class BatchNormalization(Layer):
                         epsilon=self.epsilon)
                 else:
                     # need broadcasting
-                    broadcast_running_mean = K.reshape(self.running_mean, broadcast_shape).dimshuffle(shuffle_pattern)
-                    broadcast_running_std = K.reshape(self.running_std, broadcast_shape).dimshuffle(shuffle_pattern)
-                    broadcast_beta = K.reshape(self.beta, broadcast_shape).dimshuffle(shuffle_pattern)
-                    broadcast_gamma = K.reshape(self.gamma, broadcast_shape).dimshuffle(shuffle_pattern)
+                    broadcast_running_mean = K.permute_dimensions(K.reshape(self.running_mean, broadcast_shape), shuffle_pattern)
+                    broadcast_running_std = K.permute_dimensions(K.reshape(self.running_std, broadcast_shape), shuffle_pattern)
+                    broadcast_beta = K.permute_dimensions(K.reshape(self.beta, broadcast_shape), shuffle_pattern)
+                    broadcast_gamma = K.permute_dimensions(K.reshape(self.gamma, broadcast_shape), shuffle_pattern)
                     x_normed_running = K.batch_normalization(
                         x, broadcast_running_mean, broadcast_running_std,
                         broadcast_beta, broadcast_gamma,
@@ -165,7 +165,7 @@ class BatchNormalization(Layer):
 
                 # pick the normalized form of x corresponding to the training phase
                 x_normed = K.in_train_phase(x_normed, x_normed_running)
-                x_normed = x_normed.dimshuffle(shuffle_pattern)
+                x_normed = K.permute_dimensions(x_normed, shuffle_pattern)
 
         elif self.mode == 1:
             # sample-wise normalization

--- a/keras/layers/normalization.py
+++ b/keras/layers/normalization.py
@@ -111,10 +111,17 @@ class BatchNormalization(Layer):
             assert self.built, 'Layer must be built before being called'
             input_shape = self.input_spec[0].shape
 
-            reduction_axes = list(range(len(input_shape)))
-            del reduction_axes[self.axis]
             broadcast_shape = [1] * len(input_shape)
             broadcast_shape[self.axis] = input_shape[self.axis]
+
+            shuffle_pattern = list(range(len(input_shape)))
+            shuffle_pattern[1] = shuffle_pattern[self.axis]
+            shuffle_pattern[self.axis] = 1
+            
+            reduction_axes = list(range(len(input_shape)))
+            del reduction_axes[1]
+
+            x = x.dimshuffle(shuffle_pattern)
 
             if self.mode == 2:
                 x_normed, mean, std = K.normalize_batch_in_training(
@@ -147,10 +154,10 @@ class BatchNormalization(Layer):
                         epsilon=self.epsilon)
                 else:
                     # need broadcasting
-                    broadcast_running_mean = K.reshape(self.running_mean, broadcast_shape)
-                    broadcast_running_std = K.reshape(self.running_std, broadcast_shape)
-                    broadcast_beta = K.reshape(self.beta, broadcast_shape)
-                    broadcast_gamma = K.reshape(self.gamma, broadcast_shape)
+                    broadcast_running_mean = K.reshape(self.running_mean, broadcast_shape).dimshuffle(shuffle_pattern)
+                    broadcast_running_std = K.reshape(self.running_std, broadcast_shape).dimshuffle(shuffle_pattern)
+                    broadcast_beta = K.reshape(self.beta, broadcast_shape).dimshuffle(shuffle_pattern)
+                    broadcast_gamma = K.reshape(self.gamma, broadcast_shape).dimshuffle(shuffle_pattern)
                     x_normed_running = K.batch_normalization(
                         x, broadcast_running_mean, broadcast_running_std,
                         broadcast_beta, broadcast_gamma,
@@ -158,6 +165,7 @@ class BatchNormalization(Layer):
 
                 # pick the normalized form of x corresponding to the training phase
                 x_normed = K.in_train_phase(x_normed, x_normed_running)
+                x_normed = x_normed.dimshuffle(shuffle_pattern)
 
         elif self.mode == 1:
             # sample-wise normalization


### PR DESCRIPTION
Adresses issues like : https://groups.google.com/forum/#!topic/keras-users/innS4NcLPt8

Seems like keras uses cudnn batch-norm "spatial" configuration, which normalizes over axis (0, 2, 3). When you don't use axis=1 in keras, theano tries to broadcast the axis dimension, and can't because this dimension is not 1.

One way to fix it is to shuffle dimensions to put the normalization axis over first dimension, theano batch-norm, and then shuffle it back.

I'm not sure this is the best way to do it, but I think it fixes the issue.

Results with different backends on https://github.com/keunwoochoi/music-auto_tagging-keras are now the same (they were not).

We should check the fix without cudnn too (but it should be no problem imo).

Also, it raises the question of default value of axis : for dense/conv2d, you'd want axis=1 for default (-1 would work for dense, not for conv2d), but for conv1d, you'd want axis=2 (or axis=-1).