### PR TITLE
Fix #4846

### DIFF
--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -927,7 +927,10 @@ class Layer(object):
     def get_updates_for(self, inputs):
         if not hasattr(self, '_per_input_updates'):
             return []
-        inputs_hash = object_list_uid(inputs)
+        if inputs is not None:
+            inputs_hash = object_list_uid(inputs)
+        else:
+            inputs_hash = None
         if inputs_hash in self._per_input_updates:
             return self._per_input_updates[inputs_hash]
         return []
@@ -935,7 +938,10 @@ class Layer(object):
     def get_losses_for(self, inputs):
         if not hasattr(self, '_per_input_losses'):
             return []
-        inputs_hash = object_list_uid(inputs)
+        if inputs is not None:
+            inputs_hash = object_list_uid(inputs)
+        else:
+            inputs_hash = None
         if inputs_hash in self._per_input_losses:
             return self._per_input_losses[inputs_hash]
         return []

--- a/tests/keras/engine/test_topology.py
+++ b/tests/keras/engine/test_topology.py
@@ -9,6 +9,27 @@ from keras import backend as K
 from keras.models import model_from_json, model_from_yaml
 from keras.utils.test_utils import keras_test
 
+@keras_test
+def test_get_updates_for():
+    a = Input(shape=(2,))
+    dense_layer = Dense(1)
+    dense_layer.add_update(0, inputs=a)
+    dense_layer.add_update(1, inputs=None)
+
+    assert dense_layer.get_updates_for(a) == [0]
+    assert dense_layer.get_updates_for(None) == [1]
+
+
+@keras_test
+def test_get_losses_for():
+    a = Input(shape=(2,))
+    dense_layer = Dense(1)
+    dense_layer.add_loss(0, inputs=a)
+    dense_layer.add_loss(1, inputs=None)
+    
+    assert dense_layer.get_losses_for(a) == [0]
+    assert dense_layer.get_losses_for(None) == [1]
+
 
 @keras_test
 def test_trainable_weights():


### PR DESCRIPTION
After regularization refactor, regularizers are not correctly passed when layer is reused with another model. Reason for that is that `Layer.get_losses_for` doesn't work for inputs=None, i.e. unconditional losses (like regularization). This simple test fails on current master:

```{python}
@keras_test
def test_get_losses_for():
    a = Input(shape=(2,))
    dense_layer = Dense(1)
    dense_layer.add_loss("", inputs=a)
    dense_layer.add_loss("", inputs=None)

    assert len(dense_layer.get_losses_for(None)) == 1 # <- Fails here
    assert len(dense_layer.get_losses_for(a)) == 1
```

I have fixed it by copying behavior from `Layer.add_loss` and added this test to `tests/engine/test_topology.py`