### PR TITLE
Unbroadcast initial states in Theano backend (RNNs)

### DIFF
--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1075,6 +1075,7 @@ def rnn(step_function, inputs, initial_states,
             initial_output = step_function(inputs[0], initial_states + constants)[0] * 0
             # Theano gets confused by broadcasting patterns in the scan op
             initial_output = T.unbroadcast(initial_output, 0, 1)
+            initial_states[0] = T.unbroadcast(initial_states[0], 0, 1)
 
             def _step(input, mask, output_tm1, *states):
                 output, new_states = step_function(input, states)

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1122,6 +1122,9 @@ def rnn(step_function, inputs, initial_states,
                 output, new_states = step_function(input, states)
                 return [output] + new_states
 
+            # Theano likes to make shape==1 dimensions in the initial states (outputs_info) broadcastable
+            initial_states[0] = T.unbroadcast(initial_states[0], 1)
+
             results, _ = theano.scan(
                 _step,
                 sequences=inputs,

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1075,7 +1075,8 @@ def rnn(step_function, inputs, initial_states,
             initial_output = step_function(inputs[0], initial_states + constants)[0] * 0
             # Theano gets confused by broadcasting patterns in the scan op
             initial_output = T.unbroadcast(initial_output, 0, 1)
-            initial_states[0] = T.unbroadcast(initial_states[0], 0, 1)
+            if len(initial_states) > 0:
+                initial_states[0] = T.unbroadcast(initial_states[0], 0, 1)
 
             def _step(input, mask, output_tm1, *states):
                 output, new_states = step_function(input, states)
@@ -1124,7 +1125,8 @@ def rnn(step_function, inputs, initial_states,
                 return [output] + new_states
 
             # Theano likes to make shape==1 dimensions in the initial states (outputs_info) broadcastable
-            initial_states[0] = T.unbroadcast(initial_states[0], 1)
+            if len(initial_states) > 0:
+                initial_states[0] = T.unbroadcast(initial_states[0], 1)
 
             results, _ = theano.scan(
                 _step,


### PR DESCRIPTION
Refs #5124 and #3641.

Theano sets dimensions of shape 1 to be broadcastable for tensors in the `outputs_info` of scan. This leads to issues with Recurrent layers with 1 node/output.

```python
from keras.layers import *
from keras.models import *
import numpy as np

input = np.array([[[1]]], dtype = 'float32')
    # A dummy input: batch size is 1, only 1 time step, and 1 dimension


# Two outputs, works fine
model = Sequential([LSTM(2, input_dim = 1, )])
    # Define a model with a single LSTM layer with output_dim = 2
model.predict(input).shape
#>> (1, 2)

# breaks currently
# This PR should fix
model = Sequential([LSTM(1, input_dim = 1)])
model.predict(input).shape
```
```
>> Inconsistency in the inner graph of scan 'scan_fn' : an input and an output are associated with the same recurrent state and should have the same type but have type 'CudaNdarrayType(float32, col)' and 'CudaNdarrayType(float32, matrix)' respectively.
```

Affects all recurrent layers; ~~this may not fix the issue when Masking is involved (yet to be tested).~~

Updated to also fix this issue when masking is applied.