### PR TITLE
recurse directories in DirectoryIterator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,18 @@ dist: trusty
 language: python
 matrix:
     include:
-        - python: 3.4
-          env: KERAS_BACKEND=theano
-        - python: 3.4
-          env: KERAS_BACKEND=tensorflow
         - python: 2.7
-          env: KERAS_BACKEND=theano
-        - python: 2.7
-          env: KERAS_BACKEND=tensorflow
+          env: KERAS_BACKEND=theano TEST_MODE=PEP8
         - python: 2.7
           env: KERAS_BACKEND=theano TEST_MODE=INTEGRATION_TESTS
         - python: 2.7
-          env: KERAS_BACKEND=theano TEST_MODE=PEP8
+          env: KERAS_BACKEND=tensorflow
+        - python: 3.4
+          env: KERAS_BACKEND=tensorflow
+        - python: 2.7
+          env: KERAS_BACKEND=theano
+        - python: 3.4
+          env: KERAS_BACKEND=theano
 install:
   # code below is taken from http://conda.pydata.org/docs/travis.html
   # We do this conditionally because it saves us some downloading if the

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:7.5-cudnn5-devel
+FROM nvidia/cuda:8.0-cudnn5-devel
 
 ENV CONDA_DIR /opt/conda
 ENV PATH $CONDA_DIR/bin:$PATH
@@ -24,10 +24,10 @@ RUN useradd -m -s /bin/bash -N -u $NB_UID $NB_USER && \
 USER keras
 
 # Python
-ARG python_version=3.5.1
-ARG tensorflow_version=0.9.0rc0-cp35-cp35m
+ARG python_version=3.5.2
+ARG tensorflow_version=0.12.0rc0-cp35-cp35m
 RUN conda install -y python=${python_version} && \
-    pip install https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow-${tensorflow_version}-linux_x86_64.whl && \
+    pip install https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-${tensorflow_version}-linux_x86_64.whl && \
     pip install git+git://github.com/Theano/Theano.git && \
     pip install ipdb pytest pytest-cov python-coveralls coverage==3.7.1 pytest-xdist pep8 pytest-pep8 pydot_ng && \
     conda install Pillow scikit-learn notebook pandas matplotlib nose pyyaml six h5py && \

--- a/docs/templates/preprocessing/image.md
+++ b/docs/templates/preprocessing/image.md
@@ -89,6 +89,7 @@ Generate batches of tensor image data with real-time data augmentation. The data
             - __save_to_dir__: None or str (default: None). This allows you to optimally specify a directory to which to save the augmented pictures being generated (useful for visualizing what you are doing).
             - __save_prefix__: str. Prefix to use for filenames of saved pictures (only relevant if `save_to_dir` is set).
             - __save_format__: one of "png", "jpeg" (only relevant if `save_to_dir` is set). Default: "jpeg".
+            - __follow_links__: whether to follow symlinks (default: False).
 
 
 - __Examples__:

--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -227,6 +227,10 @@ class ImageDataGenerator(object):
         rescale: rescaling factor. If None or 0, no rescaling is applied,
             otherwise we multiply the data by the value provided
             (before applying any other transformation).
+        preprocessing_function: function that will be implied on each input.
+            The function will run before any other modification on it.
+            The function should take one argument: one image (Numpy tensor with rank 3),
+            and should output a Numpy tensor with the same shape.
         dim_ordering: 'th' or 'tf'. In 'th' mode, the channels dimension
             (the depth) is at index 1, in 'tf' mode it is at index 3.
             It defaults to the `image_dim_ordering` value found in your
@@ -250,6 +254,7 @@ class ImageDataGenerator(object):
                  horizontal_flip=False,
                  vertical_flip=False,
                  rescale=None,
+                 preprocessing_function=None,
                  dim_ordering='default'):
         if dim_ordering == 'default':
             dim_ordering = K.image_dim_ordering()
