### PR TITLE
Theano batch normalization in 5D and with new gpu backend

### DIFF
--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -396,15 +396,23 @@ def normalize_batch_in_training(x, gamma, beta,
     '''Compute mean and std for batch then apply batch_normalization on batch.
     '''
     dev = theano.config.device
-    use_cudnn = ndim(x) < 5 and reduction_axes == [0, 2, 3] and (dev.startswith('cuda') or dev.startswith('gpu'))
+    use_cudnn = ((dev.startswith('cuda') or dev.startswith('gpu')) and
+                 ndim(x) in (4, 5) and
+                 reduction_axes == [0] + range(2, ndim(x)))
     if use_cudnn:
-        broadcast_beta = beta.dimshuffle('x', 0, 'x', 'x')
-        broadcast_gamma = gamma.dimshuffle('x', 0, 'x', 'x')
+        broadcast_pattern = ['x', 0] + ['x'] * (ndim(x) - 2)
+        broadcast_beta = beta.dimshuffle(*broadcast_pattern)
+        broadcast_gamma = gamma.dimshuffle(*broadcast_pattern)
         try:
             normed, mean, stdinv = theano.sandbox.cuda.dnn.dnn_batch_normalization_train(
                 x, broadcast_gamma, broadcast_beta, 'spatial', epsilon)
             var = T.inv(stdinv ** 2)
             return normed, T.flatten(mean), T.flatten(var)
+        except ValueError:
+            # TODO remove this once Theano versions older than 0.9.0dev3 are deprecated
+            # older versions of Theano did not support 5D inputs for batch normalization
+            if ndim(x) != 5:
+                raise
         except AttributeError:
             pass
 
@@ -434,7 +442,7 @@ def batch_normalization(x, mean, var, beta, gamma, epsilon=0.0001):
     '''
     ndim = x.ndim
     dev = theano.config.device
-    use_cudnn = ndim < 5 and (dev.startswith('cuda') or dev.startswith('gpu'))
+    use_cudnn = ndim in (4, 5) and (dev.startswith('cuda') or dev.startswith('gpu'))
     if use_cudnn:
         try:
             axis = mean.broadcastable.index(False)


### PR DESCRIPTION
The first patch enables Theano's cuDNN function for batch normalization for 5D tensors, if this is supported by the Theano version. (See also #3666, where cuDNN was disabled for 5D because Theano did not support it at the time.)

The second patch uses the batch normalization functions from Theano's new gpuarray backend if device=cuda. This seems to run faster than the old theano.sandbox.cuda backend.
