### PR TITLE
Added (n, 0) as a valid crop tuple

### DIFF
--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -1736,12 +1736,12 @@ class Cropping2D(Layer):
         if self.dim_ordering == 'th':
             return x[:,
                      :,
-                     self.cropping[0][0]:-self.cropping[0][1],
-                     self.cropping[1][0]:-self.cropping[1][1]]
+                     self.cropping[0][0]:(-self.cropping[0][1] if self.cropping[0][1] > 0 else x.shape[2]),
+                     self.cropping[1][0]:(-self.cropping[1][1] if self.cropping[1][1] > 0 else x.shape[3])]
         elif self.dim_ordering == 'tf':
             return x[:,
-                     self.cropping[0][0]:-self.cropping[0][1],
-                     self.cropping[1][0]:-self.cropping[1][1],
+                     self.cropping[0][0]:(-self.cropping[0][1] if self.cropping[0][1] > 0 else x.shape[1]),
+                     self.cropping[1][0]:(-self.cropping[1][1] if self.cropping[1][1] > 0 else x.shape[2]),
                      :]
 
     def get_config(self):
@@ -1823,14 +1823,14 @@ class Cropping3D(Layer):
         if self.dim_ordering == 'th':
             return x[:,
                      :,
-                     self.cropping[0][0]:-self.cropping[0][1],
-                     self.cropping[1][0]:-self.cropping[1][1],
-                     self.cropping[2][0]:-self.cropping[2][1]]
+                     self.cropping[0][0]:(-self.cropping[0][1] if self.cropping[0][1] > 0 else x.shape[2]),
+                     self.cropping[1][0]:(-self.cropping[1][1] if self.cropping[1][1] > 0 else x.shape[3]),
+                     self.cropping[2][0]:(-self.cropping[2][1] if self.cropping[2][1] > 0 else x.shape[4])]
         elif self.dim_ordering == 'tf':
             return x[:,
-                     self.cropping[0][0]:-self.cropping[0][1],
-                     self.cropping[1][0]:-self.cropping[1][1],
-                     self.cropping[2][0]:-self.cropping[2][1],
+                     self.cropping[0][0]:(-self.cropping[0][1] if self.cropping[0][1] > 0 else x.shape[1]),
+                     self.cropping[1][0]:(-self.cropping[1][1] if self.cropping[1][1] > 0 else x.shape[2]),
+                     self.cropping[2][0]:(-self.cropping[2][1] if self.cropping[2][1] > 0 else x.shape[3]),
                      :]
 
     def get_config(self):

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -1736,12 +1736,12 @@ class Cropping2D(Layer):
         if self.dim_ordering == 'th':
             return x[:,
                      :,
-                     self.cropping[0][0]:(-self.cropping[0][1] if self.cropping[0][1] > 0 else x.shape[2]),
-                     self.cropping[1][0]:(-self.cropping[1][1] if self.cropping[1][1] > 0 else x.shape[3])]
+                     self.cropping[0][0]:self.input_spec[0].shape[2] - self.cropping[0][1],
+                     self.cropping[1][0]:self.input_spec[0].shape[3] - self.cropping[1][1]]
         elif self.dim_ordering == 'tf':
             return x[:,
-                     self.cropping[0][0]:(-self.cropping[0][1] if self.cropping[0][1] > 0 else x.shape[1]),
-                     self.cropping[1][0]:(-self.cropping[1][1] if self.cropping[1][1] > 0 else x.shape[2]),
+                     self.cropping[0][0]:self.input_spec[0].shape[1] - self.cropping[0][1],
+                     self.cropping[1][0]:self.input_spec[0].shape[2] - self.cropping[1][1],
                      :]
 
     def get_config(self):
@@ -1823,14 +1823,14 @@ class Cropping3D(Layer):
         if self.dim_ordering == 'th':
             return x[:,
                      :,
-                     self.cropping[0][0]:(-self.cropping[0][1] if self.cropping[0][1] > 0 else x.shape[2]),
-                     self.cropping[1][0]:(-self.cropping[1][1] if self.cropping[1][1] > 0 else x.shape[3]),
-                     self.cropping[2][0]:(-self.cropping[2][1] if self.cropping[2][1] > 0 else x.shape[4])]
+                     self.cropping[0][0]:self.input_spec[0].shape[2] - self.cropping[0][1],
+                     self.cropping[1][0]:self.input_spec[0].shape[3] - self.cropping[1][1],
+                     self.cropping[2][0]:self.input_spec[0].shape[4] - self.cropping[2][1]]
         elif self.dim_ordering == 'tf':
             return x[:,
-                     self.cropping[0][0]:(-self.cropping[0][1] if self.cropping[0][1] > 0 else x.shape[1]),
-                     self.cropping[1][0]:(-self.cropping[1][1] if self.cropping[1][1] > 0 else x.shape[2]),
-                     self.cropping[2][0]:(-self.cropping[2][1] if self.cropping[2][1] > 0 else x.shape[3]),
+                     self.cropping[0][0]:self.input_spec[0].shape[1] - self.cropping[0][1],
+                     self.cropping[1][0]:self.input_spec[0].shape[2] - self.cropping[1][1],
+                     self.cropping[2][0]:self.input_spec[0].shape[3] - self.cropping[2][1],
                      :]
 
     def get_config(self):

--- a/tests/keras/layers/test_convolutional.py
+++ b/tests/keras/layers/test_convolutional.py
@@ -665,6 +665,15 @@ def test_cropping_2d():
                              cropping[1][0]: -cropping[1][1],
                              :]
     assert_allclose(np_output, expected_out)
+    # another correctness test (no cropping)
+    cropping = ((0, 0), (0, 0))
+    layer = convolutional.Cropping2D(cropping=cropping,
+                                     dim_ordering=dim_ordering)
+    layer.build(input.shape)
+    output = layer(K.variable(input))
+    np_output = K.eval(output)
+    # compare with input
+    assert_allclose(np_output, input)
 
 
 def test_cropping_3d():
@@ -708,6 +717,15 @@ def test_cropping_3d():
                              cropping[2][0]: -cropping[2][1],
                              :]
     assert_allclose(np_output, expected_out)
+    # another correctness test (no cropping)
+    cropping = ((0, 0), (0, 0), (0, 0))
+    layer = convolutional.Cropping2D(cropping=cropping,
+                                     dim_ordering=dim_ordering)
+    layer.build(input.shape)
+    output = layer(K.variable(input))
+    np_output = K.eval(output)
+    # compare with input
+    assert_allclose(np_output, input)
 
 if __name__ == '__main__':
     pytest.main([__file__])

--- a/tests/keras/layers/test_convolutional.py
+++ b/tests/keras/layers/test_convolutional.py
@@ -719,7 +719,7 @@ def test_cropping_3d():
     assert_allclose(np_output, expected_out)
     # another correctness test (no cropping)
     cropping = ((0, 0), (0, 0), (0, 0))
-    layer = convolutional.Cropping2D(cropping=cropping,
+    layer = convolutional.Cropping3D(cropping=cropping,
                                      dim_ordering=dim_ordering)
     layer.build(input.shape)
     output = layer(K.variable(input))


### PR DESCRIPTION
Previously, the slice of the array to return was determined by `[cropping[0] : -cropping[1]]`. However, if a crop tuple was `(n, 0)`, meaning "do not crop the far edge of this dimension", the indexing was `[n:-0]` which is invalid and returns 0 data.

Cropping2D and Cropping3D layers can now successfully not crop along a dimension.