@@ -258,6 +263,7 @@ class ImageDataGenerator(object):
         self.std = None
         self.principal_components = None
         self.rescale = rescale
+        self.preprocessing_function = preprocessing_function
 
         if dim_ordering not in {'tf', 'th'}:
             raise ValueError('dim_ordering should be "tf" (channel after row and '
@@ -304,6 +310,8 @@ class ImageDataGenerator(object):
             save_to_dir=save_to_dir, save_prefix=save_prefix, save_format=save_format)
 
     def standardize(self, x):
+        if self.preprocessing_function:
+            x = self.preprocessing_function(x)
         if self.rescale:
             x *= self.rescale
         # x is a single image, so it doesn't have image number at index 0

--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -656,6 +656,7 @@ class DirectoryIterator(Iterator):
         # second, build an index of the images in the different class subfolders
         self.filenames = []
         self.classes = np.zeros((self.nb_sample,), dtype='int32')
+        i = 0
         for subdir in classes:
             subpath = os.path.join(directory, subdir)
             for root, dirs, files in _recursive_list(subpath):
@@ -667,6 +668,7 @@ class DirectoryIterator(Iterator):
                             break
                     if is_valid:
                         self.classes[i] = self.class_indices[subdir]
+                        i += 1
                         # add filename relative to directory
                         absolute_path = os.path.join(root, fname)
                         self.filenames.append(os.path.relpath(absolute_path, directory))

--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -195,8 +195,9 @@ def load_img(path, grayscale=False, target_size=None):
 
 
 def list_pictures(directory, ext='jpg|jpeg|bmp|png'):
-    return [os.path.join(directory, f) for f in sorted(os.listdir(directory))
-            if os.path.isfile(os.path.join(directory, f)) and re.match('([\w]+\.(?:' + ext + '))', f)]
+    return [os.path.join(root, f)
+            for root, dirs, files in os.walk(directory) for f in files
+            if re.match('([\w]+\.(?:' + ext + '))', f)]
 
 
 class ImageDataGenerator(object):
@@ -300,14 +301,16 @@ class ImageDataGenerator(object):
                             target_size=(256, 256), color_mode='rgb',
                             classes=None, class_mode='categorical',
                             batch_size=32, shuffle=True, seed=None,
-                            save_to_dir=None, save_prefix='', save_format='jpeg'):
+                            save_to_dir=None, save_prefix='', save_format='jpeg',
+                            follow_links=False):
         return DirectoryIterator(
             directory, self,
             target_size=target_size, color_mode=color_mode,
             classes=classes, class_mode=class_mode,
             dim_ordering=self.dim_ordering,
             batch_size=batch_size, shuffle=shuffle, seed=seed,
-            save_to_dir=save_to_dir, save_prefix=save_prefix, save_format=save_format)
+            save_to_dir=save_to_dir, save_prefix=save_prefix, save_format=save_format,
+            follow_links=follow_links)
 
     def standardize(self, x):
         if self.preprocessing_function:
@@ -589,7 +592,8 @@ class DirectoryIterator(Iterator):
                  dim_ordering='default',
                  classes=None, class_mode='categorical',
                  batch_size=32, shuffle=True, seed=None,
-                 save_to_dir=None, save_prefix='', save_format='jpeg'):
+                 save_to_dir=None, save_prefix='', save_format='jpeg',
+                 follow_links=False):
         if dim_ordering == 'default':
             dim_ordering = K.image_dim_ordering()
         self.directory = directory
@@ -633,16 +637,20 @@ class DirectoryIterator(Iterator):
         self.nb_class = len(classes)
         self.class_indices = dict(zip(classes, range(len(classes))))
 
+        def _recursive_list(subpath):
+            return sorted(os.walk(subpath, followlinks=follow_links), key=lambda tpl: tpl[0])
+
         for subdir in classes:
             subpath = os.path.join(directory, subdir)
