### PR TITLE
[Documentation] "random_uniform" initializer doesn't exists.

### DIFF
--- a/docs/templates/layers/writing-your-own-keras-layers.md
+++ b/docs/templates/layers/writing-your-own-keras-layers.md
@@ -23,7 +23,7 @@ class MyLayer(Layer):
         self.W = self.add_weight(shape=(input_shape[1], self.output_dim),
                                  initializer='uniform',
                                  trainable=True)
-        super(MyLayer, self).build()  # Be sure to call this somewhere!
+        super(MyLayer, self).build(input_shape)  # Be sure to call this somewhere!
 
     def call(self, x, mask=None):
         return K.dot(x, self.W)

--- a/docs/templates/layers/writing-your-own-keras-layers.md
+++ b/docs/templates/layers/writing-your-own-keras-layers.md
@@ -21,7 +21,7 @@ class MyLayer(Layer):
     def build(self, input_shape):
         # Create a trainable weight variable for this layer.
         self.W = self.add_weight(shape=(input_shape[1], self.output_dim),
-                                 initializer='random_uniform',
+                                 initializer='uniform',
                                  trainable=True)
         super(MyLayer, self).build()  # Be sure to call this somewhere!
 


### PR DESCRIPTION
Some things are missing in the custom layer skeleton:

The following lines raises :`ValueError: Invalid initialization: random`
because "random_uniform" is just "uniform"

and  `TypeError: build() missing 1 required positional argument: 'input_shape'` because input shape is missing

```
self.W = self.add_weight(shape=(input_shape[1], self.output_dim),
                                 initializer='random_uniform',
                                 trainable=True)

super(Embed_Attention, self).build()  # Be sure to call this somewhere!
```


