### PR TITLE
Use requests JSON field

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -407,13 +407,11 @@ class RemoteMonitor(Callback):
     def __init__(self,
                  root='http://localhost:9000',
                  path='/publish/epoch/end/',
-                 field='data',
-                 headers={'Accept': 'application/json', 'Content-Type': 'application/json'}):
+                 field='data'):
         super(RemoteMonitor, self).__init__()
         self.root = root
         self.path = path
         self.field = field
-        self.headers = headers
 
     def on_epoch_end(self, epoch, logs={}):
         import requests
@@ -423,8 +421,7 @@ class RemoteMonitor(Callback):
             send[k] = v
         try:
             requests.post(self.root + self.path,
-                          {self.field: json.dumps(send)},
-                          headers=self.headers)
+                json={self.field: json.dumps(send)})
         except:
             print('Warning: could not reach RemoteMonitor '
                   'root server at ' + str(self.root))


### PR DESCRIPTION
Building on #4603, use requests' own json field instead of setting our own headers (see http://stackoverflow.com/a/26344315 for more details about this feature).

Fixes an issue I was having with Flask where the JSON was arriving malformed