### PR TITLE
Make build_fn argument of sckit-learn wrappers accept class methods

### DIFF
--- a/keras/wrappers/scikit_learn.py
+++ b/keras/wrappers/scikit_learn.py
@@ -66,7 +66,7 @@ class BaseWrapper(object):
                             Sequential.predict_classes, Sequential.evaluate]
         if self.build_fn is None:
             legal_params_fns.append(self.__call__)
-        elif not isinstance(self.build_fn, types.FunctionType):
+        elif not isinstance(self.build_fn, types.FunctionType) and not isinstance(self.build_fn, types.MethodType):
             legal_params_fns.append(self.build_fn.__call__)
         else:
             legal_params_fns.append(self.build_fn)
@@ -130,7 +130,7 @@ class BaseWrapper(object):
 
         if self.build_fn is None:
             self.model = self.__call__(**self.filter_sk_params(self.__call__))
-        elif not isinstance(self.build_fn, types.FunctionType):
+        elif not isinstance(self.build_fn, types.FunctionType) and not isinstance(self.build_fn, types.MethodType):
             self.model = self.build_fn(
                 **self.filter_sk_params(self.build_fn.__call__))
         else:


### PR DESCRIPTION
7 tests failed, 1 errored, but those are the same as for the current head (d745d9ee96e5d39393ac740e5b84229beca00f1d) so I'm pretty sure this trivial PR is not causing them.