### PR TITLE
Text Preprocessing unicode support

### DIFF
--- a/keras/preprocessing/text.py
+++ b/keras/preprocessing/text.py
@@ -14,7 +14,7 @@ from six.moves import zip
 import warnings
 
 if sys.version_info < (3,):
-    maketrans = string.maketrans
+    maketrans = lambda intab, outtab: string.maketrans(intab, outtab).decode('latin-1')
 else:
     maketrans = str.maketrans
 


### PR DESCRIPTION
Solves issue https://github.com/fchollet/keras/issues/5745. Allows unicode strings in  `text_to_word_sequence()`.
It's a workaround for python 2