### PR TITLE
TensorFlow backend fix for ndim() of sparse tensor

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -402,9 +402,6 @@ def ndim(x):
         2
     ```
     """
-    if is_sparse(x):
-        return x._dims
-
     dims = x.get_shape()._dims
     if dims is not None:
         return len(dims)


### PR DESCRIPTION
Sparse tensor no longer has attribute `_dims` (TensorFlow v. 0.12 and above) and instead follows same API as non-sparse tensors, i.e. `get_shape()._dims`.