### PR TITLE
Fix Sckit-learn API get_parameters bug

### DIFF
--- a/keras/wrappers/scikit_learn.py
+++ b/keras/wrappers/scikit_learn.py
@@ -84,7 +84,7 @@ class BaseWrapper(object):
             if params_name not in legal_params:
                 raise ValueError('{} is not a legal parameter'.format(params_name))
 
-    def get_params(self, _):
+    def get_params(self, **params):
         """Gets parameters for this estimator.
 
         # Returns


### PR DESCRIPTION
Add **params to BaseWrapper.get_params(self,_) to fix TypeError to fix issues #5103 