### PR TITLE
Dynamic dispatch for Keras backend

### DIFF
--- a/keras/backend/__init__.py
+++ b/keras/backend/__init__.py
@@ -74,3 +74,10 @@ def backend():
     for determining the current backend.
     '''
     return _BACKEND
+
+sin.func_name, sin.func_doc = "sin", "Computes sin of x element-wise.\n"
+cos.func_name, cos.func_doc = "cos", "Computes cos of x element-wise.\n"
+tan.func_name, tan.func_doc = "tan", "Computes tan of x element-wise.\n"
+asin.func_name, asin.func_doc = "asin", "Computes asin of x element-wise.\n"
+acos.func_name, acos.func_doc = "acos", "Computes acos of x element-wise.\n"
+atan.func_name, atan.func_doc = "atan", "Computes atan of x element-wise.\n"

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1150,19 +1150,6 @@ def minimum(x, y):
     '''
     return tf.minimum(x, y)
 
-
-def sin(x):
-    '''Computes sin of x element-wise.
-    '''
-    return tf.sin(x)
-
-
-def cos(x):
-    '''Computes cos of x element-wise.
-    '''
-    return tf.cos(x)
-
-
 def normalize_batch_in_training(x, gamma, beta,
                                 reduction_axes, epsilon=1e-3):
     '''Computes mean and std for batch then apply batch_normalization on batch.
@@ -2560,3 +2547,7 @@ def foldr(fn, elems, initializer=None, name=None):
         Same type and shape as initializer
     '''
     return tf.foldr(fn, elems, initializer=initializer, name=name)
+
+# aliases for pass-through to backend
+cos, sin, tan = lambda x: tf.cos(x), lambda x: tf.sin(x), lambda(x): tf.tan(x)
+acos, asin, atan = lambda x: tf.acos(x), lambda x: tf.asin(x), lambda(x): tf.atan(x)

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -437,15 +437,6 @@ def maximum(x, y):
 def minimum(x, y):
     return T.minimum(x, y)
 
-
-def sin(x):
-    return T.sin(x)
-
-
-def cos(x):
-    return T.cos(x)
-
-
 def normalize_batch_in_training(x, gamma, beta,
                                 reduction_axes, epsilon=1e-3):
     '''Computes mean and std for batch then apply batch_normalization on batch.
@@ -2073,3 +2064,8 @@ def foldr(fn, elems, initializer=None, name=None):
     fn2 = lambda x, acc: fn(acc, x)
 
     return theano.foldr(fn2, elems, initializer, name=name)[0]
+
+# aliases for pass-through to backend
+cos, sin, tan = lambda x: theano.tensor.cos(x), lambda x: theano.tensor.sin(x), lambda x: theano.tensor.tan(x)
+acos, asin, atan = lambda x: theano.tensor.arccos(x), lambda x: theano.tensor.arcsin(x), \
+                   lambda x: theano.tensor.arctan(x)


### PR DESCRIPTION
Hi everybody!

This PR provides dynamic dispatch in the Keras backend. Python reflection magic.

TL;DR: Instant support for any function in the theano or tensorflow backend not already in Keras backend, like arccos, etc.

* If a function is defined in the keras backend, `K.method` works as before.
* If a function is not defined in the keras backend, but defined in the backend module, `K.method` will call `tf.method` or `theano.tensor.method` depending on the backend module.
* If a function is not in keras backend or the backend module, it will throw a custom message `AttributeError` that the requested function is not in either the keras backend or the selected backend module

Many functions have the same name and invocation in theano and tensorflow. When a new function comes out in either library, we can write code like `K.method`. If eventually someone writes some custom code in the keras backend, `K.method` will start calling that custom code.

Hypothetically, could delete large portions of the backend after this pull request, but might cause performance and documentation issues.

Shouldn't impact any existing code but will wait for tests to complete before celebrating.

Cheers,
Ben