### PR TITLE
EarlyStopping should use weights with lowest validation error

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 
 import os
 import csv
+import copy
 
 import numpy as np
 import time
@@ -440,6 +441,8 @@ class EarlyStopping(Callback):
     def on_train_begin(self, logs=None):
         self.wait = 0  # Allow instances to be re-used
         self.best = np.Inf if self.monitor_op == np.less else -np.Inf
+        self.best_model_epoch = -1
+        self.best_model_weights = copy.deepcopy(self.model.get_weights())
 
     def on_epoch_end(self, epoch, logs=None):
         current = logs.get(self.monitor)
@@ -450,6 +453,8 @@ class EarlyStopping(Callback):
         if self.monitor_op(current - self.min_delta, self.best):
             self.best = current
             self.wait = 0
+            self.best_model_epoch = epoch
+            self.best_model_weights = copy.deepcopy(self.model.get_weights())
         else:
             if self.wait >= self.patience:
                 self.stopped_epoch = epoch
@@ -457,8 +462,10 @@ class EarlyStopping(Callback):
             self.wait += 1
 
     def on_train_end(self, logs=None):
+        self.model.set_weights(self.best_model_weights)
+
         if self.stopped_epoch > 0 and self.verbose > 0:
-            print('Epoch %05d: early stopping' % (self.stopped_epoch))
+            print('Epoch %05d: early stopping. Using weights from epoch %d according to lowest validation eror' % (self.stopped_epoch, self.best_model_epoch))
 
 
 class RemoteMonitor(Callback):

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -465,7 +465,7 @@ class EarlyStopping(Callback):
         self.model.set_weights(self.best_model_weights)
 
         if self.stopped_epoch > 0 and self.verbose > 0:
-            print('Epoch %05d: early stopping. Using weights from epoch %d according to lowest validation eror' % (self.stopped_epoch, self.best_model_epoch))
+            print('Epoch %05d: early stopping. Using weights from epoch %d according to lowest validation error' % (self.stopped_epoch, self.best_model_epoch))
 
 
 class RemoteMonitor(Callback):


### PR DESCRIPTION
When using EarlyStopping with `patience` > 0, I found the following issue: It will return a model with the weights from the last epoch, but this one will have a higher validation error than an earlier epoch. So I propose to save the weights with the lowest validation error and set them when the training ends.

I think this is pretty standard, it is also described in the [Deep Learning Book](http://www.deeplearningbook.org) [1], page 247, Algorithm 7.1.

This is the first time for me, looking into the internals of Keras, so sorry if I mismatch any conventions.

------------

[1]: Ian Goodfellow, Yoshua Bengio and Aaron Courville: *Deep Learning*, MIT Press 2016.