### PR TITLE
adding documentation details of function layer.get_weights(). Added missing word "biases".

### DIFF
--- a/docs/templates/layers/about-keras-layers.md
+++ b/docs/templates/layers/about-keras-layers.md
@@ -2,8 +2,8 @@
 
 All Keras layers have a number of methods in common:
 
-- `layer.get_weights()`: returns the weights of the layer as a list of Numpy arrays.
-- `layer.set_weights(weights)`: sets the weights of the layer from a list of Numpy arrays (with the same shapes as the output of `get_weights`).
+- `layer.get_weights()`: returns the weights and biases of the layer as a list of Numpy arrays.
+- `layer.set_weights(weights)`: sets the weights and biases of the layer from a list of Numpy arrays (with the same shapes as the output of `get_weights`).
 - `layer.get_config()`: returns a dictionary containing the configuration of the layer. The layer can be reinstantiated from its config via:
 ```python
 from keras.utils.layer_utils import layer_from_config


### PR DESCRIPTION
layer.get_weights() returns list containing weights and biases of the layer. Documentation doesn't mention it explicitly. Though it is assumed, it should be stated explicitly for sake of clarity. For beginners it is confusing otherwise.