### PR TITLE
Do not assume outputs.dtype is equal to inputs.dtype in rnn() (tensorflow_backend.py)

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -2249,8 +2249,9 @@ def rnn(step_function, inputs, initial_states,
         states = tuple(initial_states)
 
         time_steps = tf.shape(inputs)[0]
+        outputs, _ = step_function(inputs[0], initial_states + constants)
         output_ta = tensor_array_ops.TensorArray(
-            dtype=inputs.dtype,
+            dtype=outputs.dtype,
             size=time_steps,
             tensor_array_name='output_ta')
         input_ta = tensor_array_ops.TensorArray(


### PR DESCRIPTION
The tensorflow rnn() code currently assumes the 'outputs.dtype' of the step function is equal to the 'inputs.dtype' (the part used with a fixed batch size). It fails with step_functions as Embedding.

Added unit test of TimeDistributed Embedding with and without batch_input_shape