### PR TITLE
Fix for io utils: raise indexError for invalid key type

### DIFF
--- a/keras/utils/io_utils.py
+++ b/keras/utils/io_utils.py
@@ -87,6 +87,8 @@ class HDF5Matrix(object):
                 idx = [x + self.start for x in key]
             else:
                 raise IndexError
+        else:
+            raise IndexError
         if self.normalizer is not None:
             return self.normalizer(self.data[idx])
         else:


### PR DESCRIPTION
If an invalid key type is given, the `idx` variable will not be defined and you will get an UnboundLocalError

```

  File "/mnt/dokumneter/kode/deeplearning/keras/venv/lib/python3.5/site-packages/keras/utils/io_utils.py", line 77, in __getitem__
    return self.normalizer(self.data[idx])
UnboundLocalError: local variable 'idx' referenced before assignment

```