### PR TITLE
Bug Fix : Sequential model is ignoring trainable argument of child containers

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -250,6 +250,8 @@ def collect_trainable_weights(layer):
         for sublayer in layer.flattened_layers:
             weights += collect_trainable_weights(sublayer)
     elif layer.__class__.__name__ == 'Model':
+        if hasattr(layer, 'sequential'):
+            return collect_trainable_weights(layer.sequential)
         for sublayer in layer.layers:
             weights += collect_trainable_weights(sublayer)
     elif layer.__class__.__name__ == 'Graph':

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -250,8 +250,6 @@ def collect_trainable_weights(layer):
         for sublayer in layer.flattened_layers:
             weights += collect_trainable_weights(sublayer)
     elif layer.__class__.__name__ == 'Model':
-        if hasattr(layer, 'sequential'):
-            return collect_trainable_weights(layer.sequential)
         for sublayer in layer.layers:
             weights += collect_trainable_weights(sublayer)
     elif layer.__class__.__name__ == 'Graph':
@@ -706,7 +704,17 @@ class Model(Container):
         self.test_function = None
         self.predict_function = None
 
-        self._collected_trainable_weights = collect_trainable_weights(self)
+        # we igonre the trainable attribute of the model being compiled
+        # trainable attribute will have effect only when the model is nested
+        # inside another model.
+        if hasattr(self, 'sequential'):
+            model = self.sequential
+        else:
+            model = self
+        trainable = model.trainable
+        model.trainable = True
+        self._collected_trainable_weights = collect_trainable_weights(model)
+        model.trainable = trainable
 
     def _make_train_function(self):
         if not hasattr(self, 'train_function'):

--- a/keras/models.py
+++ b/keras/models.py
@@ -385,6 +385,10 @@ class Sequential(Model):
         # actually create the model
         self.model = Model(self.inputs, self.outputs[0], name=self.name + '_model')
 
+        # information about nesting of containers is not availabe in the internal model instance (self.model)
+        # so we save a reference to the original Sequential model
+        self.model.sequential = self
+
         # mirror model attributes
         self.supports_masking = self.model.supports_masking
         self._output_mask_cache = self.model._output_mask_cache


### PR DESCRIPTION
Found this issue while writing a vanilla GAN: Discriminator weights are changing even when trainable=False. Issue only when the final model is Sequential. 

```python
discriminator = Sequential()
discriminator.add(Dense(1, input_dim=10, activation='sigmoid'))

generator = Sequential()
generator.add(Dense(10, input_dim=10))

GAN = Sequential()
GAN.add(generator)

discriminator.trainable = False

GAN.add(discriminator)
GAN.compile(loss='mse', optimizer='sgd')

x = np.random.random((100, 10))
y = np.ones((100, 1))

discriminator_initial_weights = discriminator.get_weights()
GAN.fit(x, y)
assert np.all(discriminator.get_weights()[0] == discriminator_initial_weights[0]), 'Discriminator weights changed!'
```