### PR TITLE
Allow for learning rate schedule of type np.float32 and np.float64

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -432,7 +432,11 @@ class LearningRateScheduler(Callback):
         assert hasattr(self.model.optimizer, 'lr'), \
             'Optimizer must have a "lr" attribute.'
         lr = self.schedule(epoch)
-        assert type(lr) == float, 'The output of the "schedule" function should be float.'
+
+        if not isinstance(lr, (float, np.float32, np.float64)):
+            raise ValueError('The output of the "schedule" function '
+                             'should be float.')
+
         K.set_value(self.model.optimizer.lr, lr)
 
 


### PR DESCRIPTION
### What Does this PR Solve
Currently the `LearningRateScheduler` asserts that the returned type is a python float. This is problematic for any schedule that uses functions from `numpy`, which will most likely return a learning rate of one of numpy's dtypes (`np.float32`, `np.float64`). 

### What Does this PR Change/Add
This PR requires the learning rate to be an instance of `float`, `np.float32`, `np.float64` instead of the hard requirement of a python `float`. In addition, the `LearningRateScheduler` now raises a `TypeError` instead of an `AssertionError` in the case of failure. Finally, the test suite was update to run learning rates of the new types and a test was added to test for the failure in the case of an `int`.