### PR TITLE
Correctly check the output dimension for None instead of target

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -209,7 +209,7 @@ def check_loss_and_target_compatibility(targets, losses, output_shapes):
                                 'which does expect integer targets.')
         if loss.__name__ in key_losses:
             for target_dim, out_dim in zip(y.shape[1:], shape[1:]):
-                if target_dim is not None and target_dim != out_dim:
+                if out_dim is not None and target_dim != out_dim:
                     raise Exception('A target array with shape ' + str(y.shape) +
                                     ' was passed for an output of shape ' + str(shape) +
                                     ' while using as loss `' + loss.__name__ + '`. '

--- a/tests/keras/engine/test_training.py
+++ b/tests/keras/engine/test_training.py
@@ -226,9 +226,10 @@ def test_trainable_argument():
 
 
 @keras_test
-def test_check_not_last_is_one():
+def test_check_not_failing():
     a = np.random.random((2, 1, 3))
     check_loss_and_target_compatibility([a], [K.categorical_crossentropy], [a.shape])
+    check_loss_and_target_compatibility([a], [K.categorical_crossentropy], [(2, None, 3)])
 
 
 @keras_test


### PR DESCRIPTION
This was introduced by me in 6b04add93209. Thanks for @carlthome for reporting.