### PR TITLE
Fix documentation of K.rnn unroll parameter

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1984,8 +1984,7 @@ def rnn(step_function, inputs, initial_states,
         mask: binary tensor with shape `(samples, time, 1)`,
             with a zero for every element that is masked.
         constants: a list of constant values passed at each step.
-        unroll: with TensorFlow the RNN is always unrolled, but with Theano you
-            can use this boolean flag to unroll the RNN.
+        unroll: whether to unroll the RNN or to use a symbolic loop (`while_loop` or `scan` depending on backend).
         input_length: not relevant in the TensorFlow implementation.
             Must be specified if using unrolling with Theano.
 

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1008,7 +1008,7 @@ def rnn(step_function, inputs, initial_states,
         mask: binary tensor with shape (samples, time),
             with a zero for every element that is masked.
         constants: a list of constant values passed at each step.
-        unroll: whether to unroll the RNN or to use a symbolic loop (`scan`).
+        unroll: whether to unroll the RNN or to use a symbolic loop (`while_loop` or `scan` depending on backend).
         input_length: must be specified if using `unroll`.
 
     # Returns


### PR DESCRIPTION
Current docs say tensorflow always unrolls, which isn't true.

Old docstring

> unroll: with TensorFlow the RNN is always unrolled, but with Theano you can use this boolean flag to unroll the RNN.

New docstring

> unroll: whether to unroll the RNN or to use a symbolic loop (`while_loop` or `scan` depending on backend).

Cheers