### PR TITLE
Add custom output function and file filter to DirectoryIterator

### DIFF
--- a/docs/templates/preprocessing/image.md
+++ b/docs/templates/preprocessing/image.md
@@ -78,12 +78,12 @@ Generate batches of tensor image data with real-time data augmentation. The data
     - __flow_from_directory(directory)__: Takes the path to a directory, and generates batches of augmented/normalized data. Yields batches indefinitely, in an infinite loop.
         - __Arguments__:
             - __directory__: path to the target directory. It should contain one subdirectory per class.
-                Any PNG, JPG or BNP images inside each of the subdirectories directory tree will be included in the generator.
+                Any PNG, JPG or BMP images inside each of the subdirectories directory tree will be included in the generator.
                 See [this script](https://gist.github.com/fchollet/0830affa1f7f19fd47b06d4cf89ed44d) for more details.
             - __target_size__: tuple of integers, default: `(256, 256)`. The dimensions to which all images found will be resized.
             - __color_mode__: one of "grayscale", "rbg". Default: "rgb". Whether the images will be converted to have 1 or 3 color channels.
             - __classes__: optional list of class subdirectories (e.g. `['dogs', 'cats']`). Default: None. If not provided, the list of classes will be automatically inferred (and the order of the classes, which will map to the label indices, will be alphanumeric).
-            - __class_mode__: one of "categorical", "binary", "sparse" or None. Default: "categorical". Determines the type of label arrays that are returned: "categorical" will be 2D one-hot encoded labels, "binary" will be 1D binary labels, "sparse" will be 1D integer labels. If None, no labels are returned (the generator will only yield batches of image data, which is useful to use `model.predict_generator()`, `model.evaluate_generator()`, etc.).
+            - __class_mode__: one of "categorical", "binary", "sparse", "custom", or None. Default: "categorical". Determines the type of label arrays that are returned: "categorical" will be 2D one-hot encoded labels, "binary" will be 1D binary labels, "sparse" will be 1D integer labels. If "custom" is specified, a function `custom_output_fn` will be called for each sample. If None, no labels are returned (the generator will only yield batches of image data, which is useful to use `model.predict_generator()`, `model.evaluate_generator()`, etc.).
             - __batch_size__: size of the batches of data (default: 32).
             - __shuffle__: whether to shuffle the data (default: True)
             - __seed__: optional random seed for shuffling and transformations.
@@ -91,6 +91,8 @@ Generate batches of tensor image data with real-time data augmentation. The data
             - __save_prefix__: str. Prefix to use for filenames of saved pictures (only relevant if `save_to_dir` is set).
             - __save_format__: one of "png", "jpeg" (only relevant if `save_to_dir` is set). Default: "jpeg".
             - __follow_links__: whether to follow symlinks inside class subdirectories (default: False).
+            - __custom_output_fn__: A callback function called for each sample when the `custom` class mode is specified. This function is provided the arguments `class_name`, `filename`, and `sample_idx` which indexes into all loaded files (default: None)
+            - __included_file_filter__: When provided, this callback is executed for each sample to determine whether the sample should be included by the iterator. This function is provided the arguments `class_name`, `filename`, and `sample_idx` which indexes into all valid files in the specified directories. (default: None)
 
 
 - __Examples__:

--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -880,8 +880,8 @@ class DirectoryIterator(Iterator):
             batch_y = np.fromiter(map(lambda idx: self.custom_output_fn(self.class_index_to_name[self.classes[idx]],
                                                                         self.filenames[idx],
                                                                         idx),
-                                    index_array),
-                                'float32')
+                                      index_array),
+                                  'float32')
         else:
             return batch_x
         return batch_x, batch_y

--- a/tests/keras/preprocessing/test_image.py
+++ b/tests/keras/preprocessing/test_image.py
@@ -167,9 +167,9 @@ class TestImage:
             return idx
 
         dir_iterator_custom = generator.flow_from_directory(tmp_folder,
-            class_mode='custom',
-            shuffle=False,
-            custom_output_fn=custom_output_fn)
+                                                            class_mode='custom',
+                                                            shuffle=False,
+                                                            custom_output_fn=custom_output_fn)
 
         batch_x, batch_y = dir_iterator_custom.next()
         assert(np.array_equal(list(range(len(batch_y))), batch_y))

--- a/tests/keras/preprocessing/test_image.py
+++ b/tests/keras/preprocessing/test_image.py
@@ -5,6 +5,7 @@ import numpy as np
 import os
 import shutil
 import tempfile
+import re
 
 
 class TestImage:
@@ -158,6 +159,30 @@ class TestImage:
         assert(len(dir_iterator.class_indices) == num_classes)
         assert(len(dir_iterator.classes) == count)
         assert(sorted(dir_iterator.filenames) == sorted(filenames))
+
+        # test custom_output_fn
+        def custom_output_fn(class_name, filename, idx):
+            assert(re.match('class-\d', class_name))
+            assert(re.match('.*/image-\d+\.jpg', filename))
+            return idx
+
+        dir_iterator_custom = generator.flow_from_directory(tmp_folder,
+            class_mode='custom',
+            shuffle=False,
+            custom_output_fn=custom_output_fn)
+
+        batch_x, batch_y = dir_iterator_custom.next()
+        assert(np.array_equal(list(range(len(batch_y))), batch_y))
+
+        # test file filter
+        def included_file_filter(class_name, filename, idx):
+            assert(re.match('class-\d', class_name))
+            assert(re.match('.*/image-\d+\.jpg', filename))
+            return (idx % 2 == 0)
+
+        dir_iterator_filtered = generator.flow_from_directory(tmp_folder, included_file_filter=included_file_filter)
+        assert(len(dir_iterator_filtered.classes) == int(count / 2))
+
         shutil.rmtree(tmp_folder)
 
     def test_img_utils(self):


### PR DESCRIPTION
This PR adds a new class mode, `custom` which may be used with `flow_from_directory`. When specified, a callback function is invoked for each sample image. The PR also adds a mechanism by which files can be excluded from the dataset via a predicate similarly invoked for each sample image.

This is a follow-up to #5152.