### PR TITLE
Maintain aspect ratio of content image in style transfer example

### DIFF
--- a/examples/neural_style_transfer.py
+++ b/examples/neural_style_transfer.py
@@ -72,9 +72,9 @@ style_weight = 1.
 content_weight = 0.025
 
 # dimensions of the generated picture.
+width, height = load_img(base_image_path).size
 img_nrows = 400
-img_ncols = 400
-assert img_ncols == img_nrows, 'Due to the use of the Gram matrix, width and height must match.'
+img_ncols = int(width * img_nrows / height)
 
 # util function to open, resize and format pictures into appropriate tensors
 def preprocess_image(image_path):


### PR DESCRIPTION
It was mentioned that the width and height must match in the neural style transfer example, but this is not necessary. Since in the gram matrix computation we do a dot product of a matrix with its transpose, it would work. Since we are transferring the style of the style image onto the content image, having the aspect ratio of the content image in the final output would be ideal.