### PR TITLE
Add functionality and tests for weighting samples in metrics

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -366,9 +366,7 @@ def weighted_metric(fn):
             if K.backend() == 'theano':
                 weight_indices = weights.nonzero()[0]
             else:
-                from tensorflow import where
                 weight_indices = K.not_equal(weights, 0)
-                weight_indices = where(weight_indices)
             sub_weights = weights[weight_indices]
 
             # expand out sub_weights to allow for proper multiplication

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -369,7 +369,7 @@ def weighted_metric(fn):
             # expand out sub_weights to allow for proper multiplication
             ndim = K.ndim(y_true)
             weight_ndim = K.ndim(weights)
-            for _ in xrange(ndim - weight_ndim):
+            for _ in range(ndim - weight_ndim):
               sub_weights = K.expand_dims(sub_weights)
 
             # break out with metric on zero_vectors if sub_weights is empty

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -352,6 +352,44 @@ def weighted_objective(fn):
     return weighted
 
 
+def weighted_metric(fn):
+    '''Transforms an metric function `fn(y_true, y_pred)`
+    into a sample-weighted, cost-masked metric function
+    `fn(y_true, y_pred, weights, mask)` that sub-samples
+    the y-vectors based on weights and returns a scalar.
+    '''
+    def weighted(y_true, y_pred, weights, mask=None):
+        # metric value is a scalar
+        # `mask` does nothing
+        if weights is not None:
+            # need to get nonzero indices of the weights
+            weight_indices = weights.nonzero()[0]
+            sub_weights = weights[weight_indices]
+
+            # expand out sub_weights to allow for proper multiplication
+            ndim = K.ndim(y_true)
+            weight_ndim = K.ndim(weights)
+            for _ in xrange(ndim - weight_ndim):
+              sub_weights = K.expand_dims(sub_weights)
+
+            # break out with metric on zero_vectors if sub_weights is empty
+            # THIS DOES NOT WORK YET
+            # if not sub_weights.shape[0].eval():
+              # return fn([0], [0])
+
+            # subsampling y-vectors on weight_indices
+            sub_y_true = y_true[weight_indices]
+            sub_y_pred = y_pred[weight_indices]
+
+            # apply sample weighting
+            sub_y_true = sub_weights * sub_y_true
+            sub_y_pred = sub_weights * sub_y_pred
+
+            return fn(sub_y_true, sub_y_pred)
+        return fn(y_true, y_pred)
+    return weighted
+
+
 def standardize_weights(y, sample_weight=None, class_weight=None,
                         sample_weight_mode=None):
     '''Performs weight input validation and standardization
@@ -658,9 +696,19 @@ class Model(Container):
         for i in range(len(self.outputs)):
             y_true = self.targets[i]
             y_pred = self.outputs[i]
+            weighted_loss = weighted_losses[i]
+            sample_weight = sample_weights[i]
+            mask = masks[i]
             output_metrics = nested_metrics[i]
 
-            for metric in output_metrics:
+            for metric_iter in output_metrics:
+                weighted_metric_flag = False
+                if isinstance(metric_iter, dict):
+                    weighted_metric_flag = metric_iter.get("weighted", False)
+                    metric = metric_iter.get("metric")
+                else:
+                  metric = metric_iter
+
                 if metric == 'accuracy' or metric == 'acc':
                     # custom handling of accuracy (because of class mode duality)
                     output_shape = self.internal_output_shapes[i]
@@ -674,10 +722,19 @@ class Model(Container):
                     else:
                         acc_fn = metrics_module.categorical_accuracy
 
-                    append_metric(i, 'acc', acc_fn(y_true, y_pred))
+                    if weighted_metric_flag:
+                        append_metric(i, 'weighted_acc',
+                                      weighted_metric(acc_fn)(y_true, y_pred,
+                                                                 sample_weight, mask))
+                    else:
+                        append_metric(i, 'acc', acc_fn(y_true, y_pred))
                 else:
                     metric_fn = metrics_module.get(metric)
-                    metric_result = metric_fn(y_true, y_pred)
+                    if weighted_metric_flag:
+                        metric_result = weighted_metric(acc_fn)(y_true, y_pred,
+                                                                   sample_weight, mask)
+                    else:
+                        metric_result = metric_fn(y_true, y_pred)
 
                     if not isinstance(metric_result, dict):
                         metric_result = {

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -363,7 +363,12 @@ def weighted_metric(fn):
         # `mask` does nothing
         if weights is not None:
             # need to get nonzero indices of the weights
-            weight_indices = weights.nonzero()[0]
+            if K.backend() == 'theano':
+                weight_indices = weights.nonzero()[0]
+            else:
+                from tensorflow import where
+                weight_indices = K.not_equal(weights, 0)
+                weight_indices = where(weight_indices)
             sub_weights = weights[weight_indices]
 
             # expand out sub_weights to allow for proper multiplication

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -375,12 +375,12 @@ def weighted_metric(fn):
             ndim = K.ndim(y_true)
             weight_ndim = K.ndim(weights)
             for _ in range(ndim - weight_ndim):
-              sub_weights = K.expand_dims(sub_weights)
+                sub_weights = K.expand_dims(sub_weights)
 
             # break out with metric on zero_vectors if sub_weights is empty
             # THIS DOES NOT WORK YET
             # if not sub_weights.shape[0].eval():
-              # return fn([0], [0])
+                # return fn([0], [0])
 
             # subsampling y-vectors on weight_indices
             sub_y_true = y_true[weight_indices]
@@ -712,7 +712,7 @@ class Model(Container):
                     weighted_metric_flag = metric_iter.get("weighted", False)
                     metric = metric_iter.get("metric")
                 else:
-                  metric = metric_iter
+                    metric = metric_iter
 
                 if metric == 'accuracy' or metric == 'acc':
                     # custom handling of accuracy (because of class mode duality)
@@ -730,14 +730,14 @@ class Model(Container):
                     if weighted_metric_flag:
                         append_metric(i, 'weighted_acc',
                                       weighted_metric(acc_fn)(y_true, y_pred,
-                                                                 sample_weight, mask))
+                                                              sample_weight, mask))
                     else:
                         append_metric(i, 'acc', acc_fn(y_true, y_pred))
                 else:
                     metric_fn = metrics_module.get(metric)
                     if weighted_metric_flag:
                         metric_result = weighted_metric(acc_fn)(y_true, y_pred,
-                                                                   sample_weight, mask)
+                                                                sample_weight, mask)
                     else:
                         metric_result = metric_fn(y_true, y_pred)
 

--- a/tests/test_metric_weighting.py
+++ b/tests/test_metric_weighting.py
@@ -73,8 +73,8 @@ def create_temporal_sequential_model():
 
 
 def _fit_weights_sequential(model, class_weight=None, sample_weight=None,
-                             X_train=X_train, Y_train=Y_train,
-                             X_test=X_test, Y_test=Y_test):
+                            X_train=X_train, Y_train=Y_train,
+                            X_test=X_test, Y_test=Y_test):
     if sample_weight is not None:
         model.fit(X_train, Y_train, batch_size=batch_size,
                   nb_epoch=nb_epoch // 3, verbose=0,
@@ -100,9 +100,9 @@ def setup_module():
     # no evaluation weights: reference point
     model = create_sequential_model()
     model.compile(loss=loss, optimizer='rmsprop', metrics=['acc',
-                                                            {"metric": "accuracy",
+                                                           {"metric": "accuracy",
                                                             "weighted": "True"}])
-    _fit_weights_sequential(model,sample_weight=sample_weight)
+    _fit_weights_sequential(model, sample_weight=sample_weight)
     (loss_val, acc, weighted_acc) = model.evaluate(X_test[test_ids, :], Y_test[test_ids, :])
 
 @keras_test

--- a/tests/test_metric_weighting.py
+++ b/tests/test_metric_weighting.py
@@ -1,0 +1,257 @@
+from __future__ import absolute_import
+from __future__ import print_function
+import pytest
+import numpy as np
+np.random.seed(1337)
+
+from keras.utils.test_utils import get_test_data
+from keras.models import Sequential
+from keras.layers import Dense, Activation, RepeatVector, TimeDistributedDense, GRU
+from keras.utils import np_utils
+from keras.utils.test_utils import keras_test
+
+nb_classes = 10
+batch_size = 128
+nb_epoch = 15
+weighted_class = 5
+standard_weight = 1
+high_weight = 10
+train_samples = 5000
+test_samples = 1000
+timesteps = 3
+input_dim = 10
+loss = 'mse'
+
+(X_train, y_train), (X_test, y_test) = get_test_data(nb_train=train_samples,
+                                                     nb_test=test_samples,
+                                                     input_shape=(input_dim,),
+                                                     classification=True,
+                                                     nb_class=nb_classes)
+
+# convert class vectors to binary class matrices
+Y_train = np_utils.to_categorical(y_train, nb_classes)
+Y_test = np_utils.to_categorical(y_test, nb_classes)
+weight_ids = np.where(y_test == np.array(weighted_class))[0]
+unweight_ids = np.where(y_test != np.array(weighted_class))[0]
+test_ids = np.hstack(zip(unweight_ids, weight_ids))
+
+class_weight = dict([(i, standard_weight) for i in range(nb_classes)])
+class_weight[weighted_class] = high_weight
+
+sample_weight = np.ones((y_train.shape[0])) * standard_weight
+sample_weight[y_train == weighted_class] = high_weight
+
+temporal_X_train = np.reshape(X_train, (len(X_train), 1, X_train.shape[1]))
+temporal_X_train = np.repeat(temporal_X_train, timesteps, axis=1)
+temporal_X_test = np.reshape(X_test, (len(X_test), 1, X_test.shape[1]))
+temporal_X_test = np.repeat(temporal_X_test, timesteps, axis=1)
+
+temporal_Y_train = np.reshape(Y_train, (len(Y_train), 1, Y_train.shape[1]))
+temporal_Y_train = np.repeat(temporal_Y_train, timesteps, axis=1)
+temporal_Y_test = np.reshape(Y_test, (len(Y_test), 1, Y_test.shape[1]))
+temporal_Y_test = np.repeat(temporal_Y_test, timesteps, axis=1)
+
+temporal_sample_weight = np.reshape(sample_weight, (len(sample_weight), 1))
+temporal_sample_weight = np.repeat(temporal_sample_weight, timesteps, axis=1)
+
+
+def create_sequential_model():
+    model = Sequential()
+    model.add(Dense(32, input_shape=(input_dim,)))
+    model.add(Activation('relu'))
+    model.add(Dense(nb_classes))
+    model.add(Activation('softmax'))
+    return model
+
+
+def create_temporal_sequential_model():
+    model = Sequential()
+    model.add(GRU(32, input_shape=(timesteps, input_dim), return_sequences=True))
+    model.add(TimeDistributedDense(nb_classes))
+    model.add(Activation('softmax'))
+    return model
+
+
+# @keras_test
+def _fit_weights_sequential(model, class_weight=None, sample_weight=None,
+                             X_train=X_train, Y_train=Y_train,
+                             X_test=X_test, Y_test=Y_test):
+    if sample_weight is not None:
+        model.fit(X_train, Y_train, batch_size=batch_size,
+                  nb_epoch=nb_epoch // 3, verbose=0,
+                  class_weight=class_weight, sample_weight=sample_weight)
+        model.fit(X_train, Y_train, batch_size=batch_size,
+                  nb_epoch=nb_epoch // 3, verbose=0,
+                  class_weight=class_weight, sample_weight=sample_weight,
+                  validation_split=0.1)
+        model.fit(X_train, Y_train, batch_size=batch_size,
+                  nb_epoch=nb_epoch // 3, verbose=0,
+                  class_weight=class_weight, sample_weight=sample_weight,
+                  validation_data=(X_train, Y_train, sample_weight))
+    else:
+        model.fit(X_train, Y_train, batch_size=batch_size,
+                  nb_epoch=nb_epoch // 2, verbose=0,
+                  class_weight=class_weight, sample_weight=sample_weight)
+        model.fit(X_train, Y_train, batch_size=batch_size,
+                  nb_epoch=nb_epoch // 2, verbose=0,
+                  class_weight=class_weight, sample_weight=sample_weight,
+                  validation_split=0.1)
+
+
+# no evaluation weights: reference point
+model = create_sequential_model()
+model.compile(loss=loss, optimizer='rmsprop', metrics=['acc',
+                                                        {"metric": "accuracy",
+                                                        "weighted": "True"}])
+_fit_weights_sequential(model,sample_weight=sample_weight)
+(loss_val, acc, weighted_acc) = model.evaluate(X_test[test_ids, :], Y_test[test_ids, :])
+
+@keras_test
+def test_sequential_sample_weights_unchanged_acc():
+    model = create_sequential_model()
+    model.compile(loss=loss, optimizer='rmsprop', metrics=['acc'])
+    _fit_weights_sequential(model,sample_weight=sample_weight)
+    test_weights = np.ones(X_test.shape[:-1])
+    (test_loss_val, test_simple_acc) = model.evaluate(X_test[test_ids, :], Y_test[test_ids, :])
+    (test_loss, test_acc) = model.evaluate(X_test[test_ids, :], Y_test[test_ids, :],
+                                           sample_weight=test_weights[test_ids])
+    assert(np.isclose(test_loss_val, test_loss))
+    assert(np.isclose(test_simple_acc, test_acc))
+
+
+@keras_test
+def test_sequential_sample_weights_ones_match_acc():
+    test_weights = np.ones(X_test.shape[:-1])
+    (test_loss, test_acc, test_weighted_acc) = model.evaluate(X_test[test_ids, :],
+                                                              Y_test[test_ids, :],
+                                                              sample_weight=test_weights[test_ids])
+    assert(np.isclose(loss_val, test_loss))
+    assert(np.isclose(acc, test_acc))
+    assert(np.isclose(acc, test_weighted_acc))
+    assert(np.isclose(weighted_acc, test_weighted_acc))
+
+
+@keras_test
+def test_sequential_sample_weights_change_acc_with_fewer():
+    test_weights = np.ones(X_test.shape[:-1])
+    # prioritize on weighted
+    test_weights[test_weights==unweight_ids] = 0
+    (test_loss, test_acc, test_weighted_acc) = model.evaluate(X_test[test_ids, :],
+                                                              Y_test[test_ids, :],
+                                                              sample_weight=test_weights[test_ids])
+    assert(test_acc != test_weighted_acc)
+
+
+@keras_test
+def test_sequential_sample_weights_change_acc_with_fewer_unweighted():
+    test_weights = np.ones(X_test.shape[:-1])
+    # prioritize on unweighted
+    test_weights[test_weights==weight_ids] = 0
+    (test_loss, test_acc, test_weighted_acc) = model.evaluate(X_test[test_ids, :],
+                                                              Y_test[test_ids, :],
+                                                              sample_weight=test_weights[test_ids])
+    assert(test_acc != test_weighted_acc)
+
+
+@keras_test
+def test_sequential_temporal_sample_weights():
+    model = create_temporal_sequential_model()
+    model.compile(loss=loss, optimizer='rmsprop', metrics=['acc',
+                                                           {"metric": "accuracy",
+                                                            "weighted": "True"}],
+                  sample_weight_mode='temporal')
+    _fit_weights_sequential(model, sample_weight=temporal_sample_weight,
+                            X_train=temporal_X_train,
+                            X_test=temporal_X_test,
+                            Y_train=temporal_Y_train,
+                            Y_test=temporal_Y_test)
+    test_weights = np.ones(temporal_X_test.shape[:-1])
+    (test_loss, test_acc, test_weighted_acc) = model.evaluate(temporal_X_test[test_ids, :],
+                                                              temporal_Y_test[test_ids, :],
+                                                              sample_weight=test_weights[test_ids, :])
+    assert(np.isclose(test_acc, test_weighted_acc))
+
+
+@keras_test
+def test_sequential_temporal_sample_weights_change_acc_with_fewer():
+    model = create_temporal_sequential_model()
+    model.compile(loss=loss, optimizer='rmsprop', metrics=['acc',
+                                                           {"metric": "accuracy",
+                                                            "weighted": "True"}],
+                  sample_weight_mode='temporal')
+    _fit_weights_sequential(model, sample_weight=temporal_sample_weight,
+                            X_train=temporal_X_train,
+                            X_test=temporal_X_test,
+                            Y_train=temporal_Y_train,
+                            Y_test=temporal_Y_test)
+    test_weights = np.ones(temporal_X_test.shape[:-1])
+    test_weights[test_weights==unweight_ids, :] = 0
+    (test_loss, test_acc, test_weighted_acc) = model.evaluate(temporal_X_test[test_ids, :],
+                                                              temporal_Y_test[test_ids, :],
+                                                              sample_weight=test_weights[test_ids, :])
+    assert(test_acc != test_weighted_acc)
+
+
+@keras_test
+def test_sequential_temporal_sample_weights_change_acc_with_subvector():
+    model = create_temporal_sequential_model()
+    model.compile(loss=loss, optimizer='rmsprop', metrics=['acc',
+                                                           {"metric": "accuracy",
+                                                            "weighted": "True"}],
+                  sample_weight_mode='temporal')
+    _fit_weights_sequential(model, sample_weight=temporal_sample_weight,
+                            X_train=temporal_X_train,
+                            X_test=temporal_X_test,
+                            Y_train=temporal_Y_train,
+                            Y_test=temporal_Y_test)
+    test_weights = np.ones(temporal_X_test.shape[:-1])
+    # this tests that we can weigh subsequences in temporal inputs selectively
+    test_weights[test_weights==unweight_ids, 1:] = 0
+    (test_loss, test_acc, test_weighted_acc) = model.evaluate(temporal_X_test[test_ids, :],
+                                                              temporal_Y_test[test_ids, :],
+                                                              sample_weight=test_weights[test_ids, :])
+    assert(test_acc != test_weighted_acc)
+
+
+@keras_test
+def test_sequential_temporal_sample_weights_with_none_mode():
+    model = create_temporal_sequential_model()
+    model.compile(loss=loss, optimizer='rmsprop', metrics=['acc',
+                                                           {"metric": "accuracy",
+                                                            "weighted": "True"}],
+                  sample_weight_mode=None)
+    _fit_weights_sequential(model, sample_weight=sample_weight,
+                            X_train=temporal_X_train,
+                            X_test=temporal_X_test,
+                            Y_train=temporal_Y_train,
+                            Y_test=temporal_Y_test)
+    test_weights = np.ones(X_test.shape[:-1])
+    (test_loss, test_acc, test_weighted_acc) = model.evaluate(temporal_X_test[test_ids, :],
+                                                              temporal_Y_test[test_ids, :],
+                                                              sample_weight=test_weights[test_ids])
+    assert(np.isclose(test_acc, test_weighted_acc))
+    # model.compile(loss=loss, optimizer='rmsprop',
+                  # sample_weight_mode='temporal')
+    # score = _test_weights_sequential(model,
+                                     # sample_weight=temporal_sample_weight,
+                                     # X_train=temporal_X_train,
+                                     # X_test=temporal_X_test,
+                                     # Y_train=temporal_Y_train,
+                                     # Y_test=temporal_Y_test)
+    # assert(score < standard_score_sequential)
+
+    # # a twist: sample-wise weights with temporal output
+    # model = create_temporal_sequential_model()
+    # model.compile(loss=loss, optimizer='rmsprop',
+                  # sample_weight_mode=None)
+    # score = _test_weights_sequential(model,
+                                     # sample_weight=sample_weight,
+                                     # X_train=temporal_X_train,
+                                     # X_test=temporal_X_test,
+                                     # Y_train=temporal_Y_train,
+                                     # Y_test=temporal_Y_test)
+    # assert(score < standard_score_sequential)
+
+
+# if __name__ == '__main__':
+    # pytest.main([__file__])

--- a/tests/test_metric_weighting.py
+++ b/tests/test_metric_weighting.py
@@ -230,28 +230,6 @@ def test_sequential_temporal_sample_weights_with_none_mode():
                                                               temporal_Y_test[test_ids, :],
                                                               sample_weight=test_weights[test_ids])
     assert(np.isclose(test_acc, test_weighted_acc))
-    # model.compile(loss=loss, optimizer='rmsprop',
-                  # sample_weight_mode='temporal')
-    # score = _test_weights_sequential(model,
-                                     # sample_weight=temporal_sample_weight,
-                                     # X_train=temporal_X_train,
-                                     # X_test=temporal_X_test,
-                                     # Y_train=temporal_Y_train,
-                                     # Y_test=temporal_Y_test)
-    # assert(score < standard_score_sequential)
 
-    # # a twist: sample-wise weights with temporal output
-    # model = create_temporal_sequential_model()
-    # model.compile(loss=loss, optimizer='rmsprop',
-                  # sample_weight_mode=None)
-    # score = _test_weights_sequential(model,
-                                     # sample_weight=sample_weight,
-                                     # X_train=temporal_X_train,
-                                     # X_test=temporal_X_test,
-                                     # Y_train=temporal_Y_train,
-                                     # Y_test=temporal_Y_test)
-    # assert(score < standard_score_sequential)
-
-
-# if __name__ == '__main__':
-    # pytest.main([__file__])
+if __name__ == '__main__':
+    pytest.main([__file__])

--- a/tests/test_metric_weighting.py
+++ b/tests/test_metric_weighting.py
@@ -96,14 +96,14 @@ def _fit_weights_sequential(model, class_weight=None, sample_weight=None,
                   class_weight=class_weight, sample_weight=sample_weight,
                   validation_split=0.1)
 
-
-# no evaluation weights: reference point
-model = create_sequential_model()
-model.compile(loss=loss, optimizer='rmsprop', metrics=['acc',
-                                                        {"metric": "accuracy",
-                                                        "weighted": "True"}])
-_fit_weights_sequential(model,sample_weight=sample_weight)
-(loss_val, acc, weighted_acc) = model.evaluate(X_test[test_ids, :], Y_test[test_ids, :])
+def setup_module():
+    # no evaluation weights: reference point
+    model = create_sequential_model()
+    model.compile(loss=loss, optimizer='rmsprop', metrics=['acc',
+                                                            {"metric": "accuracy",
+                                                            "weighted": "True"}])
+    _fit_weights_sequential(model,sample_weight=sample_weight)
+    (loss_val, acc, weighted_acc) = model.evaluate(X_test[test_ids, :], Y_test[test_ids, :])
 
 @keras_test
 def test_sequential_sample_weights_unchanged_acc():

--- a/tests/test_metric_weighting.py
+++ b/tests/test_metric_weighting.py
@@ -96,14 +96,14 @@ def _fit_weights_sequential(model, class_weight=None, sample_weight=None,
                   class_weight=class_weight, sample_weight=sample_weight,
                   validation_split=0.1)
 
-def setup_module():
-    # no evaluation weights: reference point
-    model = create_sequential_model()
-    model.compile(loss=loss, optimizer='rmsprop', metrics=['acc',
-                                                           {"metric": "accuracy",
-                                                            "weighted": "True"}])
-    _fit_weights_sequential(model, sample_weight=sample_weight)
-    (loss_val, acc, weighted_acc) = model.evaluate(X_test[test_ids, :], Y_test[test_ids, :])
+# no evaluation weights: reference point
+model = create_sequential_model()
+model.compile(loss=loss, optimizer='rmsprop', metrics=['acc',
+                                                        {"metric": "accuracy",
+                                                        "weighted": "True"}])
+_fit_weights_sequential(model,sample_weight=sample_weight)
+(loss_val, acc, weighted_acc) = model.evaluate(X_test[test_ids, :], Y_test[test_ids, :])
+
 
 @keras_test
 def test_sequential_sample_weights_unchanged_acc():

--- a/tests/test_metric_weighting.py
+++ b/tests/test_metric_weighting.py
@@ -72,7 +72,6 @@ def create_temporal_sequential_model():
     return model
 
 
-# @keras_test
 def _fit_weights_sequential(model, class_weight=None, sample_weight=None,
                              X_train=X_train, Y_train=Y_train,
                              X_test=X_test, Y_test=Y_test):


### PR DESCRIPTION
As described in #4313, it would be very useful in models where `sample_weight` is utilized to monitor accuracy and other metrics in a way that respects the weighing of the samples, either removing 0-weighted samples, removing some dimensions in temporal samples, or just scaling the vectors themselves.

This pull request adds this functionality by allowing metrics to be passed in as dicts with a`"metric"` key that holds the string (or function) value that would usually be the passed in metric, and a `"weighted"` key that should only hold the `"True"` value. This metric is wrapped in `weighted_metric`, allowing it to now take `sample_weight` values as well, similar to how `weighted_objective` works.

This pull request also includes tests for this new functionality, inspired by the weighted loss tests. Tests include verifying:
- new functionality does not disturb traditional metric calculation
- new functionality does not change metric values on trivial weights
- new functionality does change metric values when considering removing samples through 0 weighting
- new functionality works in traditional weighting_mode, as well as `temporal`, in both regular and "twist" format