### PR TITLE
Bugfix to CIFAR pickle reading code in Python 3

### DIFF
--- a/keras/datasets/cifar.py
+++ b/keras/datasets/cifar.py
@@ -11,9 +11,10 @@ def load_batch(fpath, label_key='labels'):
     else:
         d = cPickle.load(f, encoding="bytes")
         # decode utf8
+        d_decoded = {}
         for k, v in d.items():
-            del(d[k])
-            d[k.decode("utf8")] = v
+            d_decoded[k.decode("utf8")] = v
+        d = d_decoded
     f.close()
     data = d["data"]
     labels = d[label_key]


### PR DESCRIPTION
The following code for reading in CIFAR batches is currently used in Python 3:

```python
d = cPickle.load(f, encoding="bytes")
# decode utf8
print("keys are: {}".format(d.keys())  # debug output
for k, v in d.items():
    print("key is: {}".format(k))      # debug output
    del(d[k])
    d[k.decode("utf8")] = v
```

This errors out with the following (running under Python 3.6b2):

```
keys are: dict_keys([b'batch_label', b'labels', b'data', b'filenames'])
key is: b'batch_label'
key is: b'labels'
key is: batch_label
Traceback (most recent call last):
  File "run.py", line 78, in <module>
    main()
  File "run.py", line 67, in main
    (X_train, y_train), (X_test, y_test) = cifar10.load_data()
  File "/usr/local/lib/python3.6/site-packages/keras/datasets/cifar10.py", line 21, in load_data
    data, labels = load_batch(fpath)
  File "/usr/local/lib/python3.6/site-packages/keras/datasets/cifar.py", line 19, in load_batch
    d[k.decode("utf8")] = v
AttributeError: 'str' object has no attribute 'decode'
```

So seems like there is a bug due to the modification if the dictionary in the iteration loop. This PR fixes this.