### PR TITLE
Refactor F-score into precision and recall metrics

### DIFF
--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -148,11 +148,31 @@ def matthews_correlation(y_true, y_pred):
     return numerator / (denominator + K.epsilon())
 
 
-def fbeta_score(y_true, y_pred, beta=1):
+def precision(y_true, y_pred):
+    '''Compute precision, a metric for multi-label classification of how
+    many selected items are relevant.
+    '''
+    true_positives = K.sum(K.round(K.clip(y_true * y_pred, 0, 1)))
+    predicted_positives = K.sum(K.round(K.clip(y_pred, 0, 1)))
+    precision = true_positives / (predicted_positives + K.epsilon())
+    return precision
+
+
+def recall(y_true, y_pred):
+    '''Compute recall, a metric for multi-label classification of how
+    many relevant items are selected.
+    '''
+    true_positives = K.sum(K.round(K.clip(y_true * y_pred, 0, 1)))
+    possible_positives = K.sum(K.round(K.clip(y_true, 0, 1)))
+    recall = true_positives / (possible_positives + K.epsilon())
+    return recall
+
+
+def fbeta_score(y_true, y_pred, beta):
     '''Computes the F score, the weighted harmonic mean of precision and recall.
 
-    This is useful for multi-label classification where input samples can be
-    tagged with a set of labels. By only using accuracy (precision) a model
+    This is useful for multi-label classification, where input samples can be
+    classified as sets of labels. By only using accuracy (precision) a model
     would achieve a perfect score by simply assigning every class to every
     input. In order to avoid this, a metric should penalize incorrect class
     assignments as well (recall). The F-beta score (ranged from 0.0 to 1.0)
@@ -162,30 +182,23 @@ def fbeta_score(y_true, y_pred, beta=1):
     With beta = 1, this is equivalent to a F-measure. With beta < 1, assigning
     correct classes becomes more important, and with beta > 1 the metric is
     instead weighted towards penalizing incorrect class assignments.
-
     '''
     if beta < 0:
         raise ValueError('The lowest choosable beta is zero (only precision).')
-
-    # Count positive samples.
-    c1 = K.sum(K.round(K.clip(y_true * y_pred, 0, 1)))
-    c2 = K.sum(K.round(K.clip(y_pred, 0, 1)))
-    c3 = K.sum(K.round(K.clip(y_true, 0, 1)))
-
-    # If there are no true samples, fix the F score at 0.
-    if c3 == 0:
+        
+    # If there are no true positives, fix the F score at 0 like sklearn.
+    if K.sum(K.round(K.clip(y_true, 0, 1))) == 0:
         return 0
 
-    # How many selected items are relevant?
-    precision = c1 / c2
+    p = precision(y_true, y_pred)
+    r = recall(y_true, y_pred)
+    bb = beta ** 2
+    fbeta_score = (1 + bb) * (p * r) / (bb * p + r + K.epsilon())
+    return fbeta_score
 
-    # How many relevant items are selected?
-    recall = c1 / c3
 
-    # Weight precision and recall together as a single scalar.
-    beta2 = beta ** 2
-    f_score = (1 + beta2) * (precision * recall) / (beta2 * precision + recall)
-    return f_score
+def fmeasure(y_true, y_pred):
+    return fbeta_score(y_true, y_pred, beta=1)
 
 
 # aliases
@@ -194,6 +207,7 @@ mae = MAE = mean_absolute_error
 mape = MAPE = mean_absolute_percentage_error
 msle = MSLE = mean_squared_logarithmic_error
 cosine = cosine_proximity
+fscore = f1score = fmeasure
 
 
 def get(identifier):

--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -198,6 +198,8 @@ def fbeta_score(y_true, y_pred, beta):
 
 
 def fmeasure(y_true, y_pred):
+    '''Calculates the f-measure, the harmonic mean of precision and recall.
+    '''
     return fbeta_score(y_true, y_pred, beta=1)
 
 

