### PR TITLE
Update Documentation: activations.md to add "elu"

### DIFF
--- a/docs/templates/activations.md
+++ b/docs/templates/activations.md
@@ -32,6 +32,7 @@ model.add(Activation(tanh))
 - __softplus__
 - __softsign__
 - __relu__
+- __elu__
 - __tanh__
 - __sigmoid__
 - __hard_sigmoid__


### PR DESCRIPTION
ELU is also available as a standard activation, and can be invoked as a string argument "elu" the same way as the other standard activations "linear", "sigmoid", "relu", "tanh" etc.