### PR TITLE
Fix `deconv_length` inference for `padding='same'` in conv_utils

### DIFF
--- a/keras/utils/conv_utils.py
+++ b/keras/utils/conv_utils.py
@@ -140,10 +140,12 @@ def conv_input_length(output_length, filter_size, padding, stride):
 
 
 def deconv_length(dim_size, stride_size, kernel_size, padding):
-    if dim_size is not None:
-        dim_size *= stride_size
-    if padding == 'valid' and dim_size is not None:
-        dim_size += max(kernel_size - stride_size, 0)
-    if padding == 'full' and dim_size is not None:
-        dim_size -= stride_size + kernel_size - 2
+    if dim_size is None:
+        return None
+    if padding == 'valid':
+        dim_size = dim_size * stride_size + max(kernel_size - stride_size, 0)
+    elif padding == 'full':
+        dim_size = dim_size * stride_size - (stride_size + kernel_size - 2)
+    elif padding == 'same':
+        dim_size = dim_size * stride_size
     return dim_size


### PR DESCRIPTION
Fix `deconv_length` inference for `padding='same'` in conv_utils, and use `if-elif` instead of multiple `if`s