### PR TITLE
on_evaluation_end for callback

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -75,6 +75,17 @@ class CallbackList(object):
         for callback in self.callbacks:
             callback.on_epoch_end(epoch, logs)
 
+    def on_evaluate_end(self, epoch, logs=None):
+        """Called at the end of evaluation of an epoch.
+
+        # Arguments
+            epoch: integer, index of epoch.
+            logs: dictionary of logs.
+        """
+        logs = logs or {}
+        for callback in self.callbacks:
+            callback.on_evaluate_end(epoch, logs)
+
     def on_batch_begin(self, batch, logs=None):
         """Called right before processing a batch.
 
@@ -179,6 +190,9 @@ class Callback(object):
         pass
 
     def on_epoch_end(self, epoch, logs=None):
+        pass
+
+    def on_evaluate_end(self, epoch, logs=None):
         pass
 
     def on_batch_begin(self, batch, logs=None):

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -864,6 +864,8 @@ class LambdaCallback(Callback):
     arguments, as:
      - `on_epoch_begin` and `on_epoch_end` expect two positional arguments:
         `epoch`, `logs`
+     - `on_evaluate_end` expect two positional arguments:
+        `epoch`, `logs`
      - `on_batch_begin` and `on_batch_end` expect two positional arguments:
         `batch`, `logs`
      - `on_train_begin` and `on_train_end` expect one positional argument:
@@ -872,6 +874,7 @@ class LambdaCallback(Callback):
     # Arguments
         on_epoch_begin: called at the beginning of every epoch.
         on_epoch_end: called at the end of every epoch.
+        on_evaluate_end: called at the end of every evaluation.
         on_batch_begin: called at the beginning of every batch.
         on_batch_end: called at the end of every batch.
         on_train_begin: called at the beginning of model training.
@@ -906,6 +909,7 @@ class LambdaCallback(Callback):
     def __init__(self,
                  on_epoch_begin=None,
                  on_epoch_end=None,
+                 on_evaluate_end=None,
                  on_batch_begin=None,
                  on_batch_end=None,
                  on_train_begin=None,
@@ -921,6 +925,10 @@ class LambdaCallback(Callback):
             self.on_epoch_end = on_epoch_end
         else:
             self.on_epoch_end = lambda epoch, logs: None
+        if on_evaluate_end is not None:
+            self.on_evaluate_end = on_evaluate_end
+        else:
+            self.on_evaluate_end = lambda epoch, logs: None
         if on_batch_begin is not None:
             self.on_batch_begin = on_batch_begin
         else:

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -910,6 +910,8 @@ class Model(Container):
                         for l, o in zip(out_labels, val_outs):
                             epoch_logs['val_' + l] = o
             callbacks.on_epoch_end(epoch, epoch_logs)
+            if do_validation:
+                callbacks.on_evaluate_end(epoch, epoch_logs)
             if callback_model.stop_training:
                 break
         callbacks.on_train_end()
@@ -1594,6 +1596,8 @@ class Model(Container):
                             epoch_logs['val_' + l] = o
 
                 callbacks.on_epoch_end(epoch, epoch_logs)
+                if do_validation:
+                    callbacks.on_evaluate_end(epoch, epoch_logs)
                 epoch += 1
                 if callback_model.stop_training:
                     break


### PR DESCRIPTION
PR for #2555, #2548 and #2521.
Add `on_evaluate_end` to `Callback` to fill the missing step and improve customized callback flexibility.

`on_train_begin`
----`on_epoch_begin`
---------`on_batch_begin`
---------`on_batch_end`
----`on_epoch_begin`
---- (evaluation)
----`on_evaluate_end` (this PR)
`on_train_end`

Here is an example:
```python
x_train, y_train = np.random.rand(1024, 10), np.random.rand(1024, 1)
x_val, y_val = np.random.rand(512, 10), np.random.rand(512, 1)

net_input = Input(shape=(10,))
net = Dense(1)(net_input)

model = Model(net_input, net)

class EvaluateEndCallback(Callback):
    def on_evaluate_end(self, epoch, logs=None):
        print('epoch: {}, logs: {}'.format(epoch, logs))

model.compile(optimizer='sgd', loss='mse')
model.fit(x_train, y_train, validation_data=(x_val, y_val), callbacks=[EvaluateEndCallback()])
```
Using `on_epoch_end` (progress bar boken):
```
Epoch 1/10
 928/1024 [==========================>...] - ETA: 0s - loss: 0.2469epoch: 0, logs: {'val_loss': 0.20372078195214272, 'loss': 0.24096788465976715}

1024/1024 [==============================] - 0s - loss: 0.2410 - val_loss: 0.2037
```
Using `on_evaluate_end`:
```
Epoch 1/10
1024/1024 [==============================] - 0s - loss: 0.3038 - val_loss: 0.2313
epoch: 0, logs: {'val_loss': 0.23126391600817442, 'loss': 0.30380106996744871}
```