### PR TITLE
Use from_logits parameter to ensure crossentropy loss functions are compatible with activations of output layer.

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -187,6 +187,34 @@ def check_array_lengths(X, Y, W):
                          str(list(set_w)[0]) + ' target samples.')
 
 
+def get_output_activation(layer_config, activation_key):
+    if isinstance(layer_config, list):
+        layer_config = layer_config[0]
+    for k, v in layer_config.items():
+        if k == activation_key:
+            return v
+        if isinstance(v, dict):
+            return get_output_activation(v, activation_key)
+        elif isinstance(v, list):
+            for d in v:
+                return get_output_activation(d, activation_key)
+
+
+def get_appropriate_loss_function(output_layer, loss):
+    activation_key = 'activation'
+    if 'LSTM' in str(output_layer) or 'GRU' in str(output_layer):
+        activation_key = 'inner_activation'
+    activation = get_output_activation(output_layer.get_config(), activation_key)
+    non_squashed_activations = {'softplus', 'softsign', 'relu', 'tanh', 'linear'}
+    loss_str = loss
+    if callable(loss):
+        loss_str = loss.__name__
+    if "crossentropy" in loss_str and activation in non_squashed_activations:
+        return objectives.get_crossentropy_loss_function(loss_str, from_logits=True)
+    else:
+        return objectives.get(loss_str)
+
+
 def check_loss_and_target_compatibility(targets, losses, output_shapes):
     key_losses = {'mean_square_error',
                   'binary_crossentropy',
@@ -498,7 +526,6 @@ class Model(Container):
                             ' - expected a list of dicts.')
 
         # prepare loss functions
-        non_squashed_activations = set(['softplus', 'softsign', 'relu', 'tanh', 'linear'])
         if isinstance(loss, dict):
             for name in loss:
                 if name not in self.output_names:
@@ -512,11 +539,7 @@ class Model(Container):
                 if name not in loss:
                     raise ValueError('Output "' + name +
                                      '" missing from loss dictionary.')
-                activation = output_layer.activation.__name__
-                if "crossentropy" in loss[name] and activation in non_squashed_activations:
-                    loss_functions.append(objectives.get_crossentropy_loss_function(loss[name], from_logits=True))
-                else:
-                    loss_functions.append(objectives.get(loss[name]))
+                loss_functions.append(get_appropriate_loss_function(output_layer, loss[name]))
         elif isinstance(loss, list):
             if len(loss) != len(self.outputs):
                 raise ValueError('When passing a list as loss, '
@@ -524,22 +547,9 @@ class Model(Container):
                                  'The model has ' + str(len(self.outputs)) +
                                  ' outputs, but you passed loss=' +
                                  str(loss))
-            loss_functions = []
-            for i, l in enumerate(loss):
-                activation = self.output_layers[i].activation.__name__
-                if "crossentropy" in l and activation in non_squashed_activations:
-                    loss_functions.append(objectives.get_crossentropy_loss_function(l, from_logits=True))
-                else:
-                    loss_functions.append(objectives.get(l))
+            loss_functions = [get_appropriate_loss_function(output_layer, loss[i]) for i, output_layer in enumerate(self.output_layers)]
         else:
-            loss_function = objectives.get(loss)
-            loss_functions = []
-            for output_layer in self.output_layers:
-                activation = output_layer.activation.__name__
-                if "crossentropy" in loss and activation in non_squashed_activations:
-                    loss_functions.append(objectives.get_crossentropy_loss_function(loss, from_logits=True))
-                else:
-                    loss_functions.append(loss_function)
+            loss_functions = [get_appropriate_loss_function(output_layer, loss) for output_layer in self.output_layers]
         self.loss_functions = loss_functions
         weighted_losses = [weighted_objective(fn) for fn in loss_functions]
 

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -535,6 +535,8 @@ class Model(Container):
                                      str(self.output_names))
             loss_functions = []
             for output_layer in self.output_layers:
+                while hasattr(output_layer, "output_layers"):
+                    output_layer = output_layer.output_layers[0]
                 name = output_layer.name
                 if name not in loss:
                     raise ValueError('Output "' + name +
@@ -547,9 +549,17 @@ class Model(Container):
                                  'The model has ' + str(len(self.outputs)) +
                                  ' outputs, but you passed loss=' +
                                  str(loss))
-            loss_functions = [get_appropriate_loss_function(output_layer, loss[i]) for i, output_layer in enumerate(self.output_layers)]
+            loss_functions = []
+            for i, output_layer in enumerate(self.output_layers):
+                while hasattr(output_layer, "output_layers"):
+                    output_layer = output_layer.output_layers[0]
+                loss_functions.append(get_appropriate_loss_function(output_layer, loss[i]))
         else:
-            loss_functions = [get_appropriate_loss_function(output_layer, loss) for output_layer in self.output_layers]
+            loss_functions = []
+            for output_layer in self.output_layers:
+                while hasattr(output_layer, "output_layers"):
+                    output_layer = output_layer.output_layers[0]
+                loss_functions.append(get_appropriate_loss_function(output_layer, loss))
         self.loss_functions = loss_functions
         weighted_losses = [weighted_objective(fn) for fn in loss_functions]
 

--- a/keras/objectives.py
+++ b/keras/objectives.py
@@ -31,22 +31,29 @@ def hinge(y_true, y_pred):
     return K.mean(K.maximum(1. - y_true * y_pred, 0.), axis=-1)
 
 
-def categorical_crossentropy(y_true, y_pred):
+def get_crossentropy_loss_function(loss, from_logits=False):
+    def correct_loss(y_true, y_pred):
+        return get(loss)(y_true, y_pred, from_logits=from_logits)
+
+    return correct_loss
+
+
+def categorical_crossentropy(y_true, y_pred, from_logits=False):
     '''Expects a binary class matrix instead of a vector of scalar classes.
     '''
-    return K.categorical_crossentropy(y_pred, y_true)
+    return K.categorical_crossentropy(y_pred, y_true, from_logits)
 
 
-def sparse_categorical_crossentropy(y_true, y_pred):
+def sparse_categorical_crossentropy(y_true, y_pred, from_logits=False):
     '''expects an array of integer classes.
     Note: labels shape must have the same number of dimensions as output shape.
     If you get a shape error, add a length-1 dimension to labels.
     '''
-    return K.sparse_categorical_crossentropy(y_pred, y_true)
+    return K.sparse_categorical_crossentropy(y_pred, y_true, from_logits)
 
 
-def binary_crossentropy(y_true, y_pred):
-    return K.mean(K.binary_crossentropy(y_pred, y_true), axis=-1)
+def binary_crossentropy(y_true, y_pred, from_logits=False):
+    return K.mean(K.binary_crossentropy(y_pred, y_true, from_logits), axis=-1)
 
 
 def kullback_leibler_divergence(y_true, y_pred):


### PR DESCRIPTION
This attempts to fix #4744. Feels pretty hacky, though, and it doesn't fix the real problem, which is Keras doing unexpected transformations to the model predictions "behind the scenes" without the user's knowledge.