### PR TITLE
Fixes value of 'pool_size' argument of unit test about 'legacy_pooling2d_support'

### DIFF
--- a/tests/keras/legacy/interface_test.py
+++ b/tests/keras/legacy/interface_test.py
@@ -199,47 +199,47 @@ def test_gaussiandropout_legacy_interface():
 
 @keras_test
 def test_maxpooling2d_legacy_interface():
-    old_layer = keras.layers.MaxPool2D(pool_size=(2, 2), border_mode='valid', name='maxpool2d')
+    old_layer = keras.layers.MaxPooling2D(pool_size=(2, 2), border_mode='valid', name='maxpool2d')
     new_layer = keras.layers.MaxPool2D(pool_size=2, padding='valid', name='maxpool2d')
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
-    old_layer = keras.layers.MaxPool2D((2, 2), 2, 'valid', name='maxpool2d')
+    old_layer = keras.layers.MaxPooling2D((2, 2), 2, 'valid', name='maxpool2d')
     new_layer = keras.layers.MaxPool2D(pool_size=2, strides=2, padding='valid', name='maxpool2d')
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
-    old_layer = keras.layers.MaxPool2D((2, 2), padding='valid', dim_ordering='tf', name='maxpool2d')
+    old_layer = keras.layers.MaxPooling2D((2, 2), padding='valid', dim_ordering='tf', name='maxpool2d')
     new_layer = keras.layers.MaxPool2D(pool_size=2, padding='valid', data_format='channels_last', name='maxpool2d')
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
-    old_layer = keras.layers.MaxPool2D((2, 2), padding='valid', dim_ordering='th', name='maxpool2d')
+    old_layer = keras.layers.MaxPooling2D((2, 2), padding='valid', dim_ordering='th', name='maxpool2d')
     new_layer = keras.layers.MaxPool2D(pool_size=2, padding='valid', data_format='channels_first', name='maxpool2d')
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
-    old_layer = keras.layers.MaxPool2D((2, 2), padding='valid', dim_ordering='default', name='maxpool2d')
+    old_layer = keras.layers.MaxPooling2D((2, 2), padding='valid', dim_ordering='default', name='maxpool2d')
     new_layer = keras.layers.MaxPool2D(pool_size=2, padding='valid', name='maxpool2d')
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
 
 @keras_test
 def test_avgpooling2d_legacy_interface():
-    old_layer = keras.layers.MaxPooling2D(pool_size=(2, 2), border_mode='valid', name='avgpooling2d')
-    new_layer = keras.layers.MaxPooling2D(pool_size=(2, 2), padding='valid', name='avgpooling2d')
+    old_layer = keras.layers.AveragePooling2D(pool_size=(2, 2), border_mode='valid', name='avgpooling2d')
+    new_layer = keras.layers.AvgPool2D(pool_size=(2, 2), padding='valid', name='avgpooling2d')
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
-    old_layer = keras.layers.MaxPooling2D((2, 2), (2, 2), 'valid', name='avgpooling2d')
-    new_layer = keras.layers.MaxPooling2D(pool_size=(2, 2), strides=(2, 2), padding='valid', name='avgpooling2d')
+    old_layer = keras.layers.AveragePooling2D((2, 2), (2, 2), 'valid', name='avgpooling2d')
+    new_layer = keras.layers.AvgPool2D(pool_size=(2, 2), strides=(2, 2), padding='valid', name='avgpooling2d')
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
     old_layer = keras.layers.AveragePooling2D((2, 2), padding='valid', dim_ordering='tf', name='avgpooling2d')
-    new_layer = keras.layers.AveragePooling2D(pool_size=2, padding='valid', data_format='channels_last', name='avgpooling2d')
+    new_layer = keras.layers.AvgPool2D(pool_size=2, padding='valid', data_format='channels_last', name='avgpooling2d')
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
     old_layer = keras.layers.AveragePooling2D((2, 2), padding='valid', dim_ordering='th', name='avgpooling2d')
