### PR TITLE
Add ability to redirect model summary

### DIFF
--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -2889,7 +2889,7 @@ class Container(Layer):
         import yaml
         return yaml.dump(self._updated_config(), **kwargs)
 
-    def summary(self, line_length=100, positions=[.33, .55, .67, 1.]):
+    def summary(self, line_length=100, positions=[.33, .55, .67, 1.], printf=print):
         from keras.utils.layer_utils import print_summary
 
         if hasattr(self, 'flattened_layers'):
@@ -2900,7 +2900,8 @@ class Container(Layer):
         print_summary(flattened_layers,
                       getattr(self, 'container_nodes', None),
                       line_length=line_length,
-                      positions=positions)
+                      positions=positions,
+                      printf=printf)
 
 
 def get_source_inputs(tensor, layer=None, node_index=None):

--- a/keras/utils/layer_utils.py
+++ b/keras/utils/layer_utils.py
@@ -44,7 +44,7 @@ def layer_from_config(config, custom_objects=None):
 
 
 def print_summary(layers, relevant_nodes=None,
-                  line_length=100, positions=None):
+                  line_length=100, positions=None, printf=print):
     """Prints a summary of a layer.
 
     # Arguments
@@ -53,6 +53,7 @@ def print_summary(layers, relevant_nodes=None,
         line_length: total length of printed lines
         positions: relative or absolute positions of log elements in each line.
             If not provided, defaults to `[.33, .55, .67, 1.]`.
+        printf: function to call with each output line. defaults is print. override to redirect or modify the output.
     """
     positions = positions or [.33, .55, .67, 1.]
     if positions[-1] <= 1:
@@ -68,11 +69,11 @@ def print_summary(layers, relevant_nodes=None,
             line += str(fields[i])
             line = line[:positions[i]]
             line += ' ' * (positions[i] - len(line))
-        print(line)
+        printf(line)
 
-    print('_' * line_length)
+    printf('_' * line_length)
     print_row(to_display, positions)
-    print('=' * line_length)
+    printf('=' * line_length)
 
     def print_layer_summary(layer):
         """Prints a summary for a single layer.
@@ -113,16 +114,16 @@ def print_summary(layers, relevant_nodes=None,
     for i in range(len(layers)):
         print_layer_summary(layers[i])
         if i == len(layers) - 1:
-            print('=' * line_length)
+            printf('=' * line_length)
         else:
-            print('_' * line_length)
+            printf('_' * line_length)
 
     trainable_count, non_trainable_count = count_total_params(layers, layer_set=None)
 
-    print('Total params: {:,}'.format(trainable_count + non_trainable_count))
-    print('Trainable params: {:,}'.format(trainable_count))
-    print('Non-trainable params: {:,}'.format(non_trainable_count))
-    print('_' * line_length)
+    printf('Total params: {:,}'.format(trainable_count + non_trainable_count))
+    printf('Trainable params: {:,}'.format(trainable_count))
+    printf('Non-trainable params: {:,}'.format(non_trainable_count))
+    printf('_' * line_length)
 
 
 def count_total_params(layers, layer_set=None):


### PR DESCRIPTION
Hi everybody,

This is just a small thing that I've been using and I thought others might find it helpful.

I like saving the summary of models when I run models. This PR allows you to send the summary to files, stderr or elsewhere.

You could send the summary directly to python logging, which is what I normally do:
```python
model.summary(printf=logging.info)
```

You could also send the summary to a file:
```python
with open("summary.txt","w") as f:
	def printf(s):
		f.write(s)
		f.write("\n")
	m.summary(printf=printf)
```

Cheers