### PR TITLE
Add more trigonometric functions to backends

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1163,6 +1163,30 @@ def cos(x):
     return tf.cos(x)
 
 
+def tan(x):
+    '''Computes tan of x element-wise.
+    '''
+    return tf.tan(x)
+
+
+def arccos(x):
+    '''Computes arccos of x element-wise.
+    '''
+    return tf.acos(x)
+
+
+def arcsin(x):
+    '''Computes arcsin of x element-wise.
+    '''
+    return tf.asin(x)
+
+
+def arctan(x):
+    '''Computes arctan of x element-wise.
+    '''
+    return tf.atan(x)
+
+
 def normalize_batch_in_training(x, gamma, beta,
                                 reduction_axes, epsilon=1e-3):
     '''Computes mean and std for batch then apply batch_normalization on batch.

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -439,11 +439,39 @@ def minimum(x, y):
 
 
 def sin(x):
+    '''Computes sin of x element-wise.
+    '''
     return T.sin(x)
 
 
 def cos(x):
+    '''Computes cos of x element-wise.
+    '''
     return T.cos(x)
+
+
+def tan(x):
+    '''Computes tan of x element-wise.
+    '''
+    return T.tan(x)
+
+
+def arcsin(x):
+    '''Computes arcsin of x element-wise.
+    '''
+    return T.arcsin(x)
+
+
+def arccos(x):
+    '''Computes arccos of x element-wise.
+    '''
+    return T.arccos(x)
+
+
+def arctan(x):
+    '''Computes arctan of x element-wise.
+    '''
+    return T.arctan(x)
 
 
 def normalize_batch_in_training(x, gamma, beta,

--- a/tests/keras/backend/test_backends.py
+++ b/tests/keras/backend/test_backends.py
@@ -217,6 +217,12 @@ class TestBackend(object):
         check_single_tensor_operation('pow', (4, 2), a=3)
         check_single_tensor_operation('clip', (4, 2), min_value=0.4,
                                       max_value=0.6)
+        check_single_tensor_operation('sin', (4, 2))
+        check_single_tensor_operation('cos', (4, 2))
+        check_single_tensor_operation('tan', (4, 2))
+        check_single_tensor_operation('arcsin', (4, 2))
+        check_single_tensor_operation('arccos', (4, 2))
+        check_single_tensor_operation('arctan', (4, 2))
 
         # two-tensor ops
         check_two_tensor_operation('equal', (4, 2), (4, 2))


### PR DESCRIPTION
This PR adds the functions `tan`, `arcsin`, `arccos`, and `arctan` to the Theano and Tensorflow backends. There are tests for these, and I also added tests for the existing functions `sin` and `cos`. 