### PR TITLE
Legacy interfaces for fit_generator, evaluate_generator, predict_generator

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -22,6 +22,7 @@ from .. import losses
 from .. import metrics as metrics_module
 from ..utils.generic_utils import Progbar
 from .. import callbacks as cbks
+from ..legacy import interfaces
 
 
 def _standardize_input_data(data, names, shapes=None,
@@ -1675,6 +1676,7 @@ class Model(Container):
             return outputs[0]
         return outputs
 
+    @interfaces.legacy_generator_methods_support
     def fit_generator(self, generator,
                       steps_per_epoch,
                       epochs=1,
@@ -1911,6 +1913,7 @@ class Model(Container):
         callbacks.on_train_end()
         return self.history
 
+    @interfaces.legacy_generator_methods_support
     def evaluate_generator(self, generator, steps,
                            max_q_size=10, workers=1, pickle_safe=False):
         """Evaluates the model on a data generator.
@@ -2007,6 +2010,7 @@ class Model(Container):
                                            weights=batch_sizes))
             return averages
 
+    @interfaces.legacy_generator_methods_support
     def predict_generator(self, generator, steps,
                           max_q_size=10, workers=1, pickle_safe=False):
         """Generates predictions for the input samples from a data generator.

--- a/keras/legacy/interfaces.py
+++ b/keras/legacy/interfaces.py
@@ -588,4 +588,3 @@ legacy_spatialdropoutNd_support = generate_legacy_interface(
 
 legacy_lambda_support = generate_legacy_interface(
     allowed_positional_args=['function', 'output_shape'])
-

--- a/keras/legacy/interfaces.py
+++ b/keras/legacy/interfaces.py
@@ -66,6 +66,71 @@ def generate_legacy_interface(allowed_positional_args=None,
     return legacy_support
 
 
+def generate_legacy_method_interface(allowed_positional_args=None,
+                                     conversions=None,
+                                     preprocessor=None,
+                                     value_conversions=None):
+    allowed_positional_args = allowed_positional_args or []
+    conversions = conversions or []
+    value_conversions = value_conversions or []
+
+    def legacy_support(func):
+        @six.wraps(func)
+        def wrapper(*args, **kwargs):
+            method_name = func.__name__
+            if preprocessor:
+                args, kwargs, converted = preprocessor(args, kwargs)
+            else:
+                converted = []
+            if len(args) > len(allowed_positional_args) + 1:
+                raise TypeError('The function `' + method_name +
+                                '` can accept only ' +
+                                str(len(allowed_positional_args)) +
+                                ' positional arguments (' +
+                                str(allowed_positional_args) + '), but '
+                                'you passed the following '
+                                'positional arguments: ' +
+                                str(args[1:]))
+            for key in value_conversions:
+                if key in kwargs:
+                    old_value = kwargs[key]
+                    if old_value in value_conversions[key]:
+                        kwargs[key] = value_conversions[key][old_value]
+            for old_name, new_name in conversions:
+                if old_name in kwargs:
+                    value = kwargs.pop(old_name)
+                    if new_name in kwargs:
+                        raise_duplicate_arg_error(old_name, new_name)
+                    kwargs[new_name] = value
+                    converted.append((new_name, old_name))
+            if converted:
+                signature = '`' + method_name + '('
+                for value in args[1:]:
+                    if isinstance(value, six.string_types):
+                        signature += '"' + value + '"'
+                    elif hasattr(value, '__name__'):
+                        signature += value.__name__ + '()'
+                    else:
+                        signature += str(value)
+                    signature += ', '
+                for i, (name, value) in enumerate(kwargs.items()):
+                    signature += name + '='
+                    if isinstance(value, six.string_types):
+                        signature += '"' + value + '"'
+                    elif hasattr(value, '__name__'):
+                        signature += value.__name__ + '()'
+                    else:
+                        signature += str(value)
+                    if i < len(kwargs) - 1:
+                        signature += ', '
+                signature += ')`'
+                warnings.warn('Update your `' + method_name +
+                              '` function call to the Keras 2 API: ' + signature)
+            return func(*args, **kwargs)
+        return wrapper
+    return legacy_support
+
+
 def raise_duplicate_arg_error(old_arg, new_arg):
     raise TypeError('For the `' + new_arg + '` argument, '
                     'the layer received both '
@@ -492,3 +557,15 @@ legacy_cropping3d_support = generate_legacy_interface(
     value_conversions={'dim_ordering': {'tf': 'channels_last',
                                         'th': 'channels_first',
                                         'default': None}})
+
+legacy_generator_methods_support = generate_legacy_method_interface(
+    allowed_positional_args=['generator', 'steps_per_epoch',
+                             'epochs', 'verbose', 'callbacks',
+                             'validation_data', 'validation_steps',
+                             'class_weight', 'max_q_size', 'workers',
+                             'pickle_safe', 'initial_epoch'],
+    conversions=[('samples_per_epoch', 'steps_per_epoch'),
+                 ('val_samples', 'steps'),
+                 ('nb_epoch', 'epochs'),
+                 ('nb_val_samples', 'validation_steps'),
+                 ('nb_worker', 'workers')])

--- a/tests/keras/legacy/interface_test.py
+++ b/tests/keras/legacy/interface_test.py
@@ -796,6 +796,7 @@ def test_generator_methods_interface():
                             val_samples=2,
                             nb_worker=1)
 
+
 def test_spatialdropout1d_legacy_interface():
     old_layer = keras.layers.SpatialDropout1D(p=0.6, name='sd1d')
     new_layer_1 = keras.layers.SpatialDropout1D(rate=0.6, name='sd1d')

--- a/tests/keras/legacy/interface_test.py
+++ b/tests/keras/legacy/interface_test.py
@@ -2,7 +2,7 @@ import pytest
 import json
 from keras.utils.test_utils import keras_test
 import keras
-
+import numpy as np
 
 @keras_test
 def test_dense_legacy_interface():
@@ -752,19 +752,19 @@ def test_cropping3d_legacy_interface():
 @keras_test
 def test_generator_methods_interface():
     def train_generator():
-        x = keras.backend.common.np.random.randn(2, 2)
-        y = keras.backend.common.np.random.randint(0, 2, size=[2, 1])
+        x = np.random.randn(2, 2)
+        y = np.random.randint(0, 2, size=[2, 1])
         while True:
             yield (x, y)
 
     def val_generator():
-        x = keras.backend.common.np.random.randn(2, 2)
-        y = keras.backend.common.np.random.randint(0, 2, size=[2, 1])
+        x = np.random.randn(2, 2)
+        y = np.random.randint(0, 2, size=[2, 1])
         while True:
             yield (x, y)
 
     def pred_generator():
-        x = keras.backend.common.np.random.randn(1, 2)
+        x = np.random.randn(1, 2)
         while True:
             yield x
 

--- a/tests/keras/legacy/interface_test.py
+++ b/tests/keras/legacy/interface_test.py
@@ -4,6 +4,7 @@ from keras.utils.test_utils import keras_test
 import keras
 import numpy as np
 
+
 @keras_test
 def test_dense_legacy_interface():
     old_layer = keras.layers.Dense(input_dim=3, output_dim=2, name='d')

--- a/tests/keras/legacy/interface_test.py
+++ b/tests/keras/legacy/interface_test.py
@@ -716,8 +716,8 @@ def test_zeropadding2d_legacy_interface():
                                                     'bottom_pad': 2,
                                                     'top_pad': 1,
                                                     'left_pad': 3},
-                                          dim_ordering='tf',
-                                          name='zp2d')
+                                           dim_ordering='tf',
+                                           name='zp2d')
     new_layer = keras.layers.ZeroPadding2D(((1, 2), (3, 4)),
                                            data_format='channels_last',
                                            name='zp2d')
@@ -748,6 +748,44 @@ def test_cropping3d_legacy_interface():
     new_layer = keras.layers.Cropping3D(data_format='channels_last', name='c3d')
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
+
+@keras_test
+def test_generator_methods_interface():
+    def train_generator():
+        x = keras.backend.common.np.random.randn(2, 2)
+        y = keras.backend.common.np.random.randint(0, 2, size=[2, 1])
+        while True:
+            yield (x, y)
+
+    def val_generator():
+        x = keras.backend.common.np.random.randn(2, 2)
+        y = keras.backend.common.np.random.randint(0, 2, size=[2, 1])
+        while True:
+            yield (x, y)
+
+    def pred_generator():
+        x = keras.backend.common.np.random.randn(1, 2)
+        while True:
+            yield x
+
+    x = keras.layers.Input(shape=(2, ))
+    y = keras.layers.Dense(2)(x)
+
+    model = keras.models.Model(inputs=x, outputs=y)
+    model.compile(optimizer='rmsprop',
+                  loss='sparse_categorical_crossentropy',
+                  metrics=['accuracy'])
+    model.fit_generator(generator=train_generator(),
+                        samples_per_epoch=1,
+                        validation_data=val_generator(),
+                        nb_val_samples=1,
+                        nb_worker=1)
+    model.evaluate_generator(generator=train_generator(),
+                             val_samples=2,
+                             nb_worker=1)
+    model.predict_generator(generator=pred_generator(),
+                            val_samples=2,
+                            nb_worker=1)
 
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
Original PR was at #5713. Closed it due to merge issues.
The following changes were requested
- [x] Rebased PR
- [x] Removed try/catch block
- [x] Added `nb_epoch` to `fit_generator` test