### PR TITLE
Cropping1D, zero right padding

### DIFF
--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -1649,7 +1649,10 @@ class Cropping1D(Layer):
                 input_shape[2])
 
     def call(self, x, mask=None):
-        return x[:, self.cropping[0]:-self.cropping[1], :]
+        if self.cropping[1] == 0:
+            return x[:, self.cropping[0]:, :]
+        else:
+            return x[:, self.cropping[0]:-self.cropping[1], :]
 
     def get_config(self):
         config = {'cropping': self.cropping}


### PR DESCRIPTION
When the right padding is zero the Cropping1D layer is returning the slice `x[:, cropping[0]:-0, :]` which results in an empty slice, very different from the `x[:, cropping[0]:, :]` desired.

This PR fixes the problem.