### PR TITLE
Display wrapped layers in graph visualization

### DIFF
--- a/keras/utils/visualize_util.py
+++ b/keras/utils/visualize_util.py
@@ -1,5 +1,7 @@
 import os
 
+from ..layers.wrappers import Wrapper
+
 try:
     # pydot-ng is a fork of pydot that is better maintained
     import pydot_ng as pydot
@@ -34,7 +36,7 @@ def model_to_dot(model, show_shapes=False, show_layer_names=True):
         # being unique identifiers.
         layer_name = layer.name
         layer_class_name = layer.__class__.__name__
-        if layer.__module__ == 'keras.layers.wrappers':
+        if issubclass(layer.__class__, Wrapper):
             layer_name += ', ' + layer.layer.name
             layer_class_name += layer.layer.__class__.__name__
         

--- a/keras/utils/visualize_util.py
+++ b/keras/utils/visualize_util.py
@@ -29,22 +29,18 @@ def model_to_dot(model, show_shapes=False, show_layer_names=True):
     for layer in layers:
         layer_id = str(id(layer))
         
-        # Append a wrapped layer's label to node's label, if it exists
-        # (e.g. TimeDistributed(Dense()) becomes "TimeDistributedDense",
-        # Bidirectional(LSTM()) becomes "BidirectionalLSTM", and so on).
-        # Layer names are comma separated, to not cause confusion about
-        # being unique identifiers.
+        # Append a wrapped layer's label to node's label, if it exists.
         layer_name = layer.name
-        layer_class_name = layer.__class__.__name__
+        class_name = layer.__class__.__name__
         if isinstance(layer, Wrapper):
-            layer_name += ', ' + layer.layer.name
-            layer_class_name += layer.layer.__class__.__name__
-        
+            layer_name = '{}({})'.format(layer_name, layer.layer.name)
+            class_name = '{}({})'.format(class_name, layer.layer.__class__.__name__)
+
         # Create node's label.
         if show_layer_names:
-            label = '{} ({})'.format(layer_name, layer_class_name)
+            label = '{}: {}'.format(layer_name, class_name)
         else:
-            label = layer_class_name
+            label = class_name
 
         # Rebuild the label as a table including input/output shapes.
         if show_shapes:

--- a/keras/utils/visualize_util.py
+++ b/keras/utils/visualize_util.py
@@ -36,7 +36,7 @@ def model_to_dot(model, show_shapes=False, show_layer_names=True):
         # being unique identifiers.
         layer_name = layer.name
         layer_class_name = layer.__class__.__name__
-        if issubclass(layer.__class__, Wrapper):
+        if isinstance(layer, Wrapper):
             layer_name += ', ' + layer.layer.name
             layer_class_name += layer.layer.__class__.__name__
         


### PR DESCRIPTION
# Proposal
Assuming all layers in `keras.layers.wrappers` always have __exactly one layer__ they're wrapping (@fchollet, is this invariably true?) this pull request appends the wrapped layer's name and class name to the graph for visualization.

# Example
![model](https://cloud.githubusercontent.com/assets/1595907/19639671/b2a8d410-99d9-11e6-8f47-37117026939c.png)
