### PR TITLE
Use six for wrapping in keras_test

### DIFF
--- a/keras/utils/test_utils.py
+++ b/keras/utils/test_utils.py
@@ -1,7 +1,7 @@
 import numpy as np
 from numpy.testing import assert_allclose
 import inspect
-import functools
+import six
 
 from ..engine import Model, Input
 from ..models import Sequential, model_from_json
@@ -112,7 +112,7 @@ def layer_test(layer_cls, kwargs={}, input_shape=None, input_dtype=None,
 def keras_test(func):
     '''Clean up after tensorflow tests.
     '''
-    @functools.wraps(func)
+    @six.wraps(func)
     def wrapper(*args, **kwargs):
         output = func(*args, **kwargs)
         if K._BACKEND == 'tensorflow':

--- a/tests/keras/layers/test_recurrent.py
+++ b/tests/keras/layers/test_recurrent.py
@@ -1,5 +1,4 @@
 import pytest
-import sys
 import numpy as np
 from numpy.testing import assert_allclose
 
@@ -21,18 +20,7 @@ def rnn_test(f):
     All the recurrent layers share the same interface,
     so we can run through them with a single function.
     """
-    kf = keras_test(f)
-
-    def wrapped(layer_class):
-        return kf(layer_class)
-
-    # functools doesnt propagate arguments info for pytest correctly in 2.7
-    # and wrapped doesnt work with pytest in 3.4
-    if sys.version_info >= (3, 0):
-        f = kf
-    else:
-        f = wrapped
-
+    f = keras_test(f)
     return pytest.mark.parametrize("layer_class", [
         recurrent.SimpleRNN,
         recurrent.GRU,


### PR DESCRIPTION
This will allow parameterized tests to work correctly in both 2.7 and
3.4

There're also some low hanging fruits for test speed up (TF only though) - test_convolutional along can probably be sped up ~2x.