### PR TITLE
Fix load_model for multiple output metrics in dictionary

### DIFF
--- a/keras/models.py
+++ b/keras/models.py
@@ -122,7 +122,14 @@ def load_model(filepath, custom_objects=None):
         if isinstance(obj, dict):
             deserialized = {}
             for key, value in obj.items():
-                if value in custom_objects:
+                deserialized[key] = []
+                if type(value) is list:
+                    for element in value:
+                        if element in custom_objects:
+                            deserialized[key].append(custom_objects[element])
+                        else:
+                            deserialized[key].append(element)
+                elif value in custom_objects:
                     deserialized[key] = custom_objects[value]
                 else:
                     deserialized[key] = value


### PR DESCRIPTION
Fixes the problem described in #3958 by adding an extra check in deserialized that recreates original dictionary.
