### PR TITLE
Docs fix - added Convolution3D as a layer supporting the regularizers  & constr API

### DIFF
--- a/docs/templates/constraints.md
+++ b/docs/templates/constraints.md
@@ -2,7 +2,7 @@
 
 Functions from the `constraints` module allow setting constraints (eg. non-negativity) on network parameters during optimization.
 
-The penalties are applied on a per-layer basis. The exact API will depend on the layer, but the layers `Dense`, `TimeDistributedDense`, `MaxoutDense`, `Convolution1D` and `Convolution2D` have a unified API.
+The penalties are applied on a per-layer basis. The exact API will depend on the layer, but the layers `Dense`, `TimeDistributedDense`, `MaxoutDense`, `Convolution1D`, `Convolution2D` and `Convolution3D` have a unified API.
 
 These layers expose 2 keyword arguments:
 

--- a/docs/templates/regularizers.md
+++ b/docs/templates/regularizers.md
@@ -2,7 +2,7 @@
 
 Regularizers allow to apply penalties on layer parameters or layer activity during optimization. These penalties are incorporated in the loss function that the network optimizes.
 
-The penalties are applied on a per-layer basis. The exact API will depend on the layer, but the layers `Dense`, `TimeDistributedDense`, `MaxoutDense`, `Convolution1D` and `Convolution2D` have a unified API.
+The penalties are applied on a per-layer basis. The exact API will depend on the layer, but the layers `Dense`, `TimeDistributedDense`, `MaxoutDense`, `Convolution1D`, `Convolution2D` and `Convolution3D` have a unified API.
 
 These layers expose 3 keyword arguments:
 


### PR DESCRIPTION
Added Convolution3D as a layer supporting the regularizers  and constraints API (as per [here](https://github.com/fchollet/keras/blob/149946c706042e0db96664aa8c7bb0d61c224d9d/keras/layers/convolutional.py#L1076)).