### PR TITLE
keras_v2+python3, `load_weights_from_hdf5_group` character type bug 

### DIFF
--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -2839,11 +2839,11 @@ def load_weights_from_hdf5_group(f, layers):
             and weights file.
     """
     if 'keras_version' in f.attrs:
-        original_keras_version = f.attrs['keras_version']
+        original_keras_version = f.attrs['keras_version'].decode('utf8')
     else:
         original_keras_version = '1'
     if 'backend' in f.attrs:
-        original_backend = f.attrs['backend']
+        original_backend = f.attrs['backend'].decode('utf8')
     else:
         original_backend = None
 
@@ -2911,11 +2911,11 @@ def load_weights_from_hdf5_group_by_name(f, layers):
             and weights file.
     """
     if 'keras_version' in f.attrs:
-        original_keras_version = f.attrs['keras_version']
+        original_keras_version = f.attrs['keras_version'].decode('utf8')
     else:
         original_keras_version = '1'
     if 'backend' in f.attrs:
-        original_backend = f.attrs['backend']
+        original_backend = f.attrs['backend'].decode('utf8')
     else:
         original_backend = None
 


### PR DESCRIPTION
Forgetting to decode bytes strings in `keras.engine.topology.load_weights_from_hdf5_group` and `load_weights_from_hdf5_group_by_name`.
`h5py` returns string as `bytes` object in Python3.   `load_weights_from_hdf5_group()` call `preprocess_weights_for_loading()` with `original_backend` as bytes string.

https://github.com/fchollet/keras/blob/master/keras/engine/topology.py#L2879-L2882

 Unnecessary weight preprocessing will be called, because string comparison between bytes and string is always false in python3.

```py
>>> b'youjo' == 'youjo'
False
```
https://github.com/fchollet/keras/blob/master/keras/engine/topology.py#L2817

## test case
```py
import keras

x = keras.layers.Input(shape=(32, 32, 3))
h = keras.layers.Conv2D(10, (10, 10))(x)
model = keras.models.Model(x, h)
model.save('conv2d.h5')

del model

model = keras.models.load_model('./conv2d.h5')
```

In python2, no error. However in python3, following error occurs.
```
W tensorflow/core/platform/cpu_feature_guard.cc:45] The TensorFlow library wasn't compiled to use SSE3 instructions, but these are available on your machine and could speed up CPU computations.
W tensorflow/core/platform/cpu_feature_guard.cc:45] The TensorFlow library wasn't compiled to use SSE4.1 instructions, but these are available on your machine and could speed up CPU computations.
W tensorflow/core/platform/cpu_feature_guard.cc:45] The TensorFlow library wasn't compiled to use SSE4.2 instructions, but these are available on your machine and could speed up CPU computations.
W tensorflow/core/platform/cpu_feature_guard.cc:45] The TensorFlow library wasn't compiled to use AVX instructions, but these are available on your machine and could speed up CPU computations.
Using TensorFlow backend.
Traceback (most recent call last):
  File "/home/cocuh/.virtualenvs/keras2/lib/python3.6/site-packages/h5py/_hl/selections.py", line 85, in select
    int(a)
TypeError: int() argument must be a string, a bytes-like object or a number, not 'list'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "hoge.py", line 10, in <module>
    model = keras.models.load_model('./conv2d.h5')
  File "/home/cocuh/.virtualenvs/keras2/lib/python3.6/site-packages/keras/models.py", line 235, in load_model
    topology.load_weights_from_hdf5_group(f['model_weights'], model.layers)
  File "/home/cocuh/.virtualenvs/keras2/lib/python3.6/site-packages/keras/engine/topology.py", line 2882, in load_weights_from_hdf5_group
    original_backend)
  File "/home/cocuh/.virtualenvs/keras2/lib/python3.6/site-packages/keras/engine/topology.py", line 2823, in preprocess_weights_for_loading
    weights[0] = conv_utils.convert_kernel(weights[0])
  File "/home/cocuh/.virtualenvs/keras2/lib/python3.6/site-packages/keras/utils/conv_utils.py", line 86, in convert_kernel
    return np.copy(kernel[slices])
  File "h5py/_objects.pyx", line 54, in h5py._objects.with_phil.wrapper (/tmp/pip-tnf92dft-build/h5py/_objects.c:2853)
  File "h5py/_objects.pyx", line 55, in h5py._objects.with_phil.wrapper (/tmp/pip-tnf92dft-build/h5py/_objects.c:2811)
  File "/home/cocuh/.virtualenvs/keras2/lib/python3.6/site-packages/h5py/_hl/dataset.py", line 462, in __getitem__
    selection = sel.select(self.shape, args, dsid=self.id)
  File "/home/cocuh/.virtualenvs/keras2/lib/python3.6/site-packages/h5py/_hl/selections.py", line 88, in select
    sel[args]
  File "/home/cocuh/.virtualenvs/keras2/lib/python3.6/site-packages/h5py/_hl/selections.py", line 356, in __getitem__
    if sorted(arg) != list(arg):
TypeError: '<' not supported between instances of 'NoneType' and 'int'
```