### PR TITLE
Instruction to backend setting for Tensorflow user

### DIFF
--- a/examples/cifar10_cnn.py
+++ b/examples/cifar10_cnn.py
@@ -2,7 +2,7 @@
 
 GPU run command with Theano backend (with TensorFlow, the GPU is automatically used):
     THEANO_FLAGS=mode=FAST_RUN,device=gpu,floatX=float32 python cifar10_cnn.py
-    
+   
 Tensorflow backend specifies color channel comes last in the dimension order.
 To use the cifar10 dataset from keras, set dimension ordering to 'th':
     from keras import backend as K

--- a/examples/cifar10_cnn.py
+++ b/examples/cifar10_cnn.py
@@ -2,6 +2,11 @@
 
 GPU run command with Theano backend (with TensorFlow, the GPU is automatically used):
     THEANO_FLAGS=mode=FAST_RUN,device=gpu,floatX=float32 python cifar10_cnn.py
+    
+Tensorflow backend specifies color channel comes last in the dimension order.
+To use the cifar10 dataset from keras, set dimension ordering to 'th':
+    from keras import backend as K
+    K.set_image_dim_ordering('th')
 
 It gets down to 0.65 test logloss in 25 epochs, and down to 0.55 after 50 epochs.
 (it's still underfitting at that point, though).


### PR DESCRIPTION
Cifar10 dataset in keras comes with the dimension order of (3, img_row, img_col) which is not comparable to Tensorflow setting of (img_row, img_col, 3).

As more Tensorflow users come in, I think it would be great to add that instruction.