### PR TITLE
Fix a warning on Python3

### DIFF
--- a/examples/addition_rnn.py
+++ b/examples/addition_rnn.py
@@ -120,7 +120,7 @@ X = X[indices]
 y = y[indices]
 
 # Explicitly set apart 10% for validation data that we never train over
-split_at = len(X) - int(len(X) / 10)
+split_at = len(X) - len(X) // 10
 (X_train, X_val) = (slice_X(X, 0, split_at), slice_X(X, split_at))
 (y_train, y_val) = (y[:split_at], y[split_at:])
 

--- a/examples/addition_rnn.py
+++ b/examples/addition_rnn.py
@@ -120,7 +120,7 @@ X = X[indices]
 y = y[indices]
 
 # Explicitly set apart 10% for validation data that we never train over
-split_at = len(X) - len(X) / 10
+split_at = len(X) - int(len(X) / 10)
 (X_train, X_val) = (slice_X(X, 0, split_at), slice_X(X, split_at))
 (y_train, y_val) = (y[:split_at], y[split_at:])
 


### PR DESCRIPTION
In Python3, 50000 / 10 = 5000.0. This will result in a warning from numpy:
VisibleDeprecationWarning: using a non-integer number instead of an integer will result in an error in the future