### PR TITLE
Add `return_state` flag to RNNs for seq2seq modeling.

### DIFF
--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -92,6 +92,8 @@ class Recurrent(Layer):
             `[(input_dim, output_dim), (output_dim, output_dim), (output_dim,)]`.
         return_sequences: Boolean. Whether to return the last output
             in the output sequence, or the full sequence.
+        return_state: Boolean. Whether to return the last state
+            in addition to the output.
         go_backwards: Boolean (default False).
             If True, process the input sequence backwards.
         stateful: Boolean (default False). If True, the last state
@@ -134,6 +136,9 @@ class Recurrent(Layer):
         (Optional) 2D tensors with shape `(batch_size, output_dim)`.
 
     # Output shape
+        - if `return_state`: a list of tensors. The first tensor is
+            the ouput. The remaining tensors are the state, with shape
+            `(batch_size, units)`.
         - if `return_sequences`: 3D tensor with shape
             `(batch_size, timesteps, units)`.
         - else, 2D tensor with shape `(batch_size, units)`.
@@ -173,6 +178,7 @@ class Recurrent(Layer):
     """
 
     def __init__(self, return_sequences=False,
+                 return_state=False,
                  go_backwards=False,
                  stateful=False,
                  unroll=False,
@@ -180,6 +186,7 @@ class Recurrent(Layer):
                  **kwargs):
         super(Recurrent, self).__init__(**kwargs)
         self.return_sequences = return_sequences
+        self.return_state = return_state
         self.go_backwards = go_backwards
         self.stateful = stateful
         self.unroll = unroll
@@ -193,16 +200,27 @@ class Recurrent(Layer):
     def compute_output_shape(self, input_shape):
         if isinstance(input_shape, list):
             input_shape = input_shape[0]
+
         if self.return_sequences:
-            return (input_shape[0], input_shape[1], self.units)
+            output_shape = (input_shape[0], input_shape[1], self.units)
         else:
-            return (input_shape[0], self.units)
+            output_shape = (input_shape[0], self.units)
+
+        if self.return_state:
+            state_shape = [(input_shape[0], self.units) for _ in self.states]
+            return [output_shape] + state_shape
+        else:
+            return output_shape
 
     def compute_mask(self, inputs, mask):
-        if self.return_sequences:
-            return mask
+        if isinstance(mask, list):
+            mask = mask[0]
+        output_mask = mask if self.return_sequences else None
+        if self.return_state:
+            state_mask = [None for _ in self.states]
+            return [output_mask] + state_mask
         else:
-            return None
+            return output_mask
 
     def step(self, inputs, states):
         raise NotImplementedError
@@ -308,9 +326,18 @@ class Recurrent(Layer):
             outputs._uses_learning_phase = True
 
         if self.return_sequences:
-            return outputs
+            output = outputs
         else:
-            return last_output
+            output = last_output
+
+        if self.return_state:
+            if not isinstance(states, (list, tuple)):
+                states = [states]
+            else:
+                states =  list(states)
+            return [output] + states
+        else:
+            return output
 
     def reset_states(self, states_value=None):
         if not self.stateful:

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -385,6 +385,7 @@ class Recurrent(Layer):
 
     def get_config(self):
         config = {'return_sequences': self.return_sequences,
+                  'return_state': self.return_state,
                   'go_backwards': self.go_backwards,
                   'stateful': self.stateful,
                   'unroll': self.unroll,

--- a/tests/keras/layers/recurrent_test.py
+++ b/tests/keras/layers/recurrent_test.py
@@ -218,5 +218,21 @@ def test_reset_states_with_values(layer_class):
                                np.ones(K.int_shape(layer.states[0])),
                                atol=1e-4)
 
+
+@rnn_test
+def test_return_state(layer_class):
+    num_states = 2 if layer_class is recurrent.LSTM else 1
+
+    inputs = Input(batch_shape=(num_samples, timesteps, embedding_dim))
+    layer = layer_class(units, return_state=True, stateful=True)
+    outputs = layer(inputs)
+    output, state = outputs[0], outputs[1:]
+    assert len(state) == num_states
+    model = Model(inputs, state[0])
+
+    inputs = np.random.random((num_samples, timesteps, embedding_dim))
+    state = model.predict(inputs)
+    np.testing.assert_allclose(K.eval(layer.states[0]), state, atol=1e-4)
+
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
When creating a seq2seq model, we need to access the final state of the encoder. For `SimpleRNN` and `GRU`, this isn't a problem, because their state is their output. However, `LSTM` hides its internal state. 

This commit adds the `return_state` flag to `Recurrent`. If `True`, the RNN will return a list of tensors of the form `[output, state1, ...]`.

See #5358