### PR TITLE
Bug fix : Model.from_config

### DIFF
--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -1587,6 +1587,7 @@ class Merge(Layer):
 
     @classmethod
     def from_config(cls, config):
+        config = config.copy()
         mode_type = config.pop('mode_type')
         if mode_type == 'function':
             mode = globals()[config['mode']]


### PR DESCRIPTION
The function pops item from the original `dict` passed to the function. This causes an error when building multiple models from the same config:

```python

config = model.get_config()
model1 = Model.from_config(config) # OK
model2 = Model.from_config(config) # error
```