### PR TITLE
Fix a small error of Iterator

### DIFF
--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -643,7 +643,7 @@ class Iterator(object):
                     index_array = np.random.permutation(n)
 
             current_index = (self.batch_index * batch_size) % n
-            if n >= current_index + batch_size:
+            if n > current_index + batch_size:
                 current_batch_size = batch_size
                 self.batch_index += 1
             else:


### PR DESCRIPTION
The problem is that when size of the last batch equals to last_batch, we should set self.batch_index=0 such that in the next batch the index array will be shuffled.