### PR TITLE
Adding a simple decorator for declaration of custom objects in Keras

### DIFF
--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -11,6 +11,17 @@ import types as python_types
 
 _GLOBAL_CUSTOM_OBJECTS = {}
 
+def custom_object(obj):
+    """A decorator for easy declaration of new custom objects
+
+    It can be used as:
+       @custom_object
+       class MyLayer(...)
+           ...
+    """
+    name = obj.__name__
+    _GLOBAL_CUSTOM_OBJECTS[name] = obj
+    return obj
 
 class CustomObjectScope(object):
     """Provides a scope that changes to `_GLOBAL_CUSTOM_OBJECTS` cannot escape.


### PR DESCRIPTION
Custom objects can be declared in a dictionary and added to load_model function or used in a with statement. However, I feel it can be easier to declare custom objects by adding them a decorator, something like:

```Python
from keras.utils.generic_utils import custom_object

@custom_object
def myloss(y_true, y_pred):
    return (y_true - y_pred)**2.0
```

This way, Keras custom objects dictionary can be extended by external applications, declaring their own layers in a transparent way for the programmer. It can be a nice way to extend Keras.