### PR TITLE
Potential deconv model saving fix?

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -2468,7 +2468,7 @@ def _preprocess_deconv_output_shape(x, shape, dim_ordering):
         shape = (shape[0], shape[2], shape[3], shape[1])
 
     if shape[0] is None:
-        shape = (tf.shape(x)[0], ) + shape[1:]
+        shape = (tf.shape(x)[0], ) + tuple(shape[1:])
     return shape
 
 


### PR DESCRIPTION
I think model serialization with a deconv layer + tf backend causes a bug. I think adding this tuple cast fixes it.

This script reproduces the bug for me with the latest keras/tensorflow
```python
from keras.models import Sequential, load_model
from keras.layers import Deconvolution2D
model = Sequential()
model.add(Deconvolution2D(3, 3, 3, output_shape=(None, 14, 14, 3), input_shape=(12, 12, 3)))
model.save('tmp.model')
del model
model = load_model('tmp.model')
```