### PR TITLE
Use Theano's abstract interface for batch normalization

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -698,7 +698,7 @@ def cos(x):
 
 
 def normalize_batch_in_training(x, gamma, beta,
-                                reduction_axes, epsilon=0.0001):
+                                reduction_axes, epsilon=1e-3):
     '''Compute mean and std for batch then apply batch_normalization on batch.
     '''
     mean, var = tf.nn.moments(x, reduction_axes,
@@ -727,7 +727,7 @@ def normalize_batch_in_training(x, gamma, beta,
     return normed, mean, var
 
 
-def batch_normalization(x, mean, var, beta, gamma, epsilon=0.0001):
+def batch_normalization(x, mean, var, beta, gamma, epsilon=1e-3):
     '''Apply batch normalization on x given mean, var, beta and gamma:
 
     output = (x - mean) / (sqrt(var) + epsilon) * gamma + beta

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -433,6 +433,16 @@ def normalize_batch_in_training(x, gamma, beta,
 def batch_normalization(x, mean, var, beta, gamma, epsilon=0.0001):
     '''Apply batch normalization on x given mean, var, beta and gamma.
     '''
+    if mean.ndim == 1 and x.ndim > 1:
+        # in TensorFlow's batch_normalization, if the parameters are vectors
+        # the batch normalization should be applied along the rightmost axis.
+        # Theano expects the parameters to always have x.ndim dimensions.
+        shuffle_pattern = ['x'] * (x.ndim - 1) + [0]
+        mean = mean.dimshuffle(shuffle_pattern)
+        var = var.dimshuffle(shuffle_pattern)
+        beta = beta.dimshuffle(shuffle_pattern)
+        gamma = gamma.dimshuffle(shuffle_pattern)
+
     ndim = x.ndim
     dev = theano.config.device
     use_cudnn = ndim < 5 and (dev.startswith('cuda') or dev.startswith('gpu'))

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -393,7 +393,7 @@ def cos(x):
 
 
 def normalize_batch_in_training(x, gamma, beta,
-                                reduction_axes, epsilon=0.0001):
+                                reduction_axes, epsilon=1e-3):
     '''Computes mean and std for batch then apply batch_normalization on batch.
     '''
     dev = theano.config.device
@@ -430,7 +430,7 @@ def normalize_batch_in_training(x, gamma, beta,
     return normed, mean, var
 
 
-def batch_normalization(x, mean, var, beta, gamma, epsilon=0.0001):
+def batch_normalization(x, mean, var, beta, gamma, epsilon=1e-3):
     '''Apply batch normalization on x given mean, var, beta and gamma.
     '''
     if mean.ndim == 1 and x.ndim > 1:

--- a/keras/layers/normalization.py
+++ b/keras/layers/normalization.py
@@ -115,16 +115,11 @@ class BatchNormalization(Layer):
             broadcast_shape = [1] * len(input_shape)
             broadcast_shape[self.axis] = input_shape[self.axis]
 
-            if self.mode == 2:
-                x_normed, mean, std = K.normalize_batch_in_training(
-                    x, self.gamma, self.beta, reduction_axes,
-                    epsilon=self.epsilon)
-            else:
-                # mode 0
-                x_normed, mean, std = K.normalize_batch_in_training(
-                    x, self.gamma, self.beta, reduction_axes,
-                    epsilon=self.epsilon)
+            x_normed, mean, std = K.normalize_batch_in_training(
+                x, self.gamma, self.beta, reduction_axes,
+                epsilon=self.epsilon)
 
+            if self.mode == 0:
                 self.add_updates([K.moving_average_update(self.running_mean, mean, self.momentum),
                                   K.moving_average_update(self.running_std, std, self.momentum)], x)
 

--- a/keras/layers/normalization.py
+++ b/keras/layers/normalization.py
@@ -10,6 +10,7 @@ class BatchNormalization(Layer):
 
     # Arguments
         epsilon: small float > 0. Fuzz parameter.
+            Theano expects epsilon >= 1e-5.
         mode: integer, 0, 1 or 2.
             - 0: feature-wise normalization.
                 Each feature map in the input will
@@ -60,7 +61,7 @@ class BatchNormalization(Layer):
     # References
         - [Batch Normalization: Accelerating Deep Network Training by Reducing Internal Covariate Shift](http://jmlr.org/proceedings/papers/v37/ioffe15.pdf)
     '''
-    def __init__(self, epsilon=1e-5, mode=0, axis=-1, momentum=0.99,
+    def __init__(self, epsilon=1e-3, mode=0, axis=-1, momentum=0.99,
                  weights=None, beta_init='zero', gamma_init='one',
                  gamma_regularizer=None, beta_regularizer=None, **kwargs):
         self.supports_masking = True

--- a/keras/layers/normalization.py
+++ b/keras/layers/normalization.py
@@ -123,7 +123,7 @@ class BatchNormalization(Layer):
                 self.add_updates([K.moving_average_update(self.running_mean, mean, self.momentum),
                                   K.moving_average_update(self.running_std, std, self.momentum)], x)
 
-                if K.backend() == 'tensorflow' and sorted(reduction_axes) == range(K.ndim(x))[:-1]:
+                if sorted(reduction_axes) == range(K.ndim(x))[:-1]:
                     x_normed_running = K.batch_normalization(
                         x, self.running_mean, self.running_std,
                         self.beta, self.gamma,


### PR DESCRIPTION
This is a continuation of #4162. The patches change the batch normalization functions to use Theano's new abstract batch normalization functions, once they are included (see Theano/Theano#5190).

The current version works for me with the appropriate Theano branch. I'll need to have another look at simplifying the code further, though. I think the parameter dimshuffle can be removed, since it should be handled by the Theano functions.