### PR TITLE
Have metrics respect mask and sample weight

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -629,8 +629,9 @@ class Model(Container):
         for i in range(len(self.outputs)):
             y_true = self.targets[i]
             y_pred = self.outputs[i]
+            sample_weight = sample_weights[i]
+            mask = masks[i]            
             output_metrics = nested_metrics[i]
-
             for metric in output_metrics:
                 if metric == 'accuracy' or metric == 'acc':
                     # custom handling of accuracy (because of class mode duality)
@@ -648,8 +649,11 @@ class Model(Container):
                     append_metric(i, 'acc', acc_fn(y_true, y_pred))
                 else:
                     metric_fn = metrics_module.get(metric)
-                    metric_result = metric_fn(y_true, y_pred)
-
+                    metric_result = weighted_objective(metric_fn)(y_true, 
+                                                                  y_pred, 
+                                                                  sample_weight, 
+                                                                  mask)
+                    
                     if not isinstance(metric_result, dict):
                         metric_result = {
                             metric_fn.__name__: metric_result


### PR DESCRIPTION
If a model uses masking, some metrics will not be calculated correctly. For example, a mask_value > 1 with precision.

```py
import numpy as np
from keras.models import *
from keras.layers import *

nb_samples = 32
nb_timesteps = 10
nb_features = 15
nb_hidden = 10
nb_labels = 5
mask_value = 2

# Generate some random data. Mask out some sequences with mask_value.
x = np.random.rand(nb_samples, nb_timesteps, nb_features)
y = np.random.rand(nb_samples, nb_timesteps, nb_labels)
x[1:, 5:] = y[1:, 5:] = mask_value

i = Input((nb_timesteps, nb_features))
o = Masking(mask_value)(i)
o = LSTM(nb_hidden, return_sequences=True)(o)
o = TimeDistributed(Dense(nb_labels, activation='sigmoid'))(o)
model = Model(i, o)
model.compile(loss='binary_crossentropy', optimizer='rmsprop', metrics=['precision'])
model.fit(x, y, batch_size=nb_samples, shuffle=False)
```

>  Epoch 1/10
32/32 [==============================] - 0s - loss: 0.7058 - precision: 1.0807
Epoch 2/10
32/32 [==============================] - 0s - loss: 0.7033 - precision: 1.1125
Epoch 3/10
32/32 [==============================] - 0s - loss: 0.7018 - precision: 1.1253
Epoch 4/10
32/32 [==============================] - 0s - loss: 0.7007 - precision: 1.1681
Epoch 5/10
32/32 [==============================] - 0s - loss: 0.6998 - precision: 1.2192
Epoch 6/10
32/32 [==============================] - 0s - loss: 0.6991 - precision: 1.1958
Epoch 7/10
32/32 [==============================] - 0s - loss: 0.6984 - precision: 1.2187
Epoch 8/10
32/32 [==============================] - 0s - loss: 0.6978 - precision: 1.2414
Epoch 9/10
32/32 [==============================] - 0s - loss: 0.6973 - precision: 1.2720
Epoch 10/10
32/32 [==============================] - 0s - loss: 0.6969 - precision: 1.2383

# TODO
 - [ ] Add unit test
 - [ ] Confirm that metrics should respect masking and sample weights. @fchollet, am I missing something?
 - [ ] Decorate accuracy metrics with weighted_objective too.