### PR TITLE
Add domain adaptation example and gradient reversal layer

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -92,3 +92,6 @@ Demonstrates how to build a variational autoencoder.
 
 [variational_autoencoder_deconv.py](variational_autoencoder_deconv.py)
 Demonstrates how to build a variational autoencoder with Keras using deconvolution layers.
+
+[dann.py](dann.py)
+Unsupervised Domain adaptation between source and target datasets to improve classification accuracy.

--- a/examples/dann.py
+++ b/examples/dann.py
@@ -83,6 +83,17 @@ def batch_gen(batches, id_array, data, labels):
             yield data[batch_ids]
         np.random.shuffle(id_array)
 
+
+def evaluate_dann(num_batches, size):
+    acc = 0
+    for i in range(0, num_batches):
+        _, prob = dann_model.predict_on_batch(XT_test[i * size:i * size + size])
+        predictions = np.argmax(prob, axis=1)
+        actual = np.argmax(y_test[i * size:i * size + size], axis=1)
+        acc += float(np.sum((predictions == actual))) / size
+    return acc / num_batches
+
+
 # Model parameters
 
 batch_size = 128
@@ -269,11 +280,10 @@ for i in range(nb_epoch):
         j += 1
 
 print('Evaluating target samples on DANN model')
-out = dann_model.predict_on_batch(XT_test[0:batch_size / 2])
-out = np.argmax(out[1], axis=1)
-actual = np.argmax(y_test[0:batch_size / 2], axis=1)
-acc = float(np.sum((out == actual))) / float(len(out))
-print('Accuracy: ', acc)
+size = batch_size / 2
+nb_testbatches = XT_test.shape[0] / size
+acc = evaluate_dann(nb_testbatches, size)
+print('Accuracy:', acc)
 print('Visualizing output of domain invariant features')
 
 # Plot both MNIST and MNIST-M

