### PR TITLE
Fix deprecation warning in `to_categorical`

### DIFF
--- a/keras/utils/np_utils.py
+++ b/keras/utils/np_utils.py
@@ -16,6 +16,7 @@ def to_categorical(y, nb_classes=None):
     # Returns
         A binary matrix representation of the input.
     '''
+    y = np.array(y, dtype='int')
     if not nb_classes:
         nb_classes = np.max(y)+1
     Y = np.zeros((len(y), nb_classes))


### PR DESCRIPTION
Currently calling `to_categorical` gives a `numpy` deprecation warning (at least on `numpy==1.11.2`):

```
/Users/brettnaul/Dropbox/Documents/keras/keras/utils/np_utils.py:22: VisibleDeprecationWarning: using a non-integer number instead of an integer will result in an error in the future
  Y = np.zeros((len(y), nb_classes))
/Users/brettnaul/Dropbox/Documents/keras/keras/utils/np_utils.py:24: VisibleDeprecationWarning: using a non-integer number instead of an integer will result in an error in the future
  Y[i, y[i]] = 1.
```

Casting `y` to an `int` array seems safe to me since the docstring/logic assume that `y` is 0-indexed integers already.