### PR TITLE
Fix/improve get_layer method in topology.py

### DIFF
--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -1853,19 +1853,19 @@ class Container(Layer):
         # based on layer names, because names can potentially
         # be changed at any point by the user
         # without the container being notified of it.
-        if index:
-            if len(self.layers) <= index:
+        if index is not None:
+            try:
+                return self.layers[index]
+            except IndexError:
                 raise Exception('Was asked to retrieve layer at index ' +
                                 str(index) + ' but model only has ' +
                                 str(len(self.layers)) + ' layers.')
-        else:
-            assert name, 'Provide either a layer name or layer index.'
-        layer = None
+
+        assert name, 'Provide either a layer name or layer index.'
         for layer in self.layers:
             if layer.name == name:
                 return layer
-        if not layer:
-            raise Exception('No such layer: ' + name)
+        raise Exception('No such layer: ' + name)
 
     @property
     def updates(self):


### PR DESCRIPTION
Changes/fixes the following:                                                       
                                                                                   
1) Checks using `if index is not None` instead of `if index`, since the latter evaluates to False if index 0 is requested.
                                                                                   
2) Returns layer for index requested, previously it still failed on the 'name' assertion even if index was passed in, as a return by index was missing 
                                                                                   
3) Uses try/except IndexError to check if layer with requested index can be returned, it's slighly less error prone (and more flexible, since it allows for negative index values) than checking for lengths (e.g. the previous check using if `len(self.layers) <= index:` doesn't catch the case where len(self.layers)==0 and index==-1)

Also removed some unnecessary conditional code.

(note: previously made this pull request with the wrong account, so deleted and recreated)