### PR TITLE
New feature: LoggingCallback

### DIFF
--- a/tests/keras/test_callbacks.py
+++ b/tests/keras/test_callbacks.py
@@ -349,5 +349,26 @@ def test_TensorBoard_with_ReduceLROnPlateau():
     shutil.rmtree(filepath)
 
 
+def test_LoggingCallback():
+    logs = []
+    (X_train, y_train), (X_test, y_test) = get_test_data(nb_train=train_samples,
+                                                         nb_test=test_samples,
+                                                         input_shape=(input_dim,),
+                                                         classification=True,
+                                                         nb_class=nb_class)
+    y_test = np_utils.to_categorical(y_test)
+    y_train = np_utils.to_categorical(y_train)
+    model = Sequential()
+    model.add(Dense(nb_hidden, input_dim=input_dim, activation='relu'))
+    model.add(Dense(nb_class, activation='softmax'))
+    nb_epoch = 5
+    cbks = [callbacks.LoggingCallback(logs.append)]
+    model.compile(loss='categorical_crossentropy',
+                  optimizer='sgd',
+                  metrics=['accuracy'])
+    model.fit(X_train, y_train, batch_size=batch_size,
+              validation_data=(X_test, y_test), callbacks=cbks, nb_epoch=nb_epoch)
+    assert(len(logs) == nb_epoch)
+
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
Hi everybody!

This is a callback that I've been using and thought other people might find handy. This PR adds a LoggingCallback that prints an end-of-epoch summary. The print function is a parameter, so it can print the summary to Python logging or a file. Each epoch it calls the given print function with a formatted summary. The format of the summary is controlled by parameters to LoggingCallback.

 ```python
# Write to Python logging
import logging
model.fit(x, y, callbacks = [LoggingCallback(logging.info)]

# Write to a file
with open("log.txt", 'w') as f:
  def print_fcn(s):
    f.write(s)
    f.write("\n")
  model.fit(x, y, callbacks = [LoggingCallback(print_fcn)]
```

The summary itself looks like the below by default but the format strings are all configurable.

> Epoch: 3 - loss: 3.4123 - val_loss: 5.4321

Cheers,
Ben