### PR TITLE
Fix typos in docs/templates/datasets.md

### DIFF
--- a/docs/templates/datasets.md
+++ b/docs/templates/datasets.md
@@ -69,7 +69,7 @@ from keras.datasets import imdb
 
 - __Arguments:__
 
-    - __path__: if you do have the data locally (at `'~/.keras/datasets/' + path`), if will be downloaded to this location (in cPickle format).
+    - __path__: if you do not have the data locally (at `'~/.keras/datasets/' + path`), it will be downloaded to this location (in cPickle format).
     - __num_words__: integer or None. Top most frequent words to consider. Any less frequent word will appear as 0 in the sequence data.
     - __skip_top__: integer. Top most frequent words to ignore (they will appear as 0s in the sequence data).
     - __maxlen__: int. Maximum sequence length. Any longer sequence will be truncated.
@@ -116,7 +116,7 @@ word_index = reuters.get_word_index(path="reuters_word_index.pkl")
 
 - __Arguments:__
 
-    - __path__: if you do have the index file locally (at `'~/.keras/datasets/' + path`), if will be downloaded to this location (in cPickle format).
+    - __path__: if you do not have the index file locally (at `'~/.keras/datasets/' + path`), it will be downloaded to this location (in cPickle format).
     
 ## MNIST database of handwritten digits
 
@@ -137,4 +137,4 @@ from keras.datasets import mnist
 
 - __Arguments:__
 
-    - __path__: if you do have the index file locally (at `'~/.keras/datasets/' + path`), if will be downloaded to this location (in cPickle format).
+    - __path__: if you do not have the index file locally (at `'~/.keras/datasets/' + path`), it will be downloaded to this location (in cPickle format).

--- a/docs/templates/datasets.md
+++ b/docs/templates/datasets.md
@@ -69,7 +69,8 @@ from keras.datasets import imdb
 
 - __Arguments:__
 
-    - __path__: if you do not have the data locally (at `'~/.keras/datasets/' + path`), it will be downloaded to this location (in cPickle format).
+    - __path__: if you do not have the data locally (at `'~/.keras/datasets/' + path`), it will be 
+    ed to this location.
     - __num_words__: integer or None. Top most frequent words to consider. Any less frequent word will appear as 0 in the sequence data.
     - __skip_top__: integer. Top most frequent words to ignore (they will appear as 0s in the sequence data).
     - __maxlen__: int. Maximum sequence length. Any longer sequence will be truncated.

--- a/docs/templates/datasets.md
+++ b/docs/templates/datasets.md
@@ -117,7 +117,7 @@ word_index = reuters.get_word_index(path="reuters_word_index.pkl")
 
 - __Arguments:__
 
-    - __path__: if you do not have the index file locally (at `'~/.keras/datasets/' + path`), it will be downloaded to this location (in cPickle format).
+    - __path__: if you do not have the index file locally (at `'~/.keras/datasets/' + path`), it will be downloaded to this location.
     
 ## MNIST database of handwritten digits
 
@@ -138,4 +138,4 @@ from keras.datasets import mnist
 
 - __Arguments:__
 
-    - __path__: if you do not have the index file locally (at `'~/.keras/datasets/' + path`), it will be downloaded to this location (in cPickle format).
+    - __path__: if you do not have the index file locally (at `'~/.keras/datasets/' + path`), it will be downloaded to this location.


### PR DESCRIPTION
Fixed two typos in this line (that appears three times in the file):

`path: if you do have the data locally (at '~/.keras/datasets/' + path), if will be downloaded to this location (in cPickle format).`

Changed "if will" to "it will" and "do have" to "do not have".

I read in another PR that there was a code freeze on the branch master so I created this PR for the branch keras-2. I hope that's correct.