### PR TITLE
Added Iteration metadata holder

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -142,6 +142,9 @@ class BaseLogger(Callback):
     def on_epoch_begin(self, epoch, logs={}):
         self.seen = 0
         self.totals = {}
+        
+        # Update iteration tracking (halfway)
+        self.model.iteration.epochs += 0.5
 
     def on_batch_end(self, batch, logs={}):
         batch_size = logs.get('size', 0)
@@ -154,6 +157,9 @@ class BaseLogger(Callback):
                 self.totals[k] = v * batch_size
 
     def on_epoch_end(self, epoch, logs={}):
+        # Update iteration tracking (halfway)
+        self.model.iteration.epochs += 0.5
+        
         for k in self.params['metrics']:
             if k in self.totals:
                 # make value available to next callbacks

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -2712,6 +2712,21 @@ class Container(Layer):
             flattened_layers = self.layers
 
         print_summary(flattened_layers, getattr(self, 'container_nodes', None), line_length=line_length, positions=positions)
+        
+    class Iteration:
+        '''Maintains metadata about the compilation and internal epoch
+            count for a model.
+        # Note
+            `Compilations` is automatically incremented during compilation.
+            `Epochs` is automatically incremented at the start and end of a training epoch.
+        '''
+        def __init__(self):
+            self.compilations = 0
+            self.epochs = 0.0
+        def __repr__(self):
+            return 'Compilations: {0}\t\tEpochs Seen: {1}'.format(self.compilations, self.epochs)
+        def __str__(self):
+            return '{0}.{1}'.format(self.compilations, self.epochs)
 
 
 def get_source_inputs(tensor, layer=None, node_index=None):

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -2724,8 +2724,10 @@ class Container(Layer):
         def __init__(self):
             self.compilations = 0
             self.epochs = 0.0
+            
         def __repr__(self):
             return 'Compilations: {0}\t\tEpochs Seen: {1}'.format(self.compilations, self.epochs)
+            
         def __str__(self):
             return '{0}.{1}'.format(self.compilations, self.epochs)
 

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -1593,6 +1593,7 @@ class Container(Layer):
             prefix = self.__class__.__name__.lower()
             name = prefix + '_' + str(K.get_uid(prefix))
         self.name = name
+        self.iteration = self.Iteration()
 
         # Whether container weights are trainable.
         self.trainable = True

--- a/keras/models.py
+++ b/keras/models.py
@@ -262,6 +262,7 @@ class Sequential(Model):
             prefix = 'sequential_'
             name = prefix + str(K.get_uid(prefix))
         self.name = name
+        self.iteration = Model.Iteration()
 
         for layer in layers:
             self.add(layer)
@@ -405,6 +406,9 @@ class Sequential(Model):
         self.model.callback_model = self
 
         self.built = True
+        
+        # Update iteration tracking
+        self.iteration.compilations += 1
 
     @property
     def uses_learning_phase(self):


### PR DESCRIPTION
"Iteration" has two components: comilations (count) and epochs (seen
count). This can be used to differentiate the same model during
different stages of training and use.

I should say that this is not meant to give an accurate count of compilations or epochs, but rather to server as a quick check to see if two different saves of a model *should* give equivalent results on a predict, and/or if the model has been interrupted during training. If `iteration.epochs` is the same between different saves of a model, the weights should be identical. If the history of `iteration.epochs` is stored and checked, and contains an update of ".5", then the model was interrupted during an epoch.

Note: this is not currently persistent with a saved model. Will reference this in a related issue.

Trimmed example:
Initial Model Creation -> Iteration of 0.0.0
```python
model = Sequential()
model.Add(..)
...
...
print(model.iteration)
model.iteration
```
```
0.0.0
Out[3]:
Compilations: 0		Epochs Seen: 0.0
```
Model Compilation -> 1.0.0
```python
model.compile(loss='categorical_crossentropy', optimizer=SGD())
print(model.iteration)
model.iteration
```
```
1.0.0
Out[5]:
Compilations: 1		Epochs Seen: 0.0
```
Model training of 5 epochs -> 1.5.0
```python
model.fit(nb_epoch=5, ..., ...)
print(model.iteration)
model.iteration
```
```
1.5.0
Out[7]:
Compilations: 1		Epochs Seen: 5.0
```
Model Training on 1 epoch, but interrupted before completion -> 1.5.5
```python
model.fit(nb_epoch=1, ..., ...)
print(model.iteration)
model.iteration
```
```
---------------------------------------------------------------------------
KeyboardInterrupt                         Traceback (most recent call last)

1.5.5
Out[9]:
Compilations: 1		Epochs Seen: 5.5
```