### PR TITLE
Now properly set self.y to None in NumpyArrayIterator

### DIFF
--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -549,7 +549,10 @@ class NumpyArrayIterator(Iterator):
                              'either 1, 3 or 4 channels on axis ' + str(channels_axis) + '. '
                              'However, it was passed an array with shape ' + str(self.X.shape) +
                              ' (' + str(self.X.shape[channels_axis]) + ' channels).')
-        self.y = np.asarray(y)
+        if y is not None:
+            self.y = np.asarray(y)
+        else:
+            self.y = None
         self.image_data_generator = image_data_generator
         self.dim_ordering = dim_ordering
         self.save_to_dir = save_to_dir


### PR DESCRIPTION
Hi.
Working with keras, i got a strange behaviour. 
In keras/preprocessing/image.py, the condition line 585 `if self.y is None:` was always False. I investigated and i found np.ndarray(y) was not returning a None type if y was none, but a ndarray. The representation of this array was none but the type of the object was not None.
I tested in local, and this change work for me. I also run all the test in keras preprocess and light was all green so i decided to do a pull requests.

Since the portion of code changed is very small, i decided not to create a git issue.

Have a nice day.