### PR TITLE
Add top-k classification accuracy metrics

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1486,6 +1486,15 @@ def l2_normalize(x, axis):
     return tf.nn.l2_normalize(x, dim=axis)
 
 
+def in_top_k(predictions, targets, k):
+    '''Given tensors representing predictions and targets, evaluates whether the
+    targets are within the top k predictions
+    '''
+    y_pred = reshape(predictions, [1, shape(predictions)[0]])
+    y_target = reshape(argmax(targets), [1])
+    return cast(any(tf.nn.in_top_k(y_pred, y_target, k)), 'float32')
+
+
 # CONVOLUTIONS
 
 def _preprocess_deconv_output_shape(shape, dim_ordering):

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1485,14 +1485,18 @@ def l2_normalize(x, axis):
         axis = axis % len(x.get_shape())
     return tf.nn.l2_normalize(x, dim=axis)
 
-
 def in_top_k(predictions, targets, k):
-    '''Given tensors representing predictions and targets, evaluates whether the
-    targets are within the top k predictions
+    '''Says whether the targets are in the top k predictions
+
+    # Arguments
+        predictions: A tensor of shape batch_size x classess and type float32.
+        targets: A tensor of shape batch_size and type int32 or int64.
+        k: An int, number of top elements to consider.
+    # Output
+        A tensor of shape batch_size and type bool. output_i is True if
+        targets_i is within top-k values of predictions_i
     '''
-    y_pred = reshape(predictions, [1, shape(predictions)[0]])
-    y_target = reshape(argmax(targets), [1])
-    return cast(any(tf.nn.in_top_k(y_pred, y_target, k)), 'float32')
+    return tf.nn.in_top_k(predictions, targets, k)
 
 
 # CONVOLUTIONS

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1486,13 +1486,14 @@ def l2_normalize(x, axis):
     return tf.nn.l2_normalize(x, dim=axis)
 
 def in_top_k(predictions, targets, k):
-    '''Says whether the targets are in the top k predictions
+    '''Says whether the `targets` are in the top `k` `predictions`
 
     # Arguments
         predictions: A tensor of shape batch_size x classess and type float32.
         targets: A tensor of shape batch_size and type int32 or int64.
         k: An int, number of top elements to consider.
-    # Output
+
+    # Returns
         A tensor of shape batch_size and type bool. output_i is True if
         targets_i is within top-k values of predictions_i
     '''

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1043,6 +1043,14 @@ def l2_normalize(x, axis):
     return x / norm
 
 
+def in_top_k(predictions, targets, k):
+    '''Given tensors representing predictions and targets, evaluates whether the
+    targets are within the top k predictions
+    '''
+    top_k_pred = T.argsort(predictions)[-k:]
+    return cast(any(equal(top_k_pred, T.argmax(targets))), 'float32')
+
+
 # CONVOLUTIONS
 
 def _preprocess_conv2d_input(x, dim_ordering):

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1044,13 +1044,14 @@ def l2_normalize(x, axis):
 
 
 def in_top_k(predictions, targets, k):
-    '''Says whether the targets are in the top k predictions
+    '''Says whether the `targets` are in the top `k` `predictions`
 
     # Arguments
         predictions: A tensor of shape batch_size x classess and type float32.
         targets: A tensor of shape batch_size and type int32 or int64.
         k: An int, number of top elements to consider.
-    # Output
+
+    # Returns
         A tensor of shape batch_size and type int. output_i is 1 if
         targets_i is within top-k values of predictions_i
     '''

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1044,11 +1044,19 @@ def l2_normalize(x, axis):
 
 
 def in_top_k(predictions, targets, k):
-    '''Given tensors representing predictions and targets, evaluates whether the
-    targets are within the top k predictions
+    '''Says whether the targets are in the top k predictions
+
+    # Arguments
+        predictions: A tensor of shape batch_size x classess and type float32.
+        targets: A tensor of shape batch_size and type int32 or int64.
+        k: An int, number of top elements to consider.
+    # Output
+        A tensor of shape batch_size and type int. output_i is 1 if
+        targets_i is within top-k values of predictions_i
     '''
-    top_k_pred = T.argsort(predictions)[-k:]
-    return cast(any(equal(top_k_pred, T.argmax(targets))), 'float32')
+    predictions_top_k = T.argsort(predictions)[:, -k:]
+    result, _ = theano.map(lambda prediction, target: any(equal(prediction, target)), sequences=[predictions_top_k, targets])
+    return result
 
 
 # CONVOLUTIONS

