### PR TITLE
replacing tf.batch_matmul with tf.matmul

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -868,9 +868,9 @@ def batch_dot(x, y, axes=None):
         adj_x = None
         adj_y = None
     try:
-        out = tf.batch_matmul(x, y, adj_a=adj_x, adj_b=adj_y)
+        out = tf.matmul(x, y, adjoint_a=adj_x, adjoint_b=adj_y)
     except TypeError:
-        out = tf.batch_matmul(x, y, adj_x=adj_x, adj_y=adj_y)
+        out = tf.matmul(x, y, adjoint_a=adj_x, adjoint_b=adj_y)
     if ndim(out) == 1:
         out = expand_dims(out, 1)
     return out


### PR DESCRIPTION
tf.batch_matmul was removed in version 0.12 and replaced with tf.matmul
Addapting tensorflow_backend for it