### PR TITLE
Only allow the addition to `Sequential` objects of layers that are instances of `Layer`

### DIFF
--- a/keras/models.py
+++ b/keras/models.py
@@ -8,7 +8,7 @@ import numpy as np
 from . import backend as K
 from .utils.io_utils import ask_to_proceed_with_overwrite
 from .engine.training import Model
-from .engine.topology import get_source_inputs, Node
+from .engine.topology import get_source_inputs, Node, Layer
 from .optimizers import optimizer_from_config
 from .legacy.models import Graph
 
@@ -260,6 +260,10 @@ class Sequential(Model):
         # Arguments
             layer: layer instance.
         '''
+        if not isinstance(layer, Layer):
+            raise ValueError(
+                "The added layer must be an instance of class %s.Layer" \
+                % Layer.__module__)
         if not self.outputs:
             # first layer in model: check that it is an input layer
             if len(layer.inbound_nodes) == 0:

--- a/keras/models.py
+++ b/keras/models.py
@@ -261,9 +261,9 @@ class Sequential(Model):
             layer: layer instance.
         '''
         if not isinstance(layer, Layer):
-            raise ValueError(
-                "The added layer must be an instance of class %s.Layer"
-                % Layer.__module__)
+            raise ValueError('The added layer must be '
+                             'an instance of class Layer. '
+                             'Found: ' + str(layer))
         if not self.outputs:
             # first layer in model: check that it is an input layer
             if len(layer.inbound_nodes) == 0:

--- a/keras/models.py
+++ b/keras/models.py
@@ -262,7 +262,7 @@ class Sequential(Model):
         '''
         if not isinstance(layer, Layer):
             raise ValueError(
-                "The added layer must be an instance of class %s.Layer" \
+                "The added layer must be an instance of class %s.Layer"
                 % Layer.__module__)
         if not self.outputs:
             # first layer in model: check that it is an input layer


### PR DESCRIPTION
This pull request will issue a clearer error message when an object that is not a `Layer` is added to a `Sequential` model (see Issue #4130 and #4074 ).

This is done by checking that the object is an instance of `keras.engine.topology.Layer` rather than through investigating that the object implements methods/properties in a layer protocol.