### PR TITLE
change rounding mode in theano backend to match tensorflow backend

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1214,7 +1214,9 @@ def log(x):
 
 
 def round(x):
-    """Element-wise rounding to the closest integer. In case of tie, rounding mode is half to even.
+    """Element-wise rounding to the closest integer.
+    
+    In case of tie, the rounding mode used is "half to even".
 
     # Arguments
         x: input tensor.

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1214,7 +1214,7 @@ def log(x):
 
 
 def round(x):
-    """Element-wise rounding to the closest integer.
+    """Element-wise rounding to the closest integer. In case of tie, rounding mode is half to even.
 
     # Arguments
         x: input tensor.

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -389,7 +389,7 @@ def log(x):
 
 
 def round(x):
-    return T.round(x)
+    return T.round(x,mode='half_to_even')
 
 
 def sign(x):

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -389,7 +389,7 @@ def log(x):
 
 
 def round(x):
-    return T.round(x,mode='half_to_even')
+    return T.round(x, mode='half_to_even')
 
 
 def sign(x):


### PR DESCRIPTION
Theano uses round away from zero, while tensorflow uses round to nearest even number.
Example to demonstrate the issue:

	class Rounder(Layer):

		def __init__(self, **kwargs):
			super(Rounder, self).__init__(**kwargs)

		def get_output_shape_for(self, input_shape):
			return (input_shape[0], input_shape[1])

		def call(self, x, mask=None):
			x1 = K.round(x)
			return x1

	model = Sequential()
	model.add(Rounder(input_shape=(4,)))
	model.compile(loss='mse', optimizer='sgd')
	A = model.predict(np.array([-0.5,0.5,1.5,2.5]).reshape(1,-1))
	print(A)

Output with tensorflow:

     [[ 0.  0.  2.  2.]]

Output with theano:

    [[-1.  1.  2.  3.]]

Output with theano after fix:

    [[-0.  0.  2.  2.]]
This night seem minor, but it introduces issues when trying to match behaviour from botch backends when rounding numbers that end in .5 (note that even when working with 32bit floats, many numbers of this form can be represented with full precision).

This pull request changes the rounding mode in Theano to match the rounding mode in tensorflow, and updates the documentation to clarify the rounding mode used.

I previously created issue #5076 that this request fixes.