### PR TITLE
feat: add support for synchronous generator (max_q_size=0)

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1744,6 +1744,8 @@ class Model(Container):
                         break
                     else:
                         time.sleep(wait_time)
+            else:
+                generator_output = next(generator)
 
             if isinstance(generator_output, tuple):
                 if len(generator_output) == 2:

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1363,6 +1363,9 @@ class Model(Container):
             class_weight: dictionary mapping class indices to a weight
                 for the class.
             max_q_size: maximum size for the generator queue
+                In case the generator depends on the current state of the
+                model and/or you cannot run the generator in parallel to the
+                model, set max_q_size to 0.
             nb_worker: maximum number of processes to spin up
                 when using process based threading
             pickle_safe: if True, use process based threading.
@@ -1591,6 +1594,9 @@ class Model(Container):
                 total number of samples to generate from `generator`
                 before returning.
             max_q_size: maximum size for the generator queue
+                In case the generator depends on the current state of the
+                model and/or you cannot run the generator in parallel to the
+                model, set max_q_size to 0.
             nb_worker: maximum number of processes to spin up
                 when using process based threading
             pickle_safe: if True, use process based threading.
@@ -1699,6 +1705,9 @@ class Model(Container):
             val_samples: total number of samples to generate from `generator`
                 before returning.
             max_q_size: maximum size for the generator queue
+                In case the generator depends on the current state of the
+                model and/or you cannot run the generator in parallel to the
+                model, set max_q_size to 0.
             nb_worker: maximum number of processes to spin up
                 when using process based threading
             pickle_safe: if True, use process based threading.

--- a/tests/keras/test_multiprocessing.py
+++ b/tests/keras/test_multiprocessing.py
@@ -53,6 +53,43 @@ def test_multiprocessing_training():
 
 
 @keras_test
+def test_monoprocessing_training():
+
+    reached_end = False
+
+    arr_data = np.random.randint(0, 256, (500, 2))
+    arr_labels = np.random.randint(0, 2, 500)
+
+    def myGenerator():
+
+        batch_size = 32
+        n_samples = 500
+
+        while True:
+            batch_index = np.random.randint(0, n_samples - batch_size)
+            start = batch_index
+            end = start + batch_size
+            X = arr_data[start: end]
+            y = arr_labels[start: end]
+            yield X, y
+
+    # Build a NN
+    model = Sequential()
+    model.add(Dense(1, input_shape=(2, )))
+    model.compile(loss='mse', optimizer='adadelta')
+
+    model.fit_generator(myGenerator(),
+                        samples_per_epoch=320,
+                        nb_epoch=1,
+                        verbose=1,
+                        max_q_size=0)
+
+    reached_end = True
+
+    assert reached_end
+
+
+@keras_test
 def test_multiprocessing_training_fromfile():
 
     reached_end = False
@@ -101,6 +138,46 @@ def test_multiprocessing_training_fromfile():
 
 
 @keras_test
+def test_monoprocessing_training_fromfile():
+
+    reached_end = False
+
+    arr_data = np.random.randint(0, 256, (500, 2))
+    arr_labels = np.random.randint(0, 2, 500)
+    np.savez("data.npz", **{"data": arr_data, "labels": arr_labels})
+
+    def myGenerator():
+
+        batch_size = 32
+        n_samples = 500
+
+        arr = np.load("data.npz")
+
+        while True:
+            batch_index = np.random.randint(0, n_samples - batch_size)
+            start = batch_index
+            end = start + batch_size
+            X = arr["data"][start: end]
+            y = arr["labels"][start: end]
+            yield X, y
+
+    # Build a NN
+    model = Sequential()
+    model.add(Dense(1, input_shape=(2, )))
+    model.compile(loss='mse', optimizer='adadelta')
+
+    model.fit_generator(myGenerator(),
+                        samples_per_epoch=320,
+                        nb_epoch=1,
+                        verbose=1,
+                        max_q_size=0)
+
+    reached_end = True
+
+    assert reached_end
+
+
+@keras_test
 def test_multiprocessing_predicting():
 
     reached_end = False
@@ -132,6 +209,38 @@ def test_multiprocessing_predicting():
                             val_samples=320,
                             max_q_size=10,
                             pickle_safe=False)
+    reached_end = True
+
+    assert reached_end
+
+
+@keras_test
+def test_monoprocessing_predicting():
+
+    reached_end = False
+
+    arr_data = np.random.randint(0, 256, (500, 2))
+
+    def myGenerator():
+
+        batch_size = 32
+        n_samples = 500
+
+        while True:
+            batch_index = np.random.randint(0, n_samples - batch_size)
+            start = batch_index
+            end = start + batch_size
+            X = arr_data[start: end]
+            yield X
+
+    # Build a NN
+    model = Sequential()
+    model.add(Dense(1, input_shape=(2, )))
+    model.compile(loss='mse', optimizer='adadelta')
+    model.predict_generator(myGenerator(),
+                            val_samples=320,
+                            max_q_size=0)
+
     reached_end = True
 
     assert reached_end
@@ -172,6 +281,41 @@ def test_multiprocessing_evaluating():
                              val_samples=320,
                              max_q_size=10,
                              pickle_safe=False)
+    reached_end = True
+
+    assert reached_end
+
+
+@keras_test
+def test_monoprocessing_evaluating():
+
+    reached_end = False
+
+    arr_data = np.random.randint(0, 256, (500, 2))
+    arr_labels = np.random.randint(0, 2, 500)
+
+    def myGenerator():
+
+        batch_size = 32
+        n_samples = 500
+
+        while True:
+            batch_index = np.random.randint(0, n_samples - batch_size)
+            start = batch_index
+            end = start + batch_size
+            X = arr_data[start: end]
+            y = arr_labels[start: end]
+            yield X, y
+
+    # Build a NN
+    model = Sequential()
+    model.add(Dense(1, input_shape=(2, )))
+    model.compile(loss='mse', optimizer='adadelta')
+
+    model.evaluate_generator(myGenerator(),
+                             val_samples=320,
+                             max_q_size=0)
+
     reached_end = True
 
     assert reached_end


### PR DESCRIPTION
This request adds support for `max_q_size=0` to `fit_generator`.

When `max_q_size=0`, this will prevent the generator from being run in parallel to the model.

This might be useful when the generator actually depends on the current state of the model itself.
An example is when the generator needs to do a forward pass of the model to only yield difficult batches (e.g. hard negative triplet sampling strategy in [FaceNet](https://arxiv.org/pdf/1503.03832.pdf) paper). 
