### PR TITLE
K.dot: use integer shape if available

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -783,14 +783,14 @@ def dot(x, y):
     if ndim(x) is not None and (ndim(x) > 2 or ndim(y) > 2):
         x_shape = []
         for i, s in zip(int_shape(x), tf.unpack(tf.shape(x))):
-            if s is None:
+            if i is not None:
                 x_shape.append(i)
             else:
                 x_shape.append(s)
         x_shape = tuple(x_shape)
         y_shape = []
         for i, s in zip(int_shape(y), tf.unpack(tf.shape(y))):
-            if s is None:
+            if i is not None:
                 y_shape.append(i)
             else:
                 y_shape.append(s)


### PR DESCRIPTION
Fixed an error when PR https://github.com/fchollet/keras/pull/4632 was rewritten. @fchollet 

`s` (symbolic shape) is never `None`. Use integer shape if available, and use symbolic shape otherwise.