-            for fname in sorted(os.listdir(subpath)):
-                is_valid = False
-                for extension in white_list_formats:
-                    if fname.lower().endswith('.' + extension):
-                        is_valid = True
-                        break
-                if is_valid:
-                    self.nb_sample += 1
+            for root, dirs, files in _recursive_list(subpath):
+                for fname in files:
+                    is_valid = False
+                    for extension in white_list_formats:
+                        if fname.lower().endswith('.' + extension):
+                            is_valid = True
+                            break
+                    if is_valid:
+                        self.nb_sample += 1
         print('Found %d images belonging to %d classes.' % (self.nb_sample, self.nb_class))
 
         # second, build an index of the images in the different class subfolders
@@ -651,16 +659,19 @@ class DirectoryIterator(Iterator):
         i = 0
         for subdir in classes:
             subpath = os.path.join(directory, subdir)
-            for fname in sorted(os.listdir(subpath)):
-                is_valid = False
-                for extension in white_list_formats:
-                    if fname.lower().endswith('.' + extension):
-                        is_valid = True
-                        break
-                if is_valid:
-                    self.classes[i] = self.class_indices[subdir]
-                    self.filenames.append(os.path.join(subdir, fname))
-                    i += 1
+            subpath_len = len(directory) + 1  # assuming separator is 1 character
+            for root, dirs, files in _recursive_list(subpath):
+                for fname in files:
+                    is_valid = False
+                    for extension in white_list_formats:
+                        if fname.lower().endswith('.' + extension):
+                            is_valid = True
+                            break
+                    if is_valid:
+                        self.classes[i] = self.class_indices[subdir]
+                        # add filename relative to subpath
+                        self.filenames.append(os.path.join(root, fname)[subpath_len:])
+                        i += 1
         super(DirectoryIterator, self).__init__(self.nb_sample, batch_size, shuffle, seed)
 
     def next(self):

--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -656,7 +656,6 @@ class DirectoryIterator(Iterator):
         # second, build an index of the images in the different class subfolders
         self.filenames = []
         self.classes = np.zeros((self.nb_sample,), dtype='int32')
-        i = 0
         for subdir in classes:
             subpath = os.path.join(directory, subdir)
             for root, dirs, files in _recursive_list(subpath):
@@ -668,7 +667,6 @@ class DirectoryIterator(Iterator):
                             break
                     if is_valid:
                         self.classes[i] = self.class_indices[subdir]
-                        i += 1
                         # add filename relative to directory
                         absolute_path = os.path.join(root, fname)
                         self.filenames.append(os.path.relpath(absolute_path, directory))

--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -671,7 +671,7 @@ class DirectoryIterator(Iterator):
                         i += 1
                         # add filename relative to directory
                         absolute_path = os.path.join(root, fname)
-                        self.filenames.append(os.path.relpath(directory, absolute_path))
+                        self.filenames.append(os.path.relpath(absolute_path, directory))
         super(DirectoryIterator, self).__init__(self.nb_sample, batch_size, shuffle, seed)
 
     def next(self):

--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -669,7 +669,7 @@ class DirectoryIterator(Iterator):
                         self.classes[i] = self.class_indices[subdir]
                         # add filename relative to directory
                         absolute_path = os.path.join(root, fname)
