### PR TITLE
Bug Fix in Image Generator - Now Allows FCN's to be used

### DIFF
--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -243,7 +243,7 @@ def array_to_img(x, dim_ordering='default', scale=True, color_mode='rgb'):
         raise ValueError('Unsupported channel number: ', x.shape[2])
 
 
-def img_to_array(img, dim_ordering='default'):
+def img_to_array(img, dim_ordering='default', color_mode='rgb'):
     """Converts a PIL Image instance to a Numpy array.
 
     # Arguments
@@ -852,7 +852,7 @@ class DirectoryIterator(Iterator):
         # optionally save augmented images to disk for debugging purposes
         if self.save_to_dir:
             for i in range(current_batch_size):
-                img = array_to_img(batch_x[i], self.dim_ordering, scale=True)
+                img = array_to_img(batch_x[i], self.dim_ordering, scale=True, color_mode=self.color_mode)
                 fname = '{prefix}_{index}_{hash}.{format}'.format(prefix=self.save_prefix,
                                                                   index=current_index + i,
                                                                   hash=np.random.randint(1e4),

--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -199,6 +199,9 @@ def array_to_img(x, dim_ordering='default', scale=True, color_mode='rgb'):
         dim_ordering: Image data format.
         scale: Whether to rescale image values
             to be within [0, 255].
+        color_mode: 'bgr' to reverse the
+            channel dimensions, otherwise it picks 
+            depending on the shape of X.
 
     # Returns
         A PIL Image instance.
@@ -249,6 +252,9 @@ def img_to_array(img, dim_ordering='default', color_mode='rgb'):
     # Arguments
         img: PIL Image instance.
         dim_ordering: Image data format.
+        color_mode: 'bgr' to reverse the
+            channel dimensions, otherwise it picks 
+            depending on the shape of X.
 
     # Returns
         A 3D Numpy array (float32).

--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -200,7 +200,7 @@ def array_to_img(x, dim_ordering='default', scale=True, color_mode='rgb'):
         scale: Whether to rescale image values
             to be within [0, 255].
         color_mode: 'bgr' to reverse the
-            channel dimensions, otherwise it picks 
+            channel dimensions, otherwise it picks
             depending on the shape of X.
 
     # Returns
@@ -253,7 +253,7 @@ def img_to_array(img, dim_ordering='default', color_mode='rgb'):
         img: PIL Image instance.
         dim_ordering: Image data format.
         color_mode: 'bgr' to reverse the
-            channel dimensions, otherwise it picks 
+            channel dimensions, otherwise it picks
             depending on the shape of X.
 
     # Returns

--- a/tests/keras/preprocessing/test_image.py
+++ b/tests/keras/preprocessing/test_image.py
@@ -159,7 +159,7 @@ class TestImage:
         assert(len(dir_iterator.classes) == count)
         assert(sorted(dir_iterator.filenames) == sorted(filenames))
         shutil.rmtree(tmp_folder)
-    
+
     ''' Test for the directory iterator when we wish to use it for a FCN.'''
     def test_directory_iterator_fcn(self):
         num_classes = 1  # 1 class encompassing all masks
@@ -186,7 +186,7 @@ class TestImage:
         assert (len(dir_iterator.classes) == count)
         assert (sorted(dir_iterator.filenames) == sorted(filenames))
         shutil.rmtree(tmp_folder)
-        
+
     def test_img_utils(self):
         height, width = 10, 8
 

--- a/tests/keras/preprocessing/test_image.py
+++ b/tests/keras/preprocessing/test_image.py
@@ -159,7 +159,34 @@ class TestImage:
         assert(len(dir_iterator.classes) == count)
         assert(sorted(dir_iterator.filenames) == sorted(filenames))
         shutil.rmtree(tmp_folder)
+    
+    ''' Test for the directory iterator when we wish to use it for a FCN.'''
+    def test_directory_iterator_fcn(self):
+        num_classes = 1  # 1 class encompassing all masks
+        tmp_folder = tempfile.mkdtemp(prefix='test_images')
 
+        # no subfolders
+
+        # save the images in the paths
+        count = 0
+        filenames = []
+        for test_images in self.all_test_images:
+            for im in test_images:
+                filename = 'image-{}.jpg'.format(count)
+                filenames.append(filename)
+                im.save(os.path.join(tmp_folder, filename))
+                count += 1
+
+        # create iterator
+        generator = image.ImageDataGenerator()
+        dir_iterator = generator.flow_from_directory(tmp_folder, classes=['.'])
+
+        # check number of classes and images
+        assert (len(dir_iterator.class_indices) == num_classes)
+        assert (len(dir_iterator.classes) == count)
+        assert (sorted(dir_iterator.filenames) == sorted(filenames))
+        shutil.rmtree(tmp_folder)
+        
     def test_img_utils(self):
         height, width = 10, 8
 


### PR DESCRIPTION
I needed FCN's so have altered this preprocessing step, I can also make a gist for the tutorials if anyone else prefers to learn through a simple example.

This does not allow for no sizes to be set if max poolings are used. In that case, the sizes can be none-square but have to be multiple of 2^m - where m is the number of max pooling layers.

In the future it might be possible to auto-resize to the nearest factor, but another variable will need adding to ensure we can disentangle the model from the preprocessing.


Made minor changes to allow for FCN's:
  - Target Size is now a tuple of (None, None) as only this can propagate through the directory iterator
  - Altered batch_x to be created in the loop, as you should only use a batch size of 1 for FCN of shape (None, None, Channels)
  - Allowed the directory iterator to use the folder it is passed if it finds no subfolders for classes (Usual use case in FCN)

Allowed BGR to be specified (for when using caffe converted models).