### PR TITLE
Multiply -> Product

### DIFF
--- a/keras/layers/merge.py
+++ b/keras/layers/merge.py
@@ -327,7 +327,7 @@ def add(inputs, **kwargs):
 
 
 def multiply(inputs, **kwargs):
-    """Functional interface to the `Product` layer.
+    """Functional interface to the `Multiply` layer.
 
     # Arguments
         inputs: A list of input tensors (at least 2).

--- a/keras/layers/merge.py
+++ b/keras/layers/merge.py
@@ -58,7 +58,7 @@ class _Merge(Layer):
 
 
 class Sum(_Merge):
-    """Layer that sums a list of inputs.
+    """Layer that adds a list of inputs.
 
     It takes as input a list of tensors,
     all of the same shape, and returns
@@ -72,7 +72,7 @@ class Sum(_Merge):
         return output
 
 
-class Multiply(_Merge):
+class Product(_Merge):
     """Layer that multiplies (element-wise) a list of inputs.
 
     It takes as input a list of tensors,
@@ -326,8 +326,8 @@ def sum(inputs, **kwargs):
     return Sum(**kwargs)(inputs)
 
 
-def multiply(inputs, **kwargs):
-    """Functional interface to the `Multiply` layer.
+def product(inputs, **kwargs):
+    """Functional interface to the `Product` layer.
 
     # Arguments
         inputs: A list of input tensors (at least 2).
@@ -336,7 +336,7 @@ def multiply(inputs, **kwargs):
     # Returns
         A tensor, the element-wise product of the inputs.
     """
-    return Multiply(**kwargs)(inputs)
+    return Product(**kwargs)(inputs)
 
 
 def average(inputs, **kwargs):

--- a/keras/layers/merge.py
+++ b/keras/layers/merge.py
@@ -314,7 +314,7 @@ class Dot(_Merge):
 
 
 def add(inputs, **kwargs):
-    """Functional interface to the `Sum` layer.
+    """Functional interface to the `Add` layer.
 
     # Arguments
         inputs: A list of input tensors (at least 2).

--- a/keras/layers/merge.py
+++ b/keras/layers/merge.py
@@ -57,7 +57,7 @@ class _Merge(Layer):
         return K.all(K.concatenate(masks, axis=0), axis=0, keepdims=False)
 
 
-class Sum(_Merge):
+class Add(_Merge):
     """Layer that adds a list of inputs.
 
     It takes as input a list of tensors,
@@ -72,7 +72,7 @@ class Sum(_Merge):
         return output
 
 
-class Product(_Merge):
+class Multiply(_Merge):
     """Layer that multiplies (element-wise) a list of inputs.
 
     It takes as input a list of tensors,
@@ -313,7 +313,7 @@ class Dot(_Merge):
         return dict(list(base_config.items()) + list(config.items()))
 
 
-def sum(inputs, **kwargs):
+def add(inputs, **kwargs):
     """Functional interface to the `Sum` layer.
 
     # Arguments
@@ -326,7 +326,7 @@ def sum(inputs, **kwargs):
     return Sum(**kwargs)(inputs)
 
 
-def product(inputs, **kwargs):
+def multiply(inputs, **kwargs):
     """Functional interface to the `Product` layer.
 
     # Arguments
@@ -336,7 +336,7 @@ def product(inputs, **kwargs):
     # Returns
         A tensor, the element-wise product of the inputs.
     """
-    return Product(**kwargs)(inputs)
+    return Multiply(**kwargs)(inputs)
 
 
 def average(inputs, **kwargs):

--- a/tests/keras/layers/merge_test.py
+++ b/tests/keras/layers/merge_test.py
@@ -9,11 +9,11 @@ from keras.layers import merge
 
 
 @keras_test
-def test_merge_sum():
+def test_merge_add():
     i1 = layers.Input(shape=(4, 5))
     i2 = layers.Input(shape=(4, 5))
     i3 = layers.Input(shape=(4, 5))
-    o = layers.sum([i1, i2, i3])
+    o = layers.add([i1, i2, i3])
     assert o._keras_shape == (None, 4, 5)
     model = models.Model([i1, i2, i3], o)
 
@@ -26,11 +26,11 @@ def test_merge_sum():
 
 
 @keras_test
-def test_merge_product():
+def test_merge_multiply():
     i1 = layers.Input(shape=(4, 5))
     i2 = layers.Input(shape=(4, 5))
     i3 = layers.Input(shape=(4, 5))
-    o = layers.product([i1, i2, i3])
+    o = layers.multiply([i1, i2, i3])
     assert o._keras_shape == (None, 4, 5)
     model = models.Model([i1, i2, i3], o)
 

--- a/tests/keras/layers/merge_test.py
+++ b/tests/keras/layers/merge_test.py
@@ -26,11 +26,11 @@ def test_merge_sum():
 
 
 @keras_test
-def test_merge_multiply():
+def test_merge_product():
     i1 = layers.Input(shape=(4, 5))
     i2 = layers.Input(shape=(4, 5))
     i3 = layers.Input(shape=(4, 5))
-    o = layers.multiply([i1, i2, i3])
+    o = layers.product([i1, i2, i3])
     assert o._keras_shape == (None, 4, 5)
     model = models.Model([i1, i2, i3], o)
 


### PR DESCRIPTION
I am not 100 % sure of this either. But I think the right relationship is add : sum = multiply : product. Add is a verb, and sum is the result of addition; same goes for multiply / product. Since the "+" layer is called `Sum`  , `Product` would be more consistent than `Multiply` even though it was called `mul` mode in Keras 1.