-                        self.filenames.append(os.path.relpath(directory, absolute_path)
+                        self.filenames.append(os.path.relpath(directory, absolute_path))
         super(DirectoryIterator, self).__init__(self.nb_sample, batch_size, shuffle, seed)
 
     def next(self):

--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -659,7 +659,6 @@ class DirectoryIterator(Iterator):
         i = 0
         for subdir in classes:
             subpath = os.path.join(directory, subdir)
-            subpath_len = len(directory) + 1  # assuming separator is 1 character
             for root, dirs, files in _recursive_list(subpath):
                 for fname in files:
                     is_valid = False
@@ -669,9 +668,10 @@ class DirectoryIterator(Iterator):
                             break
                     if is_valid:
                         self.classes[i] = self.class_indices[subdir]
-                        # add filename relative to subpath
-                        self.filenames.append(os.path.join(root, fname)[subpath_len:])
                         i += 1
+                        # add filename relative to directory
+                        absolute_path = os.path.join(root, fname)
+                        self.filenames.append(os.path.relpath(directory, absolute_path)
         super(DirectoryIterator, self).__init__(self.nb_sample, batch_size, shuffle, seed)
 
     def next(self):

--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -656,6 +656,7 @@ class DirectoryIterator(Iterator):
         # second, build an index of the images in the different class subfolders
         self.filenames = []
         self.classes = np.zeros((self.nb_sample,), dtype='int32')
+        i = 0
         for subdir in classes:
             subpath = os.path.join(directory, subdir)
             for root, dirs, files in _recursive_list(subpath):
@@ -667,6 +668,7 @@ class DirectoryIterator(Iterator):
                             break
                     if is_valid:
                         self.classes[i] = self.class_indices[subdir]
+                        i += 1
                         # add filename relative to directory
                         absolute_path = os.path.join(root, fname)
                         self.filenames.append(os.path.relpath(directory, absolute_path))

--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -656,7 +656,6 @@ class DirectoryIterator(Iterator):
         # second, build an index of the images in the different class subfolders
         self.filenames = []
         self.classes = np.zeros((self.nb_sample,), dtype='int32')
-        i = 0
         for subdir in classes:
             subpath = os.path.join(directory, subdir)
             for root, dirs, files in _recursive_list(subpath):
@@ -668,7 +667,6 @@ class DirectoryIterator(Iterator):
                             break
                     if is_valid:
                         self.classes[i] = self.class_indices[subdir]
-                        i += 1
                         # add filename relative to directory
                         absolute_path = os.path.join(root, fname)
                         self.filenames.append(os.path.relpath(directory, absolute_path)

--- a/tests/integration_tests/test_image_data_tasks.py
+++ b/tests/integration_tests/test_image_data_tasks.py
@@ -7,6 +7,7 @@ from keras.models import Sequential
 from keras.layers.core import Dense, Flatten, Activation
 from keras.layers.convolutional import Convolution2D, MaxPooling2D
 from keras.utils.np_utils import to_categorical
+from keras.preprocessing.image import ImageDataGenerator
 
 
 @keras_test
@@ -43,7 +44,6 @@ def test_image_classification():
                         validation_data=(X_test, y_test),
                         verbose=0)
     assert(history.history['val_acc'][-1] > 0.85)
-
 
 if __name__ == '__main__':
     pytest.main([__file__])

--- a/tests/integration_tests/test_image_data_tasks.py
+++ b/tests/integration_tests/test_image_data_tasks.py
@@ -7,8 +7,6 @@ from keras.models import Sequential
 from keras.layers.core import Dense, Flatten, Activation
 from keras.layers.convolutional import Convolution2D, MaxPooling2D
 from keras.utils.np_utils import to_categorical
-from keras.preprocessing.image import ImageDataGenerator
-
 
 @keras_test
 def test_image_classification():
@@ -44,6 +42,7 @@ def test_image_classification():
                         validation_data=(X_test, y_test),
                         verbose=0)
     assert(history.history['val_acc'][-1] > 0.85)
+
 
 if __name__ == '__main__':
     pytest.main([__file__])

--- a/tests/keras/preprocessing/test_image.py
+++ b/tests/keras/preprocessing/test_image.py
@@ -145,7 +145,7 @@ class TestImage:
                 im_class = count % num_classes
                 # rotate subfolders
                 classpaths = paths[im_class]
-                filename = os.path.join(classpaths[count % len(classpaths)], 'image-{}.jpg'.format(count))
+                filename = os.path.join('class-{}'.format(im_class), classpaths[count % len(classpaths)], 'image-{}.jpg'.format(count))
                 filenames.append(filename)
                 im.save(os.path.join(tmp_folder, filename))
                 count += 1

--- a/tests/keras/preprocessing/test_image.py
+++ b/tests/keras/preprocessing/test_image.py
@@ -145,7 +145,7 @@ class TestImage:
                 im_class = count % num_classes
                 # rotate subfolders
                 classpaths = paths[im_class]
-                filename = os.path.join('class-{}'.format(im_class), classpaths[count % len(classpaths)], 'image-{}.jpg'.format(count))
+                filename = os.path.join(classpaths[count % len(classpaths)], 'image-{}.jpg'.format(count))
                 filenames.append(filename)
                 im.save(os.path.join(tmp_folder, filename))
                 count += 1

--- a/tests/keras/preprocessing/test_image.py
+++ b/tests/keras/preprocessing/test_image.py
@@ -160,36 +160,6 @@ class TestImage:
         assert(sorted(dir_iterator.filenames) == sorted(filenames))
         shutil.rmtree(tmp_folder)
 
-    def test_directory_iterator_backward_compatibility(self):
-        num_classes = 2
-        tmp_folder = tempfile.mkdtemp(prefix='test_images')
-
-        # create folders and subfolders
-        for cl in range(num_classes):
-            os.mkdir(os.path.join(tmp_folder, 'class-{}'.format(cl)))
-
-        # save the images in the paths
-        count = 0
-        filenames = []
-        for test_images in self.all_test_images:
-            for im in test_images:
-                # rotate image class
-                im_class = count % num_classes
-                filename = os.path.join('class-{}'.format(im_class), 'image-{}.jpg'.format(count))
-                filenames.append(filename)
-                im.save(os.path.join(tmp_folder, filename))
-                count += 1
-
-        # create iterator
-        generator = image.ImageDataGenerator()
-        dir_iterator = generator.flow_from_directory(tmp_folder)
-
-        # check number of classes and images
-        assert(len(dir_iterator.class_indices) == num_classes)
-        assert(len(dir_iterator.classes) == count)
-        assert(sorted(dir_iterator.filenames) == sorted(filenames))
-        shutil.rmtree(tmp_folder)
-
     def test_img_utils(self):
         height, width = 10, 8
 

--- a/tests/keras/preprocessing/test_image.py
+++ b/tests/keras/preprocessing/test_image.py
@@ -118,6 +118,77 @@ class TestImage:
         x = np.random.random((32, 3, 10, 10))
         generator.fit(x)
 
+    def test_directory_iterator(self):
+        num_classes = 2
+        tmp_folder = tempfile.mkdtemp(prefix='test_images')
+
+        # create folders and subfolders
+        paths = []
+        for cl in range(num_classes):
+            classpaths = [
+                '',
+                'subfolder-1',
+                'subfolder-2',
+                os.path.join('subfolder-1', 'sub-subfolder')
+            ]
+            for path in classpaths:
+                os.mkdir(os.path.join(tmp_folder, 'class-{}'.format(cl), path))
+            paths.append(classpaths)
+
+        # save the images in the paths
+        count = 0
+        filenames = []
+        for test_images in self.all_test_images:
+            for im in test_images:
+                # rotate image class
+                im_class = count % num_classes
+                # rotate subfolders
+                classpaths = paths[im_class]
+                filename = os.path.join('class-{}'.format(im_class), classpaths[count % len(classpaths)], 'image-{}.jpg'.format(count))
+                filenames.append(filename)
+                im.save(os.path.join(tmp_folder, filename))
+                count += 1
+
+        # create iterator
+        generator = image.ImageDataGenerator()
+        dir_iterator = generator.flow_from_directory(tmp_folder)
+
+        # check number of classes and images
+        assert(len(dir_iterator.class_indices) == num_classes)
+        assert(len(dir_iterator.classes) == count)
+        assert(sorted(dir_iterator.filenames) == sorted(filenames))
+        shutil.rmtree(tmp_folder)
+
+    def test_directory_iterator_backward_compatibility(self):
+        num_classes = 2
+        tmp_folder = tempfile.mkdtemp(prefix='test_images')
+
+        # create folders and subfolders
+        for cl in range(num_classes):
+            os.mkdir(os.path.join(tmp_folder, 'class-{}'.format(cl)))
+
+        # save the images in the paths
+        count = 0
+        filenames = []
+        for test_images in self.all_test_images:
+            for im in test_images:
+                # rotate image class
+                im_class = count % num_classes
+                filename = os.path.join('class-{}'.format(im_class), 'image-{}.jpg'.format(count))
+                filenames.append(filename)
+                im.save(os.path.join(tmp_folder, filename))
+                count += 1
+
+        # create iterator
+        generator = image.ImageDataGenerator()
+        dir_iterator = generator.flow_from_directory(tmp_folder)
+
+        # check number of classes and images
+        assert(len(dir_iterator.class_indices) == num_classes)
+        assert(len(dir_iterator.classes) == count)
+        assert(sorted(dir_iterator.filenames) == sorted(filenames))
+        shutil.rmtree(tmp_folder)
+
     def test_img_utils(self):
         height, width = 10, 8
 

--- a/tests/keras/preprocessing/test_image.py
+++ b/tests/keras/preprocessing/test_image.py
@@ -125,14 +125,15 @@ class TestImage:
         # create folders and subfolders
         paths = []
         for cl in range(num_classes):
+            class_directory = 'class-{}'.format(cl)
             classpaths = [
-                '',
-                'subfolder-1',
-                'subfolder-2',
-                os.path.join('subfolder-1', 'sub-subfolder')
+                class_directory,
+                os.path.join(class_directory, 'subfolder-1'),
+                os.path.join(class_directory, 'subfolder-2'),
+                os.path.join(class_directory, 'subfolder-1', 'sub-subfolder')
             ]
             for path in classpaths:
-                os.mkdir(os.path.join(tmp_folder, 'class-{}'.format(cl), path))
+                os.mkdir(os.path.join(tmp_folder, path))
             paths.append(classpaths)
 
         # save the images in the paths
@@ -144,7 +145,7 @@ class TestImage:
                 im_class = count % num_classes
                 # rotate subfolders
                 classpaths = paths[im_class]
-                filename = os.path.join('class-{}'.format(im_class), classpaths[count % len(classpaths)], 'image-{}.jpg'.format(count))
+                filename = os.path.join(classpaths[count % len(classpaths)], 'image-{}.jpg'.format(count))
                 filenames.append(filename)
                 im.save(os.path.join(tmp_folder, filename))
                 count += 1


### PR DESCRIPTION
This is a squashed version of PR [#4552](https://github.com/fchollet/keras/pull/4552)

Added functionality to recurse subdirectories when using flow_from_directory, optionally also follow symlinks.

Sub-directories don't map to sub-classes in my code. The only change in the code is to traverse the subdirectories inside the class directories, rather than only pick the files directly in the class directories. In case where there are no sub-directories, I believe the code works as it used to.

Imagine a scenario where the cat/dog training dataset from kaggle is supplemented with a large number of cat and dog photos from other sources:

```
/cats
/cats/cats-from-kaggle
/cats/photos-of-wild-cats
/cats/external-disk -> /mnt/external-disk/cat-photos
/cats/network-volume -> /mnt/mounted-network-volume/cat-photos
/dogs
/dogs/dogs-from-kaggle
/dogs/dog-show-archive
/dogs/external-disk -> /mnt/external-disk/dog-photos
/dogs/network-volume -> /mnt/mounted-network-volume/dog-photos
```

With subfolders and links, data sources can be added or removed without actually moving or copying files. This can be especially useful with:

- shared network volumes, used also by other users
- datasets with more categories than needed for the task
- very large collections of images that are chunked into subdirectories

I hope it helps.