### PR TITLE
Do not assume outputs.dtype is equal to inputs.dtype in rnn() (tensorflow_backend.py)

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -2122,8 +2122,9 @@ def rnn(step_function, inputs, initial_states,
         states = tuple(initial_states)
 
         time_steps = tf.shape(inputs)[0]
+        outputs, _ = step_function(inputs[0], initial_states + constants)
         output_ta = tensor_array_ops.TensorArray(
-            dtype=inputs.dtype,
+            dtype=outputs.dtype,
             size=time_steps,
             tensor_array_name='output_ta')
         input_ta = tensor_array_ops.TensorArray(

--- a/tests/keras/layers/test_wrappers.py
+++ b/tests/keras/layers/test_wrappers.py
@@ -25,7 +25,7 @@ def test_TimeDistributed():
     weights = model.layers[0].get_weights()
 
     reference = Sequential()
-    reference.add(core.TimeDistributedDense(2, batch_input_shape=(1, 3, 4), weights=weights))
+    reference.add(wrappers.TimeDistributed(core.Dense(2), batch_input_shape=(1, 3, 4), weights=weights))
     reference.add(core.Activation('relu'))
     reference.compile(optimizer='rmsprop', loss='mse')
 

--- a/tests/keras/layers/test_wrappers.py
+++ b/tests/keras/layers/test_wrappers.py
@@ -25,7 +25,7 @@ def test_TimeDistributed():
     weights = model.layers[0].get_weights()
 
     reference = Sequential()
-    reference.add(wrappers.TimeDistributed(core.Dense(2), batch_input_shape=(1, 3, 4), weights=weights))
+    reference.add(wrappers.TimeDistributed(core.Dense(2, weights=weights), batch_input_shape=(1, 3, 4)))
     reference.add(core.Activation('relu'))
     reference.compile(optimizer='rmsprop', loss='mse')
 

--- a/tests/keras/layers/test_wrappers.py
+++ b/tests/keras/layers/test_wrappers.py
@@ -3,7 +3,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 from keras.utils.test_utils import keras_test
 from keras.layers import wrappers, Input
-from keras.layers import core, convolutional, recurrent
+from keras.layers import core, convolutional, recurrent, embeddings
 from keras.models import Sequential, Model, model_from_json
 
 

--- a/tests/keras/layers/test_wrappers.py
+++ b/tests/keras/layers/test_wrappers.py
@@ -19,20 +19,11 @@ def test_TimeDistributed():
     # test config
     model.get_config()
 
-    # compare to TimeDistributedDense
+    # test when specifying a batch_input_shape
     test_input = np.random.random((1, 3, 4))
     test_output = model.predict(test_input)
     weights = model.layers[0].get_weights()
 
-    reference = Sequential()
-    reference.add(core.TimeDistributedDense(2, input_shape=(3, 4), weights=weights))
-    reference.add(core.Activation('relu'))
-    reference.compile(optimizer='rmsprop', loss='mse')
-
-    reference_output = reference.predict(test_input)
-    assert_allclose(test_output, reference_output, atol=1e-05)
-
-    # test when specifying a batch_input_shape
     reference = Sequential()
     reference.add(core.TimeDistributedDense(2, batch_input_shape=(1, 3, 4), weights=weights))
     reference.add(core.Activation('relu'))


### PR DESCRIPTION
The tensorflow rnn() code assumes the outputs.dtyep is equal to the inputs.dtype (the part used only with a fixed batch size). It fails with step_functions as Embedding.

Added unit test of TimeDistributed Embedding with and without batch_input_shape