### PR TITLE
Add initial epoch argument to fit functions

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -759,7 +759,7 @@ class Model(Container):
     def _fit_loop(self, f, ins, out_labels=[], batch_size=32,
                   nb_epoch=100, verbose=1, callbacks=[],
                   val_f=None, val_ins=None, shuffle=True,
-                  callback_metrics=[]):
+                  callback_metrics=[], initial_epoch=0):
         '''Abstract fit function for f(ins).
         Assume that f returns a list, labeled by out_labels.
 
@@ -779,6 +779,8 @@ class Model(Container):
                 passed to the callbacks. They should be the
                 concatenation of list the display names of the outputs of
                  `f` and the list of display names of the outputs of `f_val`.
+            initial_epoch: epoch at which to start training
+                (useful for resuming a previous training run)
 
         # Returns
             `History` object.
@@ -819,7 +821,7 @@ class Model(Container):
         callback_model.stop_training = False
         self.validation_data = val_ins
 
-        for epoch in range(nb_epoch):
+        for epoch in range(initial_epoch, nb_epoch):
             callbacks.on_epoch_begin(epoch)
             if shuffle == 'batch':
                 index_array = batch_shuffle(index_array, batch_size)
@@ -1006,7 +1008,7 @@ class Model(Container):
 
     def fit(self, x, y, batch_size=32, nb_epoch=10, verbose=1, callbacks=[],
             validation_split=0., validation_data=None, shuffle=True,
-            class_weight=None, sample_weight=None):
+            class_weight=None, sample_weight=None, initial_epoch=0):
         '''Trains the model for a fixed number of epochs (iterations on a dataset).
 
         # Arguments
@@ -1043,6 +1045,8 @@ class Model(Container):
                 with shape (samples, sequence_length),
                 to apply a different weight to every timestep of every sample.
                 In this case you should make sure to specify sample_weight_mode="temporal" in compile().
+            initial_epoch: epoch at which to start training
+                (useful for resuming a previous training run)
 
 
         # Returns
@@ -1126,7 +1130,8 @@ class Model(Container):
                               batch_size=batch_size, nb_epoch=nb_epoch,
                               verbose=verbose, callbacks=callbacks,
                               val_f=val_f, val_ins=val_ins, shuffle=shuffle,
-                              callback_metrics=callback_metrics)
+                              callback_metrics=callback_metrics,
+                              initial_epoch=initial_epoch)
 
     def evaluate(self, x, y, batch_size=32, verbose=1, sample_weight=None):
         '''Returns the loss value and metrics values for the model
@@ -1302,7 +1307,8 @@ class Model(Container):
     def fit_generator(self, generator, samples_per_epoch, nb_epoch,
                       verbose=1, callbacks=[],
                       validation_data=None, nb_val_samples=None,
-                      class_weight={}, max_q_size=10, nb_worker=1, pickle_safe=False):
+                      class_weight={}, max_q_size=10, nb_worker=1, pickle_safe=False,
+                      initial_epoch=0):
         '''Fits the model on data generated batch-by-batch by
         a Python generator.
         The generator is run in parallel to the model, for efficiency.
@@ -1338,6 +1344,8 @@ class Model(Container):
                 this implementation relies on multiprocessing, you should not pass
                 non picklable arguments to the generator as they can't be passed
                 easily to children processes.
+            initial_epoch: epoch at which to start training
+                (useful for resuming a previous training run)
 
         # Returns
             A `History` object.
@@ -1360,7 +1368,7 @@ class Model(Container):
         ```
         '''
         wait_time = 0.01  # in seconds
-        epoch = 0
+        epoch = initial_epoch
 
         do_validation = bool(validation_data)
         self._make_train_function()

--- a/tests/keras/engine/test_training.py
+++ b/tests/keras/engine/test_training.py
@@ -8,6 +8,7 @@ from keras.engine.training import Model
 from keras.models import Sequential
 from keras import backend as K
 from keras.utils.test_utils import keras_test
+from keras.callbacks import LambdaCallback
 
 
 @keras_test
@@ -145,6 +146,25 @@ def test_model_methods():
     out = model.test_on_batch([input_a_np, input_b_np],
                               [output_a_np, output_b_np])
     assert len(out) == 4
+
+    # test starting from non-zero initial epoch
+    trained_epochs = []
+    def on_epoch_begin(epoch, logs):
+        trained_epochs.append(epoch)
+    tracker_cb = LambdaCallback(on_epoch_begin=on_epoch_begin)
+    out = model.fit([input_a_np, input_b_np],
+                    [output_a_np, output_b_np], nb_epoch=5, batch_size=4,
+                    initial_epoch=2, callbacks=[tracker_cb])
+    assert trained_epochs == [2, 3, 4]
+
+    trained_epochs = []
+    def gen_data(batch_sz):
+        while True:
+            yield ([np.random.random((batch_sz, 3)), np.random.random((batch_sz, 3))],
+                   [np.random.random((batch_sz, 4)), np.random.random((batch_sz, 3))])
+    out = model.fit_generator(gen_data(4), samples_per_epoch=10, nb_epoch=5,
+                    initial_epoch=2, callbacks=[tracker_cb])
+    assert trained_epochs == [2, 3, 4]
 
     # test with a custom metric function
     mse = lambda y_true, y_pred: K.mean(K.pow(y_true - y_pred, 2))

--- a/tests/keras/engine/test_training.py
+++ b/tests/keras/engine/test_training.py
@@ -149,6 +149,7 @@ def test_model_methods():
 
     # test starting from non-zero initial epoch
     trained_epochs = []
+
     def on_epoch_begin(epoch, logs):
         trained_epochs.append(epoch)
     tracker_cb = LambdaCallback(on_epoch_begin=on_epoch_begin)
@@ -157,13 +158,15 @@ def test_model_methods():
                     initial_epoch=2, callbacks=[tracker_cb])
     assert trained_epochs == [2, 3, 4]
 
+    # test starting from non-zero initial epoch for generator too
     trained_epochs = []
+
     def gen_data(batch_sz):
         while True:
             yield ([np.random.random((batch_sz, 3)), np.random.random((batch_sz, 3))],
                    [np.random.random((batch_sz, 4)), np.random.random((batch_sz, 3))])
     out = model.fit_generator(gen_data(4), samples_per_epoch=10, nb_epoch=5,
-                    initial_epoch=2, callbacks=[tracker_cb])
+                              initial_epoch=2, callbacks=[tracker_cb])
     assert trained_epochs == [2, 3, 4]
 
     # test with a custom metric function


### PR DESCRIPTION
This PR adds an `initial_epoch` argument to both the `fit` and `fit_generator` functions of the `Model` class. This is useful for resuming training, as can simply load in weights from a previous run and set this argument to restart where the training last finished (I also have a custom version of the `ModelCheckpoint` callback which handles this, which I can contribute if there is interest)

See also the discussion in #1872. This provides an alternative implementation addressing some of the same issues as the previous PR #2557 by @wrongu.

Unlike #2557, the break condition of the training and other parameters are respected, as instead of adding an additional 'offset' parameter the epoch counter itself, as used internally, is modified directly.