### PR TITLE
Print EarlyStopping verbose message on_train_end.

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -337,6 +337,7 @@ class EarlyStopping(Callback):
         self.verbose = verbose
         self.min_delta = min_delta
         self.wait = 0
+        self.stopped_epoch = 0
 
         if mode not in ['auto', 'min', 'max']:
             warnings.warn('EarlyStopping mode %s is unknown, '
@@ -374,10 +375,13 @@ class EarlyStopping(Callback):
             self.wait = 0
         else:
             if self.wait >= self.patience:
-                if self.verbose > 0:
-                    print('Epoch %05d: early stopping' % (epoch))
+                self.stopped_epoch = epoch
                 self.model.stop_training = True
             self.wait += 1
+
+    def on_train_end(self, logs={}):
+        if self.stopped_epoch > 0 and self.verbose > 0:
+            print('Epoch %05d: early stopping' % (self.stopped_epoch))
 
 
 class RemoteMonitor(Callback):


### PR DESCRIPTION
The message print EarlyStopping.on_epoch_end would be overwritten by ProgbarLogger.

I've found https://github.com/fchollet/keras/issues/2354 and the comment on https://github.com/fchollet/keras/pull/3195 and I understood print() in callback is bad idea if you use ProgbarLogger. But EarlyStopping is built-in class. I think EarlyStopping should work fine with ProgbarLogger.

I think printing in on_train_end callback is safe with ProgbarLogger.
In fact with this patch, EarlyStopping(verbose=1) can show its message like below.

```
Epoch 1/100
54000/54000 [==============================] - 2s - loss: 1.1670 - acc: 0.5984 - val_loss: 0.4293 - val_acc: 0.8937
Epoch 2/100
54000/54000 [==============================] - 2s - loss: 0.8022 - acc: 0.7288 - val_loss: 0.3453 - val_acc: 0.9102
Epoch 3/100
54000/54000 [==============================] - 2s - loss: 0.7428 - acc: 0.7502 - val_loss: 0.3219 - val_acc: 0.9170
Epoch 4/100
54000/54000 [==============================] - 2s - loss: 0.6987 - acc: 0.7648 - val_loss: 0.3231 - val_acc: 0.9168
Epoch 00003: early stopping
```