--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -16,6 +16,10 @@ def sparse_categorical_accuracy(y_true, y_pred):
                           K.cast(K.argmax(y_pred, axis=-1), K.floatx())))
 
 
+def top_k_categorical_accuracy(y_true, y_pred, k):
+    return K.mean(K.in_top_k(y_pred, y_true, k))
+
+
 def mean_squared_error(y_true, y_pred):
     return K.mean(K.square(y_pred - y_true))
 

--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -16,7 +16,7 @@ def sparse_categorical_accuracy(y_true, y_pred):
                           K.cast(K.argmax(y_pred, axis=-1), K.floatx())))
 
 
-def top_k_categorical_accuracy(y_true, y_pred, k):
+def top_k_categorical_accuracy(y_true, y_pred, k=5):
     return K.mean(K.in_top_k(y_pred, K.argmax(y_true, axis=-1), k))
 
 

--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -17,7 +17,7 @@ def sparse_categorical_accuracy(y_true, y_pred):
 
 
 def top_k_categorical_accuracy(y_true, y_pred, k):
-    return K.mean(K.in_top_k(y_pred, y_true, k))
+    return K.mean(K.in_top_k(y_pred, K.argmax(y_true, axis=-1), k))
 
 
 def mean_squared_error(y_true, y_pred):

--- a/tests/keras/test_metrics.py
+++ b/tests/keras/test_metrics.py
@@ -18,6 +18,7 @@ all_metrics = [
     metrics.poisson,
     metrics.cosine_proximity,
     metrics.matthews_correlation,
+    metrics.top_k_categorical_accuracy,
 ]
 
 all_sparse_metrics = [
@@ -52,6 +53,16 @@ def test_sparse_metrics():
         y_b = K.variable(np.random.random((6, 7)), dtype=K.floatx())
         assert K.eval(metric(y_a, y_b)).shape == ()
 
+
+def test_top_k_categorical_accuracy():
+    y_true = K.variable(np.array([0, 1, 0]))
+    y_pred = K.variable(np.array([0.3, 0.2, 0.1]))
+    success_result = K.eval(metrics.top_k_categorical_accuracy(y_true, y_pred,
+                            k=2))
+    assert success_result == 1
+    failure_result = K.eval(metrics.top_k_categorical_accuracy(y_true, y_pred,
+                            k=1))
+    assert failure_result == 0
 
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/keras/test_metrics.py
+++ b/tests/keras/test_metrics.py
@@ -18,7 +18,6 @@ all_metrics = [
     metrics.poisson,
     metrics.cosine_proximity,
     metrics.matthews_correlation,
-    metrics.top_k_categorical_accuracy,
 ]
 
 all_sparse_metrics = [

--- a/tests/keras/test_metrics.py
+++ b/tests/keras/test_metrics.py
@@ -54,14 +54,18 @@ def test_sparse_metrics():
 
 
 def test_top_k_categorical_accuracy():
-    y_true = K.variable(np.array([0, 1, 0]))
-    y_pred = K.variable(np.array([0.3, 0.2, 0.1]))
+    y_pred = K.variable(np.array([[0.3, 0.2, 0.1], [0.1, 0.2, 0.7]]))
+    y_true = K.variable(np.array([[0, 1, 0], [1, 0, 0]]))
     success_result = K.eval(metrics.top_k_categorical_accuracy(y_true, y_pred,
-                            k=2))
+                            k=3))
     assert success_result == 1
+    partial_result = K.eval(metrics.top_k_categorical_accuracy(y_true, y_pred,
+                            k=2))
+    assert partial_result == 0.5
     failure_result = K.eval(metrics.top_k_categorical_accuracy(y_true, y_pred,
                             k=1))
     assert failure_result == 0
+
 
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
### Synopsis

Implement a metric to track top-k accuracy rate in classification problems.

### Details

Related to #3986 . 

Added an overall metric called `top_k_categorical_accuracy()` to calculate accuracy rates while allowing for any of the top k values from `y_pred` to match against `y_true`. I have tried to keep the output format for the new function as close to the existing `categorical_accuracy()` function as possible.

For TensorFlow, this feature already exists as  [`tf.nn.in_top_k()`](https://www.tensorflow.org/versions/r0.11/api_docs/python/nn.html#in_top_k). With some re-shaping to suit tf's expectation, the existing function is used as-is.

For Theano, I have made use of `theano.tensor.argsort` to achieve the same result.

A simple test function has also been added to demonstrate expected operation.