### PR TITLE
Add method to visualize plots by figures

### DIFF
--- a/keras/utils/visualize_util.py
+++ b/keras/utils/visualize_util.py
@@ -74,42 +74,41 @@ def plot(model, to_file='model.png', show_shapes=False, show_layer_names=True):
     dot.write(to_file, format=format)
 
 
-def figures(history,figure_name="plots"):
-    from keras.callbacks import History  
+def figures(history, figure_name="plots"):
     import matplotlib.pyplot as plt
-  
-    hist = history.history   
-    epoch = history.epoch  
-    acc = hist['acc']  
-    loss = hist['loss']  
-    val_loss = hist['val_loss']  
-    val_acc  = hist['val_acc']
-  
-    plt.figure(1)  
-  
-    plt.subplot(221)  
-    plt.plot(epoch,acc)  
-    plt.title("Training accuracy vs Epoch")  
-    plt.xlabel("Epoch")  
-    plt.ylabel("Accuracy")       
-  
-    plt.subplot(222)  
-    plt.plot(epoch,loss)  
-    plt.title("Training loss vs Epoch")  
-    plt.xlabel("Epoch")  
-    plt.ylabel("Loss")    
-  
-    plt.subplot(223)  
-    plt.plot(epoch,val_acc)  
-    plt.title("Validation Acc vs Epoch")  
-    plt.xlabel("Epoch")  
-    plt.ylabel("Validation Accuracy")    
-  
-    plt.subplot(224)  
-    plt.plot(epoch,val_loss)  
-    plt.title("Validation loss vs Epoch")  
-    plt.xlabel("Epoch")  
+
+    hist = history.history
+    epoch = history.epoch
+    acc = hist['acc']
+    loss = hist['loss']
+    val_loss = hist['val_loss']
+    val_acc = hist['val_acc']
+
+    plt.figure(1)
+
+    plt.subplot(221)
+    plt.plot(epoch, acc)
+    plt.title("Training accuracy vs Epoch")
+    plt.xlabel("Epoch")
+    plt.ylabel("Accuracy")
+
+    plt.subplot(222)
+    plt.plot(epoch, loss)
+    plt.title("Training loss vs Epoch")
+    plt.xlabel("Epoch")
+    plt.ylabel("Loss")
+
+    plt.subplot(223)
+    plt.plot(epoch, val_acc)
+    plt.title("Validation Acc vs Epoch")
+    plt.xlabel("Epoch")
+    plt.ylabel("Validation Accuracy")
+
+    plt.subplot(224)
+    plt.plot(epoch, val_loss)
+    plt.title("Validation loss vs Epoch")
+    plt.xlabel("Epoch")
     plt.ylabel("Validation Loss")
-    
-    plt.tight_layout()  
+
+    plt.tight_layout()
     plt.savefig(figure_name)

--- a/keras/utils/visualize_util.py
+++ b/keras/utils/visualize_util.py
@@ -72,3 +72,44 @@ def plot(model, to_file='model.png', show_shapes=False, show_layer_names=True):
     else:
         format = format[1:]
     dot.write(to_file, format=format)
+
+
+def figures(history,figure_name="plots"):
+    from keras.callbacks import History  
+    import matplotlib.pyplot as plt
+  
+    hist = history.history   
+    epoch = history.epoch  
+    acc = hist['acc']  
+    loss = hist['loss']  
+    val_loss = hist['val_loss']  
+    val_acc  = hist['val_acc']
+  
+    plt.figure(1)  
+  
+    plt.subplot(221)  
+    plt.plot(epoch,acc)  
+    plt.title("Training accuracy vs Epoch")  
+    plt.xlabel("Epoch")  
+    plt.ylabel("Accuracy")       
+  
+    plt.subplot(222)  
+    plt.plot(epoch,loss)  
+    plt.title("Training loss vs Epoch")  
+    plt.xlabel("Epoch")  
+    plt.ylabel("Loss")    
+  
+    plt.subplot(223)  
+    plt.plot(epoch,val_acc)  
+    plt.title("Validation Acc vs Epoch")  
+    plt.xlabel("Epoch")  
+    plt.ylabel("Validation Accuracy")    
+  
+    plt.subplot(224)  
+    plt.plot(epoch,val_loss)  
+    plt.title("Validation loss vs Epoch")  
+    plt.xlabel("Epoch")  
+    plt.ylabel("Validation Loss")
+    
+    plt.tight_layout()  
+    plt.savefig(figure_name)


### PR DESCRIPTION
Add method to visualize accuracies and loss vs epoch for training and validation data

Parameter:
1. history (Necessary, an instance returned by model.fit method)
2. figure_name (Optional, a name to plots, default set to "plots")

Usage:

```
from keras.utils.visualize_util import figures
hist = model.fit(X,y)
figures(hist)
```
