### PR TITLE
Specify States of RNN Layers Symbolically

### DIFF
--- a/tests/keras/layers/recurrent_test.py
+++ b/tests/keras/layers/recurrent_test.py
@@ -170,10 +170,10 @@ def test_from_config(layer_class):
 def test_specify_state(layer_class):
     states = 2 if layer_class is recurrent.LSTM else 1
     inputs = Input((timesteps, embedding_dim))
-    initial_states = [Input((units,)) for _ in range(states)]
+    initial_state = [Input((units,)) for _ in range(states)]
     layer = layer_class(units)
-    output = layer([inputs] + initial_states)
-    model = Model([inputs] + initial_states, output)
+    output = layer(inputs, initial_state=initial_state)
+    model = Model([inputs] + initial_state, output)
     model.compile(loss='categorical_crossentropy', optimizer='adam')
 
     inputs = np.random.random((num_samples, timesteps, embedding_dim))

--- a/tests/keras/layers/recurrent_test.py
+++ b/tests/keras/layers/recurrent_test.py
@@ -7,6 +7,8 @@ from keras.utils.test_utils import keras_test
 from keras.layers import recurrent
 from keras.layers import embeddings
 from keras.models import Sequential
+from keras.models import Model
+from keras.engine.topology import Input
 from keras.layers.core import Masking
 from keras import regularizers
 from keras import backend as K
@@ -163,6 +165,23 @@ def test_from_config(layer_class):
         l1 = layer_class(units=1, stateful=stateful)
         l2 = layer_class.from_config(l1.get_config())
         assert l1.get_config() == l2.get_config()
+
+@rnn_test
+def test_specify_state(layer_class):
+    states = 2 if layer_class is recurrent.LSTM else 1
+    inputs = Input((timesteps, embedding_dim))
+    initial_states = [Input((units,)) for _ in range(states)]
+    layer = layer_class(units)
+    output = layer([inputs] + initial_states)
+    model = Model([inputs] + initial_states, output)
+    model.compile(loss='categorical_crossentropy', optimizer='adam')
+
+    inputs = np.random.random((num_samples, timesteps, embedding_dim))
+    initial_states = [np.random.random((num_samples, units))
+                      for _ in range(states)]
+    targets = np.random.random((num_samples, units))
+    model.fit([inputs] + initial_states, targets)
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This adds `specify_states` flag to the `Recurrent` Layer and modifies the `BasicRNN`, `GRU`, and `LSTM` layers to use the flag. This flag allows you to call the recurrent layer on a list of tensors. The first element of the list is the input tensor. The remaining elements are the initial state tensors.

See #5358. 