### PR TITLE
Tensorflow rnn fix. Keep shape of the initial (dummy) state

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1261,7 +1261,7 @@ def rnn(step_function, inputs, initial_states,
                     new_state = new_states[0]
                 else:
                     # return dummy state, otherwise _dynamic_rnn_loop breaks
-                    new_state = output
+                    new_state = state
                 return output, new_state
 
         _step.state_size = state_size * nb_states


### PR DESCRIPTION
Keep the dummy input state as output state.
Tensorflow breaks if the shape of the state changes
https://github.com/fchollet/keras/issues/4008