### PR TITLE
Update stacklevel and add warning for get_output_shape_for

### DIFF
--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -648,8 +648,8 @@ class Layer(object):
             An input shape tuple.
         """
         if hasattr(self,'get_output_shape_for'):
-            msg = "Class {}.{} defines get_output_shape_for but does not override compute_output_shape. " + \
-              "If this is a Keras 1 layer, please implement compute_output_shape to support Keras 2."
+            msg = "Class `{}.{}` defines `get_output_shape_for` but does not override `compute_output_shape`. " + \
+              "If this is a Keras 1 layer, please implement `compute_output_shape` to support Keras 2."
             warnings.warn(msg.format(type(self).__module__, type(self).__name__), stacklevel=2)
         return input_shape
 

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -647,9 +647,9 @@ class Layer(object):
         # Returns
             An input shape tuple.
         """
-        if hasattr(self,'get_output_shape_for'):
+        if hasattr(self, 'get_output_shape_for'):
             msg = "Class `{}.{}` defines `get_output_shape_for` but does not override `compute_output_shape`. " + \
-              "If this is a Keras 1 layer, please implement `compute_output_shape` to support Keras 2."
+                  "If this is a Keras 1 layer, please implement `compute_output_shape` to support Keras 2."
             warnings.warn(msg.format(type(self).__module__, type(self).__name__), stacklevel=2)
         return input_shape
 

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -647,6 +647,10 @@ class Layer(object):
         # Returns
             An input shape tuple.
         """
+        if hasattr(self,'get_output_shape_for'):
+            msg = "Class {}.{} defines get_output_shape_for but does not override compute_output_shape. " + \
+              "If this is a Keras 1 layer, please implement compute_output_shape to support Keras 2."
+            warnings.warn(msg.format(type(self).__module__, type(self).__name__), stacklevel=2)
         return input_shape
 
     def compute_mask(self, inputs, mask=None):

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -726,7 +726,7 @@ class Model(Container):
                                   'We assume this was done on purpose, '
                                   'and we will not be expecting '
                                   'any data to be passed to "' + name +
-                                  '" during training.')
+                                  '" during training.', stacklevel=2)
                 loss_functions.append(losses.get(loss.get(name)))
         elif isinstance(loss, list):
             if len(loss) != len(self.outputs):
@@ -1391,7 +1391,7 @@ class Model(Container):
         # Legacy support
         if 'nb_epoch' in kwargs:
             warnings.warn('The `nb_epoch` argument in `fit` '
-                          'has been renamed `epochs`.')
+                          'has been renamed `epochs`.', stacklevel=2)
             epochs = kwargs.pop('nb_epoch')
         if kwargs:
             raise TypeError('Unrecognized keyword arguments: ' + str(kwargs))

--- a/keras/legacy/interfaces.py
+++ b/keras/legacy/interfaces.py
@@ -83,7 +83,7 @@ def generate_legacy_interface(allowed_positional_args=None,
                         signature += ', '
                 signature += ')`'
                 warnings.warn('Update your `' + object_name +
-                              '` call to the Keras 2 API: ' + signature)
+                              '` call to the Keras 2 API: ' + signature, stacklevel=2)
             return func(*args, **kwargs)
         return wrapper
     return legacy_support
@@ -122,7 +122,7 @@ def embedding_kwargs_preprocessor(args, kwargs):
         kwargs.pop('dropout')
         warnings.warn('The `dropout` argument is no longer support in `Embedding`. '
                       'You can apply a `keras.layers.SpatialDropout1D` layer '
-                      'right after the `Embedding` layer to get the same behavior.')
+                      'right after the `Embedding` layer to get the same behavior.', stacklevel=3)
     return args, kwargs, converted
 
 legacy_embedding_support = generate_legacy_interface(
@@ -159,7 +159,7 @@ def recurrent_args_preprocessor(args, kwargs):
             kwargs.pop('forget_bias_init')
             warnings.warn('The `forget_bias_init` argument '
                           'has been ignored. Use `unit_forget_bias=True` '
-                          'instead to intialize with ones.')
+                          'instead to intialize with ones.', stacklevel=3)
     if 'input_dim' in kwargs:
         input_length = kwargs.pop('input_length', None)
         input_dim = kwargs.pop('input_dim')
@@ -168,7 +168,7 @@ def recurrent_args_preprocessor(args, kwargs):
         converted.append(('input_dim', 'input_shape'))
         warnings.warn('The `input_dim` and `input_length` arguments '
                       'in recurrent layers are deprecated. '
-                      'Use `input_shape` instead.')
+                      'Use `input_shape` instead.', stacklevel=3)
     return args, kwargs, converted
 
 legacy_recurrent_support = generate_legacy_interface(
@@ -459,7 +459,7 @@ def convlstm2d_args_preprocessor(args, kwargs):
         else:
             warnings.warn('The `forget_bias_init` argument '
                           'has been ignored. Use `unit_forget_bias=True` '
-                          'instead to intialize with ones.')
+                          'instead to intialize with ones.', stacklevel=3)
     args, kwargs, _converted = conv2d_args_preprocessor(args, kwargs)
     return args, kwargs, converted + _converted
 
@@ -502,7 +502,7 @@ def zeropadding2d_args_preprocessor(args, kwargs):
             kwargs['padding'] = ((top_pad, bottom_pad), (left_pad, right_pad))
             warnings.warn('The `padding` argument in the Keras 2 API no longer'
                           'accepts dict types. You can now input argument as: '
-                          '`padding=(top_pad, bottom_pad, left_pad, right_pad)`.')
+                          '`padding=(top_pad, bottom_pad, left_pad, right_pad)`.', stacklevel=3)
     elif len(args) == 2 and isinstance(args[1], dict):
         if set(args[1].keys()) <= {'top_pad', 'bottom_pad',
                                    'left_pad', 'right_pad'}:
@@ -513,7 +513,7 @@ def zeropadding2d_args_preprocessor(args, kwargs):
             args = (args[0], ((top_pad, bottom_pad), (left_pad, right_pad)))
             warnings.warn('The `padding` argument in the Keras 2 API no longer'
                           'accepts dict types. You can now input argument as: '
-                          '`padding=((top_pad, bottom_pad), (left_pad, right_pad))`')
+                          '`padding=((top_pad, bottom_pad), (left_pad, right_pad))`', stacklevel=3)
     return args, kwargs, converted
 
 legacy_zeropadding2d_support = generate_legacy_interface(
@@ -580,7 +580,7 @@ def generator_methods_args_preprocessor(args, kwargs):
                               'Keras 1 argument `samples_per_epoch`. '
                               '`steps_per_epoch` is the number of batches '
                               'to draw from the generator at each epoch. '
-                              'Update your method calls accordingly.')
+                              'Update your method calls accordingly.', stacklevel=3)
                 kwargs['steps_per_epoch'] = samples_per_epoch
             converted.append(('samples_per_epoch', 'steps_per_epoch'))
     return args, kwargs, converted


### PR DESCRIPTION
Added `stacklevel=2` in a few places, `stacklevel=3` for preprocessor functions.

Added a warning to `Layer.compute_output_shape`: if a class defines `get_output_shape_for` but is still using the default implementation of `compute_output_shape` from `Layer`, it prints a warning.

This script tests that the warnings all point to the correct lines in the test file (if the stacklevel is set correctly).

This probably isn't everything. The `get_output_shape_for` warning should save some heartache. Does anyone know other hot-spots that need extra warnings?

```python
from keras.models import Model
from keras.layers import Dense, Input, merge, Embedding, Layer, Merge
from keras.regularizers import L1L2
import numpy as np

n=100
_x = np.random.random((n, 10))
_y = np.sum(_x, axis=-1, keepdims=True)

x = Input((_x.shape[1],))
y = Dense(_y.shape[1], W_regularizer=L1L2(1e-6,1e-6))(x)
m = Model(input=[x], output=[y])
m.compile("adam","mean_squared_error")
def gen():
    while True:
        yield _x, _y
m.fit(_x, _y, nb_epoch=5, verbose=0)
m.fit_generator(generator=gen(), samples_per_epoch=32, nb_epoch=5, verbose=0)

embedding = Embedding(50, 100, dropout=0.5)

class L1(Layer):
    def get_output_shape_for(self, s):
        return s
class L2(Layer):
    def dummy(self):
        pass

l1=L1()
l2=L2()
l1.compute_output_shape((10,))
l2.compute_output_shape((10,))

z = Input((_x.shape[1],))
merge_layer = Merge(mode='concat')
merged = merge([x, z], mode="concat")
```

> D:/Projects/keras/keras/legacy_warning_test.py:11: UserWarning: Update your `Dense` call to the Keras 2 API: `Dense(1, kernel_regularizer=<keras.reg...)`
>   y = Dense(_y.shape[1], W_regularizer=L1L2(1e-6,1e-6))(x)
> D:/Projects/keras/keras/legacy_warning_test.py:12: UserWarning: Update your `Model` call to the Keras 2 API: `Model(outputs=[Elemwise{..., inputs=[/input_1])`
>   m = Model(input=[x], output=[y])
> D:/Projects/keras/keras/legacy_warning_test.py:17: UserWarning: The `nb_epoch` argument in `fit` has been renamed `epochs`.
>   m.fit(_x, _y, nb_epoch=5, verbose=0)
> D:/Projects/keras/keras/legacy_warning_test.py:18: UserWarning: The semantics of the Keras 2 argument  `steps_per_epoch` is not the same as the Keras 1 argument `samples_per_epoch`. `steps_per_epoch` is the number of batches to draw from the generator at each epoch. Update your method calls accordingly.
>   m.fit_generator(generator=gen(), samples_per_epoch=32, nb_epoch=5, verbose=0)
> D:/Projects/keras/keras/legacy_warning_test.py:18: UserWarning: Update your `fit_generator` call to the Keras 2 API: `fit_generator(verbose=0, generator=<generator..., steps_per_epoch=32, epochs=5)`
>   m.fit_generator(generator=gen(), samples_per_epoch=32, nb_epoch=5, verbose=0)
> D:/Projects/keras/keras/legacy_warning_test.py:20: UserWarning: The `dropout` argument is no longer support in `Embedding`. You can apply a `keras.layers.SpatialDropout1D` layer right after the `Embedding` layer to get the same behavior.
>   embedding = Embedding(50, 100, dropout=0.5)
> D:/Projects/keras/keras/legacy_warning_test.py:31: UserWarning: Class `__main__.L1` defines `get_output_shape_for` but does not override `compute_output_shape`. If this is a Keras 1 layer, please implement `compute_output_shape` to support Keras 2.
>   l1.compute_output_shape((10,))
> D:/Projects/keras/keras/legacy_warning_test.py:35: UserWarning: The `Merge` layer is deprecated and will be removed after 08/2017. Use instead layers from `keras.layers.merge`, e.g. `add`, `concatenate`, etc.
>   merge_layer = Merge(mode='concat')
> D:/Projects/keras/keras/legacy_warning_test.py:36: UserWarning: The `merge` function is deprecated and will be removed after 08/2017. Use instead layers from `keras.layers.merge`, e.g. `sum`, `concatenate`, etc.
>   merged = merge([x, z], mode="concat")

Cheers!