### PR TITLE
TimeDistributed masking(discussion, possible improvement)

### DIFF
--- a/keras/layers/wrappers.py
+++ b/keras/layers/wrappers.py
@@ -100,8 +100,7 @@ class TimeDistributed(Wrapper):
         self.supports_masking = True
         if reduction_dimensions is not None and (0 in reduction_dimensions):
             raise Exception("You cannot TimeDistribute a layer which reduces the time dimension.")
-        # Add in the batch dimension.
-        self.reduction_dimensions = [x + 1 for x in reduction_dimensions]
+        self.reduction_dimensions = reduction_dimensions
         super(TimeDistributed, self).__init__(layer, **kwargs)
 
     def build(self, input_shape):
@@ -174,17 +173,18 @@ class TimeDistributed(Wrapper):
             # Therefore, we no longer need a mask.
             return None
         else:
+            reduction_dims = [x + 1 for x in self.reduction_dimensions]
             # Masking was applied to the Layer, but it is possible that whole
             # dimensions were masked. Here, we generate a mask which is all ones
             # unless all of a given reduced dimension was masked.
             input_ndim = K.ndim(input)
             mask_ndim = K.ndim(input_mask)
 
-            if mask_ndim == input_ndim - 1 and mask_ndim in self.reduction_dimensions:
+            if mask_ndim == input_ndim - 1 and mask_ndim in reduction_dims:
                 # Check user hasn't masked the final dimension
                 # if the mask is smaller than the input.
-                self.reduction_dimensions.remove(input_ndim)
-            return K.any(input_mask, self.reduction_dimensions)
+                reduction_dims.remove(input_ndim)
+            return K.any(input_mask, reduction_dims)
 
 
 class Bidirectional(Wrapper):

--- a/tests/keras/layers/test_wrappers.py
+++ b/tests/keras/layers/test_wrappers.py
@@ -75,6 +75,13 @@ def test_TimeDistributed():
     outer_model.compile(optimizer='rmsprop', loss='mse')
     outer_model.fit(np.random.random((10, 3, 2)), np.random.random((10, 3, 3)), nb_epoch=1, batch_size=10)
 
+    # test wrapping a Layer which reduces dimensionality of input.
+    model = Sequential()
+    model.add(wrappers.TimeDistributed(recurrent.SimpleRNN(2), reduction_dimensions=[1], input_shape=(3, 5, 4)))
+    model.add(core.Activation('relu'))
+    model.compile(optimizer='rmsprop', loss='mse')
+    model.fit(np.random.random((10, 3, 5, 4)), np.random.random((10, 3, 2)), nb_epoch=1, batch_size=10)
+
 
 @keras_test
 def test_Bidirectional():


### PR DESCRIPTION
This PR is intended as a discussion of the function of masking in the `TimeDistributed` wrapper, with some code to potentially demonstrate a different way it could work. It's certainly possible that we have mis-used `TimeDistributed` in a way that you have not intended - if this is the case, please just say and close this PR. 

We have been using `TimeDistributed` in order to apply generic sequence encoders (eg LSTM, BOW) to a number of inputs across a particular dimension: `(num_samples, num_sentences, num_words, embedding_size) --> (num_samples, num_sentences, embedding_size)`. Specifically, the below problem arises because the function being `TimeDistributed` changes the dimension of its inputs from `(batch_size, num_words, embedding_size) --> (batch_size, embedding_size)`.

In this case, there are two issues: 

1) the mask is not passed to the `K.rnn` function applying the encoder each of the sentence inputs(where the time dimension here is num_sentences)

2) the `TimeDistributed` layer just returns the input mask, which is no longer the correct shape: `(batch_size, num_sentences, num_words)`. Normally, you would assume that after a layer which encodes inputs in such a way, you would no longer need a mask - however, in this case, it is possible that different numbers of sentences are passed for a given input, meaning that we still require a mask of shape `num_samples, num_sentences` to guard against this.


The code in this PR suggests two things:

1) The mask received by `TimeDistributed` should be passed to the `K.rnn` function. 

2) If  the dimension of the inputs is changed by the encoder, create a mask which is all ones unless for a given dimension, the input mask is all zeros (this addresses the fact that an entire sentence might be masked). One issue here is there is no way (I don't think) to check which dimensions have been reduced. This would be a possible reason to not implement this part of the PR, but we think that the first point certainly is relevant. The implementation in the `compute_mask` function of this PR assumes that if the dimension has changed by `n`, the output dimensions are just `input_shape[:-n]`. This is obviously not ideal. I've included it as a discussion point and if others can see a way to specify the dimensions which are reduced, I think this would be a good feature.

Thanks! Keras is great.

@pdasigi 







