### PR TITLE
Add reference to slides for RMSprop

### DIFF
--- a/keras/optimizers.py
+++ b/keras/optimizers.py
@@ -211,7 +211,7 @@ class RMSprop(Optimizer):
         rho: float >= 0.
         epsilon: float >= 0. Fuzz factor.
         decay: float >= 0. Learning rate decay over each update.
-        
+
     # References
         - [rmsprop: Divide the gradient by a running average of its recent magnitude](http://www.cs.toronto.edu/~tijmen/csc321/slides/lecture_slides_lec6.pdf)
     """

--- a/keras/optimizers.py
+++ b/keras/optimizers.py
@@ -211,6 +211,9 @@ class RMSprop(Optimizer):
         rho: float >= 0.
         epsilon: float >= 0. Fuzz factor.
         decay: float >= 0. Learning rate decay over each update.
+        
+    # References
+        - [rmsprop: Divide the gradient by a running average of its recent magnitude](http://www.cs.toronto.edu/~tijmen/csc321/slides/lecture_slides_lec6.pdf)
     """
 
     def __init__(self, lr=0.001, rho=0.9, epsilon=1e-8, decay=0.,


### PR DESCRIPTION
I thought as the docs cite other methods, it would be good to provide a citation for this optimiser. Hinton mentions to 'keep citing the slides' for this method. 

I chose the title of the lecture in question, if there's a better title I'm sure that can be used instead, but I think the citation should be there.