### PR TITLE
change ValueError to warnings.warn for nchannel not in {1,3,4}

### DIFF
--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -439,7 +439,7 @@ class ImageDataGenerator(object):
             raise ValueError('Input to `.fit()` should have rank 4. '
                              'Got array with shape: ' + str(X.shape))
         if X.shape[self.channel_index] not in {1, 3, 4}:
-            raise ValueError(
+            warnings.warn(
                 'Expected input to be images (as Numpy array) '
                 'following the dimension ordering convention "' + self.dim_ordering + '" '
                 '(channels on axis ' + str(self.channel_index) + '), i.e. expected '
@@ -543,12 +543,13 @@ class NumpyArrayIterator(Iterator):
                              'with shape', self.X.shape)
         channels_axis = 3 if dim_ordering == 'tf' else 1
         if self.X.shape[channels_axis] not in {1, 3, 4}:
-            raise ValueError('NumpyArrayIterator is set to use the '
-                             'dimension ordering convention "' + dim_ordering + '" '
-                             '(channels on axis ' + str(channels_axis) + '), i.e. expected '
-                             'either 1, 3 or 4 channels on axis ' + str(channels_axis) + '. '
-                             'However, it was passed an array with shape ' + str(self.X.shape) +
-                             ' (' + str(self.X.shape[channels_axis]) + ' channels).')
+            warnings.warn(
+                'NumpyArrayIterator is set to use the '
+                'dimension ordering convention "' + dim_ordering + '" '
+                '(channels on axis ' + str(channels_axis) + '), i.e. expected '
+                'either 1, 3 or 4 channels on axis ' + str(channels_axis) + '. '
+                'However, it was passed an array with shape ' + str(self.X.shape) +
+                ' (' + str(self.X.shape[channels_axis]) + ' channels).')
         if y is not None:
             self.y = np.asarray(y)
         else:


### PR DESCRIPTION
Seems many image stacks may have different number of channels.  Also seems that the transformations will work no matter the number of channels.  I found this minor change useful when working with 20 channel images.  I think the only problem (although I haven't looked very deeply) is that now a ValueError will be raised in "array_to_img" if the transformed images are being saved to disk.  I can add a ValueError further upstream triggered if the "save_to_dir" keyword is not None.  This seems to work fine though for "live augmentation" feed to a network. 