### PR TITLE
Add Resize layer and K.resize()

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -763,6 +763,52 @@ def permute_dimensions(x, pattern):
     return tf.transpose(x, perm=pattern)
 
 
+def resize(x, size, axis, interpolation='nearest_neighbor'):
+    '''Resize the tensor.
+    `size` must be an integer or a tuple of integers or a list of integers.
+    If `axis` is a tuple or a list, then the `axis` length and the `size` length must be same.
+    `interpolation` must be 'nearest_neighbor' or 'linear'. The default is 'nearest_neighbor'.
+    '''
+    if type(axis) in (tuple, list):
+        if len(axis) != len(size):
+            raise ValueError('The axis length and the size length are not same.')
+        for s, a in zip(size, axis):
+            x = resize(x, s, a, interpolation)
+        return x
+    else:
+        if interpolation == 'nearest_neighbor':
+            x_dtype = x.dtype.base_dtype
+            x_ndim = len(x.get_shape())
+            orig_size = x.get_shape()[axis]
+            ratio = tf.cast(orig_size - 1, x_dtype) / tf.cast(tf.maximum(1, size - 1), x_dtype)
+            idx_f = ratio * tf.cast(tf.range(size), x_dtype)
+            idx_i = tf.to_int32(tf.round(idx_f))
+            x = tf.transpose(x, [axis] + list(range(axis)) + list(range(axis + 1, x_ndim)))
+            x = tf.gather(x, idx_i)
+            x = tf.transpose(x, list(range(1, axis + 1)) + [0] + list(range(axis + 1, x_ndim)))
+            return x
+        elif interpolation == 'linear':
+            x_dtype = x.dtype.base_dtype
+            x_ndim = len(x.get_shape())
+            orig_size = x.get_shape()[axis]
+            ratio = tf.cast(orig_size - 1, x_dtype) / tf.cast(tf.maximum(1, size - 1), x_dtype)
+            idx_f = ratio * tf.cast(tf.range(size), x_dtype)
+            idx_i0 = tf.to_int32(idx_f)
+            idx_i1 = tf.minimum(orig_size - 1, idx_i0 + 1)
+            delta = idx_f - tf.cast(idx_i0, x_dtype)
+            delta = tf.reshape(delta, [-1] + [1] * (x_ndim - 1))
+            perm_from = [axis] + list(range(axis)) + list(range(axis + 1, x_ndim))
+            x0 = tf.transpose(x, perm_from)
+            x1 = tf.transpose(x, perm_from)
+            x0 = tf.gather(x0, idx_i0)
+            x1 = tf.gather(x1, idx_i1)
+            x = x0 * (1 - delta) + x1 * delta
+            x = tf.transpose(x, list(range(1, axis + 1)) + [0] + list(range(axis + 1, x_ndim)))
+            return x
+        else:
+            raise ValueError('Invalid interpolation: ' + str(interpolation))
+
+
 def resize_images(X, height_factor, width_factor, dim_ordering):
     '''Resizes the images contained in a 4D tensor of shape
     - [batch, channels, height, width] (for 'th' dim_ordering)

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -499,6 +499,39 @@ def repeat_elements(x, rep, axis):
     return T.repeat(x, rep, axis=axis)
 
 
+def resize(x, size, axis, interpolation='nearest_neighbor'):
+    '''Resize the tensor.
+    `size` must be an integer or a tuple of integers or a list of integers.
+    If `axis` is a tuple or a list, then the `axis` length and the `size` length must be same.
+    `interpolation` must be 'nearest_neighbor' or 'linear'. The default is 'nearest_neighbor'.
+    '''
+    if type(axis) in (tuple, list):
+        if len(axis) != len(size):
+            raise ValueError('The axis length and the size length are not same.')
+        for s, a in zip(size, axis):
+            x = resize(x, s, a, interpolation)
+        return x
+    else:
+        if interpolation == 'nearest_neighbor':
+            orig_size = x.shape[axis]
+            idx_f = (orig_size - 1) / T.maximum(1, size - 1).astype(x.dtype) * T.arange(size)
+            idx_i = T.round(idx_f).astype("int32")
+            idx_i = tuple(idx_i if i == axis else slice(None) for i in range(x.ndim))
+            return x[idx_i]
+        elif interpolation == 'linear':
+            orig_size = x.shape[axis]
+            idx_f = (orig_size - 1) / T.maximum(1, size - 1).astype(x.dtype) * T.arange(size)
+            idx_i0 = idx_f.astype("int32")
+            idx_i1 = T.minimum(orig_size - 1, idx_i0 + 1)
+            delta = (idx_f - idx_i0).astype(x.dtype)
+            delta = delta.reshape(tuple(-1 if i == axis else 1 for i in range(x.ndim)))
+            idx_i0 = tuple(idx_i0 if i == axis else slice(None) for i in range(x.ndim))
+            idx_i1 = tuple(idx_i1 if i == axis else slice(None) for i in range(x.ndim))
+            return x[idx_i0] * (1 - delta) + x[idx_i1] * delta
+        else:
+            raise ValueError('Invalid interpolation: ' + str(interpolation))
+
+
 def resize_images(X, height_factor, width_factor, dim_ordering):
     '''Resize the images contained in a 4D tensor of shape
     - [batch, channels, height, width] (for 'th' dim_ordering)

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -327,6 +327,61 @@ class Reshape(Layer):
         return dict(list(base_config.items()) + list(config.items()))
 
 
+class Resize(Layer):
+    '''Resizes an output to a certain shape using interpolation.
+
+    # Arguments
+        size: Target size. An integer or a tuple of integers. They must be positive integers.
+        axis: Resize axis. An integer or a tuple of integers.
+            Do not include the samples dimension (batch size).
+            If axis is a tuple, then the axis length and the size length must be same.
+        interpolation: 'nearest_neighbor' or 'linear'. The default is 'nearest_neighbor'.
+
+    # Example
+
+    ```python
+        # as first layer in a Sequential model
+        model = Sequential()
+        model.add(Resize(7, axis=1, interpolation='linear', input_shape=(5, 4)))
+        # now: model.output_shape == (None, 7, 4)
+        # note: `None` is the batch dimension
+
+        model.add(Resize((3, 6), axis=(1, 2), interpolation='nearest_neighbor'))
+        # now: model.output_shape == (None, 3, 6)
+    ```
+    '''
+    def __init__(self, size, axis, interpolation='nearest_neighbor', **kwargs):
+        super(Resize, self).__init__(**kwargs)
+        self.size = size if type(size) in (tuple, list) else (size,)
+        self.axis = axis if type(axis) in (tuple, list) else (axis,)
+        self.interpolation = interpolation
+
+        if not all(v > 0 for v in self.size):
+            raise ValueError('The size of "Resize" must be positive (got ' + str(size) + ').')
+        if 0 in self.axis:
+            raise ValueError('The axis of "Resize" must not include 0 (got ' + str(axis) + ').')
+        if len(self.size) != len(self.axis):
+            raise ValueError('The length of size and the length of axis of "Resize" must be same.')
+        if interpolation not in ('nearest_neighbor', 'linear'):
+            raise ValueError('Unknown interpolation of "Resize" (got ' + str(interpolation) + ').')
+
+    def get_output_shape_for(self, input_shape):
+        output_shape = list(input_shape)
+        for a, s in zip(self.axis, self.size):
+            output_shape[a] = s
+        return tuple(output_shape)
+
+    def call(self, x, mask=None):
+        return K.resize(x, size=self.size, axis=self.axis, interpolation=self.interpolation)
+
+    def get_config(self):
+        config = {'size': self.size,
+                  'axis': self.axis,
+                  'interpolation': self.interpolation}
+        base_config = super(Resize, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))
+
+
 class Permute(Layer):
     '''Permutes the dimensions of the input according to a given pattern.
 

--- a/tests/keras/backend/test_backends.py
+++ b/tests/keras/backend/test_backends.py
@@ -131,6 +131,18 @@ class TestBackend(object):
         tf_rep = KTF.eval(KTF.tile(arr_tf, n))
         assert_allclose(tf_rep, th_rep, atol=1e-05)
 
+    def test_resize(self):
+        shape = (4, 5)
+        arr = np.arange(np.prod(shape)).reshape(shape)
+        arr_th = KTH.variable(arr)
+        arr_tf = KTF.variable(arr)
+
+        for interp in ('nearest_neighbor', 'linear'):
+            for n0, n1 in [[(3, 4), (1, 0)], [(7, 8), (0, 1)], [1, 0], [6, 1]]:
+                th_rep = KTH.eval(KTH.resize(arr_th, n0, n1, interp))
+                tf_rep = KTF.eval(KTF.resize(arr_tf, n0, n1, interp))
+                assert_allclose(tf_rep, th_rep, atol=1e-05)
+
     def test_value_manipulation(self):
         val = np.random.random((4, 2))
         xth = KTH.variable(val)

--- a/tests/keras/layers/test_core.py
+++ b/tests/keras/layers/test_core.py
@@ -183,6 +183,21 @@ def test_reshape():
 
 
 @keras_test
+def test_resize():
+    for interp in ('nearest_neighbor', 'linear'):
+        layer_test(core.Resize,
+                   kwargs={'size': 10,
+                           'axis': 2,
+                           'interpolation': interp},
+                   input_shape=(3, 5, 6))
+        layer_test(core.Resize,
+                   kwargs={'size': (10, 11),
+                           'axis': (1, 2),
+                           'interpolation': interp},
+                   input_shape=(3, 5, 6))
+
+
+@keras_test
 def test_permute():
     layer_test(core.Permute,
                kwargs={'dims': (2, 1)},


### PR DESCRIPTION
There are K.resize_images() and K.resize_volumes(), but this one is more generic.

I did not use tf.image.resize_images() because this function requires to keep the aspect ratio,
and I could not use it.

I tested that this also works on Theano and TensorFlow GPU.

I used tf.gather() becuase TensorFlow has not implemented advanced indexing yet.
