### PR TITLE
Fix for issue #4640: Bug in theano_backend for _Pooling1D

### DIFF
--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1538,9 +1538,11 @@ def pool2d(x, pool_size, strides=(1, 1), border_mode='valid',
     if dim_ordering not in {'th', 'tf'}:
         raise Exception('Unknown dim_ordering ' + str(dim_ordering))
 
+    assert pool_size[0] >= 1 and pool_size[1] >= 1
+
     if border_mode == 'same':
-        w_pad = pool_size[0] - 2 if pool_size[0] % 2 == 1 else pool_size[0] - 1
-        h_pad = pool_size[1] - 2 if pool_size[1] % 2 == 1 else pool_size[1] - 1
+        w_pad = pool_size[0] - 2 if pool_size[0] > 2 and pool_size[0] % 2 == 1 else pool_size[0] - 1
+        h_pad = pool_size[1] - 2 if pool_size[1] > 2 and pool_size[1] % 2 == 1 else pool_size[1] - 1
         padding = (w_pad, h_pad)
     elif border_mode == 'valid':
         padding = (0, 0)

--- a/tests/keras/layers/test_convolutional.py
+++ b/tests/keras/layers/test_convolutional.py
@@ -84,11 +84,12 @@ def test_atrous_conv_1d():
 
 @keras_test
 def test_maxpooling_1d():
-    for stride in [1, 2]:
-        layer_test(convolutional.MaxPooling1D,
-                   kwargs={'stride': stride,
-                           'border_mode': 'valid'},
-                   input_shape=(3, 5, 4))
+    for border_mode in ['valid', 'same']:
+        for stride in [1, 2]:
+            layer_test(convolutional.MaxPooling1D,
+                       kwargs={'stride': stride,
+                               'border_mode': border_mode},
+                       input_shape=(3, 5, 4))
 
 
 @keras_test


### PR DESCRIPTION
MaxPooling1D with border_mode='same' caused `h_pad` to take illegal value -1 in theano_backend:pool2d.
Added test case.