### PR TITLE
Update docs/README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,6 @@ Our documentation uses extended Markdown, as implemented by [MkDocs](http://mkdo
 
 - install MkDocs: `pip install mkdocs`
 - `cd` to the `docs/` folder and run:
-    - `python autogen.py`
+    - `PYTHONPATH=.. python autogen.py`
     - `mkdocs serve`    # Starts a local webserver:  [localhost:8000](localhost:8000)
     - `mkdocs build`    # Builds a static site in "site" directory


### PR DESCRIPTION
In order for `import keras` to work as expected in `autogen.py`, the script should look for `keras` in the parent folder.

Else, the script would complain with an `ImportError: No module names 'keras'` or silently use the latest release of `keras` (which is not the desired behavior - when wanting to see recent edits to the documentation).