### PR TITLE
Set stacklevel so warning points to invocation instead of warning

### DIFF
--- a/keras/legacy/layers.py
+++ b/keras/legacy/layers.py
@@ -66,7 +66,7 @@ class Merge(Layer):
         warnings.warn('The `Merge` layer is deprecated '
                       'and will be removed after 08/2017. '
                       'Use instead layers from `keras.layers.merge`, '
-                      'e.g. `add`, `concatenate`, etc.')
+                      'e.g. `add`, `concatenate`, etc.', stacklevel=2)
         self.layers = layers
         self.mode = mode
         self.concat_axis = concat_axis
@@ -429,7 +429,7 @@ def merge(inputs, mode='sum', concat_axis=-1,
     warnings.warn('The `merge` function is deprecated '
                   'and will be removed after 08/2017. '
                   'Use instead layers from `keras.layers.merge`, '
-                  'e.g. `sum`, `concatenate`, etc.')
+                  'e.g. `sum`, `concatenate`, etc.', stacklevel=2)
     all_keras_tensors = True
     for x in inputs:
         if not hasattr(x, '_keras_history'):


### PR DESCRIPTION
Set `stacklevel=2` in `warning.warn`. The stacktrace will link to the invocation of `merge` instead of the warning message within `merge`.

Will make it easier to update code to the new API. Probably other places a similar change should be made.

Cheers!