### PR TITLE
Apply imagenet mean pixel on BGR instead of RGB.

### DIFF
--- a/examples/deep_dream.py
+++ b/examples/deep_dream.py
@@ -75,10 +75,12 @@ def deprocess_image(x):
         x = x.transpose((1, 2, 0))
     else:
         x = x.reshape((img_width, img_height, 3))
-    x = x[:, :, ::-1]
+    # Remove zero-center by mean pixel
     x[:, :, 0] += 103.939
     x[:, :, 1] += 116.779
     x[:, :, 2] += 123.68
+    # 'BGR'->'RGB'
+    x = x[:, :, ::-1]
     x = np.clip(x, 0, 255).astype('uint8')
     return x
 

--- a/examples/neural_doodle.py
+++ b/examples/neural_doodle.py
@@ -108,10 +108,12 @@ def deprocess_image(x):
         x = x.transpose((1, 2, 0))
     else:
         x = x.reshape((img_nrows, img_ncols, 3))
-    x = x[:, :, ::-1]
+    # Remove zero-center by mean pixel
     x[:, :, 0] += 103.939
     x[:, :, 1] += 116.779
     x[:, :, 2] += 123.68
+    # 'BGR'->'RGB'
+    x = x[:, :, ::-1]
     x = np.clip(x, 0, 255).astype('uint8')
     return x
 

--- a/examples/neural_style_transfer.py
+++ b/examples/neural_style_transfer.py
@@ -91,10 +91,12 @@ def deprocess_image(x):
         x = x.transpose((1, 2, 0))
     else:
         x = x.reshape((img_nrows, img_ncols, 3))
-    x = x[:, :, ::-1]
+    # Remove zero-center by mean pixel
     x[:, :, 0] += 103.939
     x[:, :, 1] += 116.779
     x[:, :, 2] += 123.68
+    # 'BGR'->'RGB'
+    x = x[:, :, ::-1]
     x = np.clip(x, 0, 255).astype('uint8')
     return x
 

--- a/keras/applications/imagenet_utils.py
+++ b/keras/applications/imagenet_utils.py
@@ -14,17 +14,19 @@ def preprocess_input(x, dim_ordering='default'):
     assert dim_ordering in {'tf', 'th'}
 
     if dim_ordering == 'th':
+        # 'RGB'->'BGR'
+        x = x[:, ::-1, :, :]
+        # Zero-center by mean pixel
         x[:, 0, :, :] -= 103.939
         x[:, 1, :, :] -= 116.779
         x[:, 2, :, :] -= 123.68
-        # 'RGB'->'BGR'
-        x = x[:, ::-1, :, :]
     else:
+        # 'RGB'->'BGR'
+        x = x[:, :, :, ::-1]
+        # Zero-center by mean pixel
         x[:, :, :, 0] -= 103.939
         x[:, :, :, 1] -= 116.779
         x[:, :, :, 2] -= 123.68
-        # 'RGB'->'BGR'
-        x = x[:, :, :, ::-1]
     return x
 
 


### PR DESCRIPTION
According to the authors of VGG, the mean pixel values are for BGR: 
> Namely, the following BGR values should be subtracted: [103.939, 116.779, 123.68].
[see here](https://gist.github.com/ksimonyan/211839e770f7b538e2d8#file-readme-md)

Mean was applied on RGB, now it applies on BGR.