### PR TITLE
Cast sparse placeholder shape to int64 to avoid tensorflow bug

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -344,7 +344,7 @@ def placeholder(shape=None, ndim=None, dtype=None, sparse=False, name=None):
         if ndim:
             shape = tuple([None for _ in range(ndim)])
     if sparse:
-        x = tf.sparse_placeholder(dtype, shape=np.array(shape).astype("int64"), name=name)
+        x = tf.sparse_placeholder(dtype, shape=np.array(shape).astype('int64'), name=name)
     else:
         x = tf.placeholder(dtype, shape=shape, name=name)
     x._keras_shape = shape

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -344,7 +344,7 @@ def placeholder(shape=None, ndim=None, dtype=None, sparse=False, name=None):
         if ndim:
             shape = tuple([None for _ in range(ndim)])
     if sparse:
-        x = tf.sparse_placeholder(dtype, shape=numpy.array(shape).astype("int64"), name=name)
+        x = tf.sparse_placeholder(dtype, shape=np.array(shape).astype("int64"), name=name)
     else:
         x = tf.placeholder(dtype, shape=shape, name=name)
     x._keras_shape = shape

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -344,7 +344,7 @@ def placeholder(shape=None, ndim=None, dtype=None, sparse=False, name=None):
         if ndim:
             shape = tuple([None for _ in range(ndim)])
     if sparse:
-        x = tf.sparse_placeholder(dtype, shape=shape, name=name)
+        x = tf.sparse_placeholder(dtype, shape=numpy.array(shape).astype("int64"), name=name)
     else:
         x = tf.placeholder(dtype, shape=shape, name=name)
     x._keras_shape = shape


### PR DESCRIPTION
casting the shape to int64 resolves issue [5225](https://github.com/fchollet/keras/issues/5225) with a workaround to avoid tensorflow issue [6749](https://github.com/tensorflow/tensorflow/issues/6749).