### PR TITLE
Added SpatialDropout1D

### DIFF
--- a/docs/autogen.py
+++ b/docs/autogen.py
@@ -136,6 +136,7 @@ PAGES = [
             core.Dense,
             core.Activation,
             core.Dropout,
+            core.SpatialDropout1D,
             core.SpatialDropout2D,
             core.SpatialDropout3D,
             core.Flatten,

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -115,9 +115,7 @@ class SpatialDropout1D(Dropout):
 
     # Input shape
         3D tensor with shape:
-        `(samples, channels, timesteps)` if dim_ordering='th'
-        or 3D tensor with shape:
-        `(samples, timesteps, channels)` if dim_ordering='tf'.
+        `(samples, timesteps, channels)` 
 
     # Output shape
         Same as input
@@ -134,9 +132,7 @@ class SpatialDropout1D(Dropout):
 
     def _get_noise_shape(self, x):
         input_shape = K.shape(x)
-        if self.dim_ordering == 'th':
-            noise_shape = (input_shape[0], input_shape[1], 1)
-        elif self.dim_ordering == 'tf':
+        if self.dim_ordering in ['th', 'tf']:
             noise_shape = (input_shape[0], 1, input_shape[2])
         else:
             raise Exception('Invalid dim_ordering: ' + self.dim_ordering)

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -115,7 +115,7 @@ class SpatialDropout1D(Dropout):
 
     # Input shape
         3D tensor with shape:
-        `(samples, timesteps, channels)` 
+        `(samples, timesteps, channels)`
 
     # Output shape
         Same as input

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -127,15 +127,11 @@ class SpatialDropout1D(Dropout):
         if dim_ordering == 'default':
             dim_ordering = K.image_dim_ordering()
         assert dim_ordering in {'tf', 'th'}, 'dim_ordering must be in {tf, th}'
-        self.dim_ordering = dim_ordering
         super(SpatialDropout1D, self).__init__(p, **kwargs)
 
     def _get_noise_shape(self, x):
         input_shape = K.shape(x)
-        if self.dim_ordering in ['th', 'tf']:
-            noise_shape = (input_shape[0], 1, input_shape[2])
-        else:
-            raise Exception('Invalid dim_ordering: ' + self.dim_ordering)
+        noise_shape = (input_shape[0], 1, input_shape[2])
         return noise_shape
     
     

--- a/tests/keras/layers/test_core.py
+++ b/tests/keras/layers/test_core.py
@@ -153,6 +153,10 @@ def test_dropout():
                kwargs={'p': 0.5},
                input_shape=(3, 2))
 
+        layer_test(core.SpatialDropout1D,
+               kwargs={'p': 0.5},
+               input_shape=(2, 3, 4))
+    
     layer_test(core.SpatialDropout2D,
                kwargs={'p': 0.5},
                input_shape=(2, 3, 4, 5))

--- a/tests/keras/layers/test_core.py
+++ b/tests/keras/layers/test_core.py
@@ -153,7 +153,7 @@ def test_dropout():
                kwargs={'p': 0.5},
                input_shape=(3, 2))
 
-        layer_test(core.SpatialDropout1D,
+    layer_test(core.SpatialDropout1D,
                kwargs={'p': 0.5},
                input_shape=(2, 3, 4))
     


### PR DESCRIPTION
This is a straightforward modification of SpatialDropout2D (and similarly SpatialDropout3D) for 1D data.
