### PR TITLE
fix doc typo visualize_util to vis_util

### DIFF
--- a/docs/templates/visualization.md
+++ b/docs/templates/visualization.md
@@ -19,7 +19,7 @@ You can also directly obtain the `pydot.Graph` object and render it yourself,
 for example to show it in an ipython notebook :
 ```python
 from IPython.display import SVG
-from keras.utils.visualize_util import model_to_dot
+from keras.utils.vis_util import model_to_dot
 
 SVG(model_to_dot(model).create(prog='dot', format='svg'))
 ```


### PR DESCRIPTION
keras.utils.visualize_util is renamed to keras.utils.vis_util