### PR TITLE
Fix masking for metrics

### DIFF
--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -2,79 +2,79 @@ from . import backend as K
 from .utils.generic_utils import get_from_module
 
 
-def binary_accuracy(y_true, y_pred):
-    return K.mean(K.equal(y_true, K.round(y_pred)))
+def binary_accuracy(y_true, y_pred, axis=None):
+    return K.mean(K.equal(y_true, K.round(y_pred)), axis=axis)
 
 
-def categorical_accuracy(y_true, y_pred):
+def categorical_accuracy(y_true, y_pred, axis=None):
     return K.mean(K.equal(K.argmax(y_true, axis=-1),
-                          K.argmax(y_pred, axis=-1)))
+                          K.argmax(y_pred, axis=-1)), axis=axis)
 
 
-def sparse_categorical_accuracy(y_true, y_pred):
+def sparse_categorical_accuracy(y_true, y_pred, axis=None):
     return K.mean(K.equal(K.max(y_true, axis=-1),
-                          K.cast(K.argmax(y_pred, axis=-1), K.floatx())))
+                          K.cast(K.argmax(y_pred, axis=-1), K.floatx())), axis=axis)
 
 
-def top_k_categorical_accuracy(y_true, y_pred, k=5):
-    return K.mean(K.in_top_k(y_pred, K.argmax(y_true, axis=-1), k))
+def top_k_categorical_accuracy(y_true, y_pred, k=5, axis=None):
+    return K.mean(K.in_top_k(y_pred, K.argmax(y_true, axis=-1), k), axis=axis)
 
 
-def mean_squared_error(y_true, y_pred):
-    return K.mean(K.square(y_pred - y_true))
+def mean_squared_error(y_true, y_pred, axis=None):
+    return K.mean(K.square(y_pred - y_true), axis=axis)
 
 
-def mean_absolute_error(y_true, y_pred):
-    return K.mean(K.abs(y_pred - y_true))
+def mean_absolute_error(y_true, y_pred, axis=None):
+    return K.mean(K.abs(y_pred - y_true), axis=axis)
 
 
-def mean_absolute_percentage_error(y_true, y_pred):
+def mean_absolute_percentage_error(y_true, y_pred, axis=None):
     diff = K.abs((y_true - y_pred) / K.clip(K.abs(y_true),
                                             K.epsilon(),
                                             None))
-    return 100. * K.mean(diff)
+    return 100. * K.mean(diff, axis=axis)
 
 
-def mean_squared_logarithmic_error(y_true, y_pred):
+def mean_squared_logarithmic_error(y_true, y_pred, axis=None):
     first_log = K.log(K.clip(y_pred, K.epsilon(), None) + 1.)
     second_log = K.log(K.clip(y_true, K.epsilon(), None) + 1.)
-    return K.mean(K.square(first_log - second_log))
+    return K.mean(K.square(first_log - second_log), axis=axis)
 
 
-def hinge(y_true, y_pred):
-    return K.mean(K.maximum(1. - y_true * y_pred, 0.))
+def hinge(y_true, y_pred, axis=None):
+    return K.mean(K.maximum(1. - y_true * y_pred, 0.), axis=axis)
 
 
-def squared_hinge(y_true, y_pred):
-    return K.mean(K.square(K.maximum(1. - y_true * y_pred, 0.)))
+def squared_hinge(y_true, y_pred, axis=None):
+    return K.mean(K.square(K.maximum(1. - y_true * y_pred, 0.)), axis=axis)
 
 
-def categorical_crossentropy(y_true, y_pred):
-    return K.mean(K.categorical_crossentropy(y_pred, y_true))
+def categorical_crossentropy(y_true, y_pred, axis=None):
+    return K.mean(K.categorical_crossentropy(y_pred, y_true), axis=axis)
 
 
-def sparse_categorical_crossentropy(y_true, y_pred):
-    return K.mean(K.sparse_categorical_crossentropy(y_pred, y_true))
+def sparse_categorical_crossentropy(y_true, y_pred, axis=None):
+    return K.mean(K.sparse_categorical_crossentropy(y_pred, y_true), axis=axis)
 
 
-def binary_crossentropy(y_true, y_pred):
-    return K.mean(K.binary_crossentropy(y_pred, y_true))
+def binary_crossentropy(y_true, y_pred, axis=None):
+    return K.mean(K.binary_crossentropy(y_pred, y_true), axis=axis)
 
 
-def kullback_leibler_divergence(y_true, y_pred):
+def kullback_leibler_divergence(y_true, y_pred, axis=None):
     y_true = K.clip(y_true, K.epsilon(), 1)
     y_pred = K.clip(y_pred, K.epsilon(), 1)