--- a/examples/dann.py
+++ b/examples/dann.py
@@ -1,0 +1,297 @@
+'''
+This is the Keras implementation of
+'Domain-Adversarial Training of Neural Networks' by Y. Ganin
+
+This allows domain adaptation (when you want to train on a dataset
+with different statistics than a target dataset) in an unsupervised manner
+by using the adversarial paradigm to punish features that help discriminate
+between the datasets during backpropagation.
+
+This is achieved by usage of the 'gradient reversal' layer to form
+a domain invariant embedding for classification by an MLP.
+
+The example here uses the 'MNIST-M' dataset as described in the paper.
+
+Credits:
+- Clayton Mellina (https://github.com/pumpikano/tf-dann) for providing
+  a sketch of implementation (in TF) and utility functions.
+- Yusuke Iwasawa (https://github.com/fchollet/keras/issues/3119#issuecomment-230289301)
+  for Theano implementation (op) for gradient reversal.
+
+Author: Vanush Vaswani (vanush@gmail.com)
+'''
+
+from __future__ import print_function
+from keras.layers import Input, Dense, Dropout, Flatten, Lambda
+from keras.layers import Convolution2D, MaxPooling2D
+from keras.optimizers import SGD
+from keras.models import Model
+from keras.utils.visualize_util import plot
+from keras.utils import np_utils
+from keras.datasets import mnist
+import keras.backend as K
+
+import numpy as np
+from matplotlib import pyplot as plt
+from mpl_toolkits.axes_grid1 import ImageGrid
+
+from sklearn.manifold import TSNE
+
+from keras.layers import GradientReversal
+from keras.engine.training import make_batches
+from keras.datasets import mnist_m
+
+
+# Helper functions
+
+def imshow_grid(images, shape=[2, 8]):
+    """Plot images in a grid of a given shape."""
+    fig = plt.figure()
+    grid = ImageGrid(fig, 111, nrows_ncols=shape, axes_pad=0.05)
+
+    size = shape[0] * shape[1]
+    for i in range(size):
+        grid[i].axis('off')
+        # The AxesGrid object work as a list of axes.
+        grid[i].imshow(np.swapaxes(np.swapaxes(images[i], 0, 2), 0, 1))
+
+
+def plot_embedding(X, y, d, title=None):
+    """Plot an embedding X with the class label y colored by the domain d."""
+    x_min, x_max = np.min(X, 0), np.max(X, 0)
+    X = (X - x_min) / (x_max - x_min)
+
+    # Plot colors numbers
+    plt.figure(figsize=(10, 10))
+    plt.subplot(111)
+    for i in range(X.shape[0]):
+        # plot colored number
+        plt.text(X[i, 0], X[i, 1], str(y[i]),
+                 color=plt.cm.bwr(d[i] / 1.),
+                 fontdict={'weight': 'bold', 'size': 9})
+    plt.xticks([]), plt.yticks([])
+    if title is not None:
+        plt.title(title)
+
+
+def batch_gen(batches, id_array, data, labels):
+    for batch_index, (batch_start, batch_end) in enumerate(batches):
+        batch_ids = id_array[batch_start:batch_end]
+        if labels is not None:
+            yield data[batch_ids], labels[batch_ids]
+        else:
+            yield data[batch_ids]
+        np.random.shuffle(id_array)
+
+# Model parameters
+
+batch_size = 128
+nb_epoch = 15
+nb_classes = 10
+img_rows, img_cols = 28, 28
+nb_filters = 32
+nb_pool = 2
+nb_conv = 5
+
+_TRAIN = K.variable(1, dtype='uint8')
+
+# Prep source data
+(X_train, y_train), (X_test, y_test) = mnist.load_data()
+y_train = np_utils.to_categorical(y_train, nb_classes)
+y_test = np_utils.to_categorical(y_test, nb_classes)
+
+# Prep target data
+mnistm = mnist_m.load_data()
+XT_test = np.swapaxes(np.swapaxes(mnistm['test'], 1, 3), 2, 3)
+XT_train = np.swapaxes(np.swapaxes(mnistm['train'], 1, 3), 2, 3)
+
+X_train = X_train.reshape(X_train.shape[0], 1, img_rows, img_cols)
+X_test = X_test.reshape(X_test.shape[0], 1, img_rows, img_cols)
+X_train = np.concatenate([X_train, X_train, X_train], axis=1)
+X_test = np.concatenate([X_test, X_test, X_test], axis=1)
+
+X_train = X_train.astype('float32')
+X_test = X_test.astype('float32')
+X_train /= 255
+X_test /= 255
+
+XT_train = XT_train.astype('float32')
+XT_test = XT_test.astype('float32')
+XT_train /= 255
+XT_test /= 255
+
+domain_labels = np.vstack([np.tile([0, 1], [batch_size / 2, 1]),
+                           np.tile([1., 0.], [batch_size / 2, 1])])
+
+# Created mixed dataset for TSNE visualization
+num_test = 500
+combined_test_imgs = np.vstack([X_test[:num_test], XT_test[:num_test]])
+combined_test_labels = np.vstack([y_test[:num_test], y_test[:num_test]])
+combined_test_domain = np.vstack([np.tile([1., 0.], [num_test, 1]),
+                                 np.tile([0., 1.], [num_test, 1])])
+
+
+class DANNBuilder(object):
+    def __init__(self):
+        self.model = None
+        self.net = None
+        self.domain_invariant_features = None
+        self.grl = None
+        self.opt = SGD()
+
+    def _build_feature_extractor(self, model_input):
+        '''Build segment of net for feature extraction.'''
+        net = Convolution2D(nb_filters, nb_conv, nb_conv,
+                            border_mode='valid',
+                            activation='relu')(model_input)
+        net = Convolution2D(nb_filters, nb_conv, nb_conv,
+                            activation='relu')(net)
+        net = MaxPooling2D(pool_size=(nb_pool, nb_pool))(net)
+        net = Dropout(0.5)(net)
+        net = Flatten()(net)
+        self.domain_invariant_features = net
+        return net
+
+    def _build_classifier(self, model_input):
+        net = Dense(128, activation='relu')(model_input)
+        net = Dropout(0.5)(net)
+        net = Dense(nb_classes, activation='softmax',
+                    name='classifier_output')(net)
+        return net
+
+    def build_source_model(self, main_input, plot_model=False):
+        net = self._build_feature_extractor(main_input)
+        net = self._build_classifier(net)
+        model = Model(input=main_input, output=net)
+        if plot_model:
+            plot(model, show_shapes=True)
+        model.compile(loss={'classifier_output': 'categorical_crossentropy'},
+                      optimizer=self.opt, metrics=['accuracy'])
+        return model
+
+    def build_dann_model(self, main_input, plot_model=False):
+        net = self._build_feature_extractor(main_input)
+        self.grl = GradientReversal(1.0)
+        branch = self.grl(net)
+        branch = Dense(128, activation='relu')(branch)
+        branch = Dropout(0.1)(branch)
+        branch = Dense(2, activation='softmax', name='domain_output')(branch)
+
+        # When building DANN model, route first half of batch (source examples)
+        # to domain classifier, and route full batch (half source, half target)
+        # to the domain classifier.
+        net = Lambda(lambda x: K.switch(K.learning_phase(),
+                     x[:int(batch_size / 2), :], x, lazy=True),
+                     output_shape=lambda x: ((batch_size / 2,) +
+                     x[1:]) if _TRAIN else x[0:])(net)
+
+        net = self._build_classifier(net)
+        model = Model(input=main_input, output=[branch, net])
+        if plot_model:
+            plot(model, show_shapes=True)
+        model.compile(loss={'classifier_output': 'categorical_crossentropy',
+                      'domain_output': 'categorical_crossentropy'},
+                      optimizer=self.opt, metrics=['accuracy'])
+        return model
+
+    def build_tsne_model(self, main_input):
+        '''Create model to output intermediate layer
+        activations to visualize domain invariant features'''
+        tsne_model = Model(input=main_input,
+                           output=self.domain_invariant_features)
+        return tsne_model
+
+
+main_input = Input(shape=(3, img_rows, img_cols), name='main_input')
+
+builder = DANNBuilder()
+src_model = builder.build_source_model(main_input)
+src_vis = builder.build_tsne_model(main_input)
+
+dann_model = builder.build_dann_model(main_input)
+dann_vis = builder.build_tsne_model(main_input)
+print('Training source only model')
+src_model.fit(X_train, y_train, batch_size=64, nb_epoch=10, verbose=1,
+              validation_data=(X_test, y_test))
+print('Evaluating target samples on source-only model')
+print('Accuracy: ', src_model.evaluate(XT_test, y_test)[1])
+
+# Broken out training loop for a DANN model.
+src_index_arr = np.arange(X_train.shape[0])
+target_index_arr = np.arange(XT_train.shape[0])
+
+batches_per_epoch = len(X_train) / batch_size
+num_steps = nb_epoch * batches_per_epoch
+j = 0
+
+print('Training DANN model')
+
+for i in range(nb_epoch):
+
+    batches = make_batches(X_train.shape[0], batch_size / 2)
+    target_batches = make_batches(XT_train.shape[0], batch_size / 2)
+
+    src_gen = batch_gen(batches, src_index_arr, X_train, y_train)
+    target_gen = batch_gen(target_batches, target_index_arr, XT_train, None)
+
+    losses = list()
+    acc = list()
+
+    print('Epoch ', i)
+
+    for (xb, yb) in src_gen:
+
+        # Update learning rate and gradient multiplier as described in
+        # the paper.
+        p = float(j) / num_steps
+        l = 2. / (1. + np.exp(-10. * p)) - 1
+        lr = 0.01 / (1. + 10 * p)**0.75
+        builder.grl.l = l
+        builder.opt.lr = lr
+
+        if xb.shape[0] != batch_size / 2:
+            continue
+
+        try:
+            xt = target_gen.next()
+        except:
+            # Regeneration
+            target_gen = target_gen(target_batches, target_index_arr, XT_train,
+                                    None)
+
+        # Concatenate source and target batch
+        xb = np.vstack([xb, xt])
+
+        metrics = dann_model.train_on_batch({'main_input': xb},
+                                            {'classifier_output': yb,
+                                            'domain_output': domain_labels},
+                                            check_batch_dim=False)
+        j += 1
+
+print('Evaluating target samples on DANN model')
+out = dann_model.predict_on_batch(XT_test[0:batch_size / 2])
+out = np.argmax(out[1], axis=1)
+actual = np.argmax(y_test[0:batch_size / 2], axis=1)
+acc = float(np.sum((out == actual))) / float(len(out))
+print('Accuracy: ', acc)
+print('Visualizing output of domain invariant features')
+
+# Plot both MNIST and MNIST-M
+imshow_grid(X_train)
+imshow_grid(XT_train)
+
+src_embedding = src_vis.predict([combined_test_imgs])
+src_tsne = TSNE(perplexity=30, n_components=2, init='pca', n_iter=3000)
+tsne = src_tsne.fit_transform(src_embedding)
+
+plot_embedding(tsne, combined_test_labels.argmax(1),
+               combined_test_domain.argmax(1), 'Source only')
+
+dann_embedding = dann_vis.predict([combined_test_imgs])
+dann_tsne = TSNE(perplexity=30, n_components=2, init='pca', n_iter=3000)
+tsne = dann_tsne.fit_transform(dann_embedding)
+
+plot_embedding(tsne, combined_test_labels.argmax(1),
+               combined_test_domain.argmax(1), 'DANN')
+
+plt.show()

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1927,17 +1927,18 @@ def ctc_decode(y_pred, input_length, greedy=True, beam_width=100,
     return (decoded_dense, log_prob)
 
 
-class ReverseGradientBuilder(object):
-    '''Flips the sign of incoming gradients in training'''
-    def __init__(self):
+class ReverseGradient(object):
+    '''Flips the sign of incoming gradient during training.'''
+    def __init__(self, hp_lambda):
         self.num_calls = 0
+        self.hp_lambda = hp_lambda
 
-    def __call__(self, x, l=1.0):
+    def __call__(self, x):
         grad_name = "GradientReversal%d" % self.num_calls
 
         @tf.python.framework.ops.RegisterGradient(grad_name)
         def _flip_gradients(op, grad):
-            return [tf.neg(grad) * l]
+            return [tf.neg(grad) * self.hp_lambda]
 
         g = get_session().graph
         with g.gradient_override_map({'Identity': grad_name}):

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1934,6 +1934,7 @@ class ReverseGradientBuilder(object):
 
     def __call__(self, x, l=1.0):
         grad_name = "GradientReversal%d" % self.num_calls
+
         @tf.python.framework.ops.RegisterGradient(grad_name)
         def _flip_gradients(op, grad):
             return [tf.neg(grad) * l]

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1927,22 +1927,20 @@ def ctc_decode(y_pred, input_length, greedy=True, beam_width=100,
     return (decoded_dense, log_prob)
 
 
-class ReverseGradient(object):
-    '''Flips the sign of incoming gradient during training.'''
-    def __init__(self, hp_lambda):
-        self.num_calls = 0
-        self.hp_lambda = hp_lambda
+def reverse_gradient(X, hp_lambda):
+    '''Flips the sign of the incoming gradient during training.'''
+    try:
+        reverse_gradient.num_calls += 1
+    except AttributeError:
+        reverse_gradient.num_calls = 1
 
-    def __call__(self, x):
-        grad_name = "GradientReversal%d" % self.num_calls
+    grad_name = "GradientReversal%d" % reverse_gradient.num_calls
+    @tf.python.framework.ops.RegisterGradient(grad_name)
+    def _flip_gradients(op, grad):
+        return [tf.neg(grad) * hp_lambda]
 
-        @tf.python.framework.ops.RegisterGradient(grad_name)
-        def _flip_gradients(op, grad):
-            return [tf.neg(grad) * self.hp_lambda]
+    g = get_session().graph
+    with g.gradient_override_map({'Identity': grad_name}):
+        y = tf.identity(X)
 
-        g = get_session().graph
-        with g.gradient_override_map({'Identity': grad_name}):
-            y = tf.identity(x)
-
-        self.num_calls += 1
-        return y
+    return y

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1935,6 +1935,7 @@ def reverse_gradient(X, hp_lambda):
         reverse_gradient.num_calls = 1
 
     grad_name = "GradientReversal%d" % reverse_gradient.num_calls
+
     @tf.python.framework.ops.RegisterGradient(grad_name)
     def _flip_gradients(op, grad):
         return [tf.neg(grad) * hp_lambda]

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1695,16 +1695,16 @@ def ctc_batch_cost(y_true, y_pred, input_length, label_length):
 
 
 class ReverseGradient(theano.Op):
-    '''Flips the sign of the gradient during training.'''
+    '''Flips the sign of incoming gradient during training.'''
     view_map = {0: [0]}
-    __props__ = ('l', )
+    __props__ = ('hp_lambda', )
 
-    def __init__(self, l):
+    def __init__(self, hp_lambda):
         super(ReverseGradient, self).__init__()
-        self.l = l
+        self.hp_lambda = hp_lambda
 
     def make_node(self, x):
-        assert (hasattr(self, '_props'), 'Your version of theano is too old to support __props__.')
+        assert hasattr(self, '_props'), 'Your version of theano is too old to support __props__.'
         x = T.as_tensor_variable(x)
         return theano.Apply(self, [x], [x.type()])
 
@@ -1714,7 +1714,7 @@ class ReverseGradient(theano.Op):
         xout[0] = xin
 
     def grad(self, input, output_gradients):
-        return [-self.l * output_gradients[0]]
+        return [-self.hp_lambda * output_gradients[0]]
 
     def infer_shape(self, node, i0_shapes):
         return i0_shapes

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1696,12 +1696,11 @@ def ctc_batch_cost(y_true, y_pred, input_length, label_length):
 
 class ReverseGradient(theano.Op):
     '''Flips the sign of incoming gradient during training.'''
-    view_map = {0: [0]}
     __props__ = ('hp_lambda', )
 
-    def __init__(self, hp_lambda):
+    def __init__(self):
         super(ReverseGradient, self).__init__()
-        self.hp_lambda = hp_lambda
+        self.hp_lambda = None
 
     def make_node(self, x):
         assert hasattr(self, '_props'), 'Your version of theano is too old to support __props__.'
@@ -1718,3 +1717,8 @@ class ReverseGradient(theano.Op):
 
     def infer_shape(self, node, i0_shapes):
         return i0_shapes
+
+_reverse_gradient = ReverseGradient()
+def reverse_gradient(x, hp_lambda):
+    _reverse_gradient.hp_lambda = hp_lambda
+    return _reverse_gradient(x)

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -966,8 +966,8 @@ def rnn(step_function, inputs, initial_states,
 def switch(condition, then_expression, else_expression, lazy=False):
     '''condition: scalar tensor.
 
-	# Arguments:
-	    lazy: Use ifelse op which evaluates arguments in a lazy manner.
+    # Arguments:
+        lazy: Use ifelse op which evaluates arguments in a lazy manner.
     '''
     if lazy:
         return theano.ifelse.ifelse(condition, then_expression, else_expression)
@@ -1698,13 +1698,13 @@ class ReverseGradient(theano.Op):
     '''Flips the sign of the gradient during training.'''
     view_map = {0: [0]}
     __props__ = ('l', )
+
     def __init__(self, l):
         super(ReverseGradient, self).__init__()
         self.l = l
 
     def make_node(self, x):
-        assert (hasattr(self, '_props'),
-            'Your version of theano is too old to support __props__.')
+        assert (hasattr(self, '_props'), 'Your version of theano is too old to support __props__.')
         x = T.as_tensor_variable(x)
         return theano.Apply(self, [x], [x.type()])
 

--- a/keras/datasets/mnist_m.py
+++ b/keras/datasets/mnist_m.py
@@ -11,7 +11,7 @@ def load_data(path='keras_mnistm.pkl.gz'):
     else:
         f = open(path, 'rb')
 
-    if  sys.version_info < (3,):
+    if sys.version_info < (3,):
         data = cPickle.load(f)
     else:
         data = cPickle.load(f, encoding='bytes')

--- a/keras/datasets/mnist_m.py
+++ b/keras/datasets/mnist_m.py
@@ -1,0 +1,20 @@
+import gzip
+from ..utils.data_utils import get_file
+from six.moves import cPickle
+import sys
+
+def load_data(path='keras_mnistm.pkl.gz'):
+    path = get_file(path, origin='https://github.com/VanushVaswani/keras_mnistm/releases/download/1.0/keras_mnistm.pkl.gz')
+
+    if path.endswith('.gz'):
+        f = gzip.open(path, 'rb')
+    else:
+        f = open(path, 'rb')
+
+    if  sys.version_info < (3,):
+        data = cPickle.load(f)
+    else:
+        data = cPickle.load(f, encoding='bytes')
+
+    f.close()
+    return data

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -983,7 +983,8 @@ class Model(Container):
         sample_weights = [standardize_weights(ref, sw, cw, mode)
                           for (ref, sw, cw, mode)
                           in zip(y, sample_weights, class_weights, self.sample_weight_modes)]
-        check_array_lengths(x, y, sample_weights)
+        if check_batch_dim:
+            check_array_lengths(x, y, sample_weights)
         check_loss_and_target_compatibility(y, self.loss_functions, self.internal_output_shapes)
         if self.stateful and batch_size:
             if x[0].shape[0] % batch_size != 0:
@@ -1192,7 +1193,7 @@ class Model(Container):
                                   batch_size=batch_size, verbose=verbose)
 
     def train_on_batch(self, x, y,
-                       sample_weight=None, class_weight=None):
+                       sample_weight=None, class_weight=None, check_batch_dim=True):
         '''Runs a single gradient update on a single batch of data.
 
         # Arguments
@@ -1215,6 +1216,7 @@ class Model(Container):
                 from this class during training.
                 This can be useful to tell the model to "pay more attention" to
                 samples from an under-represented class.
+            check_batch_dim: Whether to check batch dimensions for sanity.
 
         # Returns
             Scalar training loss (if the model has a single output and no metrics)
@@ -1225,7 +1227,7 @@ class Model(Container):
         x, y, sample_weights = self._standardize_user_data(x, y,
                                                            sample_weight=sample_weight,
                                                            class_weight=class_weight,
-                                                           check_batch_dim=True)
+                                                           check_batch_dim=check_batch_dim)
         if self.uses_learning_phase and type(K.learning_phase()) is not int:
             ins = x + y + sample_weights + [1.]
         else:

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1216,7 +1216,7 @@ class Model(Container):
                 from this class during training.
                 This can be useful to tell the model to "pay more attention" to
                 samples from an under-represented class.
-            check_batch_dim: Check batch dimensions for consistency. (default is True)
+            check_batch_dim: Check batch dimensions for shape consistency. (default is True)
 
         # Returns
             Scalar training loss (if the model has a single output and no metrics)

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1216,7 +1216,7 @@ class Model(Container):
                 from this class during training.
                 This can be useful to tell the model to "pay more attention" to
                 samples from an under-represented class.
-            check_batch_dim: Whether to check batch dimensions for sanity.
+            check_batch_dim: Check batch dimensions for consistency. (default is True)
 
         # Returns
             Scalar training loss (if the model has a single output and no metrics)

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -1216,29 +1216,28 @@ class TimeDistributedDense(Layer):
 
 
 class GradientReversal(Layer):
-    def __init__(self, l, **kwargs):
-        super(GradientReversal, self).__init__(**kwargs)
-        self.l = K.variable(l)
-        self.supports_masking = False
+    '''
+    Flip the sign of gradient during training.
 
-        if K._BACKEND == 'theano':
-            self.op = K.ReverseGradient(self.l)
-        elif K._BACKEND == 'tensorflow':
-            self.op = K.ReverseGradientBuilder()
+    # Arguments:
+        hp_lambda: Scalar to multiply the flipped gradient.
+    '''
+    def __init__(self, hp_lambda, **kwargs):
+        super(GradientReversal, self).__init__(**kwargs)
+        self.hp_lambda = K.variable(hp_lambda)
+        self.supports_masking = False
+        self.op = K.ReverseGradient(self.hp_lambda)
 
     def build(self, input_shape):
         self.trainable_weights = []
 
     def call(self, x, mask=None):
-        if K._BACKEND == 'theano':
-            return self.op(x)
-        elif K._BACKEND == 'tensorflow':
-            return self.op(x, self.l)
+        return self.op(x)
 
     def get_output_shape_for(self, input_shape):
         return input_shape
 
     def get_config(self):
-        config = {'lambda': self.l}
+        config = {'hp_lambda': self.hp_lambda}
         base_config = super(GradientReversal, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -1222,22 +1222,20 @@ class GradientReversal(Layer):
     # Arguments:
         hp_lambda: Scalar to multiply the flipped gradient.
     '''
-    def __init__(self, hp_lambda, **kwargs):
+    def __init__(self, **kwargs):
         super(GradientReversal, self).__init__(**kwargs)
-        self.hp_lambda = K.variable(hp_lambda)
         self.supports_masking = False
-        self.op = K.ReverseGradient(self.hp_lambda)
 
     def build(self, input_shape):
         self.trainable_weights = []
 
-    def call(self, x, mask=None):
-        return self.op(x)
+    def call(self, x, hp_lambda, mask=None):
+        return K.reverse_gradient(x, hp_lambda)
 
     def get_output_shape_for(self, input_shape):
         return input_shape
 
     def get_config(self):
-        config = {'hp_lambda': self.hp_lambda}
+        config = {}
         base_config = super(GradientReversal, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -1239,6 +1239,6 @@ class GradientReversal(Layer):
         return input_shape
 
     def get_config(self):
-        config = {'lambda' : self.l}
+        config = {'lambda': self.l}
         base_config = super(GradientReversal, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -1216,12 +1216,7 @@ class TimeDistributedDense(Layer):
 
 
 class GradientReversal(Layer):
-    '''
-    Flip the sign of gradient during training.
-
-    # Arguments:
-        hp_lambda: Scalar to multiply the flipped gradient.
-    '''
+    '''Flip the sign of gradient during training.'''
     def __init__(self, **kwargs):
         super(GradientReversal, self).__init__(**kwargs)
         self.supports_masking = False

--- a/tests/keras/backend/test_backends.py
+++ b/tests/keras/backend/test_backends.py
@@ -260,8 +260,8 @@ class TestBackend(object):
         yth = xth ** 2
         ytf = xtf ** 2
 
-        lossth = KTH.ReverseGradient(lth)(KTH.sum(yth))
-        losstf = KTF.ReverseGradient(ltf)(KTF.sum(ytf))
+        lossth = KTH.reverse_gradient(KTH.sum(yth), lth)
+        losstf = KTF.reverse_gradient(KTF.sum(ytf), ltf)
 
         gradth = KTH.gradients(lossth, [xth])
         gradtf = KTF.gradients(losstf, [xtf])

--- a/tests/keras/backend/test_backends.py
+++ b/tests/keras/backend/test_backends.py
@@ -261,7 +261,7 @@ class TestBackend(object):
         ytf = xtf ** 2
 
         lossth = KTH.ReverseGradient(lth)(KTH.sum(yth))
-        losstf = KTF.ReverseGradientBuilder()(KTF.sum(ytf), ltf)
+        losstf = KTF.ReverseGradient(ltf)(KTF.sum(ytf))
 
         gradth = KTH.gradients(lossth, [xth])
         gradtf = KTF.gradients(losstf, [xtf])

--- a/tests/keras/backend/test_backends.py
+++ b/tests/keras/backend/test_backends.py
@@ -249,6 +249,29 @@ class TestBackend(object):
         assert_allclose(zero_zth, zth, atol=1e-05)
         assert_allclose(zero_ztf, ztf, atol=1e-05)
 
+    def test_gradient_reversal(self):
+        val = np.random.random((4, 2))
+        lth = KTH.variable(0.5)
+        ltf = KTF.variable(0.5)
+
+        xth = KTH.variable(val)
+        xtf = KTF.variable(val)
+
+        yth = xth ** 2
+        ytf = xtf ** 2
+
+        lossth = KTH.ReverseGradient(lth)(KTH.sum(yth))
+        losstf = KTF.ReverseGradientBuilder()(KTF.sum(ytf), ltf)
+
+        gradth = KTH.gradients(lossth, [xth])
+        gradtf = KTF.gradients(losstf, [xtf])
+        zth = KTH.eval(gradth[0])
+        ztf = KTF.eval(gradtf[0])
+
+        assert_allclose(zth, -2 * 0.5 * val, atol=1e-05)
+        assert_allclose(ztf, -2 * 0.5 * val, atol=1e-05)
+        assert_allclose(zth, ztf, atol=1e-05)
+
     def test_function(self):
         val = np.random.random((4, 2))
         input_val = np.random.random((4, 2))


### PR DESCRIPTION
Add an example implementing the 'Domain-Adversarial Training of Neural Networks' paper (https://arxiv.org/abs/1505.07818)

This allows domain adaptation in an unsupervised manner by forcing the net to learn features that are domain invariant between training and target domains using concept of gradient reversal.

Further
- Nontrivial example of functional API.
- Shows how to visualize activations of intermediate layer.
- Example of broken out training loop.

Credits:                                                                           
- Clayton Mellina (@pumpikano) (https://github.com/pumpikano/tf-dann) for providing  
  a sketch of implementation (in TF) and utility functions.  
- Yusuke Iwasawa (@yusuke0519) (https://github.com/fchollet/keras/issues/3119#issuecomment-230289301)
  for Theano implementation (op) for gradient reversal.

![figure_1](https://cloud.githubusercontent.com/assets/7519133/19334153/c29fb772-9145-11e6-86a9-872fe84a6b2a.png)
![figure_2](https://cloud.githubusercontent.com/assets/7519133/19334152/c29eff26-9145-11e6-87ad-f3c736dce3e3.png)
![figure_3](https://cloud.githubusercontent.com/assets/7519133/19334151/c29a4a4e-9145-11e6-9d43-24c8443fa9bb.png)
![figure_4](https://cloud.githubusercontent.com/assets/7519133/19334150/c2996d54-9145-11e6-9bcc-6d3bed408db2.png)
![model](https://cloud.githubusercontent.com/assets/7519133/19722698/9d1851fc-9bc3-11e6-96af-c2c845786f28.png)
