### PR TITLE
Fix kullback_leibler_divergence #4788

### DIFF
--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -108,7 +108,7 @@ def kullback_leibler_divergence(y_true, y_pred):
     '''
     y_true = K.clip(y_true, K.epsilon(), 1)
     y_pred = K.clip(y_pred, K.epsilon(), 1)
-    return K.sum(y_true * K.log(y_true / y_pred), axis=-1)
+    return K.mean(K.sum(y_true * K.log(y_true / y_pred), axis=-1))
 
 
 def poisson(y_true, y_pred):


### PR DESCRIPTION
The kullback_leibler_divergence metric in metrics.py returned an output
with dimensionality N-1 (where N is the dimensionality of the target).
Add mean after sum to fix this, such that always a scalar is returned.