### PR TITLE
Fix LiL sparse matrix on Tensorflow

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -146,7 +146,7 @@ def variable(value, dtype=_FLOATX, name=None):
         sparse_coo = value.tocoo()
         indices = np.concatenate((np.expand_dims(sparse_coo.row, 1), np.expand_dims(sparse_coo.col, 1)), 1)
         # SparseTensor doesn't need initialization
-        return tf.SparseTensor(indices=indices, values=value.data, shape=value.shape)
+        return tf.SparseTensor(indices=indices, values=sparse_coo.data, shape=sparse_coo.shape)
 
     v = tf.Variable(value, dtype=_convert_string_dtype(dtype), name=name)
     if _MANUAL_VAR_INIT:
@@ -1034,7 +1034,7 @@ class Function(object):
             if is_sparse(tensor):
                 sparse_coo = value.tocoo()
                 indices = np.concatenate((np.expand_dims(sparse_coo.row, 1), np.expand_dims(sparse_coo.col, 1)), 1)
-                value = (indices, value.data, value.shape)
+                value = (indices, sparse_coo.data, sparse_coo.shape)
             feed_dict[tensor] = value
         session = get_session()
         updated = session.run(self.outputs + [self.updates_op], feed_dict=feed_dict)


### PR DESCRIPTION
LiL sparse matrices would not work correctly due to dtype being
different. Using the sparse_coo data fixes it.

LiL matrices work best when using the fit method because they support the list slicing form the slice_X function. They would not work before this fix, however.