### PR TITLE
Switch use of TF cond function to use public function.

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1,10 +1,11 @@
 import tensorflow as tf
-from tensorflow.python.ops import control_flow_ops
+
 from tensorflow.python.training import moving_averages
 try:
     from tensorflow.python.ops import ctc_ops as ctc
 except ImportError:
     import tensorflow.contrib.ctc as ctc
+
 import numpy as np
 import os
 import copy
@@ -1299,6 +1300,17 @@ def rnn(step_function, inputs, initial_states,
     return last_output, outputs, new_states
 
 
+def _cond(condition, then_lambda, else_lambda):
+  """Backwards compatible interface to tf.cond prior to public introduction."""
+  try:
+    cond_fn = tf.cond
+  except AttributeError:
+    from tensorflow.python.ops import control_flow_ops
+    cond_fn = control_flow_ops.cond
+
+  return cond_fn(condition, then_lambda, else_lambda)
+
+
 def switch(condition, then_expression, else_expression):
     '''Switches between two operations depending on a scalar value (int or bool).
     Note that both `then_expression` and `else_expression`
@@ -1310,9 +1322,8 @@ def switch(condition, then_expression, else_expression):
         else_expression: TensorFlow operation.
     '''
     x_shape = copy.copy(then_expression.get_shape())
-    x = control_flow_ops.cond(tf.cast(condition, 'bool'),
-                              lambda: then_expression,
-                              lambda: else_expression)
+    x = _cond(tf.cast(condition, 'bool'),
+              lambda: then_expression, lambda: else_expression)
     x.set_shape(x_shape)
     return x
 
@@ -1327,9 +1338,7 @@ def in_train_phase(x, alt):
         return alt
     # else: assume learning phase is a placeholder.
     x_shape = copy.copy(x.get_shape())
-    x = control_flow_ops.cond(tf.cast(_LEARNING_PHASE, 'bool'),
-                              lambda: x,
-                              lambda: alt)
+    x = _cond(tf.cast(_LEARNING_PHASE, 'bool'), lambda: x, lambda: alt)
     x._uses_learning_phase = True
     x.set_shape(x_shape)
     return x
@@ -1344,9 +1353,7 @@ def in_test_phase(x, alt):
     elif _LEARNING_PHASE is 0:
         return x
     x_shape = copy.copy(x.get_shape())
-    x = control_flow_ops.cond(tf.cast(_LEARNING_PHASE, 'bool'),
-                              lambda: alt,
-                              lambda: x)
+    x = _cond(tf.cast(_LEARNING_PHASE, 'bool'), lambda: alt, lambda: x)
     x._uses_learning_phase = True
     x.set_shape(x_shape)
     return x

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1301,14 +1301,13 @@ def rnn(step_function, inputs, initial_states,
 
 
 def _cond(condition, then_lambda, else_lambda):
-  """Backwards compatible interface to tf.cond prior to public introduction."""
-  try:
-    cond_fn = tf.cond
-  except AttributeError:
-    from tensorflow.python.ops import control_flow_ops
-    cond_fn = control_flow_ops.cond
-
-  return cond_fn(condition, then_lambda, else_lambda)
+    '''Backwards compatible interface to tf.cond prior to public introduction.'''
+    try:
+        cond_fn = tf.cond
+    except AttributeError:
+        from tensorflow.python.ops import control_flow_ops
+        cond_fn = control_flow_ops.cond
+    return cond_fn(condition, then_lambda, else_lambda)
 
 
 def switch(condition, then_expression, else_expression):


### PR DESCRIPTION
Prior to newer TFs, cond was unavailable and thus was being
imported via private module namespaces.

Newer TFs expose tf.cond as the public interface.  There
are plans to remove private module namespace access so
this fixes keras to first try accessing through the public
namespace, and then going through the private one for older
versions of TF.

I tested this on newer TFs and it worked, but I couldn't
find out which older version of TF the old import path
was used (I tried 0.7.1 and ctc doesn't exist, and 0.8.0
and tf.cond was already available).  Let me know what
else I can do to test.