### PR TITLE
Fixed duplicate line in keras/engine/training.py.

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -724,7 +724,6 @@ class Model(Container):
                         append_metric(i, name, tensor)
 
         # prepare gradient updates and state updates
-        self.optimizer = optimizers.get(optimizer)
         self.total_loss = total_loss
         self.sample_weights = sample_weights
 


### PR DESCRIPTION
The following occurs twice in different places, so far harmlessly but
still redundantly:

    self.optimizer = optimizers.get(optimizer)

[[First occurence]](https://github.com/fchollet/keras/blob/master/keras/engine/training.py#L517),
[[Second occurence]](https://github.com/fchollet/keras/blob/master/keras/engine/training.py#L727)