### PR TITLE
Causal Dilated Convolutions 

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -14,6 +14,7 @@ from .common import floatx
 from .common import _EPSILON
 from .common import image_data_format
 py_all = all
+py_sum = sum
 
 # INTERNAL UTILS
 
@@ -2809,14 +2810,19 @@ def conv1d(x, kernel, strides=1, padding='valid',
         x: Tensor or variable.
         kernel: kernel tensor.
         strides: stride integer.
-        padding: string, `"same"` or `"valid"`.
+        padding: string, `"same"`, `"causal"` or `"valid"`.
         data_format: string, one of "channels_last", "channels_first".
         dilation_rate: integer dilate rate.
 
     # Returns
         A tensor, result of 1D convolution.
     """
-    # pre-process dtype
+    kernel_shape = kernel.get_shape().as_list()
+    if padding == 'causal':
+        # causal (dilated) convolution:
+        left_pad = dilation_rate * (kernel_shape[0] - 1)
+        x = temporal_padding(x, (left_pad, 0))
+        padding = 'valid'
     padding = _preprocess_padding(padding)
     if data_format == 'channels_last':
         tf_data_format = 'NWC'

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -808,7 +808,7 @@ def temporal_padding(x, padding=(1, 1)):
                     input_shape[1] + padding[0] + padding[1],
                     input_shape[2])
     output = T.zeros(output_shape)
-    return T.set_subtensor(output[:, padding[0]:x.shape[1] + padding[1], :], x)
+    return T.set_subtensor(output[:, padding[0]:x.shape[1] + padding[0], :], x)
 
 
 def spatial_2d_padding(x, padding=((1, 1),  (1, 1)), data_format=None):

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -251,7 +251,11 @@ class Conv1D(_Conv):
             specifying the stride length of the convolution.
             Specifying any stride value != 1 is incompatible with specifying
             any `dilation_rate` value != 1.
-        padding: One of `"valid"` or `"same"` (case-insensitive).
+        padding: One of `"valid"`, `"causal"` or `"same"` (case-insensitive).
+            `"causal"` results in causal (dilated) convolutions, e.g. output[t]
+            depends solely on input[:t-1]. Useful when modeling temporal data
+            where the model should not violate the temporal order.
+            See [WaveNet: A Generative Model for Raw Audio, section 2.1](https://arxiv.org/abs/1609.03499).
         dilation_rate: an integer or tuple/list of a single integer, specifying
             the dilation rate to use for dilated convolution.
             Currently, specifying any `dilation_rate` value != 1 is

--- a/keras/utils/conv_utils.py
+++ b/keras/utils/conv_utils.py
@@ -55,11 +55,11 @@ def normalize_data_format(value):
 
 def normalize_padding(value):
     padding = value.lower()
-    allowed = {'valid', 'same'}
+    allowed = {'valid', 'same', 'causal'}
     if K.backend() == 'theano':
         allowed.add('full')
     if padding not in allowed:
-        raise ValueError('The `padding` argument must be one of "valid", "same". '
+        raise ValueError('The `padding` argument must be one of "valid", "same" (or "causal" for Conv1D). '
                          'Received: ' + str(padding))
     return padding
 
@@ -102,12 +102,14 @@ def conv_output_length(input_length, filter_size,
     """
     if input_length is None:
         return None
-    assert padding in {'same', 'valid', 'full'}
+    assert padding in {'same', 'valid', 'full', 'causal'}
     dilated_filter_size = filter_size + (filter_size - 1) * (dilation - 1)
     if padding == 'same':
         output_length = input_length
     elif padding == 'valid':
         output_length = input_length - dilated_filter_size + 1
+    elif padding == 'causal':
+        output_length = input_length
     elif padding == 'full':
         output_length = input_length + dilated_filter_size - 1
     return (output_length + stride - 1) // stride

--- a/keras/utils/test_utils.py
+++ b/keras/utils/test_utils.py
@@ -55,9 +55,11 @@ def layer_test(layer_cls, kwargs={}, input_shape=None, input_dtype=None,
                 input_data_shape[i] = np.random.randint(1, 4)
         input_data = (10 * np.random.random(input_data_shape))
         input_data = input_data.astype(input_dtype)
-    elif input_shape is None:
-        input_shape = input_data.shape
-
+    else:
+        if input_shape is None:
+            input_shape = input_data.shape
+        if input_dtype is None:
+            input_dtype = input_data.dtype
     if expected_output_dtype is None:
         expected_output_dtype = input_dtype
 

--- a/tests/keras/layers/convolutional_test.py
+++ b/tests/keras/layers/convolutional_test.py
@@ -17,6 +17,51 @@ else:
 
 
 @keras_test
+def test_causal_dilated_conv():
+    # Causal:
+    layer_test(convolutional.Conv1D,
+               input_data=np.reshape(np.arange(4, dtype='float32'), (1, 4, 1)),
+               kwargs={
+                   'filters': 1,
+                   'kernel_size': 2,
+                   'dilation_rate': 1,
+                   'padding': 'causal',
+                   'kernel_initializer': 'ones',
+                   'use_bias': False,
+               },
+               expected_output=[[[0], [1], [3], [5]]]
+               )
+
+    # Non-causal:
+    layer_test(convolutional.Conv1D,
+               input_data=np.reshape(np.arange(4, dtype='float32'), (1, 4, 1)),
+               kwargs={
+                   'filters': 1,
+                   'kernel_size': 2,
+                   'dilation_rate': 1,
+                   'padding': 'valid',
+                   'kernel_initializer': 'ones',
+                   'use_bias': False,
+               },
+               expected_output=[[[1], [3], [5]]]
+               )
+
+    # Causal dilated with larger kernel size:
+    layer_test(convolutional.Conv1D,
+               input_data=np.reshape(np.arange(10, dtype='float32'), (1, 10, 1)),
+               kwargs={
+                   'filters': 1,
+                   'kernel_size': 3,
+                   'dilation_rate': 2,
+                   'padding': 'causal',
+                   'kernel_initializer': 'ones',
+                   'use_bias': False,
+               },
+               expected_output=np.float32([[[0], [1], [2], [4], [6], [9], [12], [15], [18], [21]]])
+               )
+
+
+@keras_test
 def test_conv_1d():
     batch_size = 2
     steps = 8

--- a/tests/keras/layers/convolutional_test.py
+++ b/tests/keras/layers/convolutional_test.py
@@ -47,13 +47,13 @@ def test_conv_1d():
                                'strides': strides},
                        input_shape=(batch_size, steps, input_dim))
 
-    # Test dilation
-    layer_test(convolutional.Conv1D,
-               kwargs={'filters': filters,
-                       'kernel_size': kernel_size,
-                       'padding': padding,
-                       'dilation_rate': 2},
-               input_shape=(batch_size, steps, input_dim))
+        # Test dilation
+        layer_test(convolutional.Conv1D,
+                   kwargs={'filters': filters,
+                           'kernel_size': kernel_size,
+                           'padding': padding,
+                           'dilation_rate': 2},
+                   input_shape=(batch_size, steps, input_dim))
 
 
 @keras_test


### PR DESCRIPTION
Adds a boolean causal flag to Conv1D which results in Causal (Dilated) Convolutions as suggested in the Wavenet paper. See #5297. 

Additionally, this PR fixes a bug in temporal_padding for theano, an issues with using input_data for layer_test, and an issue with test_convolution_1d where dilated convolutions where tested for only one padding type. All these are in commit d1e4ef8 which can be cherry-picked.