### PR TITLE
Shape inference for Theano backend

### DIFF
--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -363,8 +363,10 @@ def batch_dot(x, y, axes=None):
 
 
 def transpose(x):
-    # TODO: `keras_shape` inference.
-    return T.transpose(x)
+    y = T.transpose(x)
+    if hasattr(x, '_keras_shape'):
+        y._keras_shape = tuple(reversed(x._keras_shape))
+    return y
 
 
 def gather(reference, indices):

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -682,8 +682,12 @@ def repeat_elements(x, rep, axis):
     If x has shape (s1, s2, s3) and axis=1, the output
     will have shape (s1, s2 * rep, s3).
     """
-    # TODO: `keras_shape` inference.
-    return T.repeat(x, rep, axis=axis)
+    y = T.repeat(x, rep, axis=axis)
+    if hasattr(x, '_keras_shape'):
+        y._keras_shape = list(x._keras_shape)
+        y._keras_shape[axis] = x._keras_shape[axis]*rep
+        y._keras_shape = tuple(y._keras_shape)
+    return y
 
 
 def resize_images(X, height_factor, width_factor, data_format):

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -799,7 +799,9 @@ def squeeze(x, axis):
     # TODO: `keras_shape` inference.
     shape = list(x.shape)
     shape.pop(axis)
-    return T.reshape(x, tuple(shape))
+    y = T.reshape(x, tuple(shape))
+    y._keras_shape = tuple(shape)
+    return y
 
 
 def temporal_padding(x, padding=(1, 1)):

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -350,7 +350,6 @@ def batch_dot(x, y, axes=None):
 
         output_shape = (100, 30)
     """
-    # TODO: `keras_shape` inference.
     if isinstance(axes, int):
         axes = (axes, axes)
     if axes is None:
@@ -359,6 +358,16 @@ def batch_dot(x, y, axes=None):
     out = T.batched_tensordot(x, y, axes=axes)
     if ndim(out) == 1:
         out = expand_dims(out, 1)
+
+    if hasattr(x, '_keras_shape') and hasattr(y, '_keras_shape'):
+        shape = []
+        for axis in range(len(x._keras_shape)):
+            if axis != axes[0]:
+                shape.append(x._keras_shape[axis])
+        for axis in range(1,len(y._keras_shape)):
+            if axis != axes[1]:
+                shape.append(y._keras_shape[axis])
+        out._keras_shape = tuple(shape)
     return out
 
 

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -671,9 +671,11 @@ def permute_dimensions(x, pattern):
     pattern should be a tuple or list of
     dimension indices, e.g. [0, 2, 1].
     """
-    # TODO: `keras_shape` inference.
     pattern = tuple(pattern)
-    return x.dimshuffle(pattern)
+    y = x.dimshuffle(pattern)
+    if hasattr(x, '_keras_shape'):
+        y._keras_shape = tuple(np.asarray(x._keras_shape)[list(pattern)])
+    return y
 
 
 def repeat_elements(x, rep, axis):
@@ -796,7 +798,6 @@ def expand_dims(x, axis=-1):
 def squeeze(x, axis):
     """Remove a 1-dimension from the tensor at index "axis".
     """
-    # TODO: `keras_shape` inference.
     shape = list(x.shape)
     shape.pop(axis)
     y = T.reshape(x, tuple(shape))

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -874,7 +874,9 @@ def spatial_2d_padding(x, padding=((1, 1), (1, 1)), data_format=None):
                    slice(None))
     else:
         raise ValueError('Invalid data_format:', data_format)
-    return T.set_subtensor(output[indices], x)
+    y = T.set_subtensor(output[indices], x)
+    y._keras_shape = output_shape
+    return y
 
 
 def spatial_3d_padding(x, padding=((1, 1), (1, 1), (1, 1)), data_format=None):

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -687,7 +687,7 @@ def repeat_elements(x, rep, axis):
     y = T.repeat(x, rep, axis=axis)
     if hasattr(x, '_keras_shape'):
         y._keras_shape = list(x._keras_shape)
-        y._keras_shape[axis] = x._keras_shape[axis]*rep
+        y._keras_shape[axis] = x._keras_shape[axis] * rep
         y._keras_shape = tuple(y._keras_shape)
     return y
 
@@ -699,7 +699,6 @@ def resize_images(X, height_factor, width_factor, data_format):
     by a factor of (height_factor, width_factor). Both factors should be
     positive integers.
     """
