### PR TITLE
Fix learning_phase int check

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1518,7 +1518,7 @@ class Model(Container):
             check_batch_axis=False,
             batch_size=batch_size)
         # prepare inputs, delegate logic to _test_loop
-        if self.uses_learning_phase and not isinstance(K.learning_phase, int):
+        if self.uses_learning_phase and not isinstance(K.learning_phase(), int):
             ins = x + y + sample_weights + [0.]
         else:
             ins = x + y + sample_weights
@@ -1562,7 +1562,7 @@ class Model(Container):
                                  'Batch size: ' + str(batch_size) + '.')
 
         # prepare inputs, delegate logic to _predict_loop
-        if self.uses_learning_phase and not isinstance(K.learning_phase, int):
+        if self.uses_learning_phase and not isinstance(K.learning_phase(), int):
             ins = x + [0.]
         else:
             ins = x
@@ -1612,7 +1612,7 @@ class Model(Container):
             sample_weight=sample_weight,
             class_weight=class_weight,
             check_batch_axis=True)
-        if self.uses_learning_phase and not isinstance(K.learning_phase, int):
+        if self.uses_learning_phase and not isinstance(K.learning_phase(), int):
             ins = x + y + sample_weights + [1.]
         else:
             ins = x + y + sample_weights
@@ -1654,7 +1654,7 @@ class Model(Container):
             x, y,
             sample_weight=sample_weight,
             check_batch_axis=True)
-        if self.uses_learning_phase and not isinstance(K.learning_phase, int):
+        if self.uses_learning_phase and not isinstance(K.learning_phase(), int):
             ins = x + y + sample_weights + [0.]
         else:
             ins = x + y + sample_weights
@@ -1675,7 +1675,7 @@ class Model(Container):
         """
         x = _standardize_input_data(x, self._feed_input_names,
                                     self._feed_input_shapes)
-        if self.uses_learning_phase and not isinstance(K.learning_phase, int):
+        if self.uses_learning_phase and not isinstance(K.learning_phase(), int):
             ins = x + [0.]
         else:
             ins = x


### PR DESCRIPTION
This PR fixes the integer check for `learning_phase` in the following functions:
- evaluate
- predict
- train_on_batch
- test_on_batch
- predict_on_batch

Without this fix, setting `learning_phase` to a fixed value won't work for theano backend.
In that case, the theano function is called with too much arguments. This results in an implicit input
for the first shared variable of the graph.

Code to reproduce:
```python
import numpy as np
import keras.backend as K
from keras.models import Sequential
from keras.layers import Dense, Dropout

K.set_learning_phase(0)
m = Sequential()
m.add(Dropout(0.5, input_shape=(10,)))
m.add(Dense(2, activation='softmax'))

m.predict(np.random.random((10,10)))
```

Error:
```
Traceback (most recent call last):

...

TypeError: Tried to provide value for implicit input: dense_1_W
```

Tensorflow seems to ignore additional arguments.

I'm not sure whether this should go to keras-2 branch or to the master. In case this is the wrong branch, I can submit it to the master again.