### PR TITLE
Correct metrics usage in getting started guide.

### DIFF
--- a/docs/templates/getting-started/sequential-model-guide.md
+++ b/docs/templates/getting-started/sequential-model-guide.md
@@ -121,7 +121,7 @@ Before training a model, you need to configure the learning process, which is do
 
 - an optimizer. This could be the string identifier of an existing optimizer (such as `rmsprop` or `adagrad`), or an instance of the `Optimizer` class. See: [optimizers](/optimizers).
 - a loss function. This is the objective that the model will try to minimize. It can be the string identifier of an existing loss function (such as `categorical_crossentropy` or `mse`), or it can be an objective function. See: [objectives](/objectives).
-- a list of metrics. For any classification problem you will want to set this to `metrics=['accuracy']`. A metric could be the string identifier of an existing metric (only `accuracy` is supported at this point), or a custom metric function.
+- a list of metrics. For any classification problem you will want to set this to `metrics=['accuracy']`. A metric could be the string identifier of an existing metric or a custom metric function.
 
 ```python
 # for a multi-class classification problem


### PR DESCRIPTION
As the code [here](https://github.com/fchollet/keras/blob/master/keras/engine/training.py#L662) suggests whenever a model is compiled with `metrics = [name_of_the_metric_function]` works, however, the documenation suggests that `accuracy` is the only supported string representation.