-    # TODO: `keras_shape` inference.
     if data_format == 'channels_first':
         output = repeat_elements(X, height_factor, axis=2)
         output = repeat_elements(output, width_factor, axis=3)
@@ -719,7 +718,6 @@ def resize_volumes(X, depth_factor, height_factor, width_factor, data_format):
     by a factor of (depth_factor, height_factor, width_factor).
     Both factors should be positive integers.
     """
-    # TODO: `keras_shape` inference.
     if data_format == 'channels_first':
         output = repeat_elements(X, depth_factor, axis=2)
         output = repeat_elements(output, height_factor, axis=3)
@@ -839,7 +837,6 @@ def spatial_2d_padding(x, padding=((1, 1), (1, 1)), data_format=None):
     """Pad the 2nd and 3rd dimensions of a 4D tensor
     with "padding[0]" and "padding[1]" (resp.) zeros left and right.
     """
-    # TODO: `keras_shape` inference.
     assert len(padding) == 2
     assert len(padding[0]) == 2
     assert len(padding[1]) == 2

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -821,7 +821,10 @@ def squeeze(x, axis):
     shape = list(x.shape)
     shape.pop(axis)
     y = T.reshape(x, tuple(shape))
-    y._keras_shape = tuple(shape)
+    if hasattr(x, '_keras_shape'):
+        kshape = list(x._keras_shape)
+        kshape.pop(axis)
+        y._keras_shape = tuple(kshape)
     return y
 
 

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -364,7 +364,7 @@ def batch_dot(x, y, axes=None):
         for axis in range(len(x._keras_shape)):
             if axis != axes[0]:
                 shape.append(x._keras_shape[axis])
-        for axis in range(1,len(y._keras_shape)):
+        for axis in range(1, len(y._keras_shape)):
             if axis != axes[1]:
                 shape.append(y._keras_shape[axis])
         if len(shape) == 1:

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -773,9 +773,10 @@ def batch_flatten(x):
     """Turn a n-D tensor into a 2D tensor where
     the first dimension is conserved.
     """
-    # TODO: `keras_shape` inference.
-    x = T.reshape(x, (x.shape[0], T.prod(x.shape) // x.shape[0]))
-    return x
+    y = T.reshape(x, (x.shape[0], T.prod(x.shape[1:])))
+    if hasattr(x, '_keras_shape'):
+        y._keras_shape = (x._keras_shape[0], np.prod(x._keras_shape[1:]))
+    return y
 
 
 def expand_dims(x, axis=-1):

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -740,10 +740,15 @@ def repeat(x, n):
     If x has shape (samples, dim) and n=2,
     the output will have shape (samples, 2, dim).
     """
-    # TODO: `keras_shape` inference.
     assert x.ndim == 2
-    x = x.dimshuffle((0, 'x', 1))
-    return T.extra_ops.repeat(x, n, axis=1)
+    y = x.dimshuffle((0, 'x', 1))
+    y = T.extra_ops.repeat(y, n, axis=1)
+    if hasattr(x, '_keras_shape'):
+        shape = list(x._keras_shape)
+        shape.insert(1, n)
+        y._keras_shape = tuple(shape)
+
+    return y
 
 
 def arange(start, stop=None, step=1, dtype='int32'):

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -783,7 +783,7 @@ def tile(x, n):
 def flatten(x):
     y = T.flatten(x)
     if hasattr(x, '_keras_shape'):
