### PR TITLE
Multiprocessing in legacy Graph models

### DIFF
--- a/keras/legacy/models.py
+++ b/keras/legacy/models.py
@@ -538,7 +538,8 @@ class Graph(Model):
                       verbose=1, callbacks=[],
                       validation_data=None, nb_val_samples=None,
                       class_weight={},
-                      max_q_size=10, **kwargs):
+                      max_q_size=10, nb_worker=1,
+                      pickle_safe=False, **kwargs):
         '''Fits a model on data generated batch-by-batch by a Python generator.
         The generator is run in parallel to the model, for efficiency.
         For instance, this allows you to do real-time data augmentation
@@ -599,10 +600,6 @@ class Graph(Model):
                           'the model at compile time:\n'
                           '`model.compile(optimizer, loss, '
                           'metrics=["accuracy"])`')
-        if 'nb_worker' in kwargs:
-            kwargs.pop('nb_worker')
-            warnings.warn('The "nb_worker" argument is deprecated, '
-                          'please remove it from your code.')
         if 'nb_val_worker' in kwargs:
             kwargs.pop('nb_val_worker')
             warnings.warn('The "nb_val_worker" argument is deprecated, '
@@ -647,13 +644,16 @@ class Graph(Model):
                                                    validation_data=validation_data,
                                                    nb_val_samples=nb_val_samples,
                                                    class_weight=class_weight,
-                                                   max_q_size=max_q_size)
+                                                   max_q_size=max_q_size,
+                                                   nb_worker=nb_worker,
+                                                   pickle_safe=pickle_safe)
         self.train_on_batch = self._train_on_batch
         self.evaluate = self._evaluate
         return history
 
     def evaluate_generator(self, generator, val_samples,
-                           verbose=1, max_q_size=10, **kwargs):
+                           verbose=1, max_q_size=10, nb_worker=1,
+                           pickle_safe=False, **kwargs):
         '''Evaluates the model on a generator. The generator should
         return the same kind of data with every yield as accepted
         by `evaluate`.
@@ -707,7 +707,9 @@ class Graph(Model):
         generator = fixed_generator()
         history = super(Graph, self).evaluate_generator(generator,
                                                         val_samples,
-                                                        max_q_size=max_q_size)
+                                                        max_q_size=max_q_size,
+                                                        nb_worker=nb_worker,
+                                                        pickle_safe=pickle_safe)
         self.test_on_batch = self._test_on_batch
         return history
 

--- a/tests/keras/engine/test_training.py
+++ b/tests/keras/engine/test_training.py
@@ -5,7 +5,7 @@ from numpy.testing import assert_allclose
 from keras.layers import Dense, Dropout
 from keras.engine.topology import merge, Input
 from keras.engine.training import Model
-from keras.models import Sequential, Graph
+from keras.models import Sequential
 from keras import backend as K
 from keras.utils.test_utils import keras_test
 

--- a/tests/keras/layers/test_normalization.py
+++ b/tests/keras/layers/test_normalization.py
@@ -5,7 +5,7 @@ from numpy.testing import assert_allclose
 from keras.layers.core import Dense, Activation
 from keras.utils.test_utils import layer_test, keras_test
 from keras.layers import normalization
-from keras.models import Sequential, Graph
+from keras.models import Sequential
 from keras import backend as K
 
 input_1 = np.arange(10)

--- a/tests/keras/test_sequential_model.py
+++ b/tests/keras/test_sequential_model.py
@@ -6,7 +6,7 @@ import numpy as np
 np.random.seed(1337)
 
 from keras import backend as K
-from keras.models import Graph, Sequential
+from keras.models import Sequential
 from keras.layers.core import Dense, Activation, Merge, Lambda
 from keras.utils import np_utils
 from keras.utils.test_utils import get_test_data, keras_test

--- a/tests/test_loss_weighting.py
+++ b/tests/test_loss_weighting.py
@@ -5,7 +5,7 @@ import numpy as np
 np.random.seed(1337)
 
 from keras.utils.test_utils import get_test_data
-from keras.models import Sequential, Graph
+from keras.models import Sequential
 from keras.layers import Dense, Activation, RepeatVector, TimeDistributedDense, GRU
 from keras.utils import np_utils
 from keras.utils.test_utils import keras_test


### PR DESCRIPTION
Extend the improvements brought by #3049 to legacy models.

The arguments where missing in graph's methods to be able to use the feature.
A few unused imports have also been removed.