### PR TITLE
Proper Keras model initialization in multithreaded environment.

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -122,7 +122,8 @@ def get_session():
             _SESSION = tf.Session(config=config)
         session = _SESSION
     if not _MANUAL_VAR_INIT:
-        _initialize_variables()
+        with session.graph.as_default():
+            _initialize_variables()
     return session
 
 


### PR DESCRIPTION
Keras fails If first model weights reading is done from another thread.
This is because:
1. TensorFlow keeps dataflow graph as thread local.
2. Keras assumes the only one dataflow graph in the backend.

See https://gist.github.com/StanislavVolodarskiy/60c770d8f9864487692c88fe6faae892 to reproduce the issue.