### PR TITLE
Faster implementation of to_categorical

### DIFF
--- a/keras/utils/np_utils.py
+++ b/keras/utils/np_utils.py
@@ -17,13 +17,13 @@ def to_categorical(y, nb_classes=None):
     # Returns
         A binary matrix representation of the input.
     """
-    y = np.array(y, dtype='int')
+    y = np.array(y, dtype='int').ravel()
     if not nb_classes:
         nb_classes = np.max(y)+1
-    Y = np.zeros((len(y), nb_classes))
-    for i in range(len(y)):
-        Y[i, y[i]] = 1.
-    return Y
+    n = y.shape[0]
+    categorical = np.zeros((n, nb_classes))
+    categorical[np.arange(n), y] = 1
+    return categorical
 
 
 def normalize(a, axis=-1, order=2):


### PR DESCRIPTION
Hi everybody,

Faster implementation of `utils.np_utils.to_categorical`. It uses fancy indexing instead of a `for` loop. Between 2x-10x faster depending on the shape (see `timeit` results below).

```python
n = y.shape[0]
Y = np.zeros((n, nb_classes))
Y[np.arange(n), y] = 1
```

The below snippet will run `timeit` comparing old and new.

```python
from keras.utils.np_utils import to_categorical
import numpy as np
from timeit import Timer
from numpy.random import randint

def faster_to_categorical(y, nb_classes=None):
    y = np.array(y, dtype='int').ravel()
    if not nb_classes:
        nb_classes = np.max(y)+1
    n = y.shape[0]
    Y = np.zeros((n, nb_classes))
    Y[np.arange(n), y] = 1
    return Y

def test(nb_classes, n):
	old_timer = Timer(lambda: to_categorical(randint(0,nb_classes,(n,)), nb_classes))
	new_timer = Timer(lambda: faster_to_categorical(randint(0,nb_classes,(n,)), nb_classes))
	old = old_timer.timeit(number=1000)
	new = new_timer.timeit(number=1000)
	print("nbclasses: {}, n: {}, Old: {}, New: {}".format(nb_classes, n, old, new))

test(10, 100)
test(10, 1000)
test(10, 10000)
test(50, 100)
test(50, 1000)
test(50, 10000)
```

> nbclasses: 10, n: 100, Old: 0.0267359691543, New: 0.010637852022
> nbclasses: 10, n: 1000, Old: 0.236200514209, New: 0.040068458587
> nbclasses: 10, n: 10000, Old: 2.26358737023, New: 0.299060704395
> nbclasses: 50, n: 100, Old: 0.0273124445121, New: 0.0118994264327
> nbclasses: 50, n: 1000, Old: 0.254948365256, New: 0.0553193964286
> nbclasses: 50, n: 10000, Old: 3.13795337563, New: 1.15628383799

Cheers,
Ben