-    new_layer = keras.layers.AveragePooling2D(pool_size=2, padding='valid', data_format='channels_first', name='avgpooling2d')
+    new_layer = keras.layers.AvgPool2D(pool_size=2, padding='valid', data_format='channels_first', name='avgpooling2d')
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
     old_layer = keras.layers.AveragePooling2D((2, 2), padding='valid', dim_ordering='default', name='avgpooling2d')
-    new_layer = keras.layers.AveragePooling2D(pool_size=2, padding='valid', name='avgpooling2d')
+    new_layer = keras.layers.AvgPool2D(pool_size=2, padding='valid', name='avgpooling2d')
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
 

--- a/tests/keras/legacy/interface_test.py
+++ b/tests/keras/legacy/interface_test.py
@@ -199,23 +199,23 @@ def test_gaussiandropout_legacy_interface():
 
 @keras_test
 def test_maxpooling2d_legacy_interface():
-    old_layer = keras.layers.MaxPool2D(pool_size=2, border_mode='valid', name='maxpool2d')
+    old_layer = keras.layers.MaxPool2D(pool_size=(2, 2), border_mode='valid', name='maxpool2d')
     new_layer = keras.layers.MaxPool2D(pool_size=2, padding='valid', name='maxpool2d')
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
-    old_layer = keras.layers.MaxPool2D(2, 2, 'valid', name='maxpool2d')
+    old_layer = keras.layers.MaxPool2D((2, 2), 2, 'valid', name='maxpool2d')
     new_layer = keras.layers.MaxPool2D(pool_size=2, strides=2, padding='valid', name='maxpool2d')
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
-    old_layer = keras.layers.MaxPool2D(2, padding='valid', dim_ordering='tf', name='maxpool2d')
+    old_layer = keras.layers.MaxPool2D((2, 2), padding='valid', dim_ordering='tf', name='maxpool2d')
     new_layer = keras.layers.MaxPool2D(pool_size=2, padding='valid', data_format='channels_last', name='maxpool2d')
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
-    old_layer = keras.layers.MaxPool2D(2, padding='valid', dim_ordering='th', name='maxpool2d')
+    old_layer = keras.layers.MaxPool2D((2, 2), padding='valid', dim_ordering='th', name='maxpool2d')
     new_layer = keras.layers.MaxPool2D(pool_size=2, padding='valid', data_format='channels_first', name='maxpool2d')
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
-    old_layer = keras.layers.MaxPool2D(2, padding='valid', dim_ordering='default', name='maxpool2d')
+    old_layer = keras.layers.MaxPool2D((2, 2), padding='valid', dim_ordering='default', name='maxpool2d')
     new_layer = keras.layers.MaxPool2D(pool_size=2, padding='valid', name='maxpool2d')
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
@@ -230,15 +230,15 @@ def test_avgpooling2d_legacy_interface():
     new_layer = keras.layers.MaxPooling2D(pool_size=(2, 2), strides=(2, 2), padding='valid', name='avgpooling2d')
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
-    old_layer = keras.layers.AveragePooling2D(2, padding='valid', dim_ordering='tf', name='avgpooling2d')
+    old_layer = keras.layers.AveragePooling2D((2, 2), padding='valid', dim_ordering='tf', name='avgpooling2d')
     new_layer = keras.layers.AveragePooling2D(pool_size=2, padding='valid', data_format='channels_last', name='avgpooling2d')
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
-    old_layer = keras.layers.AveragePooling2D(2, padding='valid', dim_ordering='th', name='avgpooling2d')
+    old_layer = keras.layers.AveragePooling2D((2, 2), padding='valid', dim_ordering='th', name='avgpooling2d')
     new_layer = keras.layers.AveragePooling2D(pool_size=2, padding='valid', data_format='channels_first', name='avgpooling2d')
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
-    old_layer = keras.layers.AveragePooling2D(2, padding='valid', dim_ordering='default', name='avgpooling2d')
+    old_layer = keras.layers.AveragePooling2D((2, 2), padding='valid', dim_ordering='default', name='avgpooling2d')
     new_layer = keras.layers.AveragePooling2D(pool_size=2, padding='valid', name='avgpooling2d')
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 


### PR DESCRIPTION
I changed `'pool_size=2'` to `'pool_size=(2,2)'` because it is impossible to use integer alone in old_layer(keras-1) 