### PR TITLE
Fix problem with old Theano batch normalization and GPU

### DIFF
--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -493,6 +493,9 @@ def _old_normalize_batch_in_training(x, gamma, beta,
         try:
             normed, mean, stdinv = theano.sandbox.cuda.dnn.dnn_batch_normalization_train(
                 x, broadcast_gamma, broadcast_beta, 'spatial', epsilon)
+            normed = theano.tensor.as_tensor_variable(normed)
+            mean = theano.tensor.as_tensor_variable(mean)
+            stdinv = theano.tensor.as_tensor_variable(stdinv)
             var = T.inv(stdinv ** 2)
             return normed, T.flatten(mean), T.flatten(var)
         except AttributeError:
@@ -544,7 +547,7 @@ def _old_batch_normalization(x, mean, var, beta, gamma, epsilon=1e-3):
                 shuffle_pattern = list(range(ndim))
                 shuffle_pattern[1] = shuffle_pattern[axis]
                 shuffle_pattern[axis] = 1
-                return theano.sandbox.cuda.dnn.dnn_batch_normalization_test(
+                result = theano.sandbox.cuda.dnn.dnn_batch_normalization_test(
                     x.dimshuffle(shuffle_pattern),
                     gamma.dimshuffle(shuffle_pattern),
                     beta.dimshuffle(shuffle_pattern),
@@ -552,8 +555,9 @@ def _old_batch_normalization(x, mean, var, beta, gamma, epsilon=1e-3):
                     var.dimshuffle(shuffle_pattern),
                     'spatial', epsilon).dimshuffle(shuffle_pattern)
             else:
-                return theano.sandbox.cuda.dnn.dnn_batch_normalization_test(
+                result = theano.sandbox.cuda.dnn.dnn_batch_normalization_test(
                     x, gamma, beta, mean, var, 'spatial', epsilon)
+            return theano.tensor.as_tensor_variable(result)
         except AttributeError:
             pass
         except ValueError:

--- a/tests/keras/layers/test_normalization.py
+++ b/tests/keras/layers/test_normalization.py
@@ -47,6 +47,19 @@ def test_batchnorm_mode_0_or_2():
 
 
 @keras_test
+def test_batchnorm_mode_0_or_2_twice():
+    # This is a regression test for issue #4881 with the old
+    # batch normalization functions in the Theano backend.
+    for mode in [0, 2]:
+        model = Sequential()
+        norm_m0 = normalization.BatchNormalization(mode=mode, input_shape=(10,), momentum=0.8)
+        model.add(norm_m0)
+        norm_m1 = normalization.BatchNormalization(mode=mode, input_shape=(10,), momentum=0.8)
+        model.add(norm_m1)
+        model.compile(loss='mse', optimizer='sgd')
+
+
+@keras_test
 def test_batchnorm_mode_0_convnet():
     model = Sequential()
     norm_m0 = normalization.BatchNormalization(mode=0, axis=1, input_shape=(3, 4, 4), momentum=0.8)


### PR DESCRIPTION
This might solve #4881. See also Theano/Theano#5385.

There seems to be a problem in the gradient Theano's `IfElse` that is triggered by giving it GPU variables as input. In the example script in issue #4881, this happens because two batch normalization layers are stacked. Directly calling the Theano functions from `theano.sandbox.cuda.dnn` moves the variables to the gpu, which triggers the problem for the second BN layer.

As a workaround, this patch avoids the problem by converting the variables back to normal non-gpu variables before they are passed to the `IfElse`.

This is only a problem in the current batch normalization implementation, since the new version does not call the gpu functions directly.