### PR TITLE
Fix Specifying Initial States of RNN Layers

### DIFF
--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -389,7 +389,7 @@ class Layer(object):
                              str(len(input_spec)) + ' inputs, '
                              'but it received ' + str(len(inputs)) +
                              ' input tensors. Input received: ' +
-                             str(input))
+                             str(inputs))
         for input_index, (x, spec) in enumerate(zip(inputs, input_spec)):
             if spec is None:
                 continue

--- a/keras/layers/convolutional_recurrent.py
+++ b/keras/layers/convolutional_recurrent.py
@@ -396,7 +396,7 @@ class ConvLSTM2D(ConvRecurrent2D):
             self.bias_o = None
         self.built = True
 
-    def get_initial_states(self, inputs):
+    def get_initial_state(self, inputs):
         # (samples, timesteps, rows, cols, filters)
         initial_state = K.zeros_like(inputs)
         # (samples, rows, cols, filters)

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -328,7 +328,7 @@ class Recurrent(Layer):
     def reset_states(self, states=None):
         if not self.stateful:
             raise AttributeError('Layer must be stateful.')
-        batch_size = self.input_spec.shape[0]
+        batch_size = self.input_spec[0].shape[0]
         if not batch_size:
             raise ValueError('If a RNN is stateful, it needs to know '
                              'its batch size. Specify the batch size '

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -165,11 +165,16 @@ class Recurrent(Layer):
         To reset the states of your model, call `.reset_states()` on either
         a specific layer, or on your entire model.
 
-    # Note on specifying initial states in RNNs
-        You can specify the initial state of RNN layers by calling them with
-        the keyword argument `initial_state`. The value of `initial_state`
-        should be a tensor or list of tensors representing the initial state
-        of the RNN layer.
+    # Note on specifying the initial states in RNNs
+        You can specify the initial states of RNN layers symbolically by
+        calling them with the keyword argument `initial_states`. The value of
+        `initial_states` should be a tensor or list of tensors representing
+        the initial states of the RNN layer.
+
+        You can specify the initial states of RNN layers by value using
+        `reset_states`. `reset_states` accepts an optional argument, `states`,
+        which should be a numpy array or list of numpy arrays representing
+        the value of the initial states of the RNN layer.
     """
 
     def __init__(self, return_sequences=False,

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -244,11 +244,11 @@ class Recurrent(Layer):
                         input_shape = K.int_shape(inputs)
                     else:
                         raise ValueError('You tried to call layer "' + self.name +
-                                        '". This layer has no information'
-                                        ' about its expected input shape, '
-                                        'and thus cannot be built. '
-                                        'You can build it manually via: '
-                                        '`layer.build(batch_input_shape)`')
+                                         '". This layer has no information'
+                                         ' about its expected input shape, '
+                                         'and thus cannot be built. '
+                                         'You can build it manually via: '
+                                         '`layer.build(batch_input_shape)`')
                     self.build(input_shape)
                     self.built = True
 
@@ -355,17 +355,17 @@ class Recurrent(Layer):
                 states = [states]
             if len(states) != len(self.states):
                 raise ValueError('Layer ' + self.name + ' expects ' +
-                                str(len(self.states)) + ' states, '
-                                'but it received ' + str(len(values)) +
-                                ' state values. Input received: ' +
-                                str(values))
+                                 str(len(self.states)) + ' states, '
+                                 'but it received ' + str(len(values)) +
+                                 ' state values. Input received: ' +
+                                 str(values))
             for index, (value, state) in enumerate(zip(states, self.states)):
                 if value.shape != (batch_size, self.units):
                     raise ValueError('State ' + str(index) +
-                                    ' is incompatible with layer ' +
-                                    self.name + ': expected shape=' +
-                                    str((batch_size, self.units)) +
-                                    ', found shape=' + str(value.shape))
+                                     ' is incompatible with layer ' +
+                                     self.name + ': expected shape=' +
+                                     str((batch_size, self.units)) +
+                                     ', found shape=' + str(value.shape))
                 K.set_value(state, value)
 
     def get_config(self):

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -171,10 +171,10 @@ class Recurrent(Layer):
         `initial_states` should be a tensor or list of tensors representing
         the initial states of the RNN layer.
 
-        You can specify the initial states of RNN layers by value using
-        `reset_states`. `reset_states` accepts an optional argument, `states`,
-        which should be a numpy array or list of numpy arrays representing
-        the value of the initial states of the RNN layer.
+        You can specify the initial states of RNN layers numerically by
+        calling `reset_states` with the keyword argument `states`. The value of
+        `states` should be a numpy array or list of numpy arrays representing
+        the initial states of the RNN layer.
     """
 
     def __init__(self, return_sequences=False,

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -331,9 +331,6 @@ class Recurrent(Layer):
     def reset_states(self, states=None):
         if not self.stateful:
             raise AttributeError('Layer must be stateful.')
-        if not self.input_spec:
-            raise RuntimeError('Layer has never been called '
-                               'and thus has no states.')
         batch_size = self.input_spec.shape[0]
         if not batch_size:
             raise ValueError('If a RNN is stateful, it needs to know '

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -248,7 +248,6 @@ class Recurrent(Layer):
                                  ' non-Keras tensors')
 
         if is_keras_tensor:
-
             # Compute the full input spec, including state
             input_spec = self.input_spec
             state_spec = self.state_spec

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -291,7 +291,7 @@ class Recurrent(Layer):
         if isinstance(inputs, list):
             initial_state = inputs[1:]
             inputs = inputs[0]
-        elif initial_state is None:
+        elif initial_state is not None:
             pass
         elif self.stateful:
             initial_state = self.states

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -205,6 +205,8 @@ class Recurrent(Layer):
 
     def compute_mask(self, inputs, mask):
         if self.return_sequences:
+            if isinstance(mask, list):
+                return mask[0]
             return mask
         else:
             return None
@@ -280,6 +282,9 @@ class Recurrent(Layer):
             initial_state = self.states
         else:
             initial_state = self.get_initial_state(inputs)
+
+        if isinstance(mask, list):
+            mask = mask[0]
 
         if len(initial_state) != len(self.states):
             raise ValueError('Layer has ' + str(len(self.states)) +

--- a/tests/keras/layers/recurrent_test.py
+++ b/tests/keras/layers/recurrent_test.py
@@ -232,6 +232,7 @@ def test_reset_states_with_values(layer_class):
                                np.ones(K.int_shape(layer.states[0])),
                                atol=1e-4)
 
+
 @rnn_test
 def test_specify_state_with_masking(layer_class):
     ''' This test based on a previously failing issue here:

--- a/tests/keras/layers/recurrent_test.py
+++ b/tests/keras/layers/recurrent_test.py
@@ -187,7 +187,7 @@ def test_specify_initial_state(layer_class):
 
     inputs = np.random.random((num_samples, timesteps, embedding_dim))
     initial_state = [np.random.random((num_samples, units))
-                      for _ in range(num_states)]
+                     for _ in range(num_states)]
     targets = np.random.random((num_samples, units))
     model.fit([inputs] + initial_state, targets)
 

--- a/tests/keras/layers/recurrent_test.py
+++ b/tests/keras/layers/recurrent_test.py
@@ -176,7 +176,10 @@ def test_specify_initial_states(layer_class):
     inputs = Input((timesteps, embedding_dim))
     initial_states = [Input((units,)) for _ in range(num_states)]
     layer = layer_class(units)
-    output = layer(inputs, initial_states=initial_states)
+    if len(initial_states) == 1:
+        output = layer(inputs, initial_states=initial_states[0])
+    else:
+        output = layer(inputs, initial_states=initial_states)
     assert initial_states[0] in layer.inbound_nodes[0].input_tensors
 
     model = Model([inputs] + initial_states, output)
@@ -203,6 +206,8 @@ def test_reset_states_with_values(layer_class):
                                atol=1e-4)
     state_shapes = [K.int_shape(state) for state in layer.states]
     values = [np.ones(shape) for shape in state_shapes]
+    if len(values) == 1:
+        values = values[0]
     layer.reset_states(values)
     np.testing.assert_allclose(K.eval(layer.states[0]),
                                np.ones(K.int_shape(layer.states[0])),

--- a/tests/keras/layers/recurrent_test.py
+++ b/tests/keras/layers/recurrent_test.py
@@ -191,6 +191,7 @@ def test_specify_initial_state_keras_tensor(layer_class):
     targets = np.random.random((num_samples, units))
     model.fit([inputs] + initial_state, targets)
 
+
 @rnn_test
 def test_specify_initial_state_non_keras_tensor(layer_class):
     num_states = 2 if layer_class is recurrent.LSTM else 1

--- a/tests/keras/layers/recurrent_test.py
+++ b/tests/keras/layers/recurrent_test.py
@@ -169,7 +169,7 @@ def test_from_config(layer_class):
 
 
 @rnn_test
-def test_specify_initial_state(layer_class):
+def test_specify_initial_state_keras_tensor(layer_class):
     num_states = 2 if layer_class is recurrent.LSTM else 1
 
     # Test with Keras tensor
@@ -190,6 +190,24 @@ def test_specify_initial_state(layer_class):
                      for _ in range(num_states)]
     targets = np.random.random((num_samples, units))
     model.fit([inputs] + initial_state, targets)
+
+@rnn_test
+def test_specify_initial_state_non_keras_tensor(layer_class):
+    num_states = 2 if layer_class is recurrent.LSTM else 1
+
+    # Test with non-Keras tensor
+    inputs = Input((timesteps, embedding_dim))
+    initial_state = [K.random_normal_variable((num_samples, units), 0, 1)
+                     for _ in range(num_states)]
+    layer = layer_class(units)
+    output = layer(inputs, initial_state=initial_state)
+
+    model = Model(inputs, output)
+    model.compile(loss='categorical_crossentropy', optimizer='adam')
+
+    inputs = np.random.random((num_samples, timesteps, embedding_dim))
+    targets = np.random.random((num_samples, units))
+    model.fit(inputs, targets)
 
 
 @rnn_test

--- a/tests/keras/layers/recurrent_test.py
+++ b/tests/keras/layers/recurrent_test.py
@@ -169,15 +169,17 @@ def test_from_config(layer_class):
 
 
 @rnn_test
-def test_specify_initial_state(layer_class):
+def test_specify_initial_states(layer_class):
     num_states = 2 if layer_class is recurrent.LSTM else 1
 
     # Test with Keras tensor
     inputs = Input((timesteps, embedding_dim))
-    initial_state = [Input((units,)) for _ in range(num_states)]
+    initial_states = [Input((units,)) for _ in range(num_states)]
     layer = layer_class(units)
-    output = layer(inputs, initial_state=initial_state)
-    model = Model([inputs] + initial_state, output)
+    output = layer(inputs, initial_states=initial_states)
+    assert initial_states[0] in layer.inbound_nodes[0].input_tensors
+
+    model = Model([inputs] + initial_states, output)
     model.compile(loss='categorical_crossentropy', optimizer='adam')
 
     inputs = np.random.random((num_samples, timesteps, embedding_dim))
@@ -185,18 +187,6 @@ def test_specify_initial_state(layer_class):
                       for _ in range(num_states)]
     targets = np.random.random((num_samples, units))
     model.fit([inputs] + initial_states, targets)
-
-    # Test with non-Keras tensor
-    inputs = Input((timesteps, embedding_dim))
-    initial_state = [K.random_normal_variable((units,), 0, 1) for _ in range(num_states)]
-    layer = layer_class(units)
-    output = layer(inputs, initial_state=initial_state)
-    model = Model([inputs], output)
-    model.compile(loss='categorical_crossentropy', optimizer='adam')
-
-    inputs = np.random.random((num_samples, timesteps, embedding_dim))
-    targets = np.random.random((num_samples, units))
-    model.fit(inputs, targets)
 
 
 @rnn_test

--- a/tests/keras/layers/recurrent_test.py
+++ b/tests/keras/layers/recurrent_test.py
@@ -169,27 +169,27 @@ def test_from_config(layer_class):
 
 
 @rnn_test
-def test_specify_initial_states(layer_class):
+def test_specify_initial_state(layer_class):
     num_states = 2 if layer_class is recurrent.LSTM else 1
 
     # Test with Keras tensor
     inputs = Input((timesteps, embedding_dim))
-    initial_states = [Input((units,)) for _ in range(num_states)]
+    initial_state = [Input((units,)) for _ in range(num_states)]
     layer = layer_class(units)
-    if len(initial_states) == 1:
-        output = layer(inputs, initial_states=initial_states[0])
+    if len(initial_state) == 1:
+        output = layer(inputs, initial_state=initial_state[0])
     else:
-        output = layer(inputs, initial_states=initial_states)
-    assert initial_states[0] in layer.inbound_nodes[0].input_tensors
+        output = layer(inputs, initial_state=initial_state)
+    assert initial_state[0] in layer.inbound_nodes[0].input_tensors
 
-    model = Model([inputs] + initial_states, output)
+    model = Model([inputs] + initial_state, output)
     model.compile(loss='categorical_crossentropy', optimizer='adam')
 
     inputs = np.random.random((num_samples, timesteps, embedding_dim))
-    initial_states = [np.random.random((num_samples, units))
+    initial_state = [np.random.random((num_samples, units))
                       for _ in range(num_states)]
     targets = np.random.random((num_samples, units))
-    model.fit([inputs] + initial_states, targets)
+    model.fit([inputs] + initial_state, targets)
 
 
 @rnn_test


### PR DESCRIPTION
I have begun to review the changes made in da21c15. There appears to a number of issues

- If `initial_states` is a list of tensors, it will not have the attribute `_keras_history`, and will be treated as a numerical value.
- If `initial_states` is passed as a keyword argument to `call`, it will be ignored / overwritten.
- `state_spec` may not be defined by the time it is used (`state_spec` is defined in `build`).
- In `reset_states`, there is a check if `input_spec` is not `None`. However, `input_spec` is never `None`, because it is defined in `__init__` to be `InputSpec(ndim=3)`.
- There is an inconsistency between using the singular and plural of `initial_state` and `initial_states`.
- the signature for `reset_states(state_values)` is inconsistent with the signature for  `set_weights(weights)`
- `test_specify_initial_states` does not check if `initial_states` is part of the computational graph.

This commit does the following to fix those issues:

- If `initial_states` is passed to `__call__` it is always treated as a tensor / list of tensors. It a user wants to specify the state numerically, they should pass a numpy array to `reset_states`.
- The layer will be build in `__call__` before using `state_spec`.
- The extraneous check of `input_spec` is removed.
- The plural form `initial_states` is used throughout the code and documentation.
- The signature for `reset_states(state_values)` is changed to `reset_states(states)`.
- `test_specify_states` explicitly checks if `initial_states` is added to the computational graph.

#5738