### PR TITLE
docs: fix typo inputs_shape -> input_shape

### DIFF
--- a/docs/templates/applications.md
+++ b/docs/templates/applications.md
@@ -200,7 +200,7 @@ The default input size for this model is 299x299.
 - include_top: whether to include the fully-connected layer at the top of the network.
 - weights: one of `None` (random initialization) or "imagenet" (pre-training on ImageNet).
 - input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as image input for the model.
-- inputs_shape: optional shape tuple, only to be specified
+- input_shape: optional shape tuple, only to be specified
     if `include_top` is False (otherwise the input shape
     has to be `(299, 299, 3)`.
     It should have exactly 3 inputs channels,
@@ -241,7 +241,7 @@ The default input size for this model is 224x224.
 - include_top: whether to include the 3 fully-connected layers at the top of the network.
 - weights: one of `None` (random initialization) or "imagenet" (pre-training on ImageNet).
 - input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as image input for the model.
-- inputs_shape: optional shape tuple, only to be specified
+- input_shape: optional shape tuple, only to be specified
     if `include_top` is False (otherwise the input shape
     has to be `(224, 224, 3)` (with `tf` dim ordering)
     or `(3, 224, 244)` (with `th` dim ordering).
@@ -283,7 +283,7 @@ The default input size for this model is 224x224.
 - include_top: whether to include the 3 fully-connected layers at the top of the network.
 - weights: one of `None` (random initialization) or "imagenet" (pre-training on ImageNet).
 - input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as image input for the model.
-- inputs_shape: optional shape tuple, only to be specified
+- input_shape: optional shape tuple, only to be specified
     if `include_top` is False (otherwise the input shape
     has to be `(224, 224, 3)` (with `tf` dim ordering)
     or `(3, 224, 244)` (with `th` dim ordering).
@@ -327,7 +327,7 @@ The default input size for this model is 224x224.
 - include_top: whether to include the fully-connected layer at the top of the network.
 - weights: one of `None` (random initialization) or "imagenet" (pre-training on ImageNet).
 - input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as image input for the model.
-- inputs_shape: optional shape tuple, only to be specified
+- input_shape: optional shape tuple, only to be specified
     if `include_top` is False (otherwise the input shape
     has to be `(224, 224, 3)` (with `tf` dim ordering)
     or `(3, 224, 244)` (with `th` dim ordering).
@@ -369,7 +369,7 @@ The default input size for this model is 299x299.
 - include_top: whether to include the fully-connected layer at the top of the network.
 - weights: one of `None` (random initialization) or "imagenet" (pre-training on ImageNet).
 - input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as image input for the model.
-- inputs_shape: optional shape tuple, only to be specified
+- input_shape: optional shape tuple, only to be specified
     if `include_top` is False (otherwise the input shape
     has to be `(299, 299, 3)` (with `tf` dim ordering)
     or `(3, 299, 299)` (with `th` dim ordering).

--- a/keras/applications/inception_v3.py
+++ b/keras/applications/inception_v3.py
@@ -83,7 +83,7 @@ def InceptionV3(include_top=True, weights='imagenet',
             or "imagenet" (pre-training on ImageNet).
         input_tensor: optional Keras tensor (i.e. output of `layers.Input()`)
             to use as image input for the model.
-        inputs_shape: optional shape tuple, only to be specified
+        input_shape: optional shape tuple, only to be specified
             if `include_top` is False (otherwise the input shape
             has to be `(299, 299, 3)` (with `tf` dim ordering)
             or `(3, 299, 299)` (with `th` dim ordering).

--- a/keras/applications/resnet50.py
+++ b/keras/applications/resnet50.py
@@ -129,7 +129,7 @@ def ResNet50(include_top=True, weights='imagenet',
             or "imagenet" (pre-training on ImageNet).
         input_tensor: optional Keras tensor (i.e. output of `layers.Input()`)
             to use as image input for the model.
-        inputs_shape: optional shape tuple, only to be specified
+        input_shape: optional shape tuple, only to be specified
             if `include_top` is False (otherwise the input shape
             has to be `(224, 224, 3)` (with `tf` dim ordering)
             or `(3, 224, 244)` (with `th` dim ordering).

--- a/keras/applications/vgg16.py
+++ b/keras/applications/vgg16.py
@@ -48,7 +48,7 @@ def VGG16(include_top=True, weights='imagenet',
             or "imagenet" (pre-training on ImageNet).
         input_tensor: optional Keras tensor (i.e. output of `layers.Input()`)
             to use as image input for the model.
-        inputs_shape: optional shape tuple, only to be specified
+        input_shape: optional shape tuple, only to be specified
             if `include_top` is False (otherwise the input shape
             has to be `(224, 224, 3)` (with `tf` dim ordering)
             or `(3, 224, 244)` (with `th` dim ordering).

--- a/keras/applications/vgg19.py
+++ b/keras/applications/vgg19.py
@@ -48,7 +48,7 @@ def VGG19(include_top=True, weights='imagenet',
             or "imagenet" (pre-training on ImageNet).
         input_tensor: optional Keras tensor (i.e. output of `layers.Input()`)
             to use as image input for the model.
-        inputs_shape: optional shape tuple, only to be specified
+        input_shape: optional shape tuple, only to be specified
             if `include_top` is False (otherwise the input shape
             has to be `(224, 224, 3)` (with `tf` dim ordering)
             or `(3, 224, 244)` (with `th` dim ordering).

--- a/keras/applications/xception.py
+++ b/keras/applications/xception.py
@@ -54,7 +54,7 @@ def Xception(include_top=True, weights='imagenet',
             or "imagenet" (pre-training on ImageNet).
         input_tensor: optional Keras tensor (i.e. output of `layers.Input()`)
             to use as image input for the model.
-        inputs_shape: optional shape tuple, only to be specified
+        input_shape: optional shape tuple, only to be specified
             if `include_top` is False (otherwise the input shape
             has to be `(299, 299, 3)`.
             It should have exactly 3 inputs channels,


### PR DESCRIPTION
Fix docs to match the correct name used through Keras applications, which is input_shape.