### PR TITLE
Fix batch normalization equation in TF backend

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1196,7 +1196,7 @@ def normalize_batch_in_training(x, gamma, beta,
 def batch_normalization(x, mean, var, beta, gamma, epsilon=1e-3):
     '''Applies batch normalization on x given mean, var, beta and gamma:
 
-    output = (x - mean) / (sqrt(var) + epsilon) * gamma + beta
+    output = (x - mean) / sqrt(var + epsilon) * gamma + beta
     '''
     return tf.nn.batch_normalization(x, mean, var, beta, gamma, epsilon)
 


### PR DESCRIPTION
Update the batch normalization equation in the TF backend to follow the [original paper][1] and the [TensorFlow source code][2].

[1]: https://arxiv.org/abs/1502.03167
[2]: https://github.com/tensorflow/tensorflow/blob/333dc32ff79af21484695157f3d141dc776f7c02/tensorflow/python/ops/nn_impl.py#L742
