### PR TITLE
Convolution3D: do not fix input_shape. (Fixes #5108.)

### DIFF
--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -1169,7 +1169,6 @@ class Convolution3D(Layer):
 
     def build(self, input_shape):
         assert len(input_shape) == 5
-        self.input_spec = [InputSpec(shape=input_shape)]
 
         if self.dim_ordering == 'th':
             stack_size = input_shape[1]
@@ -1229,11 +1228,9 @@ class Convolution3D(Layer):
             raise ValueError('Invalid dim_ordering:', self.dim_ordering)
 
     def call(self, x, mask=None):
-        input_shape = self.input_spec[0].shape
         output = K.conv3d(x, self.W, strides=self.subsample,
                           border_mode=self.border_mode,
                           dim_ordering=self.dim_ordering,
-                          volume_shape=input_shape,
                           filter_shape=self.W_shape)
         if self.bias:
             if self.dim_ordering == 'th':


### PR DESCRIPTION
This makes it possible to use a single `Convolution3D` layer with different input sizes (see #5108). The behaviour is then similar to that of `Convolution2D`, which also doesn't fix the input shape.

Potential downside: not providing the input shape makes it slightly harder for Theano to optimise the convolution. If the input shape is known, Theano will sometimes choose to use `GpuCorrMM_gradWeights` instead of the `GpuCorrMM` if this is faster, for example. In practice, however, Theano will mostly use the cuDNN version anyway and this should cause problems.