-    return K.mean(K.sum(y_true * K.log(y_true / y_pred), axis=-1))
+    return K.mean(K.sum(y_true * K.log(y_true / y_pred), axis=-1), axis=axis)
 
 
-def poisson(y_true, y_pred):
-    return K.mean(y_pred - y_true * K.log(y_pred + K.epsilon()))
+def poisson(y_true, y_pred, axis=None):
+    return K.mean(y_pred - y_true * K.log(y_pred + K.epsilon()), axis=axis)
 
 
-def cosine_proximity(y_true, y_pred):
+def cosine_proximity(y_true, y_pred, axis=None):
     y_true = K.l2_normalize(y_true, axis=-1)
     y_pred = K.l2_normalize(y_pred, axis=-1)
-    return -K.mean(y_true * y_pred)
+    return -K.mean(y_true * y_pred, axis=axis)
 
 
 def matthews_correlation(y_true, y_pred):

--- a/tests/test_metric_masking.py
+++ b/tests/test_metric_masking.py
@@ -1,0 +1,180 @@
+import numpy as np
+import pytest
+
+from keras.models import Sequential
+from keras.layers.core import Masking
+from keras.layers import Dense
+from keras.layers.wrappers import TimeDistributed
+from keras.utils.test_utils import keras_test
+from keras.engine.training import masked_metric
+from keras import metrics
+from keras import backend as K
+
+import warnings
+
+
+@keras_test
+def test_masking():
+    np.random.seed(1000)
+    X = np.array([[[1], [1]],
+                  [[0], [0]]])
+    model = Sequential()
+    model.add(Masking(mask_value=0, input_shape=(2, 1)))
+    model.add(TimeDistributed(Dense(1, init='one')))
+    model.compile(loss='mse', optimizer='sgd', metrics=['mse'])
+    y = np.array([[[1], [1]],
+                  [[1], [1]]])
+    metric = model.evaluate(X, y)[1]
+    assert metric == 0
+
+
+@keras_test
+def test_sparse_categorical_crossentropy():
+    _masking_function_test('sparse_categorical_crossentropy', output_shape=(3, 4, 5), target_shape=(3, 4, 1), target_type=int)
+
+
+@keras_test
+def test_categorical_accuracy():
+    _masking_function_test('categorical_accuracy', target_type=float)
+
+
+@keras_test
+def test_sparse_categorical_accuracy():
+    _masking_function_test('sparse_categorical_accuracy', output_shape=(3, 4, 5), target_shape=(3, 4, 1), target_type=int)
+
+
+@keras_test
+def top_k_categorical_accuracy():
+    _masking_function_test('top_k_categorical_accuracy', output_shape=(3, 4, 5), target_shape=(3, 4, 1), target_type=int)
+
+
+@keras_test
+def test_categorical_crossentropy():
+    _masking_function_test('categorical_crossentropy', target_type=int)
+
+
+@keras_test
+def test_binary_crossentropy():
+    _masking_function_test('binary_crossentropy', target_type=float)
+
+
+@keras_test
+def test_masking_binary_accuracy():
+    _masking_function_test('binary_accuracy', target_type=int)
+
+
+@keras_test
+def test_masking_mse():
+    _masking_function_test('mse', target_type=float)
+
+
+@keras_test
+def test_masking_mae():
+    _masking_function_test('mae', target_type=float)
+
+
+@keras_test
+def test_masking_mape():
+    _masking_function_test('mape', target_type=float)
+
+
+@keras_test
+def test_masking_msle():
+    _masking_function_test('msle', target_type=float)
+
+
+@keras_test
+def test_masking_hinge():
+    _masking_function_test('hinge', target_type=float)
+
+
+@keras_test
+def test_masking_squared_hinge():
+    _masking_function_test('squared_hinge', target_type=float)
+
+
+@keras_test
+def test_masking_poisson():
+    _masking_function_test('poisson', target_type=float)
+
+
+@keras_test
+def test_masking_cosine_proximity():
+    _masking_function_test('cosine_proximity', target_type=float)
+
+
+@keras_test
+def test_precision():
+    _masking_function_test('precision', output_shape=(1, 4, 5), target_shape=(1, 4, 5), target_type=bool)
+
+
+@keras_test
+def test_recall():
+    _masking_function_test('recall', output_shape=(1, 4, 5), target_shape=(1, 4, 5), target_type=bool)
+
+
+@keras_test
+def test_fmeasure():
+    _masking_function_test('fmeasure', output_shape=(1, 4, 5), target_shape=(1, 4, 5), target_type=bool)
+
+
+@keras_test
+def test_fbeta_score():
+    _masking_function_test('fbeta_score', output_shape=(1, 4, 5), target_shape=(1, 4, 5), target_type=bool)
+
+
+def _masking_function_test(fn_name, output_shape=(3, 4, 5), target_shape=(3, 4, 5), target_type=float):
+    # test if masked_metric and original metric
+    # give the same result
+    fn = metrics.get(fn_name)
+    fn_masked = masked_metric(fn)
+    X1 = np.random.ranf(np.prod(output_shape)).reshape(output_shape)
+    padding_shape = list(output_shape)
+    padding_shape[1] = 1
+    padding_shape = tuple(padding_shape)
+    X2 = np.concatenate((X1, np.random.ranf(np.prod(padding_shape)).reshape(padding_shape)), axis=1)
+
+    target_padding_shape = list(target_shape)
+    target_padding_shape[1] = 1
+    target_padding_shape = tuple(target_padding_shape)
+
+    if target_type == int:
+        Y1 = np.random.randint(0, target_shape[-1], np.prod(target_shape)).reshape(target_shape)
+        Y2 = np.concatenate((Y1, np.random.randint(0, target_shape[-1], np.prod(target_padding_shape)).reshape(target_padding_shape)), axis=1)
+
+    elif target_type == float:
+        Y1 = np.random.random(np.prod(target_shape)).reshape(target_shape)
+        Y2 = np.concatenate((Y1, np.random.ranf(np.prod(target_padding_shape)).reshape(target_padding_shape)), axis=1)
+
+    elif target_type == bool:
+        Y1 = np.random.randint(0, 2, np.prod(target_shape)).reshape(target_shape)
+        Y2 = np.concatenate((Y1, np.random.randint(0, 2, np.prod(target_padding_shape)).reshape(target_padding_shape)), axis=1)
+
+    mask = np.ones((target_shape[0], target_shape[1] + 1))
+    mask[:, -1] = 0
+
+    mse_X1_Y1 = K.eval(fn(K.variable(Y1), K.variable(X1)))
+
+    mse_X1_Y1_mask_fn = K.eval(fn_masked(K.variable(Y1), K.variable(X1)))
+
+    mse_X2_Y2 = K.eval(fn(K.variable(Y2), K.variable(X2)))
+
+    mse_X2_Y2_mask_fn = K.eval(fn_masked(K.variable(Y2), K.variable(X2)))
+
+    mse_X2_Y2_masked = K.eval(fn_masked(K.variable(Y2), K.variable(X2), K.variable(mask)))
+
+    # without mask metric output should be independent of which function is used
+    # use almost equal to account for float precision
+    assert abs(mse_X1_Y1 - mse_X1_Y1_mask_fn) < 0.0001, "Masked value not computed correctly for metric %s" % fn
+    assert abs(mse_X2_Y2 - mse_X2_Y2_mask_fn) < 0.0001, "Masked value not computed correctly for metric %s" % fn
+
+    # masked mse X2-Y2 should be equal to mse X1-Y1
+    # use almost equal to account for float precision
+    assert abs(mse_X1_Y1 - mse_X2_Y2_masked) < 0.0001, "Masked value not computed correctly for metric %s" % fn
+
+    assert abs(mse_X2_Y2 - mse_X1_Y1) > 0.0001, "Metric %s not sufficiently tested as masking did not result in different metric value" % fn_name
+
+
+if __name__ == '__main__':
+    np.random.seed(1989)
+    pytest.main([__file__])


### PR DESCRIPTION
During evaluation, the masks of a model are not taken into account,
resulting in incorrect accuracies for sequence-to-sequence models with
padded output values. An example can be found in issue 4752.

To solve this issue, treat the metrics in a way analogous to the
objective functions, by adding an optional axis argument to metrics.py
and computing the overall mean only after multiplying with the model's
mask and dividing by its length in training.py. This required a small
reorganisation of the metric preparation in training.py.

Metric masking is now fixed for binary_accuracy, categorical_accuracy,
sparse_categorical_accuracy, top_k_categorical_accuracy,
mean_squared_error, mean_absolute_error, mean_absolute_percentage_error,
mean_squared_logarithmic_error, hinge, squared_hinge,
categorical_crossentropy, sparse_categorical_crossentropy,
binary_crossentropy, poisson and cosine_proximity. Tests to confirm are
included in tests/test_metric_masking.py.

Fixes for matthews_correlation, kullback_leibler_divergence, precision,
recall,  fbeta_score and fmeasure are not written yet. When masked
metrics should be computed for these metrics a warning is raised.