### PR TITLE
Add documentation to set self.built = True in MyLayer.build()

### DIFF
--- a/docs/templates/layers/writing-your-own-keras-layers.md
+++ b/docs/templates/layers/writing-your-own-keras-layers.md
@@ -4,7 +4,7 @@ For simple, stateless custom operations, you are probably better off using `laye
 
 Here is the skeleton of a Keras layer. There are only three methods you need to implement:
 
-- `build(input_shape)`: this is where you will define your weights. Trainable weights should be added to the list `self.trainable_weights`. Other attributes of note are: `self.non_trainable_weights` (list) and `self.updates` (list of update tuples (tensor, new_tensor)). For an example of how to use `non_trainable_weights` and `updates`, see the code for the `BatchNormalization` layer.
+- `build(input_shape)`: this is where you will define your weights. Trainable weights should be added to the list `self.trainable_weights`. Other attributes of note are: `self.non_trainable_weights` (list) and `self.updates` (list of update tuples (tensor, new_tensor)). For an example of how to use `non_trainable_weights` and `updates`, see the code for the `BatchNormalization` layer.  This method must set `self.built = True`, which can be done by calling `super([Layer], self).build()`.  If you do not do this, you could end up with very cryptic errors in some cases.
 - `call(x)`: this is where the layer's logic lives. Unless you want your layer to support masking, you only have to care about the first argument passed to `call`: the input tensor.
 - `get_output_shape_for(input_shape)`: in case your layer modifies the shape of its input, you should specify here the shape transformation logic. This allows Keras to do automatic shape inference.
 
@@ -23,6 +23,7 @@ class MyLayer(Layer):
         initial_weight_value = np.random.random((input_dim, output_dim))
         self.W = K.variable(initial_weight_value)
         self.trainable_weights = [self.W]
+        super(MyLayer, self).build()  # be sure you call this somewhere!
 
     def call(self, x, mask=None):
         return K.dot(x, self.W)

--- a/docs/templates/layers/writing-your-own-keras-layers.md
+++ b/docs/templates/layers/writing-your-own-keras-layers.md
@@ -4,7 +4,7 @@ For simple, stateless custom operations, you are probably better off using `laye
 
 Here is the skeleton of a Keras layer. There are only three methods you need to implement:
 
-- `build(input_shape)`: this is where you will define your weights. Trainable weights should be added to the list `self.trainable_weights`. Other attributes of note are: `self.non_trainable_weights` (list) and `self.updates` (list of update tuples (tensor, new_tensor)). For an example of how to use `non_trainable_weights` and `updates`, see the code for the `BatchNormalization` layer.  This method must set `self.built = True`, which can be done by calling `super([Layer], self).build()`.  If you do not do this, you could end up with very cryptic errors in some cases.
+- `build(input_shape)`: this is where you will define your weights. Trainable weights should be added to the list `self.trainable_weights`. Other attributes of note are: `self.non_trainable_weights` (list) and `self.updates` (list of update tuples (tensor, new_tensor)). For an example of how to use `non_trainable_weights` and `updates`, see the code for the `BatchNormalization` layer.  This method must set `self.built = True`, which can be done by calling `super([Layer], self).build()`.
 - `call(x)`: this is where the layer's logic lives. Unless you want your layer to support masking, you only have to care about the first argument passed to `call`: the input tensor.
 - `get_output_shape_for(input_shape)`: in case your layer modifies the shape of its input, you should specify here the shape transformation logic. This allows Keras to do automatic shape inference.
 


### PR DESCRIPTION
We ran into some really odd errors in an advanced usage of keras due to not setting `self.built = True` in one of our custom layers.  This PR is an attempt to help others avoid the pain that we experienced due to this bug.

In case you're curious, the place where this happened was in trying to use `tf.while_loop` to do an adaptive computation step, similar to [this paper](https://www.semanticscholar.org/paper/Adaptive-Computation-Time-for-Recurrent-Neural-Graves/4b2c003b7eb683476f96b2e653676c6cfcb8da28) by Alex Graves.  We had a layer that was trying to be built twice, which caused some funny errors when combined with `tf.while_loop`.