### PR TITLE
Separate columns in model.summary() to improve readability

### DIFF
--- a/keras/utils/layer_utils.py
+++ b/keras/utils/layer_utils.py
@@ -53,6 +53,8 @@ def print_summary(layers, relevant_nodes=None, line_length=100, positions=[.33, 
     def print_row(fields, positions):
         line = ''
         for i in range(len(fields)):
+            if i > 0:
+                line = line[:-1] + ' '
             line += str(fields[i])
             line = line[:positions[i]]
             line += ' ' * (positions[i] - len(line))


### PR DESCRIPTION
This patch makes sure that there is always at least one space between the columns produced by `model.summary()`. This helps to separate the output shape from the parameter number. For example, this layer looks like it has a surprisingly large number of parameters:
```
____________________________________________________________________________________________________
Layer (type)                     Output Shape          Param #     Connected to                     
====================================================================================================
...
____________________________________________________________________________________________________
convolution3d_1 (Convolution3D)  (None, 100, 13, 13, 132800        input_patch[0][0]
____________________________________________________________________________________________________
...
```
This gets especially confusing if you're looking at a table with many rows. Adding a space between the two columns makes it more readable:
```
____________________________________________________________________________________________________
Layer (type)                     Output Shape          Param #     Connected to                     
====================================================================================================
...
____________________________________________________________________________________________________
convolution3d_1 (Convolution3D)  (None, 100, 13, 13, 1 2800        input_patch[0][0]
____________________________________________________________________________________________________
...
```