### PR TITLE
change 'save_array' to new tables api

### DIFF
--- a/keras/utils/io_utils.py
+++ b/keras/utils/io_utils.py
@@ -86,7 +86,7 @@ def save_array(array, name):
     import tables
     f = tables.open_file(name, 'w')
     atom = tables.Atom.from_dtype(array.dtype)
-    ds = f.createCArray(f.root, 'data', atom, array.shape)
+    ds = f.create_carray(f.root, 'data', atom, array.shape)
     ds[:] = array
     f.close()
 


### PR DESCRIPTION
The `tables` module changed its API from [2.x to 3.x](http://www.pytables.org/MIGRATING_TO_3.x.html)

Without the change `save_array` does not work with the latest tables version installed.