### PR TITLE
Theano: deconv2d should also shuffle filter_shape

### DIFF
--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1380,6 +1380,7 @@ def deconv2d(x, kernel, output_shape, strides=(1, 1),
     th_border_mode = _preprocess_border_mode(border_mode)
     np_kernel = kernel.eval()
     filter_shape = _preprocess_conv2d_filter_shape(dim_ordering, filter_shape)
+    filter_shape = tuple(filter_shape[i] for i in (1, 0, 2, 3))
 
     op = T.nnet.abstract_conv.AbstractConv2d_gradInputs(imshp=output_shape,
                                                         kshp=filter_shape,


### PR DESCRIPTION
The `deconv2d` method in the Theano backend applies a dimshuffle to the `kernel` variable, but I think it should also reorder the values in `filter_shape` to match the new `kernel.shape`.

I tried to make a test for this, but that turns out to be difficult. It seems that Theano doesn't use the `filter_shape` most of the time. (I ran into this problem while computing the gradient of the deconvolution on the old GPU backend.)