### PR TITLE
Convert function defaults to tuple if serialized as list.

### DIFF
--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -180,6 +180,8 @@ def func_load(code, defaults=None, closure=None, globs=None):
     """
     if isinstance(code, (tuple, list)):  # unpack previous dump
         code, defaults, closure = code
+        if isinstance(defaults, list):
+            defaults = tuple(defaults)
     code = marshal.loads(code.encode('raw_unicode_escape'))
     if globs is None:
         globs = globals()


### PR DESCRIPTION
When a Lambda layer is serialized as JSON, `defaults` may be serialized as a list, e.g. [None]. However `FunctionType` expects `argdefs` to be a tuple or None, not a list.

This PR addresses the primary error in #5298 