### PR TITLE
Fix link to TF install docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Keras uses the following dependencies:
 *When using the TensorFlow backend:*
 
 - TensorFlow
-    - [See installation instructions](https://github.com/tensorflow/tensorflow#download-and-setup).
+    - [See installation instructions](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/g3doc/get_started/os_setup.md)
 
 *When using the Theano backend:*
 


### PR DESCRIPTION
Current link has invalid anchor at the end. Make link go directly to the README to account for future changes.

Could also link to this page directly but there's a chance they could change the URL:
https://github.com/tensorflow/tensorflow/blob/master/tensorflow/g3doc/get_started/os_setup.md