### PR TITLE
Optimization of TimeDistributed when the batch size is specified

### DIFF
--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -911,6 +911,13 @@ class Layer(object):
                                 self.name + '.build(batch_input_shape)`.')
         return sum([K.count_params(p) for p in self.trainable_weights])
 
+    @property
+    def requires_batch_size(self):
+        '''Returns True if the layer needs the batch size.
+        For example, Recurrent(stateful=True) returns True.
+        '''
+        return False
+
 
 class InputLayer(Layer):
     '''Layer to be used as an entry point into a graph.
@@ -1908,6 +1915,10 @@ class Container(Layer):
                             inputs = node.input_tensors
                             updates += layer.get_updates_for(inputs)
         return updates
+
+    @property
+    def requires_batch_size(self):
+        return any(layer.requires_batch_size for layer in self.layers)
 
     @property
     def stateful(self):

--- a/keras/layers/convolutional_recurrent.py
+++ b/keras/layers/convolutional_recurrent.py
@@ -179,6 +179,10 @@ class ConvRecurrent2D(Layer):
         else:
             return last_output
 
+    @property
+    def requires_batch_size(self):
+        return self.stateful
+
     def get_config(self):
         config = {'return_sequences': self.return_sequences,
                   'go_backwards': self.go_backwards,

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -236,6 +236,10 @@ class Recurrent(Layer):
         else:
             return last_output
 
+    @property
+    def requires_batch_size(self):
+        return self.stateful
+
     def get_config(self):
         config = {'return_sequences': self.return_sequences,
                   'go_backwards': self.go_backwards,

--- a/tests/keras/layers/test_recurrent.py
+++ b/tests/keras/layers/test_recurrent.py
@@ -165,5 +165,11 @@ def test_from_config(layer_class):
         assert l1.get_config() == l2.get_config()
 
 
+@rnn_test
+def test_requires_batch_size(layer_class):
+    for stateful in (False, True):
+        assert layer_class(output_dim=1, stateful=stateful).requires_batch_size == stateful
+
+
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
`TimeDistributed` is always using `K.rnn()` when the batch size is specified.
This is not always necessary.
I added `Layer.requires_batch_size` and changed to use `K.rnn()` only when `Layer.requires_batch_size` is `True`.

For example, the following code will not use `K.rnn()` by this pull request.

```python
x = Input(batch_shape=(1, 1, 1))
y = TimeDistributed(Dense(1))(x)
```