### PR TITLE
Add API conversion interface for MaxPooling1D layer

### DIFF
--- a/keras/layers/pooling.py
+++ b/keras/layers/pooling.py
@@ -5,6 +5,7 @@ from .. import backend as K
 from ..engine import Layer
 from ..engine import InputSpec
 from ..utils import conv_utils
+from ..legacy import interfaces
 
 
 class _Pooling1D(Layer):
@@ -66,6 +67,7 @@ class MaxPooling1D(_Pooling1D):
         3D tensor with shape: `(batch_size, downsampled_steps, features)`.
     """
 
+    @interfaces.legacy_maxpool1d_support
     def __init__(self, pool_size=2, strides=None,
                  padding='valid', **kwargs):
         super(MaxPooling1D, self).__init__(pool_size, strides,

--- a/tests/keras/legacy/interface_test.py
+++ b/tests/keras/legacy/interface_test.py
@@ -28,5 +28,12 @@ def test_dense_legacy_interface():
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
 
+@keras_test
+def test_maxpool1d_legacy_interface():
+    old_layer = keras.layers.MaxPool1D(pool_length=2, border_mode='valid', name='maxpool1d')
+    new_layer = keras.layers.MaxPool1D(pool_size=2, padding='valid', name='maxpool1d')
+    assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
+
+
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
Add API conversion interface for MaxPooling1D layer.

`if args:`
`# The first entry in `args` is `self`. So, args[1:]`
`signature += ', '.join([str(arg) for arg in args[1:]])`

I add above to show a warning messgewhen people use just one old argument and one without argument like `old_layer = keras.layers.MaxPool1D(2, border_mode='valid', name='maxpool1d')`


I would like ask some advice.

When people use only old version of keyword argument, like `old_layer = keras.layers.MaxPool1D(pool_length=2, border_mode='valid', name='maxpool1d')`

warning message will be ``Update your `MaxPooling1D` layer call to the Keras 2 API: `MaxPooling1D(, pool_size=2, padding="valid")``. 

If I try to get rid of the first comma, code is getting messy. Is there any advice or style using in this case on Keras?