-        y._keras_shape = (1,) + np.prod(x._keras_shape, )
+        y._keras_shape = (np.prod(x._keras_shape), )
     return y
 
 

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -367,6 +367,8 @@ def batch_dot(x, y, axes=None):
         for axis in range(1,len(y._keras_shape)):
             if axis != axes[1]:
                 shape.append(y._keras_shape[axis])
+        if len(shape) == 1:
+            shape.append(1)     # Expand dims if ndim == 1
         out._keras_shape = tuple(shape)
     return out
 

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -759,8 +759,10 @@ def tile(x, n):
 
 
 def flatten(x):
-    # TODO: `keras_shape` inference.
-    return T.flatten(x)
+    y = T.flatten(x)
+    if hasattr(x, '_keras_shape'):
+        y._keras_shape = (1,) + np.prod(x._keras_shape, )
+    return y
 
 
 def batch_flatten(x):

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -789,7 +789,6 @@ def batch_flatten(x):
 def expand_dims(x, axis=-1):
     """Add a 1-sized dimension at index "dim".
     """
-    # TODO: `keras_shape` inference.
     pattern = [i for i in range(x.type.ndim)]
     if axis < 0:
         if x.type.ndim == 0:
@@ -797,7 +796,12 @@ def expand_dims(x, axis=-1):
         else:
             axis = axis % x.type.ndim + 1
     pattern.insert(axis, 'x')
-    return x.dimshuffle(pattern)
+    y = x.dimshuffle(pattern)
+    if hasattr(x, '_keras_shape'):
+        shape = list(x._keras_shape)
+        shape.insert(axis, 1)
+        y._keras_shape = tuple(shape)
+    return y
 
 
 def squeeze(x, axis):

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -152,7 +152,6 @@ class TestBackend(object):
                 if hasattr(th_z, '_keras_shape'):
                     assert th_z._keras_shape == th_rep.shape
 
-
     def test_tile(self):
         shape = (3, 4)
         arr = np.arange(np.prod(shape)).reshape(shape)
@@ -160,9 +159,12 @@ class TestBackend(object):
         arr_tf = KTF.variable(arr)
 
         n = (2, 1)
-        th_rep = KTH.eval(KTH.tile(arr_th, n))
+        th_z = KTH.tile(arr_th, n)
+        th_rep = KTH.eval(th_z)
         tf_rep = KTF.eval(KTF.tile(arr_tf, n))
         assert_allclose(tf_rep, th_rep, atol=1e-05)
+        if hasattr(th_z, '_keras_shape'):
+            assert th_z._keras_shape == th_rep.shape
 
     def test_value_manipulation(self):
         val = np.random.random((4, 2))

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -122,6 +122,7 @@ class TestBackend(object):
                                       pattern=(2, 0, 1))
         check_single_tensor_operation('repeat', (4, 1), n=3)
         check_single_tensor_operation('flatten', (4, 1))
+        check_single_tensor_operation('batch_flatten', (20, 2, 5))
         check_single_tensor_operation('expand_dims', (4, 3), axis=-1)
         check_single_tensor_operation('expand_dims', (4, 3, 2), axis=1)
         check_single_tensor_operation('squeeze', (4, 3, 1), axis=2)


### PR DESCRIPTION
Shape inferences added

| Op |Test coverage|
|-----------------|:-----------------:|
| `flatten` | :heavy_check_mark: |
| `repeat_elements` | :heavy_check_mark: |
| `batch_flatten` | :heavy_check_mark: |
| `squeeze` | :heavy_check_mark: |
| `permute_dimensions` | :heavy_check_mark: |
| `repeat` | :heavy_check_mark: |
| `expand_dims` | :heavy_check_mark: |
| `spatial_2d_pooling` |
|`transpose`|:heavy_check_mark: |
|`batch_dot`|:heavy_check_mark: |

The original PR was at https://github.com/fchollet/keras/pull/5610. The suggested changes have been fixed. Had to remove shape inference for `tile` due to certain issues (still working on it)