### PR TITLE
Issue #51 - SignalStopping

### DIFF
--- a/docs/templates/getting-started/faq.md
+++ b/docs/templates/getting-started/faq.md
@@ -242,6 +242,20 @@ Find out more in the [callbacks documentation](/callbacks).
 
 ---
 
+### How can I interrupt training with human intervention?
+
+You can use an `SignalStopping` callback to listen for SIGINT (Ctrl+C):
+
+```python
+from keras.callbacks import SignalStopping
+signal_stopping = SignalStopping(verbose=1)
+model.fit(X, y, validation_split=0.2, callbacks=[signal])
+```
+
+Find out more in the [callbacks documentation](/callbacks).
+
+---
+
 ### How is the validation split computed?
 
 If you set the `validation_split` argument in `model.fit` to e.g. 0.1, then the validation data used will be the *last 10%* of the data. If you set it to 0.25, it will be the last 25% of the data, etc. Note that the data isn't shuffled before extracting the validation split, so the validation is literally just the *last* x% of samples in the input you passed.

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -928,3 +928,47 @@ class LambdaCallback(Callback):
             self.on_train_end = on_train_end
         else:
             self.on_train_end = lambda logs: None
+
+
+import signal
+class SignalStopping(Callback):
+    '''Stop training when an interrupt signal (or other) was received
+
+    # Arguments
+        sig: the signal to listen to. Defaults to signal.SIGINT.
+        doubleSignalExits: Receiving the signal twice exits the python
+            process instead of waiting for this epoch to finish.
+        patience: number of epochs with no improvement
+            after which training will be stopped.
+        verbose: verbosity mode.
+    '''
+    def __init__(self, sig=signal.SIGINT, doubleSignalExits=False, verbose=0):
+
+        super(SignalStopping, self).__init__()
+
+        self.signal_received = False
+        self.verbose = verbose
+        self.doubleSignalExits = doubleSignalExits
+
+        def signal_handler(sig, frame):
+            if self.signal_received and self.doubleSignalExits:
+                if self.verbose > 0:
+                    print('') #new line to not print on current status bar. Better solution?
+                    print('Received signal to stop ' + str(sig)+' twice. Exiting..')
+                exit(sig)
+
+            self.signal_received = True
+            if self.verbose > 0:
+                print('') #new line to not print on current status bar. Better solution?
+                print('Received signal to stop: ' + str(sig))
+        signal.signal(signal.SIGINT, signal_handler)
+        self.stopped_epoch = 0
+
+    def on_epoch_end(self, epoch, logs={}):
+        if self.signal_received:
+            self.stopped_epoch = epoch
+            self.model.stop_training = True
+
+    def on_train_end(self, logs={}):
+        if self.stopped_epoch > 0 and self.verbose > 0:
+            print('Epoch %05d: stopping due to signal' % (self.stopped_epoch))


### PR DESCRIPTION
Regarding Issue #51  - I've made a small Callback which listens for SIGINT to allow the user to intervene during fitting and stop the training based on his judgement.
The Callback has docstrings describing it and the arguments and I've added both a relevant test which showcases the usage (both being invoked and not) as well as an example in the FAQ docs.

I believe I covered the contributing guidelines, please let me know if I've missed something.