### PR TITLE
Use custom_objects to deserialize Lambda functions

### DIFF
--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -618,20 +618,27 @@ class Lambda(Layer):
         return dict(list(base_config.items()) + list(config.items()))
 
     @classmethod
-    def from_config(cls, config):
+    def from_config(cls, config, custom_objects={}):
+        # Insert custom objects into globals.
+        if custom_objects:
+            globs = globals().copy()
+            globs.update(custom_objects)
+        else:
+            globs = globals()
+
         function_type = config.pop('function_type')
         if function_type == 'function':
-            function = globals()[config['function']]
+            function = globs[config['function']]
         elif function_type == 'lambda':
-            function = func_load(config['function'], globs=globals())
+            function = func_load(config['function'], globs=globs)
         else:
             raise TypeError('Unknown function type:', function_type)
 
         output_shape_type = config.pop('output_shape_type')
         if output_shape_type == 'function':
-            output_shape = globals()[config['output_shape']]
+            output_shape = globs[config['output_shape']]
         elif output_shape_type == 'lambda':
-            output_shape = func_load(config['output_shape'], globs=globals())
+            output_shape = func_load(config['output_shape'], globs=globs)
         else:
             output_shape = config['output_shape']
 

--- a/keras/utils/layer_utils.py
+++ b/keras/utils/layer_utils.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+import inspect
 
 from .generic_utils import get_from_module
 from .np_utils import convert_kernel
@@ -31,7 +32,12 @@ def layer_from_config(config, custom_objects={}):
     else:
         layer_class = get_from_module(class_name, globals(), 'layer',
                                       instantiate=False)
-    return layer_class.from_config(config['config'])
+
+    arg_spec = inspect.getargspec(layer_class.from_config)
+    if 'custom_objects' in arg_spec.args:
+        return layer_class.from_config(config['config'], custom_objects=custom_objects)
+    else:
+        return layer_class.from_config(config['config'])
 
 
 def print_summary(layers, relevant_nodes=None,


### PR DESCRIPTION
This patch would solve a small problem when reconstructing Lambda layers. It passes the `custom_objects` list a bit further, so that calls to (global) functions work.

Here's a small example. Running this with the current version ends with `NameError: global name 'theano' is not defined`. The patch would fix this by passing the `custom_objects` to the `lambda` function.
```python
import numpy
import theano
import keras.models as km
import keras.layers as kl

# define model with Lambda layer that calls the external function
inputs = kl.Input(shape=(3,))
output = kl.Lambda(lambda x: theano.tensor.sum(x) + x,
                   output_shape=(3,))(inputs)

# serialize model
model = km.Model(input=inputs, output=output)
json = model.to_json()

# deserialize
model = km.model_from_json(json, custom_objects={'theano': theano})

# run
print(model.predict(numpy.zeros((5, 3))))
```