### PR TITLE
Switch to tensorflow in setup.py/install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(name='Keras',
       url='https://github.com/fchollet/keras',
       download_url='https://github.com/fchollet/keras/tarball/1.1.1',
       license='MIT',
-      install_requires=['theano', 'pyyaml', 'six'],
+      install_requires=['tensorflow', 'pyyaml', 'six'],
       extras_require={
           'h5py': ['h5py'],
           'visualize': ['pydot-ng'],


### PR DESCRIPTION
Given that tensorflow is the new default for keras, it would make sense to switch the `install_requires` field as well.

As far as I can tell, theano doesn't seem to be a requirement when installing keras.