### PR TITLE
fix using val_samples < batch_size in predict_generator

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1675,8 +1675,6 @@ class Model(Container):
                 nb_samples = len(list(x.values())[0])
             else:
                 nb_samples = len(x)
-            # for val_samples < batch_size in generator
-            nb_samples = min(nb_samples, val_samples)
 
             if type(outs) != list:
                 outs = [outs]

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1684,6 +1684,10 @@ class Model(Container):
                     shape = (val_samples,) + out.shape[1:]
                     all_outs.append(np.zeros(shape, dtype=K.floatx()))
 
+            # when val_samples is not multiple of batch_size in generator
+            if processed_samples + nb_samples > val_samples:
+                nb_samples = val_samples - processed_samples
+                
             for i, out in enumerate(outs):
                 all_outs[i][processed_samples:(processed_samples + nb_samples)] = out[:nb_samples]
 

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1675,6 +1675,8 @@ class Model(Container):
                 nb_samples = len(list(x.values())[0])
             else:
                 nb_samples = len(x)
+            # for val_samples < batch_size in generator
+            nb_samples = min(nb_samples, val_samples)
 
             if type(outs) != list:
                 outs = [outs]
@@ -1685,7 +1687,7 @@ class Model(Container):
                     all_outs.append(np.zeros(shape, dtype=K.floatx()))
 
             for i, out in enumerate(outs):
-                all_outs[i][processed_samples:(processed_samples + nb_samples)] = out
+                all_outs[i][processed_samples:(processed_samples + nb_samples)] = out[:nb_samples]
 
             processed_samples += nb_samples
 


### PR DESCRIPTION
Recently I custom a data_generator for experiment and sometimes I want to see elaborate predictions of a few examples by using method `model.predict_generator()` for debugging my model.
However, when the parameter `val_examples` is smaller than batch_size in generator, it would raise an error as follows:
>  File "test.py", line 221, in <module>
    history = aux_model.predict_generator(test_data_generator, 10, max_q_size=10, nb_worker=nb_worker, pickle_safe=True)
  File "/home/gds/gds/dl_modules/keras/keras/engine/training.py", line 1690, in predict_generator
    all_outs[i][processed_samples:(processed_samples + nb_samples)] = out
ValueError: could not broadcast input array from shape (100,20) into shape (10,20)

Here I set val_samples as 10 and batch_size is set as 100 in generator for consideration of processing speed.
Thus I recommend small changes to the code.
