### PR TITLE
Fix for Issue #4851

### DIFF
--- a/keras/layers/advanced_activations.py
+++ b/keras/layers/advanced_activations.py
@@ -79,8 +79,8 @@ class PReLU(Layer):
         self.param_broadcast = [False] * len(param_shape)
         if self.shared_axes[0] is not None:
             for i in self.shared_axes:
-                param_shape[i] = 1
-                self.param_broadcast[i] = True
+                param_shape[i-1] = 1
+                self.param_broadcast[i-1] = True
 
         self.alphas = self.init(param_shape,
                                 name='{}_alphas'.format(self.name))
@@ -182,8 +182,8 @@ class ParametricSoftplus(Layer):
         self.param_broadcast = [False] * len(param_shape)
         if self.shared_axes[0] is not None:
             for i in self.shared_axes:
-                param_shape[i] = 1
-                self.param_broadcast[i] = True
+                param_shape[i-1] = 1
+                self.param_broadcast[i-1] = True
 
         self.alphas = K.variable(self.alpha_init * np.ones(param_shape),
                                  name='{}_alphas'.format(self.name))
@@ -287,8 +287,8 @@ class SReLU(Layer):
         self.param_broadcast = [False] * len(param_shape)
         if self.shared_axes[0] is not None:
             for i in self.shared_axes:
-                param_shape[i] = 1
-                self.param_broadcast[i] = True
+                param_shape[i-1] = 1
+                self.param_broadcast[i-1] = True
 
         t_left_init = initializations.get(self.t_left_init)
         a_left_init = initializations.get(self.a_left_init)

--- a/keras/layers/advanced_activations.py
+++ b/keras/layers/advanced_activations.py
@@ -79,8 +79,8 @@ class PReLU(Layer):
         self.param_broadcast = [False] * len(param_shape)
         if self.shared_axes[0] is not None:
             for i in self.shared_axes:
-                param_shape[i-1] = 1
-                self.param_broadcast[i-1] = True
+                param_shape[i - 1] = 1
+                self.param_broadcast[i - 1] = True
 
         self.alphas = self.init(param_shape,
                                 name='{}_alphas'.format(self.name))
@@ -182,8 +182,8 @@ class ParametricSoftplus(Layer):
         self.param_broadcast = [False] * len(param_shape)
         if self.shared_axes[0] is not None:
             for i in self.shared_axes:
-                param_shape[i-1] = 1
-                self.param_broadcast[i-1] = True
+                param_shape[i - 1] = 1
+                self.param_broadcast[i - 1] = True
 
         self.alphas = K.variable(self.alpha_init * np.ones(param_shape),
                                  name='{}_alphas'.format(self.name))
@@ -287,8 +287,8 @@ class SReLU(Layer):
         self.param_broadcast = [False] * len(param_shape)
         if self.shared_axes[0] is not None:
             for i in self.shared_axes:
-                param_shape[i-1] = 1
-                self.param_broadcast[i-1] = True
+                param_shape[i - 1] = 1
+                self.param_broadcast[i - 1] = True
 
         t_left_init = initializations.get(self.t_left_init)
         a_left_init = initializations.get(self.a_left_init)


### PR DESCRIPTION
I didn't catch when my original documentation was changed by @fchollet (overall for the better) but introducing this bug: https://github.com/fchollet/keras/issues/4851

My original docs only included the dimensions of the parameters (no batch dim) and were correct, but I think its better to change the functions to reflect the current docs.
My original docs were:
```
shared_axes: the axes along with to share parameters for
                      the activation function. For example if the
                      incoming feature maps from a 2D convolution
                      has dimensions 16x32x32 and you wish to share
                      parameters across space so that each feature
                      maps only has one set of parameters, set
                      shared_axes = [1, 2]
```