### PR TITLE
Fixed checking input masks in Layer.compute_mask

### DIFF
--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -662,7 +662,7 @@ class Layer(object):
         if not hasattr(self, 'supports_masking') or not self.supports_masking:
             if input_mask is not None:
                 if isinstance(input_mask, list):
-                    if any(input_mask):
+                    if any(mask is not None for mask in input_mask):
                         raise ValueError('Layer ' + self.name +
                                          ' does not support masking, '
                                          'but was passed an input_mask: ' +


### PR DESCRIPTION
`any(input_mask)` is not valid with TensorFlow because it checks if each element is "truthy" in turn, and using a TensorFlow tensor as a bool in Python is not allowed and raises an exception.