### PR TITLE
Ensure order of files is consistent in DirectoryIterator

### DIFF
--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -664,7 +664,7 @@ class DirectoryIterator(Iterator):
         for subdir in classes:
             subpath = os.path.join(directory, subdir)
             for root, dirs, files in _recursive_list(subpath):
-                for fname in files:
+                for fname in sorted(files):
                     is_valid = False
                     for extension in white_list_formats:
                         if fname.lower().endswith('.' + extension):


### PR DESCRIPTION
Currently, files are added to a DirectoryIterator in the order provided by `os.walk`, which is arbitrary. A desirable property in many cases where `shuffle` is set to false is that these files should have a consistent order between runs and across platforms.

This PR modifies the second pass of the scanning phase of DirectoryIterator initialization to add files in lexicographic order.