### PR TITLE
Checking that ndim is >= 3 for batch_dot in TensorFlow backend

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -866,6 +866,8 @@ def batch_dot(x, y, axes=None):
         (32, 1, 30)
     ```
     """
+    if ndim(x) < 3 or ndim(y) < 3:
+        raise ValueError("Invalid dimensions for batch_dot: ", ndim(x), ndim(y))
     if isinstance(axes, int):
         axes = (axes, axes)
     if axes is not None:

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -867,7 +867,7 @@ def batch_dot(x, y, axes=None):
     ```
     """
     if ndim(x) < 3 or ndim(y) < 3:
-        raise ValueError("Invalid dimensions for batch_dot: ", ndim(x), ndim(y))
+        raise ValueError('Invalid dimensions for batch_dot: ', ndim(x), ndim(y))
     if isinstance(axes, int):
         axes = (axes, axes)
     if axes is not None:

--- a/tests/keras/backend/test_backends.py
+++ b/tests/keras/backend/test_backends.py
@@ -81,6 +81,12 @@ class TestBackend(object):
         check_single_tensor_operation('reverse', (4, 3, 2), axes=1)
         check_single_tensor_operation('reverse', (4, 3, 2), axes=(1, 2))
 
+    def test_batch_dot_shape(self):
+        with pytest.raises(ValueError):
+            x_batch = K.ones(shape=(32, 20))
+            y_batch = K.ones(shape=(32, 20))
+            xy_batch_dot = KTF.batch_dot(x_batch, y_batch, axes=1)
+
     def test_shape_operations(self):
         # concatenate
         xval = np.random.random((4, 3))

--- a/tests/keras/backend/test_backends.py
+++ b/tests/keras/backend/test_backends.py
@@ -83,8 +83,8 @@ class TestBackend(object):
 
     def test_batch_dot_shape(self):
         with pytest.raises(ValueError):
-            x_batch = K.ones(shape=(32, 20))
-            y_batch = K.ones(shape=(32, 20))
+            x_batch = KTF.ones(shape=(32, 20))
+            y_batch = KTF.ones(shape=(32, 20))
             xy_batch_dot = KTF.batch_dot(x_batch, y_batch, axes=1)
 
     def test_shape_operations(self):

--- a/tests/keras/test_sequential_model.py
+++ b/tests/keras/test_sequential_model.py
@@ -7,7 +7,7 @@ np.random.seed(1337)
 
 from keras import backend as K
 from keras.models import Sequential
-from keras.layers.core import Dense, Activation, Merge, Lambda
+from keras.layers.core import Dense, Activation, Merge, Lambda, Reshape
 from keras.utils import np_utils
 from keras.utils.test_utils import get_test_data, keras_test
 from keras.models import model_from_json, model_from_yaml
@@ -287,14 +287,17 @@ def test_merge_dot():
 
     left = Sequential()
     left.add(Dense(input_dim=input_dim, output_dim=nb_hidden))
+    left.add(Reshape((nb_hidden, 1)))
     left.add(Activation('relu'))
 
     right = Sequential()
     right.add(Dense(input_dim=input_dim, output_dim=nb_hidden))
+    right.add(Reshape((nb_hidden, 1)))
     right.add(Activation('relu'))
 
     model = Sequential()
     model.add(Merge([left, right], mode='dot', dot_axes=1))
+    model.add(Reshape((1,)))
     model.add(Dense(nb_class))
     model.add(Activation('softmax'))
 
@@ -302,14 +305,17 @@ def test_merge_dot():
 
     left = Sequential()
     left.add(Dense(input_dim=input_dim, output_dim=nb_hidden))
+    left.add(Reshape((nb_hidden, 1)))
     left.add(Activation('relu'))
 
     right = Sequential()
     right.add(Dense(input_dim=input_dim, output_dim=nb_hidden))
+    right.add(Reshape((nb_hidden, 1)))
     right.add(Activation('relu'))
 
     model = Sequential()
     model.add(Merge([left, right], mode='dot', dot_axes=[1, 1]))
+    model.add(Reshape((1,)))
     model.add(Dense(nb_class))
     model.add(Activation('softmax'))
 


### PR DESCRIPTION
This PR raises an exception if ndim is < 3 in batch_dot, to avoid unexpected outputs, as described in #5131.