### PR TITLE
fix deconv2d None error

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -2494,6 +2494,7 @@ def _preprocess_deconv_output_shape(x, shape, dim_ordering):
 
     if shape[0] is None:
         shape = (tf.shape(x)[0], ) + tuple(shape[1:])
+        shape = tf.stack(list(shape))
     return shape
 
 


### PR DESCRIPTION
there is a common bug that occurs in the Deconvolution2D class when you use None for the batch size w/ the output_shape argument, which originates from tf.nn.deconv2d but can easily be alleviated in keras. It errors out saying: "TypeError: Expected binary or unicode string, got None"

The fix is to add the tf.stack() line in keras/backend/tensorflow_backend.py on line 2472:
```
def _preprocess_deconv_output_shape(x, shape, dim_ordering):
    if dim_ordering == 'th':
        shape = (shape[0], shape[2], shape[3], shape[1])

    if shape[0] is None:
        shape = (tf.shape(x)[0], ) + tuple(shape[1:])
        shape = tf.stack(list(shape))
    return shape
```
Example issue from TF that carries over to keras: https://groups.google.com/a/tensorflow.org/forum/#!topic/discuss/vf8eH9YMwVA