### PR TITLE
Added dtype to map_fn

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -3091,7 +3091,7 @@ def ctc_decode(y_pred, input_length, greedy=True, beam_width=100,
 
 # HIGH ORDER FUNCTIONS
 
-def map_fn(fn, elems, name=None):
+def map_fn(fn, elems, name=None, dtype=None):
     """Map the function fn over the elements elems and return the outputs.
 
     # Arguments
@@ -3103,7 +3103,7 @@ def map_fn(fn, elems, name=None):
         Tensor with first dimension equal to the elems and second depending on
         fn
     """
-    return tf.map_fn(fn, elems, name=name)
+    return tf.map_fn(fn, elems, name=name, dtype=dtype)
 
 
 def foldl(fn, elems, initializer=None, name=None):

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -2061,7 +2061,7 @@ def ctc_batch_cost(y_true, y_pred, input_length, label_length):
 
 # HIGH ORDER FUNCTIONS
 
-def map_fn(fn, elems, name=None):
+def map_fn(fn, elems, name=None, dtype=None):
     """Map the function fn over the elements elems and return the outputs.
 
     # Arguments

--- a/tests/keras/backend/test_backends.py
+++ b/tests/keras/backend/test_backends.py
@@ -908,15 +908,25 @@ class TestBackend(object):
     def test_map(self):
         x = np.random.rand(10, 3).astype(np.float32)
         for K in [KTF, KTH]:
-            kx = K.eval(K.map_fn(K.sum, x))
+            vx = K.variable(x)
+            kx = K.eval(K.map_fn(K.sum, vx))
+            # make sure we can also walk the indexes in tensorflow which we
+            # can't without specifying dtype
+            kx2 = K.eval(K.map_fn(
+                lambda i: K.sum(vx[i]),
+                K.arange(10),
+                dtype=K.floatx()
+            ))
 
             assert (10,) == kx.shape
+            assert (10,) == kx2.shape
             assert_allclose(x.sum(axis=1), kx, atol=1e-05)
+            assert_allclose(kx, kx2, atol=1e-05)
 
     def test_foldl(self):
         x = np.random.rand(10, 3).astype(np.float32)
         for K in [KTF, KTH]:
-            kx = K.eval(K.foldl(lambda a, b: a + b, x))
+            kx = K.eval(K.foldl(lambda a, b: a + b, K.variable(x)))
 
             assert (3,) == kx.shape
             assert_allclose(x.sum(axis=0), kx, atol=1e-05)
@@ -928,8 +938,9 @@ class TestBackend(object):
         # right to left we have no such problem and the result is larger
         x = np.array([1e-20, 1e-20, 10, 10, 10], dtype=np.float32)
         for K in [KTF, KTH]:
-            p1 = K.eval(K.foldl(lambda a, b: a * b, x))
-            p2 = K.eval(K.foldr(lambda a, b: a * b, x))
+            vx = K.variable(x)
+            p1 = K.eval(K.foldl(lambda a, b: a * b, vx))
+            p2 = K.eval(K.foldr(lambda a, b: a * b, vx))
 
             assert p1 < p2
             assert 9e-38 < p2 <= 1e-37


### PR DESCRIPTION
Tensorflow requires to declare the return dtype of the mapping function if it is different than the mapped over sequence. This means that before we couldn't map over indexes. The following code shows what we could not do.

```python
from keras import backend as K
import numpy as np
x = K.variable(np.random.rand(10, 3).astype(np.float32))
s = K.eval(K.map_fn(
    lambda i: K.sum(x[i]),
    K.arange(10),
    dtype=K.floatx()  # omitting that would result in a pretty big traceback
                      # which in the end would say that we are trying to write
                      # floats to an integer array
))
```

The above functionality could be very useful because it enables code like the following

```python
from keras import backend as K
import numpy as np
x = K.variable(np.random.rand(10, 3).astype(np.float32))
y = K.variable(np.random.rand(3, 1).astype(np.float32))
z = K.dot(x, y)
s = K.eval(K.map_fn(
    lambda i: K.gradients(z[i], y)[0],
    K.arange(10),
    dtype=K.floatx()
))
```