### PR TITLE
Fix the top layers in inception_v3 model

### DIFF
--- a/keras/applications/inception_v3.py
+++ b/keras/applications/inception_v3.py
@@ -269,7 +269,8 @@ def InceptionV3(include_top=True, weights='imagenet',
 
     if include_top:
         # Classification block
-        x = AveragePooling2D((8, 8), strides=(8, 8), name='avg_pool')(x)
+        x = AveragePooling2D((8, 8), strides=(1, 1), name='avg_pool')(x)
+        x = Dropout(0.2)(x)
         x = Flatten(name='flatten')(x)
         x = Dense(classes, activation='softmax', name='predictions')(x)
 


### PR DESCRIPTION
According to https://github.com/tensorflow/models/blob/master/slim/nets/inception_v3.py,
1) The stride of avg_pool is 1.
2) There is a dropout layer between avg_pool and flatten.