### PR TITLE
Add Kullback–Leibler divergence to metrics

### DIFF
--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -66,6 +66,12 @@ def binary_crossentropy(y_true, y_pred):
     return K.mean(K.binary_crossentropy(y_pred, y_true))
 
 
+def kullback_leibler_divergence(y_true, y_pred):
+    y_true = K.clip(y_true, K.epsilon(), 1)
+    y_pred = K.clip(y_pred, K.epsilon(), 1)
+    return K.sum(y_true * K.log(y_true / y_pred), axis=-1)
+
+
 def poisson(y_true, y_pred):
     return K.mean(y_pred - y_true * K.log(y_pred + K.epsilon()))
 


### PR DESCRIPTION
Looks like pull request https://github.com/fchollet/keras/pull/2872 added the KL divergence function to [objectives.py](https://github.com/fchollet/keras/blob/85c2d28e992f8f2a752393d7e9f65c8f3cbb7a7c/keras/objectives.py#L51-L54). 

I just thought it should be copied into [metrics.py](https://github.com/fchollet/keras/blob/85c2d28e992f8f2a752393d7e9f65c8f3cbb7a7c/keras/metrics.py) as well.