### PR TITLE
Better check of object types

### DIFF
--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -2571,7 +2571,12 @@ class Container(Layer):
                                     ' weights, but the saved weights have ' +
                                     str(len(weight_values)) +
                                     ' elements.')
-                if layer.__class__.__name__ == 'Convolution1D':
+                # Import deferred to runtime because of circular dependencies.
+                # The relative inelegance of the solution should be compared
+                # with the alternative: possibly significant refactoring
+                # to get rid of the circular dependencies
+                from keras.layers.convolutional import Convolution1D
+                if isinstance(layer, Convolution1D):
                     # this is for backwards compatibility with
                     # the old Conv1D weights format.
                     w = weight_values[0]
@@ -2658,7 +2663,7 @@ class Container(Layer):
                 return obj.item()
 
             # if obj is a python 'type'
-            if type(obj).__name__ == type.__name__:
+            if type(obj) is type:
                 return obj.__name__
 
             raise TypeError('Not JSON Serializable:', obj)

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -237,31 +237,6 @@ def collect_metrics(metrics, output_names):
                         str(metrics))
 
 
-def collect_trainable_weights(layer):
-    '''Collects all `trainable_weights` attributes,
-    excluding any sublayers where `trainable` is set the `False`.
-    '''
-    trainable = getattr(layer, 'trainable', True)
-    if not trainable:
-        return []
-    weights = []
-    if layer.__class__.__name__ == 'Sequential':
-        for sublayer in layer.flattened_layers:
-            weights += collect_trainable_weights(sublayer)
-    elif layer.__class__.__name__ == 'Model':
-        for sublayer in layer.layers:
-            weights += collect_trainable_weights(sublayer)
-    elif layer.__class__.__name__ == 'Graph':
-        for sublayer in layer._graph_nodes.values():
-            weights += collect_trainable_weights(sublayer)
-    else:
-        weights += layer.trainable_weights
-    # dedupe weights
-    weights = list(set(weights))
-    weights.sort(key=lambda x: x.name)
-    return weights
-
-
 def batch_shuffle(index_array, batch_size):
     '''This shuffles an array in a batch-wise fashion.
     Useful for shuffling HDF5 arrays
@@ -1675,3 +1650,36 @@ class Model(Container):
         if len(all_outs) == 1:
             return all_outs[0]
         return all_outs
+
+
+def collect_trainable_weights(layer):
+    '''Collects all `trainable_weights` attributes,
+    excluding any sublayers where `trainable` is set the `False`.
+    '''
+    trainable = getattr(layer, 'trainable', True)
+    if not trainable:
+        return []
+    weights = []
+    from keras.models import Sequential
+    try:
+        from keras.models import Graph
+    except ImportError:
+        warnings.warn('Error when trying to import the legacy model "Graph".')
+        # Dummy class Graph
+        class Graph(object):
+            pass
+    if isinstance(layer, Sequential):
+        for sublayer in layer.flattened_layers:
+            weights += collect_trainable_weights(sublayer)
+    elif isinstance(layer, Model):
+        for sublayer in layer.layers:
+            weights += collect_trainable_weights(sublayer)
+    elif isinstance(layer, Graph):
+        for sublayer in layer._graph_nodes.values():
+            weights += collect_trainable_weights(sublayer)
+    else:
+        weights += layer.trainable_weights
+    # dedupe weights
+    weights = list(set(weights))
+    weights.sort(key=lambda x: x.name)
+    return weights

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1667,7 +1667,11 @@ def collect_trainable_weights(layer):
         warnings.warn('Error when trying to import the legacy model "Graph".')
         # Dummy class Graph
         class Graph(object):
+            
+            
             pass
+        
+        
     if isinstance(layer, Sequential):
         for sublayer in layer.flattened_layers:
             weights += collect_trainable_weights(sublayer)

--- a/keras/utils/visualize_util.py
+++ b/keras/utils/visualize_util.py
@@ -1,4 +1,5 @@
 import os
+from keras.models import Sequential
 
 try:
     # pydot-ng is a fork of pydot that is better maintained
@@ -17,7 +18,7 @@ def model_to_dot(model, show_shapes=False, show_layer_names=True):
     dot.set('concentrate', True)
     dot.set_node_defaults(shape='record')
 
-    if model.__class__.__name__ == 'Sequential':
+    if isinstance(model, Sequential):
         if not model.built:
             model.build()
         model = model.model


### PR DESCRIPTION
The code was checking the type of objects using `obj.__class__.__name__` rather than the more conventional (and more class hierarchy-friendly) `isinstance`. Functions were moved to the
end of the module in few cases because or the order of function or class definition (but after thinking about it might not have been necessary).

This PR is arguably improving the modularity by allowing the definition of child classes and their inclusion in the rest of keras thanks to inheritability.