### PR TITLE
Added functionality: dropout in either train, test, or both phases

### DIFF
--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -85,6 +85,9 @@ class Dropout(Layer):
             you want the dropout mask to be the same for all timesteps,
             you can use `noise_shape=(batch_size, 1, features)`.
         seed: A Python integer to use as random seed.
+        active_in: string in ['train', 'test', 'both'] (default: 'train').
+            determines if dropouts are applied in training time, inference
+            time, or both.
 
     # References
         - [Dropout: A Simple Way to Prevent Neural Networks from Overfitting](http://www.cs.toronto.edu/~rsalakhu/papers/srivastava14a.pdf)

--- a/tests/keras/layers/test_core.py
+++ b/tests/keras/layers/test_core.py
@@ -227,6 +227,10 @@ def test_dropout():
                kwargs={'p': 0.5, 'noise_shape': [3, 1]},
                input_shape=(3, 2))
 
+    layer_test(core.Dropout,
+               kwargs={'p': 0.5, 'active_in': 'both'},
+               input_shape=(3, 2))
+
     layer_test(core.SpatialDropout1D,
                kwargs={'p': 0.5},
                input_shape=(2, 3, 4))


### PR DESCRIPTION
A flag added to the Dropout class that determines in which phase[s] the dropout takes place (either train, test, or both phases).