### PR TITLE
Reapply patches to legacy Merge layer

### DIFF
--- a/keras/legacy/layers.py
+++ b/keras/legacy/layers.py
@@ -361,6 +361,7 @@ class Merge(Layer):
 
     @classmethod
     def from_config(cls, config):
+        config = config.copy()
         mode_type = config.pop('mode_type')
         if mode_type == 'function':
             mode = globals()[config['mode']]

--- a/keras/legacy/layers.py
+++ b/keras/legacy/layers.py
@@ -286,7 +286,7 @@ class Merge(Layer):
 
         assert hasattr(mask, '__len__') and len(mask) == len(inputs)
 
-        if self.mode in ['sum', 'mul', 'ave']:
+        if self.mode in ['sum', 'mul', 'ave', 'max']:
             masks = [K.expand_dims(m, 0) for m in mask if m is not None]
             return K.all(K.concatenate(masks, axis=0), axis=0, keepdims=False)
         elif self.mode == 'concat':
@@ -407,7 +407,7 @@ def merge(inputs, mode='sum', concat_axis=-1,
     ```
     # Arguments
         mode: String or lambda/function. If string, must be one
-            of: 'sum', 'mul', 'concat', 'ave', 'cos', 'dot'.
+            of: 'sum', 'mul', 'concat', 'ave', 'cos', 'dot', 'max'.
             If lambda/function, it should take as input a list of tensors
             and return a single tensor.
         concat_axis: Integer, axis to use in mode `concat`.


### PR DESCRIPTION
The changes in commits 7e071cd7df38a9ace26cf44a8be64fc6b3aec394 and b43caf7b49746fcfa9738c5f9ea6fd46de9b5cd1 were lost when the Merge layer was removed from keras/engine/topology.py in the subsequent merge 1f87cff49383043f802100c73a1d26fcac80fc56.

This PR contains a replay of the changes on top of keras/legacy/layers.py