### PR TITLE
Added 3d atrous convolutions and the required backend functions (from tensorflow r0.12 onwards)

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -2741,6 +2741,50 @@ def atrous_conv2d(x, kernel, rate=1,
     return _postprocess_conv2d_output(x, dim_ordering)
 
 
+def atrous_conv3d(x, kernel, rate=1, border_mode='valid', dim_ordering='default',
+                  image_shape=None, filter_shape=None):
+    """Atrous 3D convolution.
+
+    # Arguments
+        x: input tensor
+        kernel: kernel tensor
+        rate: integer > 0 or a tuple of integers of length 3.
+              This is the sample stride.
+        border_mode: String specifying the border handling behaviour.
+                     Can be 'valid' or 'same'.
+        dim_ordering: `"tf"` or `"th"`. Whether to use tensorflow or
+                      theano dimension ordering.
+
+    # Raises
+        ValueError: if `dim_ordering` is neiter `tf` or `th`
+        ValueError: if rate is not an integer or a tuple of three integers.
+    """
+    if dim_ordering == 'default':
+        dim_ordering = image_dim_ordering()
+    if dim_ordering not in {'th', 'tf'}:
+        raise ValueError('Unknown dim_ordering ' + str(dim_ordering))
+
+    x = _preprocess_conv3d_input(x, dim_ordering)
+    kernel = _preprocess_conv3d_kernel(kernel, dim_ordering)
+    padding = _preprocess_border_mode(border_mode)
+
+    if isinstance(rate, int):
+        rate = (rate,) * 3
+    else:
+        rate = tuple(rate)
+
+    if len(rate) != 3:
+        raise ValueError("Dilation rate must be an integer or a tuple of length 3.")
+
+    if rate == (1, 1, 1):
+        return conv3d(x, kernel, strides=(1, 1, 1), border_mode=border_mode,
+                      dim_ordering=dim_ordering)
+    else:
+        x = tf.nn.convolution(input=x, filter=kernel, padding=padding, dilation_rate=rate,
+                              data_format='NDHWC')
+        return _postprocess_conv3d_output(x, dim_ordering)
+
+
 def separable_conv2d(x, depthwise_kernel, pointwise_kernel, strides=(1, 1),
                      border_mode='valid', dim_ordering='default'):
     """2-D convolution with separable filters.

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1581,6 +1581,11 @@ def atrous_conv2d(x, kernel, rate=1,
     raise NotImplementedError
 
 
+def atrous_conv3d(x, kernel, rate=1, border_mode='valid', dim_ordering='default',
+                  image_shape=None, filter_shape=None):
+    raise NotImplementedError
+
+
 def separable_conv2d(x, depthwise_kernel, pointwise_kernel, strides=(1, 1),
                      border_mode='valid', dim_ordering='default'):
     raise NotImplementedError

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -1265,6 +1265,155 @@ class Convolution3D(Layer):
         return dict(list(base_config.items()) + list(config.items()))
 
 
+class AtrousConvolution3D(Convolution3D):
+    """Atrous Convolution operator for filtering windows of 3-D inputs.
+
+    A.k.a dilated convolution or convolution with holes.
+    When using this layer as the first layer in a model,
+    provide the keyword argument `input_shape`
+    (tuple of integers, does not include the sample axis),
+    e.g. `input_shape=(3, 10, 128, 128)` for 10 frames of 128x128 RGB pictures.
+
+    # Arguments
+        nb_filter: Number of convolution filters to use.
+        nb_row: Number of rows in the convolution kernel.
+        nb_col: Number of columns in the convolution kernel.
+        init: name of initialization function for the weights of the layer
+            (see [initializations](../initializations.md)), or alternatively,
+            Theano function to use for weights initialization.
+            This parameter is only relevant if you don't pass
+            a `weights` argument.
+        activation: name of activation function to use
+            (see [activations](../activations.md)),
+            or alternatively, elementwise Theano function.
+            If you don't specify anything, no activation is applied
+            (ie. "linear" activation: a(x) = x).
+        weights: list of numpy arrays to set as initial weights.
+        border_mode: 'valid', 'same' or 'full'
+            ('full' requires the Theano backend).
+        subsample: tuple of length 3. Factor by which to subsample output.
+            Also called strides elsewhere. Should be (1, 1, 1) if
+            `atrous_rate` is not (1, 1, 1).
+        atrous_rate: tuple of length 3. Factor for kernel dilation.
+            Also called filter_dilation elsewhere.
+        W_regularizer: instance of [WeightRegularizer](../regularizers.md)
+            (eg. L1 or L2 regularization), applied to the main weights matrix.
+        b_regularizer: instance of [WeightRegularizer](../regularizers.md),
+            applied to the bias.
+        activity_regularizer: instance of [ActivityRegularizer](../regularizers.md),
+            applied to the network output.
+        W_constraint: instance of the [constraints](../constraints.md) module
+            (eg. maxnorm, nonneg), applied to the main weights matrix.
+        b_constraint: instance of the [constraints](../constraints.md) module,
+            applied to the bias.
+        dim_ordering: 'th' or 'tf'. In 'th' mode, the channels dimension
+            (the depth) is at index 1, in 'tf' mode is it at index 3.
+            It defaults to the `image_dim_ordering` value found in your
+            Keras config file at `~/.keras/keras.json`.
+            If you never set it, then it will be "tf".
+        bias: whether to include a bias
+            (i.e. make the layer affine rather than linear).
+
+    # Input shape
+        5D tensor with shape:
+        `(samples, channels, conv_dim1, conv_dim2, conv_dim3)` if dim_ordering='th'
+        or 5D tensor with shape:
+        `(samples, conv_dim1, conv_dim2, conv_dim3, channels)` if dim_ordering='tf'.
+
+    # Output shape
+        5D tensor with shape:
+        `(samples, nb_filter, new_conv_dim1, new_conv_dim2, new_conv_dim3)` if dim_ordering='th'
+        or 5D tensor with shape:
+        `(samples, new_conv_dim1, new_conv_dim2, new_conv_dim3, nb_filter)` if dim_ordering='tf'.
+        `new_conv_dim1`, `new_conv_dim2` and `new_conv_dim3` values might have changed due to padding.
+
+    # References
+        - [Multi-Scale Context Aggregation by Dilated Convolutions](https://arxiv.org/abs/1511.07122)
+    """
+
+    def __init__(self, nb_filter, kernel_dim1, kernel_dim2, kernel_dim3,
+                 init='glorot_uniform', activation=None, weights=None,
+                 border_mode='valid', subsample=(1, 1, 1), atrous_rate=(1, 1, 1),
+                 dim_ordering='default',
+                 W_regularizer=None, b_regularizer=None, activity_regularizer=None,
+                 W_constraint=None, b_constraint=None, bias=True, **kwargs):
+
+        dim_ordering = K.image_dim_ordering() if dim_ordering == 'default' else dim_ordering
+
+        if border_mode not in {'valid', 'same'}:
+            raise ValueError('Invalid border mode for AtrousConv3D:', border_mode)
+
+        if isinstance(atrous_rate, int):
+            atrous_rate = (atrous_rate,) * 3
+
+        if len(atrous_rate) != 3:
+            raise ValueError('Argument `atrous_rate` must be a tuple/list of length 3, '
+                             'got one of length {} instead.'.format(len(atrous_rate)))
+        self.atrous_rate = tuple(atrous_rate)
+
+        super(AtrousConvolution3D, self).__init__(nb_filter, kernel_dim1, kernel_dim2, kernel_dim3,
+                                                  init=init,
+                                                  activation=activation,
+                                                  weights=weights,
+                                                  border_mode=border_mode,
+                                                  subsample=subsample,
+                                                  dim_ordering=dim_ordering,
+                                                  W_regularizer=W_regularizer,
+                                                  b_regularizer=b_regularizer,
+                                                  activity_regularizer=activity_regularizer,
+                                                  W_constraint=W_constraint,
+                                                  b_constraint=b_constraint,
+                                                  bias=bias,
+                                                  **kwargs)
+
+    def get_output_shape_for(self, input_shape):
+        if self.dim_ordering == 'th':
+            conv_dim1 = input_shape[2]
+            conv_dim2 = input_shape[3]
+            conv_dim3 = input_shape[4]
+        elif self.dim_ordering == 'tf':
+            conv_dim1 = input_shape[1]
+            conv_dim2 = input_shape[2]
+            conv_dim3 = input_shape[3]
+        else:
+            raise ValueError('Invalid dim_ordering:', self.dim_ordering)
+
+        conv_dim1 = conv_output_length(conv_dim1, self.kernel_dim1,
+                                       self.border_mode, self.subsample[0],
+                                       dilation=self.atrous_rate[0])
+        conv_dim2 = conv_output_length(conv_dim2, self.kernel_dim2,
+                                       self.border_mode, self.subsample[1],
+                                       dilation=self.atrous_rate[1])
+        conv_dim3 = conv_output_length(conv_dim3, self.kernel_dim3,
+                                       self.border_mode, self.subsample[2],
+                                       dilation=self.atrous_rate[2])
+
+        if self.dim_ordering == 'th':
+            return input_shape[0], self.nb_filter, conv_dim1, conv_dim2, conv_dim3
+        elif self.dim_ordering == 'tf':
+            return input_shape[0], conv_dim1, conv_dim2, conv_dim3, self.nb_filter
+        else:
+            raise ValueError('Invalid dim_ordering:', self.dim_ordering)
+
+    def call(self, x, mask=None):
+        output = K.atrous_conv3d(x, self.W, rate=self.atrous_rate, border_mode=self.border_mode,
+                                 dim_ordering=self.dim_ordering)
+        if self.bias:
+            if self.dim_ordering == 'th':
+                output += K.reshape(self.b, (1, self.nb_filter, 1, 1, 1))
+            elif self.dim_ordering == 'tf':
+                output += K.reshape(self.b, (1, 1, 1, 1, self.nb_filter))
+            else:
+                raise ValueError('Invalid dim_ordering:', self.dim_ordering)
+        output = self.activation(output)
+        return output
+
+    def get_config(self):
+        config = {'atrous_rate': self.atrous_rate}
+        base_config = super(AtrousConvolution3D, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))
+
+
 class UpSampling1D(Layer):
     """Upsampling layer for 1D inputs.
 


### PR DESCRIPTION
A low hanging fruit, given `keras.layers.convolutional.Convolution3D` and `keras.layers.convolutional.AtrousConvolution2D` together with the new `tf.nn.convolution` op. 