### PR TITLE
[Documentation] problem in dot documentation

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -714,7 +714,8 @@ def cast(x, dtype):
         # you need to assign it.
         >>> input = K.cast(input, dtype='float16')
         >>> input
-        <tf.Tensor 'Cast_2:0' shape=(2, 3) dtype=float16>    ```
+        <tf.Tensor 'Cast_2:0' shape=(2, 3) dtype=float16>    
+    ```
     """
     return tf.cast(x, dtype)
 


### PR DESCRIPTION
Corrected cast function spec formatting which is causing (i believe) the misformatting in backend documentation: Dot hasn't got a title and is embedded in previous cast exemple, see "cast" definition here:  https://keras.io/backend


![image](https://cloud.githubusercontent.com/assets/1705336/22339653/0c20b3d6-e3eb-11e6-8013-5d12092d8c85.png)
