### PR TITLE
Deconvolution2D fix.

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1253,7 +1253,7 @@ def resize_images(X, height_factor, width_factor, dim_ordering):
         X = tf.image.resize_nearest_neighbor(X, new_shape)
         X = permute_dimensions(X, [0, 3, 1, 2])
         X.set_shape((None, None, original_shape[2] * height_factor if original_shape[2] is not None else None,
-                    original_shape[3] * width_factor if original_shape[3] is not None else None))
+                     original_shape[3] * width_factor if original_shape[3] is not None else None))
         return X
     elif dim_ordering == 'tf':
         original_shape = int_shape(X)
@@ -1261,7 +1261,7 @@ def resize_images(X, height_factor, width_factor, dim_ordering):
         new_shape *= tf.constant(np.array([height_factor, width_factor]).astype('int32'))
         X = tf.image.resize_nearest_neighbor(X, new_shape)
         X.set_shape((None, original_shape[1] * height_factor if original_shape[1] is not None else None,
-                    original_shape[2] * width_factor if original_shape[2] is not None else None, None))
+                     original_shape[2] * width_factor if original_shape[2] is not None else None, None))
         return X
     else:
         raise ValueError('Invalid dim_ordering:', dim_ordering)
@@ -2076,9 +2076,12 @@ def in_top_k(predictions, targets, k):
 
 # CONVOLUTIONS
 
-def _preprocess_deconv_output_shape(shape, dim_ordering):
+def _preprocess_deconv_output_shape(x, shape, dim_ordering):
     if dim_ordering == 'th':
         shape = (shape[0], shape[2], shape[3], shape[1])
+
+    if shape[0] is None:
+        shape = (tf.shape(x)[0], ) + shape[1:]
     return shape
 
 
@@ -2233,7 +2236,7 @@ def deconv2d(x, kernel, output_shape, strides=(1, 1),
         raise ValueError('Unknown dim_ordering ' + str(dim_ordering))
 
     x = _preprocess_conv2d_input(x, dim_ordering)
-    output_shape = _preprocess_deconv_output_shape(output_shape, dim_ordering)
+    output_shape = _preprocess_deconv_output_shape(x, output_shape, dim_ordering)
     kernel = _preprocess_conv2d_kernel(kernel, dim_ordering)
     kernel = tf.transpose(kernel, (0, 1, 3, 2))
     padding = _preprocess_border_mode(border_mode)
@@ -2443,7 +2446,6 @@ def ctc_label_dense_to_sparse(labels, label_lengths):
 
 
 def ctc_batch_cost(y_true, y_pred, input_length, label_length):
-
     '''Runs CTC loss algorithm on each batch element.
 
     # Arguments

--- a/tests/keras/layers/test_convolutional.py
+++ b/tests/keras/layers/test_convolutional.py
@@ -142,37 +142,38 @@ def test_deconvolution_2d():
     nb_row = 10
     nb_col = 6
 
-    for border_mode in _convolution_border_modes:
-        for subsample in [(1, 1), (2, 2)]:
-            if border_mode == 'same' and subsample != (1, 1):
-                continue
+    for batch_size in [None, nb_samples]:
+        for border_mode in _convolution_border_modes:
+            for subsample in [(1, 1), (2, 2)]:
+                if border_mode == 'same' and subsample != (1, 1):
+                    continue
 
-            rows = conv_input_length(nb_row, 3, border_mode, subsample[0])
-            cols = conv_input_length(nb_col, 3, border_mode, subsample[1])
-            layer_test(convolutional.Deconvolution2D,
-                       kwargs={'nb_filter': nb_filter,
-                               'nb_row': 3,
-                               'nb_col': 3,
-                               'output_shape': (nb_samples, nb_filter, rows, cols),
-                               'border_mode': border_mode,
-                               'subsample': subsample,
-                               'dim_ordering': 'th'},
-                       input_shape=(nb_samples, stack_size, nb_row, nb_col),
-                       fixed_batch_size=True)
+                rows = conv_input_length(nb_row, 3, border_mode, subsample[0])
+                cols = conv_input_length(nb_col, 3, border_mode, subsample[1])
+                layer_test(convolutional.Deconvolution2D,
+                           kwargs={'nb_filter': nb_filter,
+                                   'nb_row': 3,
+                                   'nb_col': 3,
+                                   'output_shape': (batch_size, nb_filter, rows, cols),
+                                   'border_mode': border_mode,
+                                   'subsample': subsample,
+                                   'dim_ordering': 'th'},
+                           input_shape=(nb_samples, stack_size, nb_row, nb_col),
+                           fixed_batch_size=True)
 
-            layer_test(convolutional.Deconvolution2D,
-                       kwargs={'nb_filter': nb_filter,
-                               'nb_row': 3,
-                               'nb_col': 3,
-                               'output_shape': (nb_samples, nb_filter, rows, cols),
-                               'border_mode': border_mode,
-                               'dim_ordering': 'th',
-                               'W_regularizer': 'l2',
-                               'b_regularizer': 'l2',
-                               'activity_regularizer': 'activity_l2',
-                               'subsample': subsample},
-                       input_shape=(nb_samples, stack_size, nb_row, nb_col),
-                       fixed_batch_size=True)
+                layer_test(convolutional.Deconvolution2D,
+                           kwargs={'nb_filter': nb_filter,
+                                   'nb_row': 3,
+                                   'nb_col': 3,
+                                   'output_shape': (batch_size, nb_filter, rows, cols),
+                                   'border_mode': border_mode,
+                                   'dim_ordering': 'th',
+                                   'W_regularizer': 'l2',
+                                   'b_regularizer': 'l2',
+                                   'activity_regularizer': 'activity_l2',
+                                   'subsample': subsample},
+                           input_shape=(nb_samples, stack_size, nb_row, nb_col),
+                           fixed_batch_size=True)
 
 
 @keras_test


### PR DESCRIPTION
Previously, running the example in [the documentation](https://keras.io/layers/convolutional/#deconvolution2d) resulted in an error for the TF backend. This fix adds the ability to handle `None` in the first dim of the `output_shape` for the TF backend. Added a test that passes for TH, but fails for TF, which under the changes from the PR now passes for both.