### PR TITLE
Fix the output shape reported by simple merge layers

### DIFF
--- a/keras/layers/merge.py
+++ b/keras/layers/merge.py
@@ -41,6 +41,13 @@ class _Merge(Layer):
     def call(self, inputs):
         return self._merge_function(inputs)
 
+    def compute_output_shape(self, input_shape):
+        # Layers that change the shape should already implement
+        # compute_output_shape anyway
+        # TODO: If the merge layer in the future accepts broadcastable inputs
+        #       then both this function and build should be changed
+        return input_shape[0]
+
     def compute_mask(self, inputs, mask=None):
         if mask is None:
             return None

--- a/tests/keras/layers/merge_test.py
+++ b/tests/keras/layers/merge_test.py
@@ -17,6 +17,10 @@ def test_merge_add():
     assert o._keras_shape == (None, 4, 5)
     model = models.Model([i1, i2, i3], o)
 
+    add_layer = layers.Add()
+    o2 = add_layer([i1, i2, i3])
+    assert add_layer.output_shape == (None, 4, 5)
+
     x1 = np.random.random((2, 4, 5))
     x2 = np.random.random((2, 4, 5))
     x3 = np.random.random((2, 4, 5))
@@ -34,6 +38,10 @@ def test_merge_multiply():
     assert o._keras_shape == (None, 4, 5)
     model = models.Model([i1, i2, i3], o)
 
+    mul_layer = layers.Multiply()
+    o2 = mul_layer([i1, i2, i3])
+    assert mul_layer.output_shape == (None, 4, 5)
+
     x1 = np.random.random((2, 4, 5))
     x2 = np.random.random((2, 4, 5))
     x3 = np.random.random((2, 4, 5))
@@ -50,6 +58,10 @@ def test_merge_average():
     assert o._keras_shape == (None, 4, 5)
     model = models.Model([i1, i2], o)
 
+    avg_layer = layers.Average()
+    o2 = avg_layer([i1, i2])
+    assert avg_layer.output_shape == (None, 4, 5)
+
     x1 = np.random.random((2, 4, 5))
     x2 = np.random.random((2, 4, 5))
     out = model.predict([x1, x2])
@@ -64,6 +76,10 @@ def test_merge_maximum():
     o = layers.maximum([i1, i2])
     assert o._keras_shape == (None, 4, 5)
     model = models.Model([i1, i2], o)
+
+    max_layer = layers.Maximum()
+    o2 = max_layer([i1, i2])
+    assert max_layer.output_shape == (None, 4, 5)
 
     x1 = np.random.random((2, 4, 5))
     x2 = np.random.random((2, 4, 5))
@@ -80,6 +96,10 @@ def test_merge_concatenate():
     assert o._keras_shape == (None, 8, 5)
     model = models.Model([i1, i2], o)
 
+    concat_layer = layers.Concatenate(axis=1)
+    o2 = concat_layer([i1, i2])
+    assert concat_layer.output_shape == (None, 8, 5)
+
     x1 = np.random.random((2, 4, 5))
     x2 = np.random.random((2, 4, 5))
     out = model.predict([x1, x2])
@@ -94,6 +114,10 @@ def test_merge_dot():
     o = layers.dot([i1, i2], axes=1)
     assert o._keras_shape == (None, 1)
     model = models.Model([i1, i2], o)
+
+    dot_layer = layers.Dot(axes=1)
+    o2 = dot_layer([i1, i2])
+    assert dot_layer.output_shape == (None, 1)
 
     x1 = np.random.random((2, 4))
     x2 = np.random.random((2, 4))


### PR DESCRIPTION
Simple merge layers that just extend `_Merge` and implement `_merge_function` report that they have multiple outputs (as many as inputs) with the same shape. A simple code example that showcases the problem follows.

```python
from keras.layers import Add, Input

a = Input(shape=(10, 3))
b = Input(shape=(10, 3))
add_layer = Add()
c = add_layer([a, b])

assert add_layer.output_shape == (None, 10, 3)
```

That doesn't cause any obvious problems because Keras uses the tensor shape inference which is correct but it still is wrong and could cause problems in the future (besides messing up `model.summary()` and visualizations which is already a case).

Although #5812 could probably be fixing this problem, it seemed way too complicated for what it introduces (broadcasting) and thought that a simple PR as this might be better while the case of broadcasting is dealt with separately.