### PR TITLE
Change batch_flatten to compute shape at construction time

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1620,7 +1620,7 @@ def batch_flatten(x):
     # Returns
         A tensor.
     """
-    x = tf.reshape(x, stack([-1, prod(shape(x)[1:])]))
+    x = tf.reshape(x, stack([-1, np.prod(int_shape(x)[1:])]))
     return x
 
 

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -697,9 +697,7 @@ def batch_flatten(x):
     the first dimension is conserved.
     """
     # TODO: `keras_shape` inference.
-    s = int_shape(x)
-    x = T.reshape(x, (s[0] if s[0] is not None else -1, np.prod(s[1:])))
-    return x
+    return T.flatten(x, outdim=2)
 
 
 def expand_dims(x, dim=-1):

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -697,7 +697,8 @@ def batch_flatten(x):
     the first dimension is conserved.
     """
     # TODO: `keras_shape` inference.
-    x = T.reshape(x, (x.shape[0], T.prod(x.shape) // x.shape[0]))
+    s = int_shape(x)
+    x = T.reshape(x, (s[0] if s[0] is not None else -1, np.prod(s[1:])))
     return x
 
 


### PR DESCRIPTION
Hello,

not sure if this is better as a PR or an issue:
Currently, batch_flatten and the Flatten layer drop backend shape information, at least for Tensorflow.
I ran into trouble with that a couple of times, notably when using Lambda layers for experiments or when trying to do an auxiliary computation in tensorflow.

This changes batch_flatten to compute the shape passed to reshape
at construction time (via K.int_shape) rather than using a
symbolic shape (via K.shape).
This has the advantage that the output tensor of a Flatten layer
has a (native) shape.

This can be important when using the output
tensor directly, e.g. with a Lambda layer after the Flatten
layer or when using output in the backend directly.
In particular, this change would solve the issue of this SO
question regarding a Flatten layer followed a Lambda layer:
http://stackoverflow.com/questions/37035944/unable-to-connect-lambda-layer-in-keras-directly-to-flatten-layer-without-an-exc

As far as I can see, the tests all pass. I have not found users of batch_flatten other than the Flatten layer in Keras.

Thank you for your consideration.

Best regards

Thomas
