### PR TITLE
Fixed argument for 'convert_legacy_kwrags'

### DIFF
--- a/keras/legacy/interfaces.py
+++ b/keras/legacy/interfaces.py
@@ -86,7 +86,7 @@ def legacy_dense_support(func):
             ('bias', 'use_bias'),
         ]
         kwargs = convert_legacy_kwargs('Dense',
-                                       args,
+                                       args[1:],
                                        kwargs,
                                        conversions)
         return func(*args, **kwargs)


### PR DESCRIPTION
The first entry in `args` is `self`. So, change args to args[1:]