### PR TITLE
Use TF backend docstrings for theano docstrings if theano undocumented

### DIFF
--- a/keras/backend/__init__.py
+++ b/keras/backend/__init__.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import os
 import json
 import sys
+import six
 from .common import epsilon
 from .common import floatx
 from .common import set_epsilon
@@ -58,19 +59,26 @@ if 'KERAS_BACKEND' in os.environ:
     assert _backend in {'theano', 'tensorflow'}
     _BACKEND = _backend
 
-# import backend
-if _BACKEND == 'theano':
-    sys.stderr.write('Using Theano backend.\n')
-    from .theano_backend import *
-elif _BACKEND == 'tensorflow':
-    sys.stderr.write('Using TensorFlow backend.\n')
-    from .tensorflow_backend import *
-else:
-    raise ValueError('Unknown backend: ' + str(_BACKEND))
-
 
 def backend():
     """Publicly accessible method
     for determining the current backend.
     """
     return _BACKEND
+
+
+# import backend
+if _BACKEND == 'theano':
+    sys.stderr.write('Using Theano backend.\n')
+    from .theano_backend import *
+    from . import tensorflow_backend
+    for k, v in six.iteritems(tensorflow_backend.__dict__):
+        if v.__doc__ and callable(v) and k in globals():
+                f = globals()[k]
+                if not f.__doc__:
+                    f.__doc__ = v.__doc__
+elif _BACKEND == 'tensorflow':
+    sys.stderr.write('Using TensorFlow backend.\n')
+    from .tensorflow_backend import *
+else:
+    raise ValueError('Unknown backend: ' + str(_BACKEND))

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1,17 +1,21 @@
-import tensorflow as tf
-
-from tensorflow.python.training import moving_averages
-from tensorflow.python.ops import tensor_array_ops
-from tensorflow.python.ops import control_flow_ops
-try:
-    from tensorflow.python.ops import ctc_ops as ctc
-except ImportError:
-    import tensorflow.contrib.ctc as ctc
-
+from . import backend
 import numpy as np
 import os
 import warnings
 from .common import floatx, _EPSILON, image_dim_ordering, reset_uids
+try:
+    import tensorflow as tf
+    from tensorflow.python.training import moving_averages
+    from tensorflow.python.ops import tensor_array_ops
+    from tensorflow.python.ops import control_flow_ops
+    try:
+        from tensorflow.python.ops import ctc_ops as ctc
+    except ImportError:
+        import tensorflow.contrib.ctc as ctc
+except ImportError:
+    if backend() == 'tensorflow':
+        raise
+
 py_all = all
 
 # INTERNAL UTILS


### PR DESCRIPTION
The theano backend currently has 69 functions that are undocumented but documented in the TF backend. However, we don't want to replicate a lot of documentation. This PR doesn't affect Keras on TF. However, on Theano backend, this PR fills in missing docstrings from TF. If the function is documented in theano_backend, it is not affected, but if it is undocumented in theano_backend and documented in tensorflow_backend, the documentation is copied over.

I changed `tensorflow_backend.py` to conditionally import tensorflow.
* If you set keras to tensorflow and do not have tensorflow installed, importing tensorflow_backend will fail with an import error as expected.
* If you set keras to theano and do not have tensorflow installed, you can still import tensorflow_backend. You can't run any of the functions but can still access dostrings.

I updated backend `__init__.py` to have a for loop that temporarily imports tensorflow_backend, and for any function documented there but not in theano_backend, copies the docstring, then deletes the reference to the tensorflow backend. 

The end result is that something like `help(K.binary_crossentropy)` will show documentation in both theano and tensorflow. Additionally, running autogen and mkdocs will show meaningful documentation with both backends.

As a result of this PR, you could delete any docstrings in theano_backend that are not intentionally meant to indicate a difference. The only docstrings in theano_backend should be those where someone wants to specifically describe a difference between the backends.

Cheers!