### PR TITLE
Dense layer with multiple dimensions

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -387,6 +387,35 @@ def dot(x, y):
     return out
 
 
+def tensordot(x, y, axes):
+    '''Computes a generalized dot product over the provided axes.
+
+    This implements a subset of the options available in Theano's
+    `theano.tensor.tensordot` function.
+
+    # Arguments
+        x, y: tensors with ndim >= 2
+        axes: single int with the number of axes to sum over.
+            This partial implementation only supports ndim(x) - 1.
+    '''
+    # This implements a subset of Theano's tensordot options.
+    assert isinstance(axes, int)
+    assert ndim(x) > axes
+    assert ndim(y) > axes
+    assert axes == ndim(x) - 1, "tensordot is only implemented for axes == ndim(x) - 1."
+    x_shape = int_shape(x)
+    y_shape = int_shape(y)
+    x_dims = x_shape[1:]
+    output_dims = y_shape[len(x_dims):]
+    x_1d = x if ndim(x) == 2 else tf.reshape(x, (-1, np.prod(x_dims)))
+    y_1d = y if ndim(y) == 2 else tf.reshape(y, (np.prod(x_dims), np.prod(output_dims)))
+    output_1d = dot(x_1d, y_1d)
+    if len(output_dims) == 1:
+        return output_1d
+    else:
+        return tf.reshape(output_1d, (-1,) + output_dims)
+
+
 def batch_dot(x, y, axes=None):
     '''Batchwise dot product.
 

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -193,6 +193,10 @@ def dot(x, y):
         return T.dot(x, y)
 
 
+def tensordot(x, y, axes):
+    return T.tensordot(x, y, axes=axes)
+
+
 def batch_dot(x, y, axes=None):
     '''Batchwise dot product.
 

--- a/tests/keras/backend/test_backends.py
+++ b/tests/keras/backend/test_backends.py
@@ -68,6 +68,11 @@ class TestBackend(object):
         check_two_tensor_operation('dot', (4, 2), (2, 4))
         check_two_tensor_operation('dot', (4, 2), (5, 2, 3))
 
+        check_two_tensor_operation('tensordot', (4, 2), (2, 4), axes=1)
+        check_two_tensor_operation('tensordot', (4, 2), (2, 4, 5), axes=1)
+        check_two_tensor_operation('tensordot', (4, 2, 4), (2, 4, 5), axes=2)
+        check_two_tensor_operation('tensordot', (4, 2, 4), (2, 4, 3), axes=2)
+
         check_two_tensor_operation('batch_dot', (4, 2, 3), (4, 5, 3),
                                    axes=(2, 2))
         check_single_tensor_operation('transpose', (4, 2))

--- a/tests/keras/layers/test_core.py
+++ b/tests/keras/layers/test_core.py
@@ -321,12 +321,39 @@ def test_dense():
     from keras import regularizers
     from keras import constraints
 
+    # 1D input and 1D output
     layer_test(core.Dense,
                kwargs={'output_dim': 3},
                input_shape=(3, 2))
 
+    # 1D input and 1D output with options
     layer_test(core.Dense,
                kwargs={'output_dim': 3,
+                       'W_regularizer': regularizers.l2(0.01),
+                       'b_regularizer': regularizers.l1(0.01),
+                       'activity_regularizer': regularizers.activity_l2(0.01),
+                       'W_constraint': constraints.MaxNorm(1),
+                       'b_constraint': constraints.MaxNorm(1)},
+               input_shape=(3, 2))
+
+    # 1D input and 2D output
+    layer_test(core.Dense,
+               kwargs={'output_dim': (3, 5)},
+               input_shape=(3, 2))
+
+    # 2D input and 1D output
+    layer_test(core.Dense,
+               kwargs={'output_dim': 3},
+               input_shape=(3, 2, 5))
+
+    # 2D input and 3D output
+    layer_test(core.Dense,
+               kwargs={'output_dim': (3, 5, 7)},
+               input_shape=(3, 2, 5))
+
+    # 2D input and 2D output with options
+    layer_test(core.Dense,
+               kwargs={'output_dim': (3, 5),
                        'W_regularizer': regularizers.l2(0.01),
                        'b_regularizer': regularizers.l1(0.01),
                        'activity_regularizer': regularizers.activity_l2(0.01),


### PR DESCRIPTION
This patch would make it possible to create `Dense` layers with multi-dimensional inputs or outputs. You can get a similar result by stacking `Flatten`, `Dense` and `Reshape`, but in some cases it can be more convenient to have it all in a single layer.