### PR TITLE
Fix the load_model() bug by sorting weights by names

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -258,10 +258,12 @@ def collect_trainable_weights(layer):
         weights += layer.trainable_weights
     # dedupe weights
     weights = list(set(weights))
-    # TF variables have auto-generated the name, while Theano has auto-generated the auto_name variable. name in Theano is None
+    # TF variables have auto-generated the name, while Theano has auto-generated the auto_name variable.
+    # name in Theano is sometimes None.
+    # However, to work save_model() and load_model() properly, weights must be sorted by names.
     if weights:
         if K.backend() == 'theano':
-            weights.sort(key=lambda x: x.auto_name)
+            weights.sort(key=lambda x: x.name if x.name else x.auto_name)
         else:
             weights.sort(key=lambda x: x.name)
     return weights


### PR DESCRIPTION
Weights must be sorted by names for save_model() and load_model() work properly.

This pull request fixes https://github.com/fchollet/keras/issues/3964 , https://github.com/fchollet/keras/issues/4044 and https://github.com/fchollet/keras/issues/4143 .
The discussion is https://github.com/fchollet/keras/issues/4044 .