### PR TITLE
fix mnist_sklearn_wrapper.py error when default image_dim_ordering=tf

### DIFF
--- a/examples/mnist_sklearn_wrapper.py
+++ b/examples/mnist_sklearn_wrapper.py
@@ -13,6 +13,7 @@ from keras.layers import Dense, Dropout, Activation, Flatten
 from keras.layers import Convolution2D, MaxPooling2D
 from keras.utils import np_utils
 from keras.wrappers.scikit_learn import KerasClassifier
+from keras import backend as K
 from sklearn.grid_search import GridSearchCV
 
 
@@ -23,8 +24,16 @@ img_rows, img_cols = 28, 28
 
 # load training data and do basic data normalization
 (X_train, y_train), (X_test, y_test) = mnist.load_data()
-X_train = X_train.reshape(X_train.shape[0], 1, img_rows, img_cols)
-X_test = X_test.reshape(X_test.shape[0], 1, img_rows, img_cols)
+
+if K.image_dim_ordering() == 'th':
+    X_train = X_train.reshape(X_train.shape[0], 1, img_rows, img_cols)
+    X_test = X_test.reshape(X_test.shape[0], 1, img_rows, img_cols)
+    input_shape = (1, img_rows, img_cols)
+else:
+    X_train = X_train.reshape(X_train.shape[0], img_rows, img_cols, 1)
+    X_test = X_test.reshape(X_test.shape[0], img_rows, img_cols, 1)
+    input_shape = (img_rows, img_cols, 1)
+
 X_train = X_train.astype('float32')
 X_test = X_test.astype('float32')
 X_train /= 255
@@ -48,12 +57,11 @@ def make_model(dense_layer_sizes, nb_filters, nb_conv, nb_pool):
 
     model.add(Convolution2D(nb_filters, nb_conv, nb_conv,
                             border_mode='valid',
-                            input_shape=(1, img_rows, img_cols),
-                            dim_ordering='th'))
+                            input_shape=input_shape))
     model.add(Activation('relu'))
-    model.add(Convolution2D(nb_filters, nb_conv, nb_conv, dim_ordering='th'))
+    model.add(Convolution2D(nb_filters, nb_conv, nb_conv))
     model.add(Activation('relu'))
-    model.add(MaxPooling2D(pool_size=(nb_pool, nb_pool), dim_ordering='th'))
+    model.add(MaxPooling2D(pool_size=(nb_pool, nb_pool)))
     model.add(Dropout(0.25))
 
     model.add(Flatten())

--- a/examples/mnist_sklearn_wrapper.py
+++ b/examples/mnist_sklearn_wrapper.py
@@ -48,11 +48,12 @@ def make_model(dense_layer_sizes, nb_filters, nb_conv, nb_pool):
 
     model.add(Convolution2D(nb_filters, nb_conv, nb_conv,
                             border_mode='valid',
-                            input_shape=(1, img_rows, img_cols)))
+                            input_shape=(1, img_rows, img_cols),
+                            dim_ordering='th'))
     model.add(Activation('relu'))
-    model.add(Convolution2D(nb_filters, nb_conv, nb_conv))
+    model.add(Convolution2D(nb_filters, nb_conv, nb_conv, dim_ordering='th'))
     model.add(Activation('relu'))
-    model.add(MaxPooling2D(pool_size=(nb_pool, nb_pool)))
+    model.add(MaxPooling2D(pool_size=(nb_pool, nb_pool), dim_ordering='th'))
     model.add(Dropout(0.25))
 
     model.add(Flatten())


### PR DESCRIPTION
as title, mnist_sklearn_wrapper.py assumes image_dim_ordering to be "th"
                                                                                                                                                                                                                      Test Plan:                                                                                                                                                                                                        KERAS_BACKEND=theano condapython examples/mnist_sklearn_wrapper.py                                                                                                                                                KERAS_BACKEND=tensorflow condapython examples/mnist_sklearn_wrapper.py