### PR TITLE
Theano test case fix: Fix for saving models

### DIFF
--- a/keras/models.py
+++ b/keras/models.py
@@ -137,10 +137,17 @@ def save_model(model, filepath, overwrite=True):
                 weight_values = K.batch_get_value(symbolic_weights)
                 weight_names = []
                 for i, (w, val) in enumerate(zip(symbolic_weights, weight_values)):
-                    if hasattr(w, 'name') and w.name:
-                        name = str(w.name)
+                    # Default values of symbolic_weights is /variable for theano
+                    if K.backend() == 'theano':
+                        if hasattr(w, 'name') and w.name != "/variable":
+                            name = str(w.name)
+                        else:
+                            name = 'param_' + str(i)
                     else:
-                        name = 'param_' + str(i)
+                        if hasattr(w, 'name') and w.name:
+                            name = str(w.name)
+                        else:
+                            name = 'param_' + str(i)
                     weight_names.append(name.encode('utf8'))
                 optimizer_weights_group.attrs['weight_names'] = weight_names
                 for name, val in zip(weight_names, weight_values):


### PR DESCRIPTION
Theano default variable name is "/variable".  Fixed save_model method for theano.

I am on to other theano related errors as well.

tests/test_model_saving.py::test_sequential_model_saving 
tests/test_model_saving.py::test_sequential_model_saving_2 
[gw0] PASSED tests/test_model_saving.py::test_sequential_model_saving_2 
tests/test_model_saving.py::test_saving_without_compilation 
[gw0] PASSED tests/test_model_saving.py::test_saving_without_compilation 
tests/test_model_saving.py::test_saving_right_after_compilation 
[gw1] PASSED tests/test_model_saving.py::test_sequential_model_saving 
tests/test_model_saving.py::test_fuctional_model_saving 
[gw0] PASSED tests/test_model_saving.py::test_saving_right_after_compilation 
tests/test_model_saving.py::test_loading_weights_by_name 
[gw1] PASSED tests/test_model_saving.py::test_fuctional_model_saving 
[gw0] PASSED tests/test_model_saving.py::test_loading_weights_by_name 
tests/test_model_saving.py::test_saving_lambda_custom_objects 
tests/test_model_saving.py::test_loading_weights_by_name_2 
[gw1] PASSED tests/test_model_saving.py::test_loading_weights_by_name_2 
[gw0] PASSED tests/test_model_saving.py::test_saving_lambda_custom_objects 
