### PR TITLE
Update variational_autoencoder_deconv.py

### DIFF
--- a/examples/variational_autoencoder_deconv.py
+++ b/examples/variational_autoencoder_deconv.py
@@ -107,7 +107,7 @@ def vae_loss(x, x_decoded_mean):
     x = K.flatten(x)
     x_decoded_mean = K.flatten(x_decoded_mean)
     xent_loss = img_rows * img_cols * objectives.binary_crossentropy(x, x_decoded_mean)
-    kl_loss = - 0.5 * K.mean(1 + z_log_var - K.square(z_mean) - K.exp(z_log_var), axis=-1)
+    kl_loss = - 0.5 * K.sum(1 + z_log_var - K.square(z_mean) - K.exp(z_log_var), axis=-1)
     return xent_loss + kl_loss
 
 vae = Model(x, x_decoded_mean_squash)


### PR DESCRIPTION
change the weighting KL divergence loss term to be consistent with VAE paper. It has already been similarly updated in the variational_autoencoder.py code.