### PR TITLE
Fix custom_objects for regularizers and other issues

### DIFF
--- a/docs/autogen.py
+++ b/docs/autogen.py
@@ -89,6 +89,7 @@ from keras.utils import data_utils
 from keras.utils import io_utils
 from keras.utils import layer_utils
 from keras.utils import np_utils
+from keras.utils import generic_utils
 
 
 EXCLUDE = {
@@ -264,6 +265,11 @@ PAGES = [
     {
         'page': 'utils/np_utils.md',
         'all_module_functions': [np_utils]
+    },
+    {
+        'page': 'utils/generic_utils.md',
+        'all_module_functions': [generic_utils],
+        'classes': [generic_utils.CustomObjectScope]
     },
 ]
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -55,6 +55,7 @@ pages:
   - I/O Utils: utils/io_utils.md
   - Layer Utils: utils/layer_utils.md
   - Numpy Utils: utils/np_utils.md
+  - Generic Utils: utils/generic_utils.md
 
 
 

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -19,6 +19,7 @@ from ..engine import Layer
 from ..engine import Merge
 from ..utils.generic_utils import func_dump
 from ..utils.generic_utils import func_load
+from ..utils.generic_utils import get_from_module
 
 
 class Masking(Layer):
@@ -676,7 +677,7 @@ class Lambda(Layer):
 
         function_type = config.pop('function_type')
         if function_type == 'function':
-            function = globs[config['function']]
+            function = get_from_module(config['function'], globs, 'core')
         elif function_type == 'lambda':
             function = func_load(config['function'], globs=globs)
         else:
@@ -684,7 +685,7 @@ class Lambda(Layer):
 
         output_shape_type = config.pop('output_shape_type')
         if output_shape_type == 'function':
-            output_shape = globs[config['output_shape']]
+            output_shape = get_from_module(config['output_shape'], globs, 'core')
         elif output_shape_type == 'lambda':
             output_shape = func_load(config['output_shape'], globs=globs)
         else:

--- a/keras/optimizers.py
+++ b/keras/optimizers.py
@@ -42,8 +42,8 @@ def optimizer_from_config(config, custom_objects=None):
     class_name = config['class_name']
     if custom_objects and class_name in custom_objects:
         cls = custom_objects[class_name]
-    if class_name in get_custom_objects():
-        cls = get_custom_objects()[cls]
+    elif class_name in get_custom_objects():
+        cls = get_custom_objects()[class_name]
     else:
         if class_name.lower() not in all_classes:
             raise ValueError('Optimizer class not found:', class_name)

--- a/keras/optimizers.py
+++ b/keras/optimizers.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from six.moves import zip
 
 from . import backend as K
-from .utils.generic_utils import get_from_module
+from .utils.generic_utils import get_from_module, get_custom_objects
 
 if K.backend() == 'tensorflow':
     import tensorflow as tf
@@ -42,6 +42,8 @@ def optimizer_from_config(config, custom_objects=None):
     class_name = config['class_name']
     if custom_objects and class_name in custom_objects:
         cls = custom_objects[class_name]
+    if class_name in get_custom_objects():
+        cls = get_custom_objects()[cls]
     else:
         if class_name.lower() not in all_classes:
             raise ValueError('Optimizer class not found:', class_name)

--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -9,10 +9,21 @@ import six
 import marshal
 import types as python_types
 
+global_custom_objects = {}
+
+
+def get_custom_objects():
+    """Retrieves a live reference to the global dictionary of custom objects
+
+    # Returns
+        dictionary of names to classes
+    """
+    return global_custom_objects
+
 
 def get_from_module(identifier, module_params, module_name,
                     instantiate=False, kwargs=None):
-    """Retrieves a class of function member of a module.
+    """Retrieves a class of function member of a module. First checks global_custom_objects then the requested module.
 
     # Arguments
         identifier: the object to retrieve. It could be specified
@@ -34,7 +45,11 @@ def get_from_module(identifier, module_params, module_name,
         ValueError: if the identifier cannot be found.
     """
     if isinstance(identifier, six.string_types):
-        res = module_params.get(identifier)
+        res = None
+        if identifier in global_custom_objects:
+            res = global_custom_objects[identifier]
+        if not res:
+            res = module_params.get(identifier)
         if not res:
             raise ValueError('Invalid ' + str(module_name) + ': ' +
                              str(identifier))
@@ -46,7 +61,11 @@ def get_from_module(identifier, module_params, module_name,
             return res
     elif isinstance(identifier, dict):
         name = identifier.pop('name')
-        res = module_params.get(name)
+        res = None
+        if name in global_custom_objects:
+            res = global_custom_objects[name]
+        if not res:
+            res = module_params.get(name)
         if res:
             return res(**identifier)
         else:

--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -12,8 +12,33 @@ import types as python_types
 global_custom_objects = {}
 
 
+class CustomObjectScope(object):
+    def __init__(self, custom_objects=None):
+        self.custom_objects = custom_objects or {}
+        self.backup = None
+
+    def __enter__(self):
+        self.backup = global_custom_objects.copy()
+        global_custom_objects.update(self.custom_objects)
+        return self
+
+    def __exit__(self, type, value, traceback):
+        global_custom_objects.clear()
+        global_custom_objects.update(self.backup)
+
+
+def custom_object_scope(custom_objects=None):
+    """
+    Provides a scope that changes to global_custom_objects cannot escape.
+
+    # Returns
+        Object with __enter__ and __exit__ functions
+    """
+    return CustomObjectScope(custom_objects=custom_objects)
+
+
 def get_custom_objects():
-    """Retrieves a live reference to the global dictionary of custom objects
+    """Retrieves a live reference to the global dictionary of custom objects.
 
     # Returns
         dictionary of names to classes

--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -13,13 +13,14 @@ global_custom_objects = {}
 
 
 class CustomObjectScope(object):
-    def __init__(self, custom_objects=None):
-        self.custom_objects = custom_objects or {}
+    def __init__(self, *args):
+        self.custom_objects = args
         self.backup = None
 
     def __enter__(self):
         self.backup = global_custom_objects.copy()
-        global_custom_objects.update(self.custom_objects)
+        for objects in self.custom_objects:
+            global_custom_objects.update(objects)
         return self
 
     def __exit__(self, type, value, traceback):
@@ -27,14 +28,14 @@ class CustomObjectScope(object):
         global_custom_objects.update(self.backup)
 
 
-def custom_object_scope(custom_objects=None):
+def custom_object_scope(*args):
     """
     Provides a scope that changes to global_custom_objects cannot escape.
 
     # Returns
         Object with __enter__ and __exit__ functions
     """
-    return CustomObjectScope(custom_objects=custom_objects)
+    return CustomObjectScope(*args)
 
 
 def get_custom_objects():

--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -26,7 +26,7 @@ class CustomObjectScope(object):
     ```python
         with CustomObjectScope({"MyObject":MyObject}):
             layer = Dense(..., W_regularizer="MyObject")
-            # use save, load, etc.
+            # save, load, etc. will recognize custom object by name
     ```
     """
     def __init__(self, *args):
@@ -58,11 +58,11 @@ def custom_object_scope(*args):
     ```python
         with custom_object_scope({"MyObject":MyObject}):
             layer = Dense(..., W_regularizer="MyObject")
-            ...
-            # save, load, etc. will properly recognize object by name
+            # save, load, etc. will recognize custom object by name
     ```
+
     # Arguments
-        args: dictionaries of name, class pairs to add to custom objects.
+        *args: Variable length list of dictionaries of name, class pairs to add to custom objects.
 
     # Returns
         Object of type `CustomObjectScope`.

--- a/keras/utils/layer_utils.py
+++ b/keras/utils/layer_utils.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 import inspect
 
-from .generic_utils import get_from_module
+from .generic_utils import get_from_module, get_custom_objects
 from .np_utils import convert_kernel
 from ..layers import *
 from ..models import Model, Sequential
@@ -22,8 +22,7 @@ def layer_from_config(config, custom_objects=None):
     # Insert custom layers into globals so they can
     # be accessed by `get_from_module`.
     if custom_objects:
-        for cls_key in custom_objects:
-            globals()[cls_key] = custom_objects[cls_key]
+        get_custom_objects().update(custom_objects)
 
     class_name = config['class_name']
 

--- a/tests/keras/utils/test_generic_utils.py
+++ b/tests/keras/utils/test_generic_utils.py
@@ -1,0 +1,30 @@
+import pytest
+import keras
+from keras import backend as K
+from keras.utils.generic_utils import custom_object_scope, get_custom_objects, get_from_module
+
+
+def test_custom_object_scope_adds_objects():
+    get_custom_objects().clear()
+    assert (len(get_custom_objects()) == 0)
+    with custom_object_scope({"Test1": object, "Test2": object}, {"Test3": object}):
+        assert (len(get_custom_objects()) == 3)
+    assert (len(get_custom_objects()) == 0)
+
+
+class CustomObject(object):
+    def __init__(self):
+        pass
+
+
+def test_get_from_module_uses_custom_object():
+    get_custom_objects().clear()
+    assert (get_from_module("CustomObject", globals(), "test_generic_utils") == CustomObject)
+    with pytest.raises(ValueError):
+        get_from_module("TestObject", globals(), "test_generic_utils")
+    with custom_object_scope({"TestObject": CustomObject}):
+        assert (get_from_module("TestObject", globals(), "test_generic_utils") == CustomObject)
+
+
+if __name__ == '__main__':
+    pytest.main([__file__])


### PR DESCRIPTION
Hi everybody!

Please let me know your thoughts regarding this quick fix and slight quality-of-life for custom_objects.

* Instead of copying custom objects into globals(), they are copied into a separate dictionary.
* get_from_module checks that dictionary before checking the requested module.
* users can clear the custom objects or otherwise manipulate the dictionary if they want to

This also means that custom_objects work for custom regularizers. 

A side effect of the code is that you now can do something like:
```python
get_custom_objects()["CustomRegularizer"]=CustomRegularizer
d = Dense(dim, activity_regularizer='CustomRegularizer')
```

Below code is broken currently but works with this PR.

https://github.com/fchollet/keras/issues/4990

```python
level_1_dim = 256
level_2_dim = 64
encoding_dim = 16

from keras import regularizers
from keras.layers import Input, Dense
from keras.models import Model, model_from_json

class CustomRegularizer (regularizers.ActivityRegularizer):
  def __call__ (self, x):
    # this is just for purposes of demonstrating a bug
    return super(CustomRegularizer, self).__call__(x)

input_img = Input(shape=(784,))
encoded = Dense(level_1_dim, activation='relu')(input_img)
encoded = Dense(level_2_dim, activation='relu')(encoded)
encoded = Dense(encoding_dim, activation='relu', activity_regularizer=CustomRegularizer(1e-6))(encoded)
decoded = Dense(level_2_dim, activation='relu')(encoded)
decoded = Dense(level_1_dim, activation='relu')(decoded)
decoded = Dense(784, activation='sigmoid')(decoded)

autoencoder = Model(input=input_img, output=decoded)

encoder = Model(input=input_img, output=encoded)

with open('auto.encoder.model', 'w') as outfile:
  outfile.write(encoder.to_json())

"""
# This was the workaround, no longer required
import keras.regularizers
keras.regularizers.CustomRegularizer=CustomRegularizer
"""

with open('auto.encoder.model', 'r') as infile:
  encoder = model_from_json(infile.read(), custom_objects={"CustomRegularizer":CustomRegularizer})

```

As a side note, I think
```python
for cls_key in custom_objects:
            globals()[cls_key] = custom_objects[cls_key]
```
could be replaced by `globals().update(custom_objects)`

There are some places in the code that are accessing globals directly instead of through get_from_module. If we use get_from_module consistently then there is a consistent place we can deal with customizations. I didn't make those fixes yet but I could based on discussion.

Cheers,
Ben

