### PR TITLE
fix: CSVLogger raises ValueError when it is reused.

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -844,6 +844,7 @@ class CSVLogger(Callback):
 
     def on_train_end(self, logs=None):
         self.csv_file.close()
+        self.writer = None
 
 
 class LambdaCallback(Callback):

--- a/tests/keras/test_callbacks.py
+++ b/tests/keras/test_callbacks.py
@@ -245,6 +245,10 @@ def test_CSVLogger():
     model.fit(X_train, y_train, batch_size=batch_size,
               validation_data=(X_test, y_test), callbacks=cbks, nb_epoch=1)
 
+    # case 3, reuse of CSVLogger object
+    model.fit(X_train, y_train, batch_size=batch_size,
+              validation_data=(X_test, y_test), callbacks=cbks, nb_epoch=1)
+
     import re
     with open(filepath) as csvfile:
         output = " ".join(csvfile.readlines())


### PR DESCRIPTION
Reuse of `CSVLogger` object raises `ValueError: I/O operation on closed file.` because in `on_train_end` method `self.csv_file` is closed but `self.writer` is not reset to `None`.