### PR TITLE
Added quantile regression loss function for some of the more popular quantiles

### DIFF
--- a/keras/objectives.py
+++ b/keras/objectives.py
@@ -63,6 +63,36 @@ def cosine_proximity(y_true, y_pred):
     y_pred = K.l2_normalize(y_pred, axis=-1)
     return -K.mean(y_true * y_pred, axis=-1)
 
+# The actual pinball/ tilted loss function for quantile regression
+def tilted_loss(q,y,f):
+    """
+    Pinball loss function used in quantile regression where q is the quantile.
+    """
+    e = (y-f)
+    return K.mean(q*e + K.clip(-e,K.epsilon(),np.inf),axis=-1)
+
+# Wrappers for the most popular quantiles
+def q1(y_true,y_pred):
+    return tilted_loss(0.01,y_true,y_pred)
+
+def q5(y_true,y_pred):
+    return tilted_loss(0.05,y_true,y_pred)
+
+def q10(y_true,y_pred):
+    return tilted_loss(0.10,y_true,y_pred)
+
+def q50(y_true,y_pred):
+    return tilted_loss(0.50,y_true,y_pred)
+
+def q90(y_true,y_pred):
+    return tilted_loss(0.90,y_true,y_pred)
+
+def q95(y_true,y_pred):
+    return tilted_loss(0.95,y_true,y_pred)
+
+def q99(y_true,y_pred):
+    return tilted_loss(0.99,y_true,y_pred)
+
 
 # aliases
 mse = MSE = mean_squared_error

--- a/tests/keras/test_objectives.py
+++ b/tests/keras/test_objectives.py
@@ -14,7 +14,14 @@ allobj = [objectives.mean_squared_error,
           objectives.binary_crossentropy,
           objectives.kullback_leibler_divergence,
           objectives.poisson,
-          objectives.cosine_proximity]
+          objectives.cosine_proximity,
+          objectives.q1,
+          objectives.q5,
+          objectives.q10,
+          objectives.q50,
+          objectives.q90,
+          objectives.q95,
+          objectives.q99]
 
 
 def test_objective_shapes_3d():
@@ -42,6 +49,18 @@ def test_cce_one_hot():
     y_a = K.variable(np.random.randint(0, 7, (6,)))
     y_b = K.variable(np.random.random((6, 7)))
     assert K.eval(objectives.sparse_categorical_crossentropy(y_a, y_b)).shape == (6,)
+
+def test_q50_abs():
+    """
+    This function tests if the output of the mean absolute and the 50th quantile
+    are the same.
+    """
+    y_a = K.variable((6,1))
+    y_b = K.variable((6,1))
+    q50_out = objectives.q50(y_a,y_b)
+    abs_out = objectives.mean_absolute_error(y_a,y_b)
+    
+    assert np.abs(K.eval(q50_out - abs_out))<1e-06
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The tilted (pinball) loss function is used in quantile regression. Thought it would be useful for keras to implement atleast a few of those quantiles as shown below in objectives.py. I've wrapped the quantiles 1%, 5%, 10%, 50%, 90%, 95% and 99% as q1, q5 etc.

The tilted loss function shown here: https://www.lokad.com/pinball-loss-function-definition can be summarised as mean(q*err + clip(-err)) where err = observation - quantile_function.