### PR TITLE
Use non-daemon threading for generators

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -432,7 +432,7 @@ def generator_queue(generator, max_q_size=10,
             else:
                 thread = threading.Thread(target=data_generator_task)
             generator_threads.append(thread)
-            thread.daemon = True
+            thread.daemon = False
             thread.start()
     except:
         _stop.set()


### PR DESCRIPTION
*Fix #4392*

> One step of [the daemon thread tear-down process] appears to be to set the values inside globals() to None, meaning that any module resolution results in an AttributeError attempting to dereference NoneType.
> 
> This is Python bug 1856. It was fixed in Python 3.2.1 and 3.3, but the fix was never backported to 2.x.
https://joeshaw.org/python-daemon-threads-considered-harmful/

@tdeboissiere, was there any particular reason you chose to set `thread.daemon = True` in https://github.com/fchollet/keras/pull/3049?

/cc @joeshaw