### PR TITLE
Allow (n, 0) croppings on Cropping2d and 3d

### DIFF
--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -1740,11 +1740,41 @@ class Cropping2D(Layer):
 
     def call(self, x, mask=None):
         if self.dim_ordering == 'th':
+            if self.cropping[0][1] == self.cropping[1][1] == 0:
+                return x[:,
+                         :,
+                         self.cropping[0][0]:,
+                         self.cropping[1][0]:]
+            elif self.cropping[0][1] == 0:
+                return x[:,
+                         :,
+                         self.cropping[0][0]:,
+                         self.cropping[1][0]:-self.cropping[1][1]]
+            elif self.cropping[1][1] == 0:
+                return x[:,
+                         :,
+                         self.cropping[0][0]:-self.cropping[0][1],
+                         self.cropping[1][0]:]
             return x[:,
                      :,
                      self.cropping[0][0]:-self.cropping[0][1],
                      self.cropping[1][0]:-self.cropping[1][1]]
         elif self.dim_ordering == 'tf':
+            if self.cropping[0][1] == self.cropping[1][1] == 0:
+                return x[:,
+                         self.cropping[0][0]:,
+                         self.cropping[1][0]:,
+                         :]
+            elif self.cropping[0][1] == 0:
+                return x[:,
+                         self.cropping[0][0]:,
+                         self.cropping[1][0]:-self.cropping[1][1],
+                         :]
+            elif self.cropping[1][1] == 0:
+                return x[:,
+                         self.cropping[0][0]:-self.cropping[0][1],
+                         self.cropping[1][0]:,
+                         :]
             return x[:,
                      self.cropping[0][0]:-self.cropping[0][1],
                      self.cropping[1][0]:-self.cropping[1][1],
@@ -1827,12 +1857,96 @@ class Cropping3D(Layer):
 
     def call(self, x, mask=None):
         if self.dim_ordering == 'th':
+            if self.cropping[0][1] == self.cropping[1][1] == self.cropping[2][1] == 0:
+                return x[:,
+                         :,
+                         self.cropping[0][0]:,
+                         self.cropping[1][0]:,
+                         self.cropping[2][0]:]
+            elif self.cropping[0][1] == self.cropping[1][1] == 0:
+                return x[:,
+                         :,
+                         self.cropping[0][0]:,
+                         self.cropping[1][0]:,
+                         self.cropping[2][0]:-self.cropping[2][1]]
+            elif self.cropping[1][1] == self.cropping[2][1] == 0:
+                return x[:,
+                         :,
+                         self.cropping[0][0]:-self.cropping[0][1],
+                         self.cropping[1][0]:,
+                         self.cropping[2][0]:]
+            elif self.cropping[0][1] == self.cropping[2][1] == 0:
+                return x[:,
+                         :,
+                         self.cropping[0][0]:,
+                         self.cropping[1][0]:-self.cropping[1][1],
+                         self.cropping[2][0]:]
+            elif self.cropping[0][1] == 0:
+                return x[:,
+                         :,
+                         self.cropping[0][0]:,
+                         self.cropping[1][0]:-self.cropping[1][1],
+                         self.cropping[2][0]:-self.cropping[2][1]]
+            elif self.cropping[1][1] == 0:
+                return x[:,
+                         :,
+                         self.cropping[0][0]:-self.cropping[0][1],
+                         self.cropping[1][0]:,
+                         self.cropping[2][0]:-self.cropping[2][1]]
+            elif self.cropping[2][1] == 0:
+                return x[:,
+                         :,
+                         self.cropping[0][0]:-self.cropping[0][1],
+                         self.cropping[1][0]:-self.cropping[1][1],
+                         self.cropping[2][0]:]
             return x[:,
                      :,
                      self.cropping[0][0]:-self.cropping[0][1],
                      self.cropping[1][0]:-self.cropping[1][1],
                      self.cropping[2][0]:-self.cropping[2][1]]
         elif self.dim_ordering == 'tf':
+            if self.cropping[0][1] == self.cropping[1][1] == self.cropping[2][1] == 0:
+                return x[:,
+                         self.cropping[0][0]:,
+                         self.cropping[1][0]:,
+                         self.cropping[2][0]:,
+                         :]
+            elif self.cropping[0][1] == self.cropping[1][1] == 0:
+                return x[:,
+                         self.cropping[0][0]:,
+                         self.cropping[1][0]:,
+                         self.cropping[2][0]:-self.cropping[2][1],
+                         :]
+            elif self.cropping[1][1] == self.cropping[2][1] == 0:
+                return x[:,
+                         self.cropping[0][0]:-self.cropping[0][1],
+                         self.cropping[1][0]:,
+                         self.cropping[2][0]:,
+                         :]
+            elif self.cropping[0][1] == self.cropping[2][1] == 0:
+                return x[:,
+                         self.cropping[0][0]:,
+                         self.cropping[1][0]:-self.cropping[1][1],
+                         self.cropping[2][0]:,
+                         :]
+            elif self.cropping[0][1] == 0:
+                return x[:,
+                         self.cropping[0][0]:,
+                         self.cropping[1][0]:-self.cropping[1][1],
+                         self.cropping[2][0]:-self.cropping[2][1],
+                         :]
+            elif self.cropping[1][1] == 0:
+                return x[:,
+                         self.cropping[0][0]:-self.cropping[0][1],
+                         self.cropping[1][0]:,
+                         self.cropping[2][0]:-self.cropping[2][1],
+                         :]
+            elif self.cropping[2][1] == 0:
+                return x[:,
+                         self.cropping[0][0]:-self.cropping[0][1],
+                         self.cropping[1][0]:-self.cropping[1][1],
+                         self.cropping[2][0]:,
+                         :]
             return x[:,
                      self.cropping[0][0]:-self.cropping[0][1],
                      self.cropping[1][0]:-self.cropping[1][1],

--- a/tests/keras/layers/test_convolutional.py
+++ b/tests/keras/layers/test_convolutional.py
@@ -666,6 +666,15 @@ def test_cropping_2d():
                              cropping[1][0]: -cropping[1][1],
                              :]
     assert_allclose(np_output, expected_out)
+    # another correctness test (no cropping)
+    cropping = ((0, 0), (0, 0))
+    layer = convolutional.Cropping2D(cropping=cropping,
+                                     dim_ordering=dim_ordering)
+    layer.build(input.shape)
+    output = layer(K.variable(input))
+    np_output = K.eval(output)
+    # compare with input
+    assert_allclose(np_output, input)
 
 
 def test_cropping_3d():
@@ -709,6 +718,15 @@ def test_cropping_3d():
                              cropping[2][0]: -cropping[2][1],
                              :]
     assert_allclose(np_output, expected_out)
+    # another correctness test (no cropping)
+    cropping = ((0, 0), (0, 0), (0, 0))
+    layer = convolutional.Cropping3D(cropping=cropping,
+                                     dim_ordering=dim_ordering)
+    layer.build(input.shape)
+    output = layer(K.variable(input))
+    np_output = K.eval(output)
+    # compare with input
+    assert_allclose(np_output, input)
 
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
- A cropping of `(n, 0)` is now valid on any axis
  - Previously, these would cause a slice of `[n : -0]` which is valid, but returns 0 items
- Added tests for the case of `(0, 0)` crops

I did it in this ugly way to allow for non-defined shapes (even though this is an odd case for images) and to minimize memory usage.