### PR TITLE
Always evaluate callables if learning phase is set, solves #5268

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -2232,9 +2232,15 @@ def in_train_phase(x, alt):
         Either `x` or `alt` based on `K.learning_phase`.
     """
     if learning_phase() is 1:
-        return x
+        if callable(x):
+            return x()
+        else:
+            return x
     elif learning_phase() is 0:
-        return alt
+        if callable(alt):
+            return alt()
+        else:
+            return alt
     # else: assume learning phase is a placeholder tensor.
     x = switch(learning_phase(), x, alt)
     x._uses_learning_phase = True
@@ -2249,9 +2255,15 @@ def in_test_phase(x, alt):
         Either `x` or `alt` based on `K.learning_phase`.
     """
     if learning_phase() is 1:
-        return alt
+        if callable(alt):
+            return alt()
+        else:
+            return alt
     elif learning_phase() is 0:
-        return x
+        if callable(x):
+            return x()
+        else:
+            return x
     # else: assume learning phase is a placeholder tensor.
     x = switch(learning_phase(), alt, x)
     x._uses_learning_phase = True

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1163,28 +1163,28 @@ def switch(condition, then_expression, else_expression):
 
 
 def in_train_phase(x, alt):
-    if _LEARNING_PHASE is 1:
-        return x
-    elif _LEARNING_PHASE is 0:
-        return alt
     if callable(x):
         x = x()
     if callable(alt):
         alt = alt()
+    if _LEARNING_PHASE is 1:
+        return x
+    elif _LEARNING_PHASE is 0:
+        return alt
     x = theano.ifelse.ifelse(_LEARNING_PHASE, x, alt)
     x._uses_learning_phase = True
     return x
 
 
 def in_test_phase(x, alt):
-    if _LEARNING_PHASE is 1:
-        return alt
-    elif _LEARNING_PHASE is 0:
-        return x
     if callable(x):
         x = x()
     if callable(alt):
         alt = alt()
+    if _LEARNING_PHASE is 1:
+        return alt
+    elif _LEARNING_PHASE is 0:
+        return x
     x = theano.ifelse.ifelse(_LEARNING_PHASE, alt, x)
     x._uses_learning_phase = True
     return x


### PR DESCRIPTION
This is a fix for #5268 which makes sure the callables are evaluated on the learning_phrase branches.