### PR TITLE
Add use_variables flag to L1L2Regularizer

### DIFF
--- a/keras/regularizers.py
+++ b/keras/regularizers.py
@@ -77,8 +77,9 @@ class L1L2Regularizer(Regularizer):
 
     def get_config(self):
         return {'name': self.__class__.__name__,
-                'l1': float(self.l1),
-                'l2': float(self.l2)}
+                'l1': float(K.get_value(self.l1)) if self.use_variables else float(self.l1),
+                'l2': float(K.get_value(self.l2)) if self.use_variables else float(self.l2),
+                'use_variables': self.use_variables}
 
 
 # Aliases.

--- a/keras/regularizers.py
+++ b/keras/regularizers.py
@@ -59,15 +59,19 @@ class EigenvalueRegularizer(Regularizer):
 
 class L1L2Regularizer(Regularizer):
 
-    def __init__(self, l1=0., l2=0.):
+    def __init__(self, l1=0., l2=0., use_variables=False):
         self.l1 = K.cast_to_floatx(l1)
         self.l2 = K.cast_to_floatx(l2)
+        if use_variables:
+            self.l1 = K.variable(self.l1)
+            self.l2 = K.variable(self.l2)
+        self.use_variables=use_variables
 
     def __call__(self, x):
         regularization = 0
-        if self.l1:
+        if self.use_variables or self.l1:
             regularization += K.sum(self.l1 * K.abs(x))
-        if self.l2:
+        if self.use_variables or self.l2:
             regularization += K.sum(self.l2 * K.square(x))
         return regularization
 


### PR DESCRIPTION
Add a flag "use_variables" (default=False) so that L1L2Regularizer will use variables instead of constants. 

Raised in this issue: https://github.com/fchollet/keras/issues/4813. I would also use this for a project on learning to dynamically control hyper-parameters using RL.

If use_variables=False, existing functionality. l1 and l2 are floats and are only in the computation graph if nonzero.

If use_variables=True, l1 and l2 are variables and are always in the computation graph. They can be modified during training using set_value.

I added unit tests for serialization with use_variables True and False. Also removed some unused imports from test_regularizers.py.

Cheers,
Ben