### PR TITLE
Add missed "classes_" and "n_classes_" to KerasClassifier (fix #5371)

### DIFF
--- a/keras/wrappers/scikit_learn.py
+++ b/keras/wrappers/scikit_learn.py
@@ -217,6 +217,27 @@ class KerasClassifier(BaseWrapper):
             probs = np.hstack([1 - probs, probs])
         return probs
 
+    def fit(self, x, y, **kwargs):
+        """Constructs a new model with `build_fn` & fit the model to `(x, y)`.
+
+        # Arguments
+            x : array-like, shape `(n_samples, n_features)`
+                Training samples where n_samples in the number of samples
+                and n_features is the number of features.
+            y : array-like, shape `(n_samples,)` or `(n_samples, n_outputs)`
+                True labels for X.
+            **kwargs: dictionary arguments
+                Legal arguments are the arguments of `Sequential.fit`
+
+        # Returns
+            history : object
+                details about the training history at each epoch.
+        """
+        self.classes_ = np.unique(y)
+        self.n_classes_ = len(self.classes_)
+
+        return super(KerasClassifier, self).fit(x, y, **kwargs)
+
     def score(self, x, y, **kwargs):
         """Returns the mean accuracy on the given test data and labels.
 

--- a/tests/keras/wrappers/test_scikit_learn.py
+++ b/tests/keras/wrappers/test_scikit_learn.py
@@ -76,6 +76,8 @@ def test_clasify_inherit_class_build_fn():
 def assert_classification_works(clf):
     clf.fit(X_train, y_train, batch_size=batch_size, nb_epoch=nb_epoch)
 
+    assert hasattr(clf, 'classes_') and hasattr(clf, 'n_classes_')
+
     score = clf.score(X_train, y_train, batch_size=batch_size)
     assert np.isscalar(score) and np.isfinite(score)
 


### PR DESCRIPTION
There is behavior in the current master and behavior after my fix:
https://gist.github.com/diswest/640772af7d24b5532a6a4a07c1864fcd

There is a script with the problem demonstration:
https://gist.github.com/diswest/8a92d317192726694d3fdd8373201211