--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -5,14 +5,14 @@ from .utils.generic_utils import get_from_module
 
 def binary_accuracy(y_true, y_pred):
     '''Calculates the mean accuracy rate across all predictions for binary
-    classification problems
+    classification problems.
     '''
     return K.mean(K.equal(y_true, K.round(y_pred)))
 
 
 def categorical_accuracy(y_true, y_pred):
     '''Calculates the mean accuracy rate across all predictions for
-    multiclass classification problems
+    multiclass classification problems.
     '''
     return K.mean(K.equal(K.argmax(y_true, axis=-1),
                   K.argmax(y_pred, axis=-1)))
@@ -20,7 +20,7 @@ def categorical_accuracy(y_true, y_pred):
 
 def sparse_categorical_accuracy(y_true, y_pred):
     '''Same as categorical_accuracy, but useful when the predictions are for
-    sparse targets
+    sparse targets.
     '''
     return K.mean(K.equal(K.max(y_true, axis=-1),
                           K.cast(K.argmax(y_pred, axis=-1), K.floatx())))
@@ -28,28 +28,28 @@ def sparse_categorical_accuracy(y_true, y_pred):
 
 def top_k_categorical_accuracy(y_true, y_pred, k=5):
     '''Calculates the top-k categorical accuracy rate, i.e. success when the
-    target class is within the top-k predictions provided
+    target class is within the top-k predictions provided.
     '''
     return K.mean(K.in_top_k(y_pred, K.argmax(y_true, axis=-1), k))
 
 
 def mean_squared_error(y_true, y_pred):
     '''Calculates the mean squared error (mse) rate
-    between predicted and target values
+    between predicted and target values.
     '''
     return K.mean(K.square(y_pred - y_true))
 
 
 def mean_absolute_error(y_true, y_pred):
     '''Calculates the mean absolute error (mae) rate
-    between predicted and target values
+    between predicted and target values.
     '''
     return K.mean(K.abs(y_pred - y_true))
 
 
 def mean_absolute_percentage_error(y_true, y_pred):
     '''Calculates the mean absolute percentage error (mape) rate
-    between predicted and target values
+    between predicted and target values.
     '''
     diff = K.abs((y_true - y_pred) / K.clip(K.abs(y_true), K.epsilon(), np.inf))
     return 100. * K.mean(diff)
@@ -57,7 +57,7 @@ def mean_absolute_percentage_error(y_true, y_pred):
 
 def mean_squared_logarithmic_error(y_true, y_pred):
     '''Calculates the mean squared logarithmic error (msle) rate
-    between predicted and target values
+    between predicted and target values.
     '''
     first_log = K.log(K.clip(y_pred, K.epsilon(), np.inf) + 1.)
     second_log = K.log(K.clip(y_true, K.epsilon(), np.inf) + 1.)
@@ -66,13 +66,13 @@ def mean_squared_logarithmic_error(y_true, y_pred):
 
 def hinge(y_true, y_pred):
     '''Calculates the hinge loss, which is defined as
-    `max(1 - y_true * y_pred, 0)`
+    `max(1 - y_true * y_pred, 0)`.
     '''
     return K.mean(K.maximum(1. - y_true * y_pred, 0.))
 
 
 def squared_hinge(y_true, y_pred):
-    '''Calculates the squared value of the hinge loss
+    '''Calculates the squared value of the hinge loss.
     '''
     return K.mean(K.square(K.maximum(1. - y_true * y_pred, 0.)))
 
@@ -104,7 +104,7 @@ def binary_crossentropy(y_true, y_pred):
 
 def kullback_leibler_divergence(y_true, y_pred):
     '''Calculates the Kullback-Leibler (KL) divergence between prediction
-    and target values
+    and target values.
     '''
     y_true = K.clip(y_true, K.epsilon(), 1)
     y_pred = K.clip(y_pred, K.epsilon(), 1)
@@ -149,8 +149,8 @@ def matthews_correlation(y_true, y_pred):
 
 
 def precision(y_true, y_pred):
-    '''Compute precision, a metric for multi-label classification of how
-    many selected items are relevant.
+    '''Calculates the precision, a metric for multi-label classification of
+    how many selected items are relevant.
     '''
     true_positives = K.sum(K.round(K.clip(y_true * y_pred, 0, 1)))
     predicted_positives = K.sum(K.round(K.clip(y_pred, 0, 1)))
@@ -159,8 +159,8 @@ def precision(y_true, y_pred):
 
 
 def recall(y_true, y_pred):
-    '''Compute recall, a metric for multi-label classification of how
-    many relevant items are selected.
+    '''Calculates the recall, a metric for multi-label classification of
+    how many relevant items are selected.
     '''
     true_positives = K.sum(K.round(K.clip(y_true * y_pred, 0, 1)))
     possible_positives = K.sum(K.round(K.clip(y_true, 0, 1)))
@@ -169,7 +169,7 @@ def recall(y_true, y_pred):
 
 
 def fbeta_score(y_true, y_pred, beta):
-    '''Computes the F score, the weighted harmonic mean of precision and recall.
+    '''Calculates the F score, the weighted harmonic mean of precision and recall.
 
     This is useful for multi-label classification, where input samples can be
     classified as sets of labels. By only using accuracy (precision) a model

--- a/tests/keras/test_metrics.py
+++ b/tests/keras/test_metrics.py
@@ -46,14 +46,50 @@ def test_matthews_correlation():
     assert expected - epsilon <= actual <= expected + epsilon
 
 
+def test_precision():
+    y_true = K.variable(np.array([0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 1, 0, 0]))
+    y_pred = K.variable(np.array([1, 0, 1, 0, 1, 0, 0, 1, 0, 0, 0, 0, 1, 0]))
+
+    # Calculated using sklearn.metrics.precision_score
+    expected = 0.40000000000000002
+
+    actual = K.eval(metrics.precision(y_true, y_pred))
+    epsilon = 1e-05
+    assert expected - epsilon <= actual <= expected + epsilon
+
+
+def test_recall():
+    y_true = K.variable(np.array([0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 1, 0, 0]))
+    y_pred = K.variable(np.array([1, 0, 1, 0, 1, 0, 0, 1, 0, 0, 0, 0, 1, 0]))
+
+    # Calculated using sklearn.metrics.recall_score
+    expected = 0.2857142857142857
+
+    actual = K.eval(metrics.recall(y_true, y_pred))
+    epsilon = 1e-05
+    assert expected - epsilon <= actual <= expected + epsilon
+
+
 def test_fbeta_score():
+    y_true = K.variable(np.array([0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 1, 0, 0]))
+    y_pred = K.variable(np.array([1, 0, 1, 0, 1, 0, 0, 1, 0, 0, 0, 0, 1, 0]))
+
+    # Calculated using sklearn.metrics.fbeta_score
+    expected = 0.30303030303030304
+
+    actual = K.eval(metrics.fbeta_score(y_true, y_pred, beta=2))
+    epsilon = 1e-05
+    assert expected - epsilon <= actual <= expected + epsilon
+
+
+def test_fmeasure():
     y_true = K.variable(np.array([0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 1, 0, 0]))
     y_pred = K.variable(np.array([1, 0, 1, 0, 1, 0, 0, 1, 0, 0, 0, 0, 1, 0]))
 
     # Calculated using sklearn.metrics.f1_score
     expected = 0.33333333333333331
 
-    actual = K.eval(metrics.fbeta_score(y_true, y_pred))
+    actual = K.eval(metrics.fmeasure(y_true, y_pred))
     epsilon = 1e-05
     assert expected - epsilon <= actual <= expected + epsilon
 


### PR DESCRIPTION
# Fixes
 - Better names (`true_positives`, instead of `c1`, etc.)
 - Refactored F-score into separate precision and recall functions for better progress reporting. It's very useful to see whether a model is learning to assign labels to samples without being regularized enough to maintain a high recall. It's also standard to report all three metrics in papers, and having the metrics available directly with model.evaluate would be very useful for this.
 - Added `K.epsilon` to denominators like in `matthews_correlation`, to avoid getting `inf` in early epochs.
 - Added F1 score with common aliases from different research fields (f-measure, etc.).