### PR TITLE
Deconvolution3D

### DIFF
--- a/docs/autogen.py
+++ b/docs/autogen.py
@@ -162,6 +162,7 @@ PAGES = [
             convolutional.SeparableConvolution2D,
             convolutional.Deconvolution2D,
             convolutional.Convolution3D,
+            convolutional.Deconvolution3D,
             convolutional.Cropping1D,
             convolutional.Cropping2D,
             convolutional.Cropping3D,

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -2855,7 +2855,7 @@ def deconv3d(x, kernel, output_shape, strides=(1, 1, 1),
     x = _preprocess_conv3d_input(x, dim_ordering)
     output_shape = _preprocess_deconv_output_shape(x, output_shape, dim_ordering)
     kernel = _preprocess_conv3d_kernel(kernel, dim_ordering)
-    kernel = tf.transpose(kernel, (0, 1, 3, 4, 2))
+    kernel = tf.transpose(kernel, (0, 1, 2, 4, 3))
     padding = _preprocess_border_mode(border_mode)
     strides = (1,) + strides + (1,)
 

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -2544,8 +2544,7 @@ def in_top_k(predictions, targets, k):
 
 def _preprocess_deconv_output_shape(x, shape, dim_ordering):
     if dim_ordering == 'th':
-        shape = (shape[0], shape[2], shape[3], shape[1])
-
+        shape = (shape[0],) + tuple(shape[2:]) + (shape[1],)
     if shape[0] is None:
         shape = (tf.shape(x)[0], ) + tuple(shape[1:])
         shape = tf.stack(list(shape))
@@ -2823,6 +2822,45 @@ def conv3d(x, kernel, strides=(1, 1, 1),
     strides = (1,) + strides + (1,)
 
     x = tf.nn.conv3d(x, kernel, strides, padding)
+    return _postprocess_conv3d_output(x, dim_ordering)
+
+
+def deconv3d(x, kernel, output_shape, strides=(1, 1, 1),
+             border_mode='valid',
+             dim_ordering='default',
+             image_shape=None, filter_shape=None):
+    '''3D deconvolution (i.e. transposed convolution).
+
+    # Arguments
+        x: input tensor.
+        kernel: kernel tensor.
+        output_shape: 1D int tensor for the output shape.
+        strides: strides tuple.
+        border_mode: string, "same" or "valid".
+        dim_ordering: "tf" or "th".
+            Whether to use Theano or TensorFlow dimension ordering
+            for inputs/kernels/ouputs.
+
+    # Returns
+        A tensor, result of transposed 3D convolution.
+
+    # Raises
+        ValueError: if `dim_ordering` is neither `tf` or `th`.
+    '''
+    if dim_ordering == 'default':
+        dim_ordering = image_dim_ordering()
+    if dim_ordering not in {'th', 'tf'}:
+        raise ValueError('Unknown dim_ordering ' + str(dim_ordering))
+
+    x = _preprocess_conv3d_input(x, dim_ordering)
+    output_shape = _preprocess_deconv_output_shape(x, output_shape, dim_ordering)
+    kernel = _preprocess_conv3d_kernel(kernel, dim_ordering)
+    kernel = tf.transpose(kernel, (0, 1, 3, 4, 2))
+    padding = _preprocess_border_mode(border_mode)
+    strides = (1,) + strides + (1,)
+
+    x = tf.nn.conv3d_transpose(x, kernel, output_shape, strides,
+                               padding=padding)
     return _postprocess_conv3d_output(x, dim_ordering)
 
 

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1574,12 +1574,12 @@ def deconv2d(x, kernel, output_shape, strides=(1, 1),
     filter_shape = _preprocess_conv2d_filter_shape(dim_ordering, filter_shape)
     filter_shape = tuple(filter_shape[i] for i in (1, 0, 2, 3))
 
-    op = T.nnet.abstract_conv.AbstractConv2d_gradInputs(imshp=output_shape,
-                                                        kshp=filter_shape,
-                                                        subsample=strides,
-                                                        border_mode=th_border_mode,
-                                                        filter_flip=not flip_filters)
-    conv_out = op(kernel, x, output_shape[2:])
+    conv_out = T.nnet.abstract_conv.conv2d_grad_wrt_inputs(
+        x, kernel, output_shape,
+        filter_shape=filter_shape,
+        border_mode=th_border_mode,
+        subsample=strides,
+        filter_flip=not flip_filters)
 
     conv_out = _postprocess_conv2d_output(conv_out, x, border_mode,
                                           kernel_shape, strides, dim_ordering)
@@ -1690,12 +1690,12 @@ def deconv3d(x, kernel, output_shape, strides=(1, 1, 1),
     filter_shape = _preprocess_conv3d_filter_shape(dim_ordering, filter_shape)
     filter_shape = tuple(filter_shape[i] for i in (1, 0, 2, 3, 4))
 
-    op = T.nnet.abstract_conv.AbstractConv3d_gradInputs(imshp=output_shape,
-                                                        kshp=filter_shape,
-                                                        subsample=strides,
-                                                        border_mode=th_border_mode,
-                                                        filter_flip=not flip_filters)
-    conv_out = op(kernel, x, output_shape[2:])
+    conv_out = T.nnet.abstract_conv.conv3d_grad_wrt_inputs(
+        x, kernel, output_shape,
+        filter_shape=filter_shape,
+        border_mode=th_border_mode,
+        subsample=strides,
+        filter_flip=not flip_filters)
 
     conv_out = _postprocess_conv3d_output(conv_out, x, border_mode,
                                           kernel_shape, strides, dim_ordering)

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1651,6 +1651,57 @@ def conv3d(x, kernel, strides=(1, 1, 1),
     return conv_out
 
 
+def deconv3d(x, kernel, output_shape, strides=(1, 1, 1),
+             border_mode='valid',
+             dim_ordering='default',
+             image_shape=None, filter_shape=None):
+    '''3D deconvolution (transposed convolution).
+
+    # Arguments
+        kernel: kernel tensor.
+        output_shape: desired dimensions of output.
+        strides: strides tuple.
+        border_mode: string, "same" or "valid".
+        dim_ordering: "tf" or "th".
+            Whether to use Theano or TensorFlow dimension ordering
+        in inputs/kernels/ouputs.
+    '''
+    flip_filters = False
+    if dim_ordering == 'default':
+        dim_ordering = image_dim_ordering()
+    if dim_ordering not in {'th', 'tf'}:
+        raise ValueError('Unknown dim_ordering ' + str(dim_ordering))
+
+    if dim_ordering == 'tf':
+        output_shape = (output_shape[0], output_shape[4], output_shape[1],
+                        output_shape[2], output_shape[3])
+
+    x = _preprocess_conv3d_input(x, dim_ordering)
+    kernel = _preprocess_conv3d_kernel(kernel, dim_ordering)
+    kernel = kernel.dimshuffle((1, 0, 2, 3, 4))
+    th_border_mode = _preprocess_border_mode(border_mode)
+
+    if hasattr(kernel, '_keras_shape'):
+        kernel_shape = kernel._keras_shape
+    else:
+        # Will only work if `kernel` is a shared variable.
+        kernel_shape = kernel.eval().shape
+
+    filter_shape = _preprocess_conv3d_filter_shape(dim_ordering, filter_shape)
+    filter_shape = tuple(filter_shape[i] for i in (1, 0, 2, 3, 4))
+
+    op = T.nnet.abstract_conv.AbstractConv3d_gradInputs(imshp=output_shape,
+                                                        kshp=filter_shape,
+                                                        subsample=strides,
+                                                        border_mode=th_border_mode,
+                                                        filter_flip=not flip_filters)
+    conv_out = op(kernel, x, output_shape[2:])
+
+    conv_out = _postprocess_conv3d_output(conv_out, x, border_mode,
+                                          kernel_shape, strides, dim_ordering)
+    return conv_out
+
+
 # TODO: remove this function when theano without AbstractConv3d is deprecated
 def _old_theano_conv3d(x, kernel, strides=(1, 1, 1),
                        border_mode='valid', dim_ordering='default',

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -633,6 +633,9 @@ class Deconvolution2D(Convolution2D):
             dim_ordering = K.image_dim_ordering()
         if border_mode not in {'valid', 'same', 'full'}:
             raise ValueError('Invalid border mode for Deconvolution2D:', border_mode)
+        if len(output_shape) == 3:
+            # missing the batch size
+            output_shape = (None,) + tuple(output_shape)
 
         self.output_shape_ = output_shape
 
@@ -1389,6 +1392,9 @@ class Deconvolution3D(Convolution3D):
             dim_ordering = K.image_dim_ordering()
         if border_mode not in {'valid', 'same', 'full'}:
             raise ValueError('Invalid border mode for Deconvolution3D:', border_mode)
+        if len(output_shape) == 4:
+            # missing the batch size
+            output_shape = (None,) + tuple(output_shape)
 
         self.output_shape_ = output_shape
 

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -523,23 +523,18 @@ class Deconvolution2D(Convolution2D):
     # Examples
 
     ```python
+        # TH dim ordering.
         # apply a 3x3 transposed convolution
         # with stride 1x1 and 3 output filters on a 12x12 image:
         model = Sequential()
         model.add(Deconvolution2D(3, 3, 3, output_shape=(None, 3, 14, 14),
                                   border_mode='valid',
                                   input_shape=(3, 12, 12)))
-        # Note that you will have to change
-        # the output_shape depending on the backend used.
 
         # we can predict with the model and print the shape of the array.
         dummy_input = np.ones((32, 3, 12, 12))
-        # For TensorFlow dummy_input = np.ones((32, 12, 12, 3))
         preds = model.predict(dummy_input)
-        print(preds.shape)
-        # Theano GPU: (None, 3, 13, 13)
-        # Theano CPU: (None, 3, 14, 14)
-        # TensorFlow: (None, 14, 14, 3)
+        print(preds.shape)  # (None, 3, 14, 14)
 
         # apply a 3x3 transposed convolution
         # with stride 2x2 and 3 output filters on a 12x12 image:
@@ -552,12 +547,37 @@ class Deconvolution2D(Convolution2D):
 
         # we can predict with the model and print the shape of the array.
         dummy_input = np.ones((32, 3, 12, 12))
-        # For TensorFlow dummy_input = np.ones((32, 12, 12, 3))
         preds = model.predict(dummy_input)
-        print(preds.shape)
-        # Theano GPU: (None, 3, 25, 25)
-        # Theano CPU: (None, 3, 25, 25)
-        # TensorFlow: (None, 25, 25, 3)
+        print(preds.shape)  # (None, 3, 25, 25)
+    ```
+
+    ```python
+        # TF dim ordering.
+        # apply a 3x3 transposed convolution
+        # with stride 1x1 and 3 output filters on a 12x12 image:
+        model = Sequential()
+        model.add(Deconvolution2D(3, 3, 3, output_shape=(None, 14, 14, 3),
+                                  border_mode='valid',
+                                  input_shape=(12, 12, 3)))
+
+        # we can predict with the model and print the shape of the array.
+        dummy_input = np.ones((32, 12, 12, 3))
+        preds = model.predict(dummy_input)
+        print(preds.shape)  # (None, 14, 14, 3)
+
+        # apply a 3x3 transposed convolution
+        # with stride 2x2 and 3 output filters on a 12x12 image:
+        model = Sequential()
+        model.add(Deconvolution2D(3, 3, 3, output_shape=(None, 25, 25, 3),
+                                  subsample=(2, 2),
+                                  border_mode='valid',
+                                  input_shape=(12, 12, 3)))
+        model.summary()
+
+        # we can predict with the model and print the shape of the array.
+        dummy_input = np.ones((32, 12, 12, 3))
+        preds = model.predict(dummy_input)
+        print(preds.shape)  # (None, 25, 25, 3)
     ```
 
     # Arguments
@@ -1266,17 +1286,20 @@ class Convolution3D(Layer):
 
 
 class Deconvolution3D(Convolution3D):
-    '''Transposed convolution operator for filtering windows of three-dimensional inputs.
-    The need for transposed convolutions generally arises from the desire
-    to use a transformation going in the opposite direction of a normal convolution,
-    i.e., from something that has the shape of the output of some convolution
-    to something that has the shape of its input
-    while maintaining a connectivity pattern that is compatible with said convolution. [1]
+    """Transposed convolution operator for filtering windows of 3-D inputs.
+
+    The need for transposed convolutions generally arises from the desire to
+    use a transformation going in the opposite direction
+    of a normal convolution, i.e., from something that has the shape
+    of the output of some convolution to something that has the shape
+    of its input while maintaining a connectivity pattern
+    that is compatible with said convolution.
 
     When using this layer as the first layer in a model,
     provide the keyword argument `input_shape`
     (tuple of integers, does not include the sample axis),
-    e.g. `input_shape=(3, 128, 128, 128)` for a 128x128x128 voxel volume with three channels.
+    e.g. `input_shape=(3, 128, 128, 128)` for a 128x128x128 volume with
+    three channels.
 
     To pass the correct `output_shape` to this layer,
     one could use a test model to predict and observe the actual output shape.
@@ -1284,33 +1307,61 @@ class Deconvolution3D(Convolution3D):
     # Examples
 
     ```python
-        # apply a 3x3x3 transposed convolution with stride 1x1x1 and 3 output filters on a 12x12x12 volume:
+        # TH dim ordering.
+        # apply a 3x3x3 transposed convolution
+        # with stride 1x1x1 and 3 output filters on a 12x12x12 image:
         model = Sequential()
-        model.add(Deconvolution3D(3, 3, 3, 3, output_shape=(None, 3, 14, 14, 14), border_mode='valid', input_shape=(3, 12, 12, 12)))
-        # Note that you will have to change the output_shape depending on the backend used.
+        model.add(Deconvolution3D(3, 3, 3, 3, output_shape=(None, 3, 14, 14, 14),
+                                  border_mode='valid',
+                                  input_shape=(3, 12, 12, 12)))
 
         # we can predict with the model and print the shape of the array.
         dummy_input = np.ones((32, 3, 12, 12, 12))
-        # For TensorFlow dummy_input = np.ones((32, 12, 12, 12, 3))
         preds = model.predict(dummy_input)
-        print(preds.shape)
-        # Theano GPU: (None, 3, 13, 13, 13)
-        # Theano CPU: (None, 3, 14, 14, 14)
-        # TensorFlow: (None, 14, 14, 14, 3)
+        print(preds.shape)  # (None, 3, 14, 14, 14)
 
-        # apply a 3x3x3 transposed convolution with stride 2x2x2 and 3 output filters on a 12x12x12 volume:
+        # apply a 3x3x3 transposed convolution
+        # with stride 2x2x2 and 3 output filters on a 12x12x12 image:
         model = Sequential()
-        model.add(Deconvolution3D(3, 3, 3, 3, output_shape=(None, 3, 25, 25, 25), subsample=(2, 2, 2), border_mode='valid', input_shape=(3, 12, 12, 12)))
+        model.add(Deconvolution3D(3, 3, 3, 3, output_shape=(None, 3, 25, 25, 25),
+                                  subsample=(2, 2, 2),
+                                  border_mode='valid',
+                                  input_shape=(3, 12, 12, 12)))
         model.summary()
 
         # we can predict with the model and print the shape of the array.
         dummy_input = np.ones((32, 3, 12, 12, 12))
-        # For TensorFlow dummy_input = np.ones((32, 12, 12, 12, 3))
         preds = model.predict(dummy_input)
-        print(preds.shape)
-        # Theano GPU: (None, 3, 25, 25, 25)
-        # Theano CPU: (None, 3, 25, 25, 25)
-        # TensorFlow: (None, 25, 25, 3)
+        print(preds.shape)  # (None, 3, 25, 25, 25)
+    ```
+
+    ```python
+        # TF dim ordering.
+        # apply a 3x3x3 transposed convolution
+        # with stride 1x1x1 and 3 output filters on a 12x12x12 image:
+        model = Sequential()
+        model.add(Deconvolution3D(3, 3, 3, 3, output_shape=(None, 14, 14, 14, 3),
+                                  border_mode='valid',
+                                  input_shape=(12, 12, 12, 3)))
+
+        # we can predict with the model and print the shape of the array.
+        dummy_input = np.ones((32, 12, 12, 12, 3))
+        preds = model.predict(dummy_input)
+        print(preds.shape)  # (None, 14, 14, 14, 3)
+
+        # apply a 3x3x3 transposed convolution
+        # with stride 2x2x2 and 3 output filters on a 12x12x12 image:
+        model = Sequential()
+        model.add(Deconvolution3D(3, 3, 3, 3, output_shape=(None, 25, 25, 25, 3),
+                                  subsample=(2, 2, 2),
+                                  border_mode='valid',
+                                  input_shape=(12, 12, 12, 3)))
+        model.summary()
+
+        # we can predict with the model and print the shape of the array.
+        dummy_input = np.ones((32, 12, 12, 12, 3))
+        preds = model.predict(dummy_input)
+        print(preds.shape)  # (None, 25, 25, 25, 3)
     ```
 
     # Arguments
@@ -1319,19 +1370,11 @@ class Deconvolution3D(Convolution3D):
         kernel_dim2: Length of the second dimension in the transposed convolution kernel.
         kernel_dim3: Length of the third dimension in the transposed convolution kernel.
         output_shape: Output shape of the transposed convolution operation.
-            tuple of integers (nb_samples, nb_filter, conv_dim1, conv_dim2, conv_dim3)
-            Formula for calculation of the output shape [1], [2]:
-                o = s (i - 1) + a + k - 2p, \quad a \in \{0, \ldots, s - 1\}
-                where:
-                    i - input size (rows or cols),
-                    k - kernel size (nb_filter),
-                    s - stride (subsample for rows or cols respectively),
-                    p - padding size,
-                    a - user-specified quantity used to distinguish between
-                        the s different possible output sizes.
-             Because a is not specified explicitly and Theano and Tensorflow
-             use different values, it is better to use a dummy input and observe
-             the actual output shape of a layer as specified in the examples.
+            tuple of integers
+            `(nb_samples, nb_filter, conv_dim1, conv_dim2, conv_dim3)`.
+             It is better to use
+             a dummy input and observe the actual output shape of
+             a layer, as specified in the examples.
         init: name of initialization function for the weights of the layer
             (see [initializations](../initializations.md)), or alternatively,
             Theano function to use for weights initialization.
@@ -1343,7 +1386,8 @@ class Deconvolution3D(Convolution3D):
             If you don't specify anything, no activation is applied
             (ie. "linear" activation: a(x) = x).
         weights: list of numpy arrays to set as initial weights.
-        border_mode: 'valid', 'same' or 'full'. ('full' requires the Theano backend.)
+        border_mode: 'valid', 'same' or 'full'
+            ('full' requires the Theano backend).
         subsample: tuple of length 3. Factor by which to oversample output.
             Also called strides elsewhere.
         W_regularizer: instance of [WeightRegularizer](../regularizers.md)
@@ -1361,7 +1405,8 @@ class Deconvolution3D(Convolution3D):
             It defaults to the `image_dim_ordering` value found in your
             Keras config file at `~/.keras/keras.json`.
             If you never set it, then it will be "tf".
-        bias: whether to include a bias (i.e. make the layer affine rather than linear).
+        bias: whether to include a bias
+            (i.e. make the layer affine rather than linear).
 
     # Input shape
         5D tensor with shape:
@@ -1377,10 +1422,10 @@ class Deconvolution3D(Convolution3D):
         `new_conv_dim1`, `new_conv_dim2` and `new_conv_dim3` values might have changed due to padding.
 
     # References
-        [1] [A guide to convolution arithmetic for deep learning](https://arxiv.org/abs/1603.07285 "arXiv:1603.07285v1 [stat.ML]")
-        [2] [Transposed convolution arithmetic](http://deeplearning.net/software/theano_versions/dev/tutorial/conv_arithmetic.html#transposed-convolution-arithmetic)
-        [3] [Deconvolutional Networks](http://www.matthewzeiler.com/pubs/cvpr2010/cvpr2010.pdf)
-    '''
+        - [A guide to convolution arithmetic for deep learning](https://arxiv.org/abs/1603.07285v1)
+        - [Transposed convolution arithmetic](http://deeplearning.net/software/theano_versions/dev/tutorial/conv_arithmetic.html#transposed-convolution-arithmetic)
+        - [Deconvolutional Networks](http://www.matthewzeiler.com/pubs/cvpr2010/cvpr2010.pdf)
+    """
     def __init__(self, nb_filter, kernel_dim1, kernel_dim2, kernel_dim3,
                  output_shape, init='glorot_uniform', activation=None, weights=None,
                  border_mode='valid', subsample=(1, 1, 1),

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -1262,6 +1262,188 @@ class Convolution3D(Layer):
         return dict(list(base_config.items()) + list(config.items()))
 
 
+class Deconvolution3D(Convolution3D):
+    '''Transposed convolution operator for filtering windows of three-dimensional inputs.
+    The need for transposed convolutions generally arises from the desire
+    to use a transformation going in the opposite direction of a normal convolution,
+    i.e., from something that has the shape of the output of some convolution
+    to something that has the shape of its input
+    while maintaining a connectivity pattern that is compatible with said convolution. [1]
+
+    When using this layer as the first layer in a model,
+    provide the keyword argument `input_shape`
+    (tuple of integers, does not include the sample axis),
+    e.g. `input_shape=(3, 128, 128, 128)` for a 128x128x128 voxel volume with three channels.
+
+    To pass the correct `output_shape` to this layer,
+    one could use a test model to predict and observe the actual output shape.
+
+    # Examples
+
+    ```python
+        # apply a 3x3x3 transposed convolution with stride 1x1x1 and 3 output filters on a 12x12x12 volume:
+        model = Sequential()
+        model.add(Deconvolution3D(3, 3, 3, 3, output_shape=(None, 3, 14, 14, 14), border_mode='valid', input_shape=(3, 12, 12, 12)))
+        # Note that you will have to change the output_shape depending on the backend used.
+
+        # we can predict with the model and print the shape of the array.
+        dummy_input = np.ones((32, 3, 12, 12, 12))
+        # For TensorFlow dummy_input = np.ones((32, 12, 12, 12, 3))
+        preds = model.predict(dummy_input)
+        print(preds.shape)
+        # Theano GPU: (None, 3, 13, 13, 13)
+        # Theano CPU: (None, 3, 14, 14, 14)
+        # TensorFlow: (None, 14, 14, 14, 3)
+
+        # apply a 3x3x3 transposed convolution with stride 2x2x2 and 3 output filters on a 12x12x12 volume:
+        model = Sequential()
+        model.add(Deconvolution3D(3, 3, 3, 3, output_shape=(None, 3, 25, 25, 25), subsample=(2, 2, 2), border_mode='valid', input_shape=(3, 12, 12, 12)))
+        model.summary()
+
+        # we can predict with the model and print the shape of the array.
+        dummy_input = np.ones((32, 3, 12, 12, 12))
+        # For TensorFlow dummy_input = np.ones((32, 12, 12, 12, 3))
+        preds = model.predict(dummy_input)
+        print(preds.shape)
+        # Theano GPU: (None, 3, 25, 25, 25)
+        # Theano CPU: (None, 3, 25, 25, 25)
+        # TensorFlow: (None, 25, 25, 3)
+    ```
+
+    # Arguments
+        nb_filter: Number of transposed convolution filters to use.
+        kernel_dim1: Length of the first dimension in the transposed convolution kernel.
+        kernel_dim2: Length of the second dimension in the transposed convolution kernel.
+        kernel_dim3: Length of the third dimension in the transposed convolution kernel.
+        output_shape: Output shape of the transposed convolution operation.
+            tuple of integers (nb_samples, nb_filter, conv_dim1, conv_dim2, conv_dim3)
+            Formula for calculation of the output shape [1], [2]:
+                o = s (i - 1) + a + k - 2p, \quad a \in \{0, \ldots, s - 1\}
+                where:
+                    i - input size (rows or cols),
+                    k - kernel size (nb_filter),
+                    s - stride (subsample for rows or cols respectively),
+                    p - padding size,
+                    a - user-specified quantity used to distinguish between
+                        the s different possible output sizes.
+             Because a is not specified explicitly and Theano and Tensorflow
+             use different values, it is better to use a dummy input and observe
+             the actual output shape of a layer as specified in the examples.
+        init: name of initialization function for the weights of the layer
+            (see [initializations](../initializations.md)), or alternatively,
+            Theano function to use for weights initialization.
+            This parameter is only relevant if you don't pass
+            a `weights` argument.
+        activation: name of activation function to use
+            (see [activations](../activations.md)),
+            or alternatively, elementwise Theano/TensorFlow function.
+            If you don't specify anything, no activation is applied
+            (ie. "linear" activation: a(x) = x).
+        weights: list of numpy arrays to set as initial weights.
+        border_mode: 'valid', 'same' or 'full'. ('full' requires the Theano backend.)
+        subsample: tuple of length 3. Factor by which to oversample output.
+            Also called strides elsewhere.
+        W_regularizer: instance of [WeightRegularizer](../regularizers.md)
+            (eg. L1 or L2 regularization), applied to the main weights matrix.
+        b_regularizer: instance of [WeightRegularizer](../regularizers.md),
+            applied to the bias.
+        activity_regularizer: instance of [ActivityRegularizer](../regularizers.md),
+            applied to the network output.
+        W_constraint: instance of the [constraints](../constraints.md) module
+            (eg. maxnorm, nonneg), applied to the main weights matrix.
+        b_constraint: instance of the [constraints](../constraints.md) module,
+            applied to the bias.
+        dim_ordering: 'th' or 'tf'. In 'th' mode, the channels dimension
+            (the depth) is at index 1, in 'tf' mode is it at index 4.
+            It defaults to the `image_dim_ordering` value found in your
+            Keras config file at `~/.keras/keras.json`.
+            If you never set it, then it will be "tf".
+        bias: whether to include a bias (i.e. make the layer affine rather than linear).
+
+    # Input shape
+        5D tensor with shape:
+        `(samples, channels, conv_dim1, conv_dim2, conv_dim3)` if dim_ordering='th'
+        or 5D tensor with shape:
+        `(samples, conv_dim1, conv_dim2, conv_dim3, channels)` if dim_ordering='tf'.
+
+    # Output shape
+        5D tensor with shape:
+        `(samples, nb_filter, new_conv_dim1, new_conv_dim2, new_conv_dim3)` if dim_ordering='th'
+        or 5D tensor with shape:
+        `(samples, new_conv_dim1, new_conv_dim2, new_conv_dim3, nb_filter)` if dim_ordering='tf'.
+        `new_conv_dim1`, `new_conv_dim2` and `new_conv_dim3` values might have changed due to padding.
+
+    # References
+        [1] [A guide to convolution arithmetic for deep learning](https://arxiv.org/abs/1603.07285 "arXiv:1603.07285v1 [stat.ML]")
+        [2] [Transposed convolution arithmetic](http://deeplearning.net/software/theano_versions/dev/tutorial/conv_arithmetic.html#transposed-convolution-arithmetic)
+        [3] [Deconvolutional Networks](http://www.matthewzeiler.com/pubs/cvpr2010/cvpr2010.pdf)
+    '''
+    def __init__(self, nb_filter, kernel_dim1, kernel_dim2, kernel_dim3,
+                 output_shape, init='glorot_uniform', activation=None, weights=None,
+                 border_mode='valid', subsample=(1, 1, 1),
+                 dim_ordering='default',
+                 W_regularizer=None, b_regularizer=None, activity_regularizer=None,
+                 W_constraint=None, b_constraint=None,
+                 bias=True, **kwargs):
+        if dim_ordering == 'default':
+            dim_ordering = K.image_dim_ordering()
+        if border_mode not in {'valid', 'same', 'full'}:
+            raise ValueError('Invalid border mode for Deconvolution3D:', border_mode)
+
+        self.output_shape_ = output_shape
+
+        super(Deconvolution3D, self).__init__(nb_filter,
+                                              kernel_dim1, kernel_dim2, kernel_dim3,
+                                              init=init,
+                                              activation=activation,
+                                              weights=weights,
+                                              border_mode=border_mode,
+                                              subsample=subsample,
+                                              dim_ordering=dim_ordering,
+                                              W_regularizer=W_regularizer,
+                                              b_regularizer=b_regularizer,
+                                              activity_regularizer=activity_regularizer,
+                                              W_constraint=W_constraint,
+                                              b_constraint=b_constraint,
+                                              bias=bias,
+                                              **kwargs)
+
+    def get_output_shape_for(self, input_shape):
+        if self.dim_ordering == 'th':
+            conv_dim1 = self.output_shape_[2]
+            conv_dim2 = self.output_shape_[3]
+            conv_dim3 = self.output_shape_[4]
+            return (input_shape[0], self.nb_filter, conv_dim1, conv_dim2, conv_dim3)
+        elif self.dim_ordering == 'tf':
+            conv_dim1 = self.output_shape_[1]
+            conv_dim2 = self.output_shape_[2]
+            conv_dim3 = self.output_shape_[3]
+            return (input_shape[0], conv_dim1, conv_dim2, conv_dim3, self.nb_filter)
+        else:
+            raise ValueError('Invalid dim_ordering:', self.dim_ordering)
+
+    def call(self, x, mask=None):
+        output = K.deconv3d(x, self.W, self.output_shape_,
+                            strides=self.subsample,
+                            border_mode=self.border_mode,
+                            dim_ordering=self.dim_ordering,
+                            filter_shape=self.W_shape)
+        if self.bias:
+            if self.dim_ordering == 'th':
+                output += K.reshape(self.b, (1, self.nb_filter, 1, 1, 1))
+            elif self.dim_ordering == 'tf':
+                output += K.reshape(self.b, (1, 1, 1, 1, self.nb_filter))
+            else:
+                raise ValueError('Invalid dim_ordering:', self.dim_ordering)
+        output = self.activation(output)
+        return output
+
+    def get_config(self):
+        config = {'output_shape': self.output_shape_}
+        base_config = super(Deconvolution3D, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))
+
+
 class UpSampling1D(Layer):
     """Upsampling layer for 1D inputs.
 
@@ -2018,6 +2200,7 @@ Conv1D = Convolution1D
 Conv2D = Convolution2D
 Conv3D = Convolution3D
 Deconv2D = Deconvolution2D
+Deconv3D = Deconvolution3D
 AtrousConv1D = AtrousConvolution1D
 AtrousConv2D = AtrousConvolution2D
 SeparableConv2D = SeparableConvolution2D

--- a/keras/utils/layer_utils.py
+++ b/keras/utils/layer_utils.py
@@ -169,6 +169,7 @@ def convert_all_kernels_in_model(model):
         'Convolution3D',
         'AtrousConvolution2D',
         'Deconvolution2D',
+        'Deconvolution3D',
     }
     to_assign = []
     for layer in model.layers:

--- a/tests/keras/layers/test_convolutional.py
+++ b/tests/keras/layers/test_convolutional.py
@@ -177,6 +177,52 @@ def test_deconvolution_2d():
 
 
 @keras_test
+def test_deconvolution_3d():
+    nb_samples = 2
+    nb_filter = 2
+    stack_size = 3
+    kernel_dim1 = 10
+    kernel_dim2 = 6
+    kernel_dim3 = 5
+
+    for batch_size in [None, nb_samples]:
+        for border_mode in _convolution_border_modes:
+            for subsample in [(1, 1, 1), (2, 2, 2)]:
+                if border_mode == 'same' and subsample != (1, 1, 1):
+                    continue
+
+                dim1 = conv_input_length(kernel_dim1, 3, border_mode, subsample[0])
+                dim2 = conv_input_length(kernel_dim2, 3, border_mode, subsample[1])
+                dim3 = conv_input_length(kernel_dim3, 3, border_mode, subsample[2])
+                layer_test(convolutional.Deconvolution3D,
+                           kwargs={'nb_filter': nb_filter,
+                                   'kernel_dim1': 3,
+                                   'kernel_dim2': 3,
+                                   'kernel_dim3': 3,
+                                   'output_shape': (batch_size, nb_filter, dim1, dim2, dim3),
+                                   'border_mode': border_mode,
+                                   'subsample': subsample,
+                                   'dim_ordering': 'th'},
+                           input_shape=(nb_samples, stack_size, kernel_dim1, kernel_dim2, kernel_dim3),
+                           fixed_batch_size=True)
+
+                layer_test(convolutional.Deconvolution3D,
+                           kwargs={'nb_filter': nb_filter,
+                                   'kernel_dim1': 3,
+                                   'kernel_dim2': 3,
+                                   'kernel_dim3': 3,
+                                   'output_shape': (batch_size, nb_filter, dim1, dim2, dim3),
+                                   'border_mode': border_mode,
+                                   'dim_ordering': 'th',
+                                   'W_regularizer': 'l2',
+                                   'b_regularizer': 'l2',
+                                   'activity_regularizer': 'activity_l2',
+                                   'subsample': subsample},
+                           input_shape=(nb_samples, stack_size, kernel_dim1, kernel_dim2, kernel_dim3),
+                           fixed_batch_size=True)
+
+
+@keras_test
 def test_atrous_conv_2d():
     nb_samples = 2
     nb_filter = 2

--- a/tests/keras/layers/test_convolutional.py
+++ b/tests/keras/layers/test_convolutional.py
@@ -175,6 +175,19 @@ def test_deconvolution_2d():
                            input_shape=(nb_samples, stack_size, nb_row, nb_col),
                            fixed_batch_size=True)
 
+                layer_test(convolutional.Deconvolution2D,
+                           kwargs={'nb_filter': nb_filter,
+                                   'nb_row': 3,
+                                   'nb_col': 3,
+                                   'output_shape': (nb_filter, rows, cols),
+                                   'border_mode': border_mode,
+                                   'dim_ordering': 'th',
+                                   'W_regularizer': 'l2',
+                                   'b_regularizer': 'l2',
+                                   'activity_regularizer': 'activity_l2',
+                                   'subsample': subsample},
+                           input_shape=(nb_samples, stack_size, nb_row, nb_col))
+
 
 @keras_test
 def test_deconvolution_3d():
@@ -220,6 +233,20 @@ def test_deconvolution_3d():
                                    'subsample': subsample},
                            input_shape=(nb_samples, stack_size, kernel_dim1, kernel_dim2, kernel_dim3),
                            fixed_batch_size=True)
+
+                layer_test(convolutional.Deconvolution3D,
+                           kwargs={'nb_filter': nb_filter,
+                                   'kernel_dim1': 3,
+                                   'kernel_dim2': 3,
+                                   'kernel_dim3': 3,
+                                   'output_shape': (nb_filter, dim1, dim2, dim3),
+                                   'border_mode': border_mode,
+                                   'dim_ordering': 'th',
+                                   'W_regularizer': 'l2',
+                                   'b_regularizer': 'l2',
+                                   'activity_regularizer': 'activity_l2',
+                                   'subsample': subsample},
+                           input_shape=(nb_samples, stack_size, kernel_dim1, kernel_dim2, kernel_dim3))
 
 
 @keras_test

--- a/tests/keras/layers/test_convolutional.py
+++ b/tests/keras/layers/test_convolutional.py
@@ -191,12 +191,12 @@ def test_deconvolution_2d():
 
 @keras_test
 def test_deconvolution_3d():
-    nb_samples = 2
-    nb_filter = 2
-    stack_size = 3
-    kernel_dim1 = 10
-    kernel_dim2 = 6
-    kernel_dim3 = 5
+    nb_samples = 6
+    nb_filter = 4
+    stack_size = 2
+    kernel_dim1 = 12
+    kernel_dim2 = 10
+    kernel_dim3 = 8
 
     for batch_size in [None, nb_samples]:
         for border_mode in _convolution_border_modes:
@@ -204,13 +204,14 @@ def test_deconvolution_3d():
                 if border_mode == 'same' and subsample != (1, 1, 1):
                     continue
 
-                dim1 = conv_input_length(kernel_dim1, 3, border_mode, subsample[0])
-                dim2 = conv_input_length(kernel_dim2, 3, border_mode, subsample[1])
+                dim1 = conv_input_length(kernel_dim1, 7, border_mode, subsample[0])
+                dim2 = conv_input_length(kernel_dim2, 5, border_mode, subsample[1])
                 dim3 = conv_input_length(kernel_dim3, 3, border_mode, subsample[2])
+                print(dim1, dim2, dim3)
                 layer_test(convolutional.Deconvolution3D,
                            kwargs={'nb_filter': nb_filter,
-                                   'kernel_dim1': 3,
-                                   'kernel_dim2': 3,
+                                   'kernel_dim1': 7,
+                                   'kernel_dim2': 5,
                                    'kernel_dim3': 3,
                                    'output_shape': (batch_size, nb_filter, dim1, dim2, dim3),
                                    'border_mode': border_mode,
@@ -221,8 +222,8 @@ def test_deconvolution_3d():
 
                 layer_test(convolutional.Deconvolution3D,
                            kwargs={'nb_filter': nb_filter,
-                                   'kernel_dim1': 3,
-                                   'kernel_dim2': 3,
+                                   'kernel_dim1': 7,
+                                   'kernel_dim2': 5,
                                    'kernel_dim3': 3,
                                    'output_shape': (batch_size, nb_filter, dim1, dim2, dim3),
                                    'border_mode': border_mode,
@@ -236,8 +237,8 @@ def test_deconvolution_3d():
 
                 layer_test(convolutional.Deconvolution3D,
                            kwargs={'nb_filter': nb_filter,
-                                   'kernel_dim1': 3,
-                                   'kernel_dim2': 3,
+                                   'kernel_dim1': 7,
+                                   'kernel_dim2': 5,
                                    'kernel_dim3': 3,
                                    'output_shape': (nb_filter, dim1, dim2, dim3),
                                    'border_mode': border_mode,


### PR DESCRIPTION
This patch should provide a 3D equivalent of Deconvolution2D.
(See also #3773, #3981 and #4238.)