### PR TITLE
adding AtrousConvolution3D

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1713,7 +1713,7 @@ def separable_conv2d(x, depthwise_kernel, pointwise_kernel, strides=(1, 1),
 
 def conv3d(x, kernel, strides=(1, 1, 1),
            border_mode='valid', dim_ordering=_IMAGE_DIM_ORDERING,
-           volume_shape=None, filter_shape=None):
+           volume_shape=None, filter_shape=None, filter_dilation=(1, 1, 1)):
     '''3D convolution.
 
     # Arguments
@@ -1730,9 +1730,11 @@ def conv3d(x, kernel, strides=(1, 1, 1),
     x = _preprocess_conv3d_input(x, dim_ordering)
     kernel = _preprocess_conv3d_kernel(kernel, dim_ordering)
     padding = _preprocess_border_mode(border_mode)
-    strides = (1,) + strides + (1,)
+    if filter_dilation != (1, 1, 1):
+        assert strides == (1, 1, 1), 'Invalid strides for dilated convolution'
 
-    x = tf.nn.conv3d(x, kernel, strides, padding)
+    x = tf.nn.convolution(x, kernel, padding,
+                          strides=strides, dilation_rate=filter_dilation)
     return _postprocess_conv3d_output(x, dim_ordering)
 
 

--- a/tests/keras/layers/test_convolutional.py
+++ b/tests/keras/layers/test_convolutional.py
@@ -354,6 +354,49 @@ def test_convolution_3d():
 
 
 @keras_test
+def test_atrous_conv_3d():
+    nb_samples = 2
+    nb_filter = 2
+    stack_size = 3
+    kernel_dim1 = 7
+    kernel_dim2 = 5
+    kernel_dim3 = 6
+
+    for border_mode in ['valid', 'same']:
+        for subsample in [(1, 1, 1), (2, 2, 2)]:
+            for atrous_rate in [(1, 1, 1), (2, 2, 2)]:
+                if border_mode == 'same' and subsample != (1, 1, 1):
+                    continue
+                if subsample != (1, 1, 1) and atrous_rate != (1, 1, 1):
+                    continue
+
+                layer_test(convolutional.AtrousConv3D,
+                           kwargs={'nb_filter': nb_filter,
+                                   'kernel_dim1': 3,
+                                   'kernel_dim2': 3,
+                                   'kernel_dim3': 3,
+                                   'border_mode': border_mode,
+                                   'subsample': subsample,
+                                   'atrous_rate': atrous_rate},
+                           input_shape=(nb_samples, kernel_dim1, kernel_dim2,
+                                        kernel_dim3, stack_size))
+
+                layer_test(convolutional.AtrousConv3D,
+                           kwargs={'nb_filter': nb_filter,
+                                   'kernel_dim1': 3,
+                                   'kernel_dim2': 3,
+                                   'kernel_dim3': 3,
+                                   'border_mode': border_mode,
+                                   'W_regularizer': 'l2',
+                                   'b_regularizer': 'l2',
+                                   'activity_regularizer': 'activity_l2',
+                                   'subsample': subsample,
+                                   'atrous_rate': atrous_rate},
+                           input_shape=(nb_samples, kernel_dim1, kernel_dim2,
+                                        kernel_dim3, stack_size))
+
+
+@keras_test
 def test_maxpooling_3d():
     pool_size = (3, 3, 3)
 


### PR DESCRIPTION
Adding `AtrousConvolution3D` since it is now available in tensorflow (https://github.com/tensorflow/tensorflow/issues/3492).
This would be a tensorflow only feature with this PR.
Support for this feature in keras has been requested in https://github.com/fchollet/keras/issues/2978 .

Note that with the N-D `convolution` function in tensorflow (https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/ops/nn_ops.py#L335), we could perform similar changes on the `conv2d` function of the keras tensorflow backend.

I believe this will have the side effect of solving this issue: https://github.com/fchollet/keras/issues/4018

Indeed, if you look at `atrous_conv2d` in tensorflow (https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/ops/nn_ops.py#L741), you have:

``` python
    # Handle input whose shape is unknown during graph creation.
    if value.get_shape().is_fully_defined():
      value_shape = value.get_shape().as_list()
    else:
      value_shape = array_ops.shape(value)
```

which could be changed to:

``` python
    # Handle input whose shape is unknown during graph creation.
    # we do not care if the batch size is not fully defined
    # this is necessary to avoid `TypeError: Expected int for argument 'num_split' not None.`
    # when using the Keras layer `Upsampling2D`
    if value[0].get_shape().is_fully_defined():
      value_shape = value.get_shape().as_list()
    else:
      value_shape = array_ops.shape(value)
```

However, using the new N-D `convolution` function removes the necessity of the above patch as it makes `atrous_conv2d` obsolete.

A potential downside of merging this PR is the following test failure, related to upgrading to the current master branch of tensorflow:

``` python
____________________________________________________________________________________________ TestBackend.test_rnn_no_states ____________________________________________________________________________________________
[gw0] darwin -- Python 3.5.1 /Users/kevin/my-venv/bin/python3.5
self = <test_backends.TestBackend object at 0x117c4f710>

    def test_rnn_no_states(self):
        # implement a simple RNN without states
        input_dim = 8
        output_dim = 4
        timesteps = 5

        input_val = np.random.random((32, timesteps, input_dim))
        W_i_val = np.random.random((input_dim, output_dim))

        def rnn_step_fn(input_dim, output_dim, K):
            W_i = K.variable(W_i_val)

            def step_function(x, states):
                assert len(states) == 0
                output = K.dot(x, W_i)
                return output, []
            return step_function

        # test default setup
        th_rnn_step_fn = rnn_step_fn(input_dim, output_dim, KTH)
        th_inputs = KTH.variable(input_val)
        th_initial_states = []
        last_output, outputs, new_states = KTH.rnn(th_rnn_step_fn, th_inputs,
                                                   th_initial_states,
                                                   go_backwards=False,
                                                   mask=None)
        th_last_output = KTH.eval(last_output)
        th_outputs = KTH.eval(outputs)
        assert len(new_states) == 0

        tf_rnn_step_fn = rnn_step_fn(input_dim, output_dim, KTF)
        tf_inputs = KTF.variable(input_val)
        tf_initial_states = []
        last_output, outputs, new_states = KTF.rnn(tf_rnn_step_fn, tf_inputs,
                                                   tf_initial_states,
                                                   go_backwards=False,
>                                                  mask=None)

tests/keras/backend/test_backends.py:469:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
keras/backend/tensorflow_backend.py:1281: in rnn
    sequence_length=None)
../../../my-venv/lib/python3.5/site-packages/tensorflow/python/ops/rnn.py:1015: in _dynamic_rnn_loop
    swap_memory=swap_memory)
../../../my-venv/lib/python3.5/site-packages/tensorflow/python/ops/control_flow_ops.py:2541: in while_loop
    result = context.BuildLoop(cond, body, loop_vars, shape_invariants)
../../../my-venv/lib/python3.5/site-packages/tensorflow/python/ops/control_flow_ops.py:2377: in BuildLoop
    pred, body, original_loop_vars, loop_vars, shape_invariants)
../../../my-venv/lib/python3.5/site-packages/tensorflow/python/ops/control_flow_ops.py:2358: in _BuildLoop
    _EnforceShapeInvariant(m_var, n_var)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

merge_var = <tf.Tensor 'while_2/Merge_2:0' shape=(5, 8) dtype=float32>
next_var = <tf.Tensor 'while_2/NextIteration_2:0' shape=(32, 4) dtype=float32>

    def _EnforceShapeInvariant(merge_var, next_var):
      """Check if the shapes of the loops variables are invariants.

      Args:
        merge_vars: The list of tensors representing the initial values of the
          loop variables.
        next_vars: The list of tensors representing the values of the loop
          variables after one loop iteration.

      Raises:
        ValueError: If any tensor in `merge_vars` has a more specific shape than
          its correspnding tensor in `next_var`.
      """
      if isinstance(merge_var, ops.Tensor):
        m_shape = merge_var.get_shape()
        n_shape = next_var.get_shape()
        if not _ShapeLessThanOrEqual(n_shape, m_shape):
          raise ValueError(
              "The shape for %s is not an invariant for the loop. It enters "
              "the loop with shape %s, but has shape %s after one iteration. "
              "Provide shape invariants using either the `shape_invariants` "
              "argument of tf.while_loop or set_shape() on the loop variables."
>             % (merge_var.name, m_shape, n_shape))
E         ValueError: The shape for while_2/Merge_2:0 is not an invariant for the loop. It enters the loop with shape (5, 8), but has shape (32, 4) after one iteration. Provide shape invariants using either the `shape_invariants` argument of tf.while_loop or set_shape() on the loop variables.

../../../my-venv/lib/python3.5/site-packages/tensorflow/python/ops/control_flow_ops.py:578: ValueError
```
