### PR TITLE
BUG: Deconvolution2D output shape not correctly referenced

### DIFF
--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -665,7 +665,7 @@ class Deconvolution2D(Convolution2D):
         return output
 
     def get_config(self):
-        config = {'output_shape': self.output_shape}
+        config = {'output_shape': self.output_shape_}
         base_config = super(Deconvolution2D, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
 


### PR DESCRIPTION
Error with the  get_config method from Deconvolution2D.

Throws the following error when saving a model with such layer.
Exception: The layer has never been called and thus has no defined output shape.
