### PR TITLE
Keras-2: SWWAE example: changed conv ksize and switched to ELU activations

### DIFF
--- a/examples/mnist_swwae.py
+++ b/examples/mnist_swwae.py
@@ -65,7 +65,8 @@ def convresblock(x, nfeats=8, ksize=3, nskipped=2, elu=True):
         if elu:
             y = ELU()(y)
         else:
-            y = BatchNormalization(mode=0, axis=1)(y)
+            # This example assume 'channels_first' data format.
+            y = BatchNormalization(axis=1)(y)
             y = Activation('relu')(y)
         y = Convolution2D(nfeats, 1, 1, border_mode='same')(y)
     return merge([y0, y], mode='sum')

--- a/examples/mnist_swwae.py
+++ b/examples/mnist_swwae.py
@@ -52,19 +52,22 @@ from keras.datasets import mnist
 from keras.models import Model
 from keras.layers import Activation, merge
 from keras.layers import UpSampling2D, Convolution2D, MaxPooling2D
-from keras.layers import Input, BatchNormalization
+from keras.layers import Input, BatchNormalization, ELU
 import matplotlib.pyplot as plt
 import keras.backend as K
 
 
-def convresblock(x, nfeats=8, ksize=3, nskipped=2):
+def convresblock(x, nfeats=8, ksize=3, nskipped=2, elu=True):
     ''' The proposed residual block from [4]'''
     y0 = Convolution2D(nfeats, ksize, ksize, border_mode='same')(x)
     y = y0
     for i in range(nskipped):
-        y = BatchNormalization(mode=0, axis=1)(y)
-        y = Activation('relu')(y)
-        y = Convolution2D(nfeats, ksize, ksize, border_mode='same')(y)
+        if elu:
+            y = ELU()(y)
+        else:
+            y = BatchNormalization(mode=0, axis=1)(y)
+            y = Activation('relu')(y)
+        y = Convolution2D(nfeats, 1, 1, border_mode='same')(y)
     return merge([y0, y], mode='sum')
 
 


### PR DESCRIPTION
I am checking in a few small changes that have irked me ever since we first merged this SWWAE example.

First, I changed the convolution kernels in the residual pathway from size 3x3 to 1x1. Before, with border_mode='same', the image had an extra border of zeros added at every layer of the residual path (2 layers were used in the residual pathway), which made the effective receptive field stupidly big. So that should no longer be the case.

Second, I switched from batchnorm + relu -> ELU, and could train not only almost 2x faster, but also more accurately overall. It seems that batchnorm overhead in theano can slow things down a bit too much for in the context of this toy problem. Because this might not be the case for other problems (larger images for example), I have added the option in the convresblock function that allows the choice of ELU or BN + RELU.

I made the changes and ran again and saw a decent improvement, yet the number of parameters is smaller and the receptive field is smaller (both good things in the context of this toy problem). These changes led to faster training, fewer parameters, and better results, so an overall win.

BEFORE CHANGES:
Epoch 1/5
60000/60000 [==============================] - 110s - loss: 0.0349 - val_loss: 0.0095
Epoch 2/5
60000/60000 [==============================] - 111s - loss: 0.0066 - val_loss: 0.0054
Epoch 3/5
60000/60000 [==============================] - 112s - loss: 0.0051 - val_loss: 0.0045
Epoch 4/5
60000/60000 [==============================] - 157s - loss: 0.0043 - val_loss: 0.0040
Epoch 5/5
60000/60000 [==============================] - 116s - loss: 0.0038 - val_loss: 0.0035

AFTER CHANGES:
Epoch 1/5
60000/60000 [==============================] - 66s - loss: 0.0202 - val_loss: 0.0055
Epoch 2/5
60000/60000 [==============================] - 69s - loss: 0.0044 - val_loss: 0.0035
Epoch 3/5
60000/60000 [==============================] - 72s - loss: 0.0031 - val_loss: 0.0027
Epoch 4/5
60000/60000 [==============================] - 73s - loss: 0.0025 - val_loss: 0.0024
Epoch 5/5
60000/60000 [==============================] - 74s - loss: 0.0022 - val_loss: 0.0021

If there is not a general agreement with these changes, by all means we can ignore this request, but I at least wanted to put it in front of people to get their thoughts.

Thanks,
Anton