### PR TITLE
tensorflow_backend.py rnn does not work if the output.dtype is different from the input dtype (Embedding)

### DIFF
--- a/keras/layers/wrappers.py
+++ b/keras/layers/wrappers.py
@@ -105,7 +105,8 @@ class TimeDistributed(Wrapper):
 
     def call(self, inputs, mask=None):
         input_shape = K.int_shape(inputs)
-        if input_shape[0]:
+        output_shape = self.get_output_shape_for(input_shape)
+        if input_shape[0] and not (K.backend() == 'tensorflow' and len(output_shape) > 3):
             # batch size matters, use rnn-based implementation
             def step(x, _):
                 output = self.layer.call(x)
@@ -127,7 +128,6 @@ class TimeDistributed(Wrapper):
             inputs = K.reshape(inputs, (-1,) + input_shape[2:])
             y = self.layer.call(inputs)  # (nb_samples * timesteps, ...)
             # (nb_samples, timesteps, ...)
-            output_shape = self.get_output_shape_for(input_shape)
             y = K.reshape(y, (-1, input_length) + output_shape[2:])
 
         # Apply activity regularizer if any:

--- a/keras/layers/wrappers.py
+++ b/keras/layers/wrappers.py
@@ -105,8 +105,7 @@ class TimeDistributed(Wrapper):
 
     def call(self, inputs, mask=None):
         input_shape = K.int_shape(inputs)
-        output_shape = self.get_output_shape_for(input_shape)
-        if input_shape[0] and not (K.backend() == 'tensorflow' and len(output_shape) > 3):
+        if input_shape[0]:
             # batch size matters, use rnn-based implementation
             def step(x, _):
                 output = self.layer.call(x)
@@ -125,6 +124,7 @@ class TimeDistributed(Wrapper):
             if not input_length:
                 input_length = K.shape(inputs)[1]
             # (nb_samples * timesteps, ...)
+            output_shape = self.get_output_shape_for(input_shape)
             inputs = K.reshape(inputs, (-1,) + input_shape[2:])
             y = self.layer.call(inputs)  # (nb_samples * timesteps, ...)
             # (nb_samples, timesteps, ...)

--- a/tests/keras/layers/test_wrappers.py
+++ b/tests/keras/layers/test_wrappers.py
@@ -19,7 +19,7 @@ def test_TimeDistributed():
     # test config
     model.get_config()
 
-    # get test_output
+    # get test_output and weights
     test_input = np.random.random((1, 3, 4))
     test_output = model.predict(test_input)
     weights = model.layers[0].get_weights()

--- a/tests/keras/layers/test_wrappers.py
+++ b/tests/keras/layers/test_wrappers.py
@@ -3,7 +3,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 from keras.utils.test_utils import keras_test
 from keras.layers import wrappers, Input
-from keras.layers import core, convolutional, recurrent
+from keras.layers import core, convolutional, recurrent, embeddings
 from keras.models import Sequential, Model, model_from_json
 
 
@@ -74,6 +74,24 @@ def test_TimeDistributed():
     outer_model = Model(x, y)
     outer_model.compile(optimizer='rmsprop', loss='mse')
     outer_model.fit(np.random.random((10, 3, 2)), np.random.random((10, 3, 3)), nb_epoch=1, batch_size=10)
+
+    # test with Embedding
+    model = Sequential()
+    model.add(wrappers.TimeDistributed(embeddings.Embedding(5, 6), batch_input_shape=(10, 3, 4), input_dtype='int32'))
+    model.compile(optimizer='rmsprop', loss='mse')
+    model.fit(np.random.randint(5, size=(10, 3, 4), dtype='int32'), np.random.random((10, 3, 4, 6)), nb_epoch=1, batch_size=10)
+
+    # compare to not using batch_input_shape
+    test_input = np.random.randint(5, size=(10, 3, 4), dtype='int32')
+    test_output = model.predict(test_input)
+    weights = model.layers[0].get_weights()
+
+    reference = Sequential()
+    reference.add(wrappers.TimeDistributed(embeddings.Embedding(5, 6), input_shape=(3, 4), input_dtype='int32', weights=weights))
+    reference.compile(optimizer='rmsprop', loss='mse')
+
+    reference_output = reference.predict(test_input)
+    assert_allclose(test_output, reference_output, atol=1e-05)
 
 
 @keras_test

--- a/tests/keras/layers/test_wrappers.py
+++ b/tests/keras/layers/test_wrappers.py
@@ -19,22 +19,14 @@ def test_TimeDistributed():
     # test config
     model.get_config()
 
-    # compare to TimeDistributedDense
+    # get test_output
     test_input = np.random.random((1, 3, 4))
     test_output = model.predict(test_input)
     weights = model.layers[0].get_weights()
 
-    reference = Sequential()
-    reference.add(core.TimeDistributedDense(2, input_shape=(3, 4), weights=weights))
-    reference.add(core.Activation('relu'))
-    reference.compile(optimizer='rmsprop', loss='mse')
-
-    reference_output = reference.predict(test_input)
-    assert_allclose(test_output, reference_output, atol=1e-05)
-
     # test when specifying a batch_input_shape
     reference = Sequential()
-    reference.add(core.TimeDistributedDense(2, batch_input_shape=(1, 3, 4), weights=weights))
+    reference.add(wrappers.TimeDistributed(core.Dense(2, weights=weights), batch_input_shape=(1, 3, 4)))
     reference.add(core.Activation('relu'))
     reference.compile(optimizer='rmsprop', loss='mse')
 
@@ -87,7 +79,7 @@ def test_TimeDistributed():
     weights = model.layers[0].get_weights()
 
     reference = Sequential()
-    reference.add(wrappers.TimeDistributed(embeddings.Embedding(5, 6), input_shape=(3, 4), input_dtype='int32', weights=weights))
+    reference.add(wrappers.TimeDistributed(embeddings.Embedding(5, 6, weights=weights), input_shape=(3, 4), input_dtype='int32'))
     reference.compile(optimizer='rmsprop', loss='mse')
 
     reference_output = reference.predict(test_input)


### PR DESCRIPTION
tensorflow_backend.py rnn does not work if the output.dtype is different from the input.dtype.
For example TimeDistributed(Embeddings) (with fixed batch size)

Example that was not working with the tensorflow backend:
        chars = Input(batch_shape=(opt.batch_size, opt.seq_length, opt.max_word_l), dtype='int32', name='chars')
        chars_embedding = TimeDistributed(Embedding(opt.char_vocab_size, opt.char_vec_size, name='chars_embedding'))(chars)