### PR TITLE
Add python3 compatibility for some examples

### DIFF
--- a/examples/mnist_acgan.py
+++ b/examples/mnist_acgan.py
@@ -23,7 +23,10 @@ example output
 from __future__ import print_function
 
 from collections import defaultdict
-import cPickle as pickle
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
 from PIL import Image
 
 from six.moves import range

--- a/examples/mnist_net2net.py
+++ b/examples/mnist_net2net.py
@@ -55,6 +55,7 @@ Results
 '''
 
 from __future__ import print_function
+from six.moves import xrange
 import numpy as np
 np.random.seed(1337)
 


### PR DESCRIPTION
mnist_net2net.py and mnist_acgan.py can't directly run in python3.