### PR TITLE
Theano backend consistancy

### DIFF
--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -129,11 +129,11 @@ def eye(size, dtype=_FLOATX, name=None):
     return variable(np.eye(size), dtype, name)
 
 
-def ones_like(x,name=None):
+def ones_like(x, name=None):
     return T.ones_like(x)
 
 
-def zeros_like(x,name=None):
+def zeros_like(x, name=None):
     return T.zeros_like(x)
 
 

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -129,11 +129,11 @@ def eye(size, dtype=_FLOATX, name=None):
     return variable(np.eye(size), dtype, name)
 
 
-def ones_like(x):
+def ones_like(x,name=None):
     return T.ones_like(x)
 
 
-def zeros_like(x):
+def zeros_like(x,name=None):
     return T.zeros_like(x)
 
 


### PR DESCRIPTION
ones_like and zeros_like don't have the name parameter in their signature for theano backend so it can trigger an error if it is used.