### PR TITLE
skip newsgroup header

### DIFF
--- a/examples/pretrained_word_embeddings.py
+++ b/examples/pretrained_word_embeddings.py
@@ -66,7 +66,11 @@ for name in sorted(os.listdir(TEXT_DATA_DIR)):
                     f = open(fpath)
                 else:
                     f = open(fpath, encoding='latin-1')
-                texts.append(f.read())
+                t = f.read()
+                i = t.find('\n\n')  # skip header
+                if 0 < i:
+                    t = t[i:]
+                texts.append(t)
                 f.close()
                 labels.append(label_id)
 
@@ -141,4 +145,4 @@ model.compile(loss='categorical_crossentropy',
 
 # happy learning!
 model.fit(x_train, y_train, validation_data=(x_val, y_val),
-          epochs=2, batch_size=128)
+          epochs=10, batch_size=128)


### PR DESCRIPTION
(Re-submitted to keras-2 branch.)

Newsgroups message contains header like 'Newsgroups: alt.atheism', which inflates the accuracy to 0.95 (2 epochs).
After removing the header, the val accuracy is 0.47 (2 epochs) and 0.71 (10 epochs).