### PR TITLE
Update imdb_cnn.py to use GlobalMaxPooling1D

### DIFF
--- a/examples/imdb_cnn.py
+++ b/examples/imdb_cnn.py
@@ -12,9 +12,9 @@ np.random.seed(1337)  # for reproducibility
 
 from keras.preprocessing import sequence
 from keras.models import Sequential
-from keras.layers import Dense, Dropout, Activation, Flatten
+from keras.layers import Dense, Dropout, Activation
 from keras.layers import Embedding
-from keras.layers import Convolution1D, MaxPooling1D
+from keras.layers import Convolution1D, GlobalMaxPooling1D
 from keras.datasets import imdb
 from keras import backend as K
 
@@ -58,11 +58,7 @@ model.add(Convolution1D(nb_filter=nb_filter,
                         activation='relu',
                         subsample_length=1))
 # we use max pooling:
-model.add(MaxPooling1D(pool_length=model.output_shape[1]))
-
-# We flatten the output of the conv layer,
-# so that we can add a vanilla dense layer:
-model.add(Flatten())
+model.add(GlobalMaxPooling1D())
 
 # We add a vanilla hidden layer:
 model.add(Dense(hidden_dims))


### PR DESCRIPTION
The imdb_cnn.py example is uses `MaxPooling1D(pool_length=model.output_shape[1])` for pooling. Changed it to use GlobalMaxPooling1D instead.