### PR TITLE
Bugfix: K.rnn() is ignoring theano.scan() updates

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -256,9 +256,17 @@ def dtype(x):
     return x.dtype.name
 
 
-def eval(x):
+def eval(x, updates=None):
     '''Evaluates the value of a tensor.
-    Returns a Numpy array.
+
+    # Arguments
+        x: tensor
+        updates: The updates of theano.scan().
+            This is passed to theano.function().
+            This is ignored in TensorFlow.
+
+    # Returns
+        A Numpy array.
     '''
     return to_dense(x).eval(session=get_session())
 
@@ -1157,7 +1165,7 @@ def rnn(step_function, inputs, initial_states,
             Must be specified if using unrolling with Theano.
 
     # Returns
-        A tuple (last_output, outputs, new_states).
+        A tuple (last_output, outputs, new_states, updates).
 
         last_output: the latest output of the rnn, of shape (samples, ...)
         outputs: tensor with shape (samples, time, ...) where each
@@ -1165,6 +1173,11 @@ def rnn(step_function, inputs, initial_states,
             at time t for sample s.
         new_states: list of tensors, latest states returned by
             the step function, of shape (samples, ...).
+        updates: The return value of theano.scan() updates.
+            Theano returns OrderedUpdates but it is converted to a Python list.
+            This must be passed to K.function() and K.eval().
+            If you are using inside a Layer, call Layer.add_rnn_updates().
+            TensorFlow always returns [].
     '''
     ndim = len(inputs.get_shape())
     assert ndim >= 3, 'Input should be at least 3D.'
@@ -1307,7 +1320,7 @@ def rnn(step_function, inputs, initial_states,
 
     axes = [1, 0] + list(range(2, len(outputs.get_shape())))
     outputs = tf.transpose(outputs, axes)
-    return last_output, outputs, new_states
+    return last_output, outputs, new_states, []
 
 
 def _cond(condition, then_lambda, else_lambda):

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -718,7 +718,7 @@ class Model(Container):
             training_updates = self.optimizer.get_updates(self._collected_trainable_weights,
                                                           self.constraints,
                                                           self.total_loss)
-            updates = self.updates + training_updates
+            updates = self.rnn_updates + self.updates + training_updates
 
             # returns loss and metrics. Updates weights at each call.
             self.train_function = K.function(inputs,
@@ -738,7 +738,7 @@ class Model(Container):
             # Does update the network states.
             self.test_function = K.function(inputs,
                                             [self.total_loss] + self.metrics_tensors,
-                                            updates=self.state_updates,
+                                            updates=self.rnn_updates + self.state_updates,
                                             **self._function_kwargs)
 
     def _make_predict_function(self):
@@ -754,7 +754,7 @@ class Model(Container):
             kwargs = getattr(self, '_function_kwargs', {})
             self.predict_function = K.function(inputs,
                                                self.outputs,
-                                               updates=self.state_updates,
+                                               updates=self.rnn_updates + self.state_updates,
                                                **kwargs)
 
     def _fit_loop(self, f, ins, out_labels=[], batch_size=32,

--- a/keras/layers/convolutional_recurrent.py
+++ b/keras/layers/convolutional_recurrent.py
@@ -162,17 +162,19 @@ class ConvRecurrent2D(Layer):
         constants = self.get_constants(x)
         preprocessed_input = self.preprocess_input(x)
 
-        last_output, outputs, states = K.rnn(self.step, preprocessed_input,
-                                             initial_states,
-                                             go_backwards=self.go_backwards,
-                                             mask=mask,
-                                             constants=constants,
-                                             unroll=unroll,
-                                             input_length=input_shape[1])
+        last_output, outputs, states, updates = K.rnn(self.step, preprocessed_input,
+                                                      initial_states,
+                                                      go_backwards=self.go_backwards,
+                                                      mask=mask,
+                                                      constants=constants,
+                                                      unroll=unroll,
+                                                      input_length=input_shape[1])
+        self.add_rnn_updates(updates)
         if self.stateful:
-            self.updates = []
+            updates = []
             for i in range(len(states)):
-                self.updates.append((self.states[i], states[i]))
+                updates.append((self.states[i], states[i]))
+            self.add_updates(updates)
 
         if self.return_sequences:
             return outputs

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -218,13 +218,14 @@ class Recurrent(Layer):
         constants = self.get_constants(x)
         preprocessed_input = self.preprocess_input(x)
 
-        last_output, outputs, states = K.rnn(self.step, preprocessed_input,
-                                             initial_states,
-                                             go_backwards=self.go_backwards,
-                                             mask=mask,
-                                             constants=constants,
-                                             unroll=self.unroll,
-                                             input_length=input_shape[1])
+        last_output, outputs, states, updates = K.rnn(self.step, preprocessed_input,
+                                                      initial_states,
+                                                      go_backwards=self.go_backwards,
+                                                      mask=mask,
+                                                      constants=constants,
+                                                      unroll=self.unroll,
+                                                      input_length=input_shape[1])
+        self.add_rnn_updates(updates)
         if self.stateful:
             updates = []
             for i in range(len(states)):

--- a/keras/layers/wrappers.py
+++ b/keras/layers/wrappers.py
@@ -113,10 +113,11 @@ class TimeDistributed(Wrapper):
                 output = self.layer.call(x)
                 return output, []
 
-            _, outputs, _ = K.rnn(step, X,
-                                  initial_states=[],
-                                  input_length=input_shape[1],
-                                  unroll=False)
+            _, outputs, _, updates = K.rnn(step, X,
+                                           initial_states=[],
+                                           input_length=input_shape[1],
+                                           unroll=False)
+            self.add_rnn_updates(updates)
             y = outputs
         else:
             # no batch size specified, therefore the layer will be able

--- a/tests/keras/backend/test_backends.py
+++ b/tests/keras/backend/test_backends.py
@@ -295,6 +295,7 @@ class TestBackend(object):
                 assert len(states) == 1
                 prev_output = states[0]
                 output = K.dot(x, W_i) + K.dot(prev_output, W_o)
+                output = output + K.random_uniform(K.shape(output), high=1e-12)
                 return output, [output]
             return step_function
 
@@ -302,33 +303,33 @@ class TestBackend(object):
         th_rnn_step_fn = rnn_step_fn(input_dim, output_dim, KTH)
         th_inputs = KTH.variable(input_val)
         th_initial_states = [KTH.variable(init_state_val)]
-        last_output, outputs, new_states = KTH.rnn(th_rnn_step_fn, th_inputs,
-                                                   th_initial_states,
-                                                   go_backwards=False,
-                                                   mask=None)
-        th_last_output = KTH.eval(last_output)
-        th_outputs = KTH.eval(outputs)
+        last_output, outputs, new_states, updates = KTH.rnn(th_rnn_step_fn, th_inputs,
+                                                            th_initial_states,
+                                                            go_backwards=False,
+                                                            mask=None)
+        th_last_output = KTH.eval(last_output, updates)
+        th_outputs = KTH.eval(outputs, updates)
         assert len(new_states) == 1
-        th_state = KTH.eval(new_states[0])
+        th_state = KTH.eval(new_states[0], updates)
 
         tf_rnn_step_fn = rnn_step_fn(input_dim, output_dim, KTF)
         tf_inputs = KTF.variable(input_val)
         tf_initial_states = [KTF.variable(init_state_val)]
-        last_output, outputs, new_states = KTF.rnn(tf_rnn_step_fn, tf_inputs,
-                                                   tf_initial_states,
-                                                   go_backwards=False,
-                                                   mask=None)
-        tf_last_output = KTF.eval(last_output)
-        tf_outputs = KTF.eval(outputs)
+        last_output, outputs, new_states, updates = KTF.rnn(tf_rnn_step_fn, tf_inputs,
+                                                            tf_initial_states,
+                                                            go_backwards=False,
+                                                            mask=None)
+        tf_last_output = KTF.eval(last_output, updates)
+        tf_outputs = KTF.eval(outputs, updates)
         assert len(new_states) == 1
-        tf_state = KTF.eval(new_states[0])
+        tf_state = KTF.eval(new_states[0], updates)
 
         assert_allclose(tf_last_output, th_last_output, atol=1e-04)
         assert_allclose(tf_outputs, th_outputs, atol=1e-04)
         assert_allclose(tf_state, th_state, atol=1e-04)
 
         # test unroll
-        unrolled_last_output, unrolled_outputs, unrolled_new_states = KTH.rnn(
+        unrolled_last_output, unrolled_outputs, unrolled_new_states, updates = KTH.rnn(
             th_rnn_step_fn, th_inputs,
             th_initial_states,
             go_backwards=False,
@@ -336,10 +337,10 @@ class TestBackend(object):
             unroll=True,
             input_length=timesteps)
 
-        unrolled_th_last_output = KTH.eval(unrolled_last_output)
-        unrolled_th_outputs = KTH.eval(unrolled_outputs)
+        unrolled_th_last_output = KTH.eval(unrolled_last_output, updates)
+        unrolled_th_outputs = KTH.eval(unrolled_outputs, updates)
         assert len(unrolled_new_states) == 1
-        unrolled_th_state = KTH.eval(unrolled_new_states[0])
+        unrolled_th_state = KTH.eval(unrolled_new_states[0], updates)
         assert_allclose(th_last_output, unrolled_th_last_output, atol=1e-04)
         assert_allclose(th_outputs, unrolled_th_outputs, atol=1e-04)
         assert_allclose(th_state, unrolled_th_state, atol=1e-04)
@@ -348,43 +349,43 @@ class TestBackend(object):
         th_rnn_step_fn = rnn_step_fn(input_dim, output_dim, KTH)
         th_inputs = KTH.variable(input_val)
         th_initial_states = [KTH.variable(init_state_val)]
-        last_output, outputs, new_states = KTH.rnn(th_rnn_step_fn, th_inputs,
-                                                   th_initial_states,
-                                                   go_backwards=True,
-                                                   mask=None)
-        th_last_output = KTH.eval(last_output)
-        th_outputs = KTH.eval(outputs)
+        last_output, outputs, new_states, updates = KTH.rnn(th_rnn_step_fn, th_inputs,
+                                                            th_initial_states,
+                                                            go_backwards=True,
+                                                            mask=None)
+        th_last_output = KTH.eval(last_output, updates)
+        th_outputs = KTH.eval(outputs, updates)
         assert len(new_states) == 1
-        th_state = KTH.eval(new_states[0])
+        th_state = KTH.eval(new_states[0], updates)
 
         tf_rnn_step_fn = rnn_step_fn(input_dim, output_dim, KTF)
         tf_inputs = KTF.variable(input_val)
         tf_initial_states = [KTF.variable(init_state_val)]
-        last_output, outputs, new_states = KTF.rnn(tf_rnn_step_fn, tf_inputs,
-                                                   tf_initial_states,
-                                                   go_backwards=True,
-                                                   mask=None)
-        tf_last_output = KTF.eval(last_output)
-        tf_outputs = KTF.eval(outputs)
+        last_output, outputs, new_states, updates = KTF.rnn(tf_rnn_step_fn, tf_inputs,
+                                                            tf_initial_states,
+                                                            go_backwards=True,
+                                                            mask=None)
+        tf_last_output = KTF.eval(last_output, updates)
+        tf_outputs = KTF.eval(outputs, updates)
         assert len(new_states) == 1
-        tf_state = KTF.eval(new_states[0])
+        tf_state = KTF.eval(new_states[0], updates)
 
         assert_allclose(tf_last_output, th_last_output, atol=1e-04)
         assert_allclose(tf_outputs, th_outputs, atol=1e-04)
         assert_allclose(tf_state, th_state, atol=1e-04)
 
         # test unroll with backwards = True
-        bwd_last_output, bwd_outputs, bwd_new_states = KTH.rnn(
+        bwd_last_output, bwd_outputs, bwd_new_states, updates = KTH.rnn(
             th_rnn_step_fn, th_inputs,
             th_initial_states,
             go_backwards=True,
             mask=None)
-        bwd_th_last_output = KTH.eval(bwd_last_output)
-        bwd_th_outputs = KTH.eval(bwd_outputs)
+        bwd_th_last_output = KTH.eval(bwd_last_output, updates)
+        bwd_th_outputs = KTH.eval(bwd_outputs, updates)
         assert len(bwd_new_states) == 1
-        bwd_th_state = KTH.eval(bwd_new_states[0])
+        bwd_th_state = KTH.eval(bwd_new_states[0], updates)
 
-        bwd_unrolled_last_output, bwd_unrolled_outputs, bwd_unrolled_new_states = KTH.rnn(
+        bwd_unrolled_last_output, bwd_unrolled_outputs, bwd_unrolled_new_states, updates = KTH.rnn(
             th_rnn_step_fn, th_inputs,
             th_initial_states,
             go_backwards=True,
@@ -392,10 +393,10 @@ class TestBackend(object):
             unroll=True,
             input_length=timesteps)
 
-        bwd_unrolled_th_last_output = KTH.eval(bwd_unrolled_last_output)
-        bwd_unrolled_th_outputs = KTH.eval(bwd_unrolled_outputs)
+        bwd_unrolled_th_last_output = KTH.eval(bwd_unrolled_last_output, updates)
+        bwd_unrolled_th_outputs = KTH.eval(bwd_unrolled_outputs, updates)
         assert len(bwd_unrolled_new_states) == 1
-        bwd_unrolled_th_state = KTH.eval(bwd_unrolled_new_states[0])
+        bwd_unrolled_th_state = KTH.eval(bwd_unrolled_new_states[0], updates)
         assert_allclose(bwd_th_last_output, bwd_unrolled_th_last_output, atol=1e-04)
         assert_allclose(bwd_th_outputs, bwd_unrolled_th_outputs, atol=1e-04)
         assert_allclose(bwd_th_state, bwd_unrolled_th_state, atol=1e-04)
@@ -404,27 +405,27 @@ class TestBackend(object):
         np_mask = np.random.randint(2, size=(32, timesteps))
         th_mask = KTH.variable(np_mask)
 
-        masked_last_output, masked_outputs, masked_new_states = KTH.rnn(
+        masked_last_output, masked_outputs, masked_new_states, updates = KTH.rnn(
             th_rnn_step_fn, th_inputs,
             th_initial_states,
             go_backwards=False,
             mask=th_mask)
-        masked_th_last_output = KTH.eval(masked_last_output)
-        masked_th_outputs = KTH.eval(masked_outputs)
+        masked_th_last_output = KTH.eval(masked_last_output, updates)
+        masked_th_outputs = KTH.eval(masked_outputs, updates)
         assert len(masked_new_states) == 1
-        masked_th_state = KTH.eval(masked_new_states[0])
+        masked_th_state = KTH.eval(masked_new_states[0], updates)
 
-        unrolled_masked_last_output, unrolled_masked_outputs, unrolled_masked_new_states = KTH.rnn(
+        unrolled_masked_last_output, unrolled_masked_outputs, unrolled_masked_new_states, updates = KTH.rnn(
             th_rnn_step_fn, th_inputs,
             th_initial_states,
             go_backwards=False,
             mask=th_mask,
             unroll=True,
             input_length=timesteps)
-        unrolled_masked_th_last_output = KTH.eval(unrolled_masked_last_output)
-        unrolled_masked_th_outputs = KTH.eval(unrolled_masked_outputs)
+        unrolled_masked_th_last_output = KTH.eval(unrolled_masked_last_output, updates)
+        unrolled_masked_th_outputs = KTH.eval(unrolled_masked_outputs, updates)
         assert len(unrolled_masked_new_states) == 1
-        unrolled_masked_th_state = KTH.eval(unrolled_masked_new_states[0])
+        unrolled_masked_th_state = KTH.eval(unrolled_masked_new_states[0], updates)
 
         assert_allclose(unrolled_masked_th_last_output, masked_th_last_output, atol=1e-04)
         assert_allclose(unrolled_masked_th_outputs, masked_th_outputs, atol=1e-04)
@@ -445,6 +446,7 @@ class TestBackend(object):
             def step_function(x, states):
                 assert len(states) == 0
                 output = K.dot(x, W_i)
+                output = output + K.random_uniform(K.shape(output), high=1e-12)
                 return output, []
             return step_function
 
@@ -452,23 +454,23 @@ class TestBackend(object):
         th_rnn_step_fn = rnn_step_fn(input_dim, output_dim, KTH)
         th_inputs = KTH.variable(input_val)
         th_initial_states = []
-        last_output, outputs, new_states = KTH.rnn(th_rnn_step_fn, th_inputs,
-                                                   th_initial_states,
-                                                   go_backwards=False,
-                                                   mask=None)
-        th_last_output = KTH.eval(last_output)
-        th_outputs = KTH.eval(outputs)
+        last_output, outputs, new_states, updates = KTH.rnn(th_rnn_step_fn, th_inputs,
+                                                            th_initial_states,
+                                                            go_backwards=False,
+                                                            mask=None)
+        th_last_output = KTH.eval(last_output, updates)
+        th_outputs = KTH.eval(outputs, updates)
         assert len(new_states) == 0
 
         tf_rnn_step_fn = rnn_step_fn(input_dim, output_dim, KTF)
         tf_inputs = KTF.variable(input_val)
         tf_initial_states = []
-        last_output, outputs, new_states = KTF.rnn(tf_rnn_step_fn, tf_inputs,
-                                                   tf_initial_states,
-                                                   go_backwards=False,
-                                                   mask=None)
-        tf_last_output = KTF.eval(last_output)
-        tf_outputs = KTF.eval(outputs)
+        last_output, outputs, new_states, updates = KTF.rnn(tf_rnn_step_fn, tf_inputs,
+                                                            tf_initial_states,
+                                                            go_backwards=False,
+                                                            mask=None)
+        tf_last_output = KTF.eval(last_output, updates)
+        tf_outputs = KTF.eval(outputs, updates)
         assert len(new_states) == 0
 
         assert_allclose(tf_last_output, th_last_output, atol=1e-04)

--- a/tests/keras/layers/test_wrappers.py
+++ b/tests/keras/layers/test_wrappers.py
@@ -2,7 +2,7 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 from keras.utils.test_utils import keras_test
-from keras.layers import wrappers, Input
+from keras.layers import wrappers, Input, Dropout
 from keras.layers import core, convolutional, recurrent
 from keras.models import Sequential, Model, model_from_json
 
@@ -74,6 +74,16 @@ def test_TimeDistributed():
     outer_model = Model(x, y)
     outer_model.compile(optimizer='rmsprop', loss='mse')
     outer_model.fit(np.random.random((10, 3, 2)), np.random.random((10, 3, 3)), nb_epoch=1, batch_size=10)
+
+    # batch_input_shape + TimeDistributed + random number
+    x = Input(batch_shape=(1, 1, 1))
+    y = wrappers.TimeDistributed(Dropout(0.5))(x)
+    outer_model = Model(x, y)
+    outer_model.compile(optimizer='rmsprop', loss='mse')
+    outer_model.fit(np.random.random((1, 1, 1)),
+                    np.random.random((1, 1, 1)),
+                    validation_data=[np.random.random((1, 1, 1)), np.random.random((1, 1, 1))],
+                    nb_epoch=1, batch_size=1)
 
 
 @keras_test


### PR DESCRIPTION
Currently, `K.rnn()` is ignoring `theano.scan()` `updates`.
This should not be ignored.
If you ignore this, you cannot use random numbers inside `K.rnn()`.

What I modified:

1. Add the 4th return value to `K.rnn()`. This is `theano.scan()` `updates`. But this change breaks compatibility.
2. Add `updates` argument to `K.eval()`.
3. Add `rnn_updates` to `Layer`. I split `updates` and `rnn_updates` because `rnn_updates` needs for training, testing and predicting phase. `Recurrent` and `TimeDistributed` uses `K.rnn()`, and I passed `updates` to `Layer.add_rnn_updates()`.

By this fix, I can run this code on Theano.
`TimeDistributed` uses `K.rnn()` and `Dropout` uses random numbers.

```python
import numpy as np
from keras.layers import Input, TimeDistributed, Dropout
from keras.models import Model

x = Input(batch_shape=(1, 1, 1))
y = TimeDistributed(Dropout(0.5))(x)
model = Model(input=[x], output=[y])
model.compile(optimizer="sgd", loss="mse")
model.fit(np.zeros([1, 1, 1], np.float32), np.zeros([1, 1, 1], np.float32), batch_size=1)
```


