### PR TITLE
Added JSON content headers

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -401,11 +401,13 @@ class RemoteMonitor(Callback):
     def __init__(self,
                  root='http://localhost:9000',
                  path='/publish/epoch/end/',
-                 field='data'):
+                 field='data',
+                 headers={'Accept': 'application/json', 'Content-Type': 'application/json'}):
         super(RemoteMonitor, self).__init__()
         self.root = root
         self.path = path
         self.field = field
+        self.headers = headers
 
     def on_epoch_end(self, epoch, logs={}):
         import requests
@@ -415,7 +417,8 @@ class RemoteMonitor(Callback):
             send[k] = v
         try:
             requests.post(self.root + self.path,
-                          {self.field: json.dumps(send)})
+                          {self.field: json.dumps(send)},
+                          headers=self.headers)
         except:
             print('Warning: could not reach RemoteMonitor '
                   'root server at ' + str(self.root))


### PR DESCRIPTION
I've added support for headers in the `RemoteMonitor` callback. I've defaulted them to be the generic JSON headers, as that is currently the only type dumped from this callback.

I plan on utilizing this callback extensively in the coming days for a Keras-specific, backend-independent logging/monitoring/interfacing web app.