### PR TITLE
Correct calculation of metrics with masking (#2260)

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1326,6 +1326,26 @@ def lesser_equal(x, y):
     return tf.less_equal(x, y)
 
 
+def where(x):
+    """Returns locations of true values in a boolean tensor.
+
+    This operation returns the coordinates of true elements in input. The coordinates are
+    returned in a 2-D tensor where the first dimension (rows) represents the number of
+    true elements, and the second dimension (columns) represents the coordinates of the
+    true elements. Keep in mind, the shape of the output tensor can vary depending on
+    how many true values there are in input.
+
+    # Arguments
+        x: input bool tensor.
+
+    # Returns
+        An integer tensor of indices.
+
+    """
+    x = tf.cast(x, tf.bool)
+    return tf.where(x)
+
+
 def maximum(x, y):
     """Element-wise maximum of two tensors.
 
@@ -1587,13 +1607,27 @@ def tile(x, n):
     return tf.tile(x, n)
 
 
-def flatten(x):
-    """Flatten a tensor.
+def flatten(x, outdim=1):
+    """Returns a view of this tensor with `outdim` dimensions, whose shape
+    for the first `outdim-1` dimensions will be the same as `x`, and
+    shape in the remaining dimension will be expanded to fit in
+    all the data from `x`.
+
+    # Arguments
+        x: input tensor.
+        outdim: number of dimensions in the output tensor.
 
     # Returns
-        A tensor, reshaped into 1-D
+        A tensor, reshaped outdim dimensions.
+
     """
-    return tf.reshape(x, [-1])
+
+    if outdim > 1:
+        shape = concatenate([tf.shape(x)[:outdim - 1], variable([-1], dtype='int32')])
+    else:
+        shape = [-1]
+
+    return tf.reshape(x, shape)
 
 
 def batch_flatten(x):
@@ -2023,7 +2057,10 @@ def rnn(step_function, inputs, initial_states,
 
     # TODO: remove later.
     if hasattr(tf, 'select'):
-        tf.where = tf.select
+        where_op = tf.select
+    else:
+        where_op = tf.where
+
     if hasattr(tf, 'stack'):
         stack = tf.stack
         unstack = tf.unstack
@@ -2069,14 +2106,14 @@ def rnn(step_function, inputs, initial_states,
                 else:
                     prev_output = successive_outputs[-1]
 
-                output = tf.where(tiled_mask_t, output, prev_output)
+                output = where_op(tiled_mask_t, output, prev_output)
 
                 return_states = []
                 for state, new_state in zip(states, new_states):
                     # (see earlier comment for tile explanation)
                     tiled_mask_t = tf.tile(mask_t,
                                            stack([1, tf.shape(new_state)[1]]))
-                    return_states.append(tf.where(tiled_mask_t,
+                    return_states.append(where_op(tiled_mask_t,
                                                   new_state,
                                                   state))
                 states = return_states
@@ -2145,8 +2182,8 @@ def rnn(step_function, inputs, initial_states,
                     new_state.set_shape(state.get_shape())
                 tiled_mask_t = tf.tile(mask_t,
                                        stack([1, tf.shape(output)[1]]))
-                output = tf.where(tiled_mask_t, output, states[0])
-                new_states = [tf.where(tiled_mask_t, new_states[i], states[i]) for i in range(len(states))]
+                output = where_op(tiled_mask_t, output, states[0])
+                new_states = [where_op(tiled_mask_t, new_states[i], states[i]) for i in range(len(states))]
                 output_ta_t = output_ta_t.write(time, output)
                 return (time + 1, output_ta_t) + tuple(new_states)
         else:

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -432,6 +432,25 @@ def lesser_equal(x, y):
     return T.le(x, y)
 
 
+def where(x):
+    """Returns locations of true values in a boolean tensor.
+
+    This operation returns the coordinates of true elements in input. The coordinates are
+    returned in a 2-D tensor where the first dimension (rows) represents the number of
+    true elements, and the second dimension (columns) represents the coordinates of the
+    true elements. Keep in mind, the shape of the output tensor can vary depending on
+    how many true values there are in input.
+
+    # Arguments
+        x: input bool tensor.
+
+    # Returns
+        An integer tensor of indices.
+
+    """
+    return transpose(x.nonzero(return_matrix=True))
+
+
 def maximum(x, y):
     return T.maximum(x, y)
 
@@ -687,9 +706,23 @@ def tile(x, n):
     return T.tile(x, n)
 
 
-def flatten(x):
+def flatten(x, outdim=1):
+    """Returns a view of this tensor with `outdim` dimensions, whose shape
+    for the first `outdim-1` dimensions will be the same as `x`, and
+    shape in the remaining dimension will be expanded to fit in
+    all the data from `x`.
+
+    # Arguments
+        x: input tensor.
+        outdim: number of dimensions in the output tensor.
+
+    # Returns
+        A tensor, reshaped outdim dimensions.
+
+    """
+
     # TODO: `keras_shape` inference.
-    return T.flatten(x)
+    return T.flatten(x, outdim)
 
 
 def batch_flatten(x):

--- a/tests/keras/backend/test_backends.py
+++ b/tests/keras/backend/test_backends.py
@@ -105,6 +105,7 @@ class TestBackend(object):
                                       pattern=(2, 0, 1))
         check_single_tensor_operation('repeat', (4, 1), n=3)
         check_single_tensor_operation('flatten', (4, 1))
+        check_single_tensor_operation('flatten', (4, 4, 4), outdim=2)
         check_single_tensor_operation('expand_dims', (4, 3), dim=-1)
         check_single_tensor_operation('expand_dims', (4, 3, 2), dim=1)
         check_single_tensor_operation('squeeze', (4, 3, 1), axis=2)
@@ -838,6 +839,13 @@ class TestBackend(object):
         for K in [KTH, KTF]:
             koh = K.eval(K.one_hot(K.variable(indices, dtype='int32'), nb_classes))
             assert np.all(koh == oh)
+
+    def test_where(self):
+        x = np.random.randint(0, 2, size=(10, 10))
+        exp_out = np.stack(np.nonzero(x), axis=1)
+        for K in [KTH, KTF]:
+            k_out = K.eval(K.where(K.variable(x, dtype='int32')))
+            assert np.all(k_out == exp_out)
 
     def test_sparse_dot(self):
         x_d = np.array([0, 7, 2, 3], dtype=np.float32)

--- a/tests/test_loss_masking.py
+++ b/tests/test_loss_masking.py
@@ -2,8 +2,9 @@ import numpy as np
 import pytest
 
 from keras.models import Sequential
-from keras.engine.training import weighted_objective
-from keras.layers.core import TimeDistributedDense, Masking
+from keras.engine.training import weighted_objective, masked_tensor
+from keras.layers.core import Dense, Masking
+from keras.layers.wrappers import TimeDistributed
 from keras.utils.test_utils import keras_test
 from keras import objectives
 from keras import backend as K
@@ -16,12 +17,14 @@ def test_masking():
                   [[0], [0]]])
     model = Sequential()
     model.add(Masking(mask_value=0, input_shape=(2, 1)))
-    model.add(TimeDistributedDense(1, init='one'))
-    model.compile(loss='mse', optimizer='sgd')
+    model.add(TimeDistributed(Dense(1, init='one')))
+    model.compile(loss='mse', optimizer='sgd', metrics=['accuracy'])
     y = np.array([[[1], [1]],
                   [[1], [1]]])
-    loss = model.train_on_batch(X, y)
+    (loss, acc) = model.train_on_batch(X, y)
+
     assert loss == 0
+    assert acc == 1
 
 
 @keras_test
@@ -40,6 +43,18 @@ def test_loss_masking():
                                K.variable(Y),
                                K.variable(weights),
                                K.variable(mask)))
+
+
+@keras_test
+def test_masked_tensor():
+    x = np.random.randint(0, 10, size=(5, 10, 5))
+    mask = np.random.randint(0, 2, size=(5, 10))
+    i = np.nonzero(mask)
+    exp_out = x[i[0], i[1], :]
+
+    k_out = K.eval(masked_tensor(K.variable(x, dtype='int32'), K.variable(mask, dtype='int32')))
+
+    assert np.all(k_out == exp_out)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
As mentioned in (#2260), metrics don't skip output values that ought to be masked out. Normally, masking assumes that our output tensors are of shape `(samples, timesteps, outputs )`. Problem is that a variable number of timesteps should be masked out and be excluded from the metrics (same as was done for the objective function). Looking at `training.py` I saw two possible ways to fix this issue:

1. Take the same approach as for objective functions (see `weighted_objective()`). _Pros:_ more consistent with existing approach, enables metrics to be scaled by weight as well; _Cons:_ requires rewriting of metrics functions to return values per-timestep, possible back-compat issues for users who have written custom metrics

2. Reshape the output tensors to have shape `(samples * timesteps, outputs )` and then remove all timesteps that should be  masked out. _Pros:_ more clean, no change in the way metric functions are written; _Cons:_ doesn't permit weighted metrics

Although, in terms of overall design, solution (1) is probably better, but since I didn't want to introduce back-compat issues, I figured solution (2) was a cleaner approach.

In order to realize this solution, I needed to introduce 2 changes to the backend:

1. Change `flatten()` function by adding an optional parameter `outdim` which specifies the output dimension of the flattening operation. This works in the same way as in Theano.

2. Add a `where()` function which takes a boolean tensor and returns a M-by-N tensor of indices where M is the number of true values and N is the number of dimensions in the input tensor. This is implemented similarly to the way it works in Tensorflow, when `x` and `y` are set to `None`.

Some tests were failing because in the `rnn()` function in `tensorflow_backend.py` the `tf.where` function was being overwritten with `tf.select`, so I had to fix this. After that change, all tests were passing.