### PR TITLE
Fix epoch_log undefined error during training.

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1516,6 +1516,7 @@ class Model(Container):
                 callbacks.on_epoch_begin(epoch)
                 samples_seen = 0
                 batch_index = 0
+                epoch_logs = {}
                 while samples_seen < samples_per_epoch:
                     generator_output = None
                     while enqueuer.is_running():
@@ -1563,8 +1564,6 @@ class Model(Container):
 
                     callbacks.on_batch_end(batch_index, batch_logs)
 
-                    # construct epoch logs
-                    epoch_logs = {}
                     batch_index += 1
                     samples_seen += batch_size
 


### PR DESCRIPTION
In some control flow initialization of epoch_logs variable is skipped,  causing runtime exception.