### PR TITLE
support masking for ConvLSTM2D

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1207,7 +1207,7 @@ def rnn(step_function, inputs, initial_states,
             for _ in range(tmp):
                 mask = expand_dims(mask)
         assert mask.ndim == ndim
-        mask = mask.dimshuffle(axes)
+        mask = tf.transpose(mask, axes)
 
     if constants is None:
         constants = []

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1228,7 +1228,7 @@ def rnn(step_function, inputs, initial_states,
                 output, new_states = step_function(input, states + constants)
 
                 # tf.select needs its condition tensor
-                # to be the same shape as its two
+                # to be the same shape or compatible as its two
                 # result tensors, but in our case
                 # the condition (mask) tensor is
                 # (nsamples, 1), and A and B are (nsamples, ndimensions).
@@ -1237,8 +1237,7 @@ def rnn(step_function, inputs, initial_states,
                 # That's what the tile call does,
                 # it just repeats the mask along its second dimension
                 # n times.
-                tiled_mask_t = tf.tile(mask_t,
-                                       tf.pack([1, tf.shape(output)[1]]))
+                tiled_mask_t = mask_t
 
                 if len(successive_outputs) == 0:
                     prev_output = zeros_like(output)
@@ -1250,8 +1249,7 @@ def rnn(step_function, inputs, initial_states,
                 return_states = []
                 for state, new_state in zip(states, new_states):
                     # (see earlier comment for tile explanation)
-                    tiled_mask_t = tf.tile(mask_t,
-                                           tf.pack([1, tf.shape(new_state)[1]]))
+                    tiled_mask_t = mask_t
                     return_states.append(tf.select(tiled_mask_t,
                                                    new_state,
                                                    state))

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1242,6 +1242,7 @@ def rnn(step_function, inputs, initial_states,
                 # That's what the tile call does,
                 # it just repeats the mask along its second dimension
                 # n times.
+                mask_t = tf.squeeze(mask_t)
                 tiled_mask_t = mask_t
 
                 if len(successive_outputs) == 0:

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1206,7 +1206,7 @@ def rnn(step_function, inputs, initial_states,
             tmp = ndim - len(mask.get_shape())
             for _ in range(tmp):
                 mask = expand_dims(mask)
-        assert mask.ndim == ndim
+        assert len(mask.get_shape()) == ndim
         mask = tf.transpose(mask, axes)
 
     if constants is None:

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1202,9 +1202,7 @@ def rnn(step_function, inputs, initial_states,
     if mask is not None:
         if mask.dtype != tf.bool:
             mask = tf.cast(mask, tf.bool)
-        if len(mask.get_shape()) == ndim - 1:
-            mask = expand_dims(mask)
-        mask = tf.transpose(mask, axes)
+        mask = tf.transpose(mask, axes[:len(mask.get_shape())])
 
     if constants is None:
         constants = []

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -376,10 +376,15 @@ def dot(x, y):
         x_shape = (-1,) + int_shape(x)[1:]
         y_shape = int_shape(y)
         y_permute_dim = list(range(ndim(y)))
-        y_permute_dim = [y_permute_dim.pop(-2)] + y_permute_dim
         xt = tf.reshape(x, [-1, x_shape[-1]])
-        yt = tf.reshape(tf.transpose(y, perm=y_permute_dim), [y_shape[-2], -1])
-        return tf.reshape(tf.matmul(xt, yt), x_shape[:-1] + y_shape[:-2] + y_shape[-1:])
+        if ndim(y) >= 2:
+            y_permute_dim = [y_permute_dim.pop(-2)] + y_permute_dim
+            yt = tf.reshape(tf.transpose(y, perm=y_permute_dim), [y_shape[-2], -1])
+            return tf.reshape(tf.matmul(xt, yt), x_shape[:-1] + y_shape[:-2] + y_shape[-1:])
+        # when ndim(y) is 1, for replicating the behavior in theano (e.g. (2, 3, 4).(4,) = (2, 3))
+        else:
+            yt = expand_dims(y)
+            return tf.reshape(tf.matmul(xt, yt), x_shape[:-1])
     if is_sparse(x):
         out = tf.sparse_tensor_dense_matmul(x, y)
     else:

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1209,7 +1209,6 @@ def rnn(step_function, inputs, initial_states,
         assert mask.ndim == ndim
         mask = mask.dimshuffle(axes)
 
-
     if constants is None:
         constants = []
 

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1202,7 +1202,13 @@ def rnn(step_function, inputs, initial_states,
     if mask is not None:
         if mask.dtype != tf.bool:
             mask = tf.cast(mask, tf.bool)
-        mask = tf.transpose(mask, axes[:len(mask.get_shape())])
+        if len(mask.get_shape()) < ndim:
+            tmp = ndim - len(mask.get_shape())
+            for _ in range(tmp):
+                mask = expand_dims(mask)
+        assert mask.ndim == ndim
+        mask = mask.dimshuffle(axes)
+
 
     if constants is None:
         constants = []

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -901,10 +901,12 @@ def rnn(step_function, inputs, initial_states,
 
     if mask is not None:
         if mask.ndim < ndim:
-            tmp = ndim - mask.ndim
-            for _ in range(tmp):
+            diff_ndim = ndim - mask.ndim
+            for _ in range(diff_ndim):
                 mask = expand_dims(mask)
-        assert mask.ndim == ndim
+        if mask.ndim > ndim:
+            raise ValueError('The mask should not have a higher rank than x. '
+                             'Found rank of mask is ' + str(mask.ndim) + ' rank of x is ' + str(ndim))
         mask = mask.dimshuffle(axes)
 
         if unroll:

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -900,7 +900,12 @@ def rnn(step_function, inputs, initial_states,
         constants = []
 
     if mask is not None:
-        mask = mask.dimshuffle(axes[:mask.ndim])
+        if mask.ndim < ndim:
+            tmp = ndim - mask.ndim
+            for _ in range(tmp):
+                mask = expand_dims(mask)
+        assert mask.ndim == ndim
+        mask = mask.dimshuffle(axes)
 
         if unroll:
             indices = list(range(input_length))

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -900,8 +900,10 @@ def rnn(step_function, inputs, initial_states,
         constants = []
 
     if mask is not None:
-        if mask.ndim == ndim-1:
-            mask = expand_dims(mask)
+        if mask.ndim < ndim:
+            tmp = ndim - mask.ndim
+            for _ in range(tmp):
+                mask = expand_dims(mask)
         assert mask.ndim == ndim
         mask = mask.dimshuffle(axes)
 

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -900,12 +900,7 @@ def rnn(step_function, inputs, initial_states,
         constants = []
 
     if mask is not None:
-        if mask.ndim < ndim:
-            tmp = ndim - mask.ndim
-            for _ in range(tmp):
-                mask = expand_dims(mask)
-        assert mask.ndim == ndim
-        mask = mask.dimshuffle(axes)
+        mask = mask.dimshuffle(axes[:mask.ndim])
 
         if unroll:
             indices = list(range(input_length))


### PR DESCRIPTION
There raises an error when utilizing mask in layer `ConvLSTM2D(x, mask)`, which is caused by the assumption that `mask.ndim == x.ndim - 1 ` in function `K.rnn()`.
Since both `tf.select(cond, a, b)` and `T.switch(cond, a, b)` support `cond.shape` to be compatible with `a.shape`, we have to apply `expand_dims` for mask several times in backend and don't have to utilize `tf.tile` for mask in `tensorflow.backend`.