### PR TITLE
Decrease default progress interval to 5/second

### DIFF
--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -197,7 +197,7 @@ class Progbar(object):
         interval: Minimum visual progress update interval (in seconds).
     """
 
-    def __init__(self, target, width=30, verbose=1, interval=0.01):
+    def __init__(self, target, width=30, verbose=1, interval=0.2):
         self.width = width
         self.target = target
         self.sum_values = {}

--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -197,7 +197,7 @@ class Progbar(object):
         interval: Minimum visual progress update interval (in seconds).
     """
 
-    def __init__(self, target, width=30, verbose=1, interval=0.2):
+    def __init__(self, target, width=30, verbose=1, interval=0.5):
         self.width = width
         self.target = target
         self.sum_values = {}


### PR DESCRIPTION
Running this in Jupyter tends to lock the browser and/or make the kernel unresponsive for the duration of training. Updating 100 times per second by default is crazy anyway, considering most monitors can't refresh that quickly.

I would consider once per second a reasonable threshold, but for short-duration calls it's probably nice to see sub-second progress updates. `interval=0.2` gives 5 updates per second, that should be sufficient and reasonable for both real-time local execution and web-based IPython notebooks.