### PR TITLE
DeConvolution2D: Make output_shape parameter respect dim_ordering

### DIFF
--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1540,6 +1540,9 @@ def deconv2d(x, kernel, output_shape, strides=(1, 1),
     if dim_ordering not in {'th', 'tf'}:
         raise ValueError('Unknown dim_ordering ' + dim_ordering)
 
+    if dim_ordering == 'tf':
+        output_shape = (output_shape[0], output_shape[3], output_shape[1], output_shape[2])
+
     x = _preprocess_conv2d_input(x, dim_ordering)
     kernel = _preprocess_conv2d_kernel(kernel, dim_ordering)
     kernel = kernel.dimshuffle((1, 0, 2, 3))


### PR DESCRIPTION
See #5001 for the issue.

This simply ensures that the `output_shape` parameter to the DeConv2d layer matches the dim_ordering defined.