### PR TITLE
Bugfix: Don't add another header line to CSV logfile when appending to an existing file

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
+import os
 import csv
 
 import numpy as np
@@ -683,10 +684,14 @@ class CSVLogger(Callback):
         self.append = append
         self.writer = None
         self.keys = None
+        self.append_header = True
         super(CSVLogger, self).__init__()
 
     def on_train_begin(self, logs={}):
         if self.append:
+            if os.path.exists(self.filename):
+                with open(self.filename) as f:
+                    self.append_header = len(f.readline()) == 0
             self.csv_file = open(self.filename, 'a')
         else:
             self.csv_file = open(self.filename, 'w')
@@ -702,7 +707,8 @@ class CSVLogger(Callback):
         if not self.writer:
             self.keys = sorted(logs.keys())
             self.writer = csv.DictWriter(self.csv_file, fieldnames=['epoch'] + self.keys)
-            self.writer.writeheader()
+            if self.append_header:
+                self.writer.writeheader()
 
         row_dict = OrderedDict({'epoch': epoch})
         row_dict.update((key, handle_value(logs[key])) for key in self.keys)


### PR DESCRIPTION
Currently when using the `CSVLogger` callback with `append=True`, at the beginning of a new training run which appends to an existing file the header file will be rewritten to the output

e.g. if training is resumed after epoch 2, the output would be:

```
epoch,categorical_accuracy,loss,val_categorical_accuracy,val_loss
0,0.130208333333,2.32610692581,0.154399999142,2.26858918381
1,0.173394097222,2.17767716779,0.196799999881,2.10534226418
2,0.186197916667,2.07855245802,0.177600000429,2.06805825005
epoch,categorical_accuracy,loss,val_categorical_accuracy,val_loss
3,0.201605902778,2.03062710166,0.199999999762,2.03451372261
4,0.204427083333,1.96939406792,0.229799997854,1.94915147133
```

This PR prevents the writing of the additional header line in the middle of the CSV file, so the output is instead:

```
epoch,categorical_accuracy,loss,val_categorical_accuracy,val_loss
0,0.130208333333,2.32610692581,0.154399999142,2.26858918381
1,0.173394097222,2.17767716779,0.196799999881,2.10534226418
2,0.186197916667,2.07855245802,0.177600000429,2.06805825005
3,0.201605902778,2.03062710166,0.199999999762,2.03451372261
4,0.204427083333,1.96939406792,0.229799997854,1.94915147133
```