### PR TITLE
Check for filter_dilation support in Theano conv2d

### DIFF
--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1507,6 +1507,11 @@ def conv2d(x, kernel, strides=(1, 1), border_mode='valid',
                                  input_shape=image_shape,
                                  filter_shape=filter_shape)
     else:
+        # T.nnet.conv2d uses **kwargs, so the filter_dilation parameter will be
+        # ignored by versions that do not support it
+        if 'filter_dilation' not in inspect.getargspec(T.nnet.conv2d).args:
+            raise ValueError('conv2d with filter dilation requires Theano '
+                             '0.9.0dev2 or newer.')
         conv_out = T.nnet.conv2d(x, kernel,
                                  border_mode=th_border_mode,
                                  subsample=strides,


### PR DESCRIPTION
This patch adds a better check for the `filter_dilation` parameter of `T.nnet.conv2d`. Earlier versions of Theano (such as 0.8.2) do not support filter dilation, but because `T.nnet.conv2d` accepts any `**kwargs` it also doesn't warn you if you specify this parameter. Instead, it just ignores it.

Theano 0.8.2 does show a warning that the `filter_dilation` parameter is "deprecated", but I think having a more explicit check would be helpful for cases such as #5024.