### PR TITLE
Fix tensorflow_backend stack arguments, add merge mode: interleave

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1743,19 +1743,20 @@ def spatial_3d_padding(x, padding=(1, 1, 1), dim_ordering='default'):
     return tf.pad(x, pattern)
 
 
-def stack(x):
+def stack(x, axis=0):
     """Stacks a list of rank `R` tensors into a rank `R+1` tensor.
 
     # Arguments
         x: input tensor.
+        axis: axis to stack along, defaults to 0.
 
     # Returns
         A tensor.
     """
     try:
-        return tf.stack(x)
+        return tf.stack(x, axis)
     except AttributeError:
-        return tf.pack(x)
+        return tf.pack(x, axis)
 
 
 def one_hot(indices, nb_classes):

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -1308,7 +1308,7 @@ class Merge(Layer):
         as appropriate.
         """
         if not callable(mode):
-            if mode not in {'sum', 'mul', 'concat', 'ave', 'cos', 'dot', 'max'}:
+            if mode not in {'sum', 'mul', 'concat', 'interleave', 'ave', 'cos', 'dot', 'max'}:
                 raise ValueError('Invalid merge mode: ' + str(mode))
         if not isinstance(layers, (list, tuple)) or len(layers) < 2:
             raise TypeError('A Merge should only be applied to a list of '
@@ -1358,17 +1358,17 @@ class Merge(Layer):
                 raise ValueError('Dimension incompatibility using dot mode: '
                                  '%s != %s. ' % (shape1[self.dot_axes[0]], shape2[self.dot_axes[1]]) +
                                  'Layer shapes: %s, %s' % (shape1, shape2))
-        elif mode == 'concat':
+        elif mode in {'concat', 'interleave'}:
             reduced_inputs_shapes = [list(shape) for shape in input_shapes]
             shape_set = set()
             for i in range(len(reduced_inputs_shapes)):
                 del reduced_inputs_shapes[i][self.concat_axis]
                 shape_set.add(tuple(reduced_inputs_shapes[i]))
             if len(shape_set) > 1:
-                raise ValueError('"concat" mode can only merge '
+                raise ValueError('"%s" mode can only merge '
                                  'layers with matching '
                                  'output shapes except for the concat axis. '
-                                 'Layer shapes: %s' % (input_shapes))
+                                 'Layer shapes: %s' % (mode, input_shapes))
 
     def call(self, inputs, mask=None):
         if not isinstance(inputs, list) or len(inputs) <= 1:
@@ -1392,6 +1392,15 @@ class Merge(Layer):
 
         elif self.mode == 'concat':
             return K.concatenate(inputs, axis=self.concat_axis)
+
+        elif self.mode == 'interleave':
+            input_shape = None
+            if hasattr(inputs[0], '_keras_shape'):
+                input_shape = inputs[0]._keras_shape
+            elif hasattr(K, 'int_shape'):
+                input_shape = K.int_shape(inputs[0])
+            target_shape = self.get_output_shape_for([input_shape] * len(inputs))
+            return K.reshape(K.stack(inputs, self.concat_axis + 1), (-1,) + target_shape[1:])
 
         elif self.mode == 'mul':
             s = inputs[0]
@@ -1487,7 +1496,7 @@ class Merge(Layer):
         if self.mode in ['sum', 'mul', 'ave', 'max']:
             # All tuples in input_shapes should be the same.
             return input_shapes[0]
-        elif self.mode == 'concat':
+        elif self.mode in {'concat', 'interleave'}:
             output_shape = list(input_shapes[0])
             for shape in input_shapes[1:]:
                 if output_shape[self.concat_axis] is None or shape[self.concat_axis] is None:
@@ -1515,7 +1524,7 @@ class Merge(Layer):
         if self.mode in ['sum', 'mul', 'ave']:
             masks = [K.expand_dims(m, 0) for m in mask if m is not None]
             return K.all(K.concatenate(masks, axis=0), axis=0, keepdims=False)
-        elif self.mode == 'concat':
+        elif self.mode in {'concat', 'interleave'}:
             # Make a list of masks while making sure
             # the dimensionality of each mask
             # is the same as the corresponding input.


### PR DESCRIPTION
Interleave merge mode should be generally useful. For example, Upsampling can be implemented using interleave. The specific use I had in mind is to implement the Fast Up-Convolution blocks in [Deeper Depth Prediction with Fully Convolutional Residual Networks](https://arxiv.org/abs/1606.00373).

Here is an example implementation of a FastUpConvolution:
```python
def FastUpConvolution(nb_out_chan, init='glorot_normal'):
    def out(input_tensor):
        a = Convolution2D(nb_out_chan, 3, 3, init=init, border_mode='same')(input_tensor)
        b = Convolution2D(nb_out_chan, 2, 3, init=init, border_mode='same')(input_tensor)
        c = Convolution2D(nb_out_chan, 3, 2, init=init, border_mode='same')(input_tensor)
        d = Convolution2D(nb_out_chan, 2, 2, init=init, border_mode='same')(input_tensor)

        ab = merge([a, b], 'interleave', concat_axis=1)
        cd = merge([c, d], 'interleave', concat_axis=1)
        result = merge([ab, cd], 'interleave', concat_axis=2)
        return result
    return out
```

Here is a simple test to make sure interleave works:
```python
from scipy.ndimage import imread
import matplotlib.pyplot as plt
import numpy as np
from keras.layers import Input
from keras.models import Model

img = imread('some_test_image.jpg')
img = np.expand_dims(img, 0)
inp = Input(img.shape[1:])
ab = merge([inp, inp], 'interleave', concat_axis=1)
cd = merge([inp, inp], 'interleave', concat_axis=1)
result = merge([ab, cd], 'interleave', concat_axis=2)
model = Model(inp, result)

result_ = np.asarray(model.predict(img, batch_size=1), dtype=np.uint8)

fig = plt.figure()
fig.add_subplot(1, 2, 1)
plt.imshow(img[0, :, :, :])
fig.add_subplot(1, 2, 2)
plt.imshow(result_[0, :, :, :])
plt.show()
```
The resulting image should be the same as the input image, but double the size. By interleaving it with itself, we're effectively upsampling.
UpConvolutions are useful for implementing architectures like the one in [Feature Pyramid Networks for Object Detection](https://arxiv.org/abs/1612.03144) where there are down-sampling and up-sampling pathways in the network architecture.

Note: For FastUpConvolution, I haven't considered what would happen with border_mode same on feature maps with odd-sized Height and Width dimensions, but that's besides the point of this PR.