### PR TITLE
SWWAE Example: Conv kernel size in resid pathway to 1x1 and activation from BN+RELU to ELU

### DIFF
--- a/examples/mnist_swwae.py
+++ b/examples/mnist_swwae.py
@@ -58,7 +58,29 @@ from keras import layers
 
 
 def convresblock(x, nfeats=8, ksize=3, nskipped=2, elu=True):
-    ''' The proposed residual block from [4]'''
+    """The proposed residual block from [4].
+    
+    Running with elu=True will use ELU nonlinearity and running with
+    elu=False will use BatchNorm + RELU nonlinearity.  While ELU's are fast
+    due to the fact they do not suffer from BatchNorm overhead, they may
+    overfit because they do not offer the stochastic element of the batch
+    formation process of BatchNorm, which acts as a good regularizer.
+
+    # Arguments
+        x: 4D tensor, the tensor to feed through the block
+        nfeats: Integer, number of feature maps for conv layers.
+        ksize: Integer, width and height of conv kernels in first convolution.
+        nskipped: Integer, number of conv layers for the residual function.
+        elu: Boolean, whether to use ELU or BN+RELU.
+
+    # Input shape
+        4D tensor with shape:
+        `(batch, channels, rows, cols)`
+
+    # Output shape
+        4D tensor with shape:
+        `(batch, filters, rows, cols)`
+    """                                            
     y0 = Conv2D(nfeats, ksize, padding='same')(x)
     y = y0
     for i in range(nskipped):

--- a/examples/mnist_swwae.py
+++ b/examples/mnist_swwae.py
@@ -51,20 +51,23 @@ from keras.datasets import mnist
 from keras.models import Model
 from keras.layers import Activation
 from keras.layers import UpSampling2D, Conv2D, MaxPooling2D
-from keras.layers import Input, BatchNormalization
+from keras.layers import Input, BatchNormalization, ELU
 import matplotlib.pyplot as plt
 import keras.backend as K
 from keras import layers
 
 
-def convresblock(x, nfeats=8, ksize=3, nskipped=2):
+def convresblock(x, nfeats=8, ksize=3, nskipped=2, elu=True):
     ''' The proposed residual block from [4]'''
     y0 = Conv2D(nfeats, ksize, padding='same')(x)
     y = y0
     for i in range(nskipped):
-        y = BatchNormalization(axis=1)(y)
-        y = Activation('relu')(y)
-        y = Conv2D(nfeats, ksize, padding='same')(y)
+        if elu:
+            y = ELU()(y)
+        else:
+            y = BatchNormalization(axis=1)(y)
+            y = Activation('relu')(y)
+        y = Conv2D(nfeats, 1, padding='same')(y)
     return layers.add([y0, y])
 
 


### PR DESCRIPTION
The original thread: [https://github.com/fchollet/keras/pull/5722](url)

Long story short, cleaned up resid block by making the resid pathway kernel size 1x1 and added ELU activation instead of the slower BN+RELU. The option to do either one is available; obviously each has its own advantages.

In the end (@nouiz), on Windows 10 with Theano 0.9.0rc4 and cudnn 5 I had the following results for each activation type:

ELU:

Using gpu device 0: GeForce GTX 780 (CNMeM is disabled, cuDNN 5005)
x_train shape: (60000L, 1L, 28L, 28L)
60000 train samples
10000 test samples
Train on 60000 samples, validate on 10000 samples
Epoch 1/5
60000/60000 [==============================] - 69s - loss: 0.0247 - val_loss: 0.0062
Epoch 2/5
60000/60000 [==============================] - 71s - loss: 0.0049 - val_loss: 0.0041
Epoch 3/5
60000/60000 [==============================] - 74s - loss: 0.0037 - val_loss: 0.0033
Epoch 4/5
60000/60000 [==============================] - 76s - loss: 0.0030 - val_loss: 0.0027
Epoch 5/5
60000/60000 [==============================] - 76s - loss: 0.0025 - val_loss: 0.0023

BN+RELU:
Using gpu device 0: GeForce GTX 780 (CNMeM is disabled, cuDNN 5005)
x_train shape: (60000L, 1L, 28L, 28L)
60000 train samples
10000 test samples
Train on 60000 samples, validate on 10000 samples
Epoch 1/5
60000/60000 [==============================] - 104s - loss: 0.0364 - val_loss: 0.0094
Epoch 2/5
60000/60000 [==============================] - 106s - loss: 0.0071 - val_loss: 0.0057
Epoch 3/5
60000/60000 [==============================] - 108s - loss: 0.0052 - val_loss: 0.0049
Epoch 4/5
60000/60000 [==============================] - 108s - loss: 0.0043 - val_loss: 0.0040
Epoch 5/5
60000/60000 [==============================] - 111s - loss: 0.0038 - val_loss: 0.0036