### PR TITLE
Add RReLU(Randomized Leaky ReLU)

### DIFF
--- a/docs/templates/activations.md
+++ b/docs/templates/activations.md
@@ -39,4 +39,4 @@ model.add(Activation(tanh))
 
 ## On Advanced Activations
 
-Activations that are more complex than a simple Theano/TensorFlow function (eg. learnable activations, configurable activations, etc.) are available as [Advanced Activation layers](layers/advanced-activations.md), and can be found in the module `keras.layers.advanced_activations`. These include PReLU and LeakyReLU.
+Activations that are more complex than a simple Theano/TensorFlow function (eg. learnable activations, configurable activations, etc.) are available as [Advanced Activation layers](layers/advanced-activations.md), and can be found in the module `keras.layers.advanced_activations`. These include PReLU, LeakyReLU and RReU.

--- a/keras/layers/advanced_activations.py
+++ b/keras/layers/advanced_activations.py
@@ -37,6 +37,49 @@ class LeakyReLU(Layer):
         base_config = super(LeakyReLU, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
 
+class RReLU(Layer):
+    '''Randomized Leaky Rectified Linear Unit
+    that uses a random alpha in training while using the average of alphas
+    in testing phase:
+    During training
+    `f(x) = alpha * x for x < 0, where alpha ~ U(l, u), l < u`,
+    `f(x) = x for x >= 0`.
+    During testing:
+    `f(x) = (l + u) / 2 * x for x < 0`,
+    `f(x) = x for x >= 0`.
+
+    # Input shape
+        Arbitrary. Use the keyword argument `input_shape`
+        (tuple of integers, does not include the samples axis)
+        when using this layer as the first layer in a model.
+
+    # Output shape
+        Same shape as the input.
+
+    # Arguments
+        l: lower bound of the uniform distribution, default is 1/8
+        u: upper bound of the uniform distribution, default is 1/3
+
+    # References
+        - [Empirical Evaluation of Rectified Activations in Convolution Network](https://arxiv.org/pdf/1505.00853v2.pdf)
+    '''
+    def __init__(self, l=1/8., u=1/3., **kwargs):
+        self.supports_masking = True
+        self.l = l
+        self.u = u
+        self.average = (l + u) / 2
+        self.uses_learning_phase = True
+        super(RReLU, self).__init__(**kwargs)
+
+    def call(self, x, mask=None):
+        return K.in_train_phase(K.relu(x, np.random.uniform(self.l, self.u)),
+                                K.relu(x, self.average))
+
+    def get_config(self):
+        config = {'l': self.l, 'u': self.u}
+        base_config = super(RReLU, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))
+
 
 class PReLU(Layer):
     '''Parametric Rectified Linear Unit:
@@ -138,7 +181,6 @@ class ELU(Layer):
         config = {'alpha': float(self.alpha)}
         base_config = super(ELU, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
-
 
 class ParametricSoftplus(Layer):
     '''Parametric Softplus:


### PR DESCRIPTION
Add a new advanced activation: RReLU(Randomized Leaky ReLU), please refer to [Empirical Evaluation of Rectified Activations in Convolutional Network](https://arxiv.org/abs/1505.00853) for more details.

Similar to Dropout, RReLU use different negative slope coefficients in training and testing phrase respectively. During training, RReLU uses a random negative slope coefficients sampled from [l, u) while using the a fixed one (l+u)/2 during testing.

On the mnist_cnn.py example, using RReLU and ReLU can get accuracy of 98.61% and 98.57% respectively after 12 epochs.

I'm glad to add test cases if needed even though several current test cases fails due to unknown reasons.