### PR TITLE
Add ability for KerasClassifier to process string classes.

### DIFF
--- a/keras/wrappers/scikit_learn.py
+++ b/keras/wrappers/scikit_learn.py
@@ -175,6 +175,27 @@ class KerasClassifier(BaseWrapper):
     """Implementation of the scikit-learn classifier API for Keras.
     """
 
+    def fit(self, x, y, **kwargs):
+        """Constructs a new model with `build_fn` & fit the model to `(x, y)`.
+
+        # Arguments
+            x : array-like, shape `(n_samples, n_features)`
+                Training samples where n_samples in the number of samples
+                and n_features is the number of features.
+            y : array-like, shape `(n_samples,)` or `(n_samples, n_outputs)`
+                True labels for X.
+            **kwargs: dictionary arguments
+                Legal arguments are the arguments of `Sequential.fit`
+
+        # Returns
+            history : object
+                details about the training history at each epoch.
+        """
+        self.classes_ = np.unique(y)
+        self.n_classes_ = len(self.classes_)
+        y = np.searchsorted(self.classes_, y)
+        return super(KerasClassifier, self).fit(x, y, **kwargs)
+
     def predict(self, x, **kwargs):
         """Returns the class predictions for the given test data.
 
@@ -191,7 +212,8 @@ class KerasClassifier(BaseWrapper):
                 Class predictions.
         """
         kwargs = self.filter_sk_params(Sequential.predict_classes, kwargs)
-        return self.model.predict_classes(x, **kwargs)
+        classes = self.model.predict_classes(x, **kwargs)
+        return self.classes_[classes]
 
     def predict_proba(self, x, **kwargs):
         """Returns class probability estimates for the given test data.
@@ -242,6 +264,7 @@ class KerasClassifier(BaseWrapper):
                 compute accuracy. You should pass `metrics=["accuracy"]` to
                 the `.compile()` method of the model.
         """
+        y = np.searchsorted(self.classes_, y)
         kwargs = self.filter_sk_params(Sequential.evaluate, kwargs)
 
         loss_name = self.model.loss

--- a/keras/wrappers/scikit_learn.py
+++ b/keras/wrappers/scikit_learn.py
@@ -191,9 +191,13 @@ class KerasClassifier(BaseWrapper):
             history : object
                 details about the training history at each epoch.
         """
-        self.classes_ = np.unique(y)
+        y = np.array(y)
+        if len(y.shape) != 1:
+            self.classes_ = np.arange(y.shape[1])
+        else:
+            self.classes_ = np.unique(y)
+            y = np.searchsorted(self.classes_, y)
         self.n_classes_ = len(self.classes_)
-        y = np.searchsorted(self.classes_, y)
         return super(KerasClassifier, self).fit(x, y, **kwargs)
 
     def predict(self, x, **kwargs):

--- a/tests/keras/wrappers/scikit_learn_test.py
+++ b/tests/keras/wrappers/scikit_learn_test.py
@@ -45,6 +45,7 @@ def test_clasify_build_fn():
         batch_size=batch_size, epochs=epochs)
 
     assert_classification_works(clf)
+    assert_string_classification_works(clf)
 
 
 def test_clasify_class_build_fn():
@@ -58,6 +59,7 @@ def test_clasify_class_build_fn():
         batch_size=batch_size, epochs=epochs)
 
     assert_classification_works(clf)
+    assert_string_classification_works(clf)
 
 
 def test_clasify_inherit_class_build_fn():
@@ -71,6 +73,7 @@ def test_clasify_inherit_class_build_fn():
         batch_size=batch_size, epochs=epochs)
 
     assert_classification_works(clf)
+    assert_string_classification_works(clf)
 
 
 def assert_classification_works(clf):
@@ -83,6 +86,24 @@ def assert_classification_works(clf):
     assert preds.shape == (num_test, )
     for prediction in np.unique(preds):
         assert prediction in range(num_class)
+
+    proba = clf.predict_proba(X_test, batch_size=batch_size)
+    assert proba.shape == (num_test, num_class)
+    assert np.allclose(np.sum(proba, axis=1), np.ones(num_test))
+
+
+def assert_string_classification_works(clf):
+    str_y_train = np.array(['cls1', 'cls2', 'cls3'])[y_train]
+
+    clf.fit(X_train, str_y_train, batch_size=batch_size, nb_epoch=epochs)
+
+    score = clf.score(X_train, str_y_train, batch_size=batch_size)
+    assert np.isscalar(score) and np.isfinite(score)
+
+    preds = clf.predict(X_test, batch_size=batch_size)
+    assert preds.shape == (num_test, )
+    for prediction in np.unique(preds):
+        assert prediction in ['cls1', 'cls2', 'cls3']
 
     proba = clf.predict_proba(X_test, batch_size=batch_size)
     assert proba.shape == (num_test, num_class)

--- a/tests/keras/wrappers/scikit_learn_test.py
+++ b/tests/keras/wrappers/scikit_learn_test.py
@@ -93,7 +93,8 @@ def assert_classification_works(clf):
 
 
 def assert_string_classification_works(clf):
-    str_y_train = np.array(['cls1', 'cls2', 'cls3'])[y_train]
+    string_classes = ['cls{}'.format(x) for x in range(num_class)]
+    str_y_train = np.array(string_classes)[y_train]
 
     clf.fit(X_train, str_y_train, batch_size=batch_size, nb_epoch=epochs)
 
@@ -103,7 +104,7 @@ def assert_string_classification_works(clf):
     preds = clf.predict(X_test, batch_size=batch_size)
     assert preds.shape == (num_test, )
     for prediction in np.unique(preds):
-        assert prediction in ['cls1', 'cls2', 'cls3']
+        assert prediction in string_classes
 
     proba = clf.predict_proba(X_test, batch_size=batch_size)
     assert proba.shape == (num_test, num_class)


### PR DESCRIPTION
This is a resubmission of #5321 

Scikit-learn classifiers are able to process strings in their target classes. This PR allows KerasClassifier to do the same while also exposing a `.classes_` attribute containing the classes used during fitting.

I modified the corresponding unit tests to test the behavior of KerasClassifier when fitted with string labels.