### PR TITLE
Replace references to get_output_shape_for with compute_output_shape

### DIFF
--- a/examples/antirectifier.py
+++ b/examples/antirectifier.py
@@ -2,7 +2,7 @@
 
 We build a custom activation layer called 'Antirectifier',
 which modifies the shape of the tensor that passes through it.
-We need to specify two methods: `get_output_shape_for` and `call`.
+We need to specify two methods: `compute_output_shape` and `call`.
 
 Note that the same result can also be achieved via a Lambda layer.
 

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -477,7 +477,7 @@ class Layer(object):
             - If necessary, we `build` the layer to match
                 the _keras_shape of the input(s).
             - We update the _keras_shape of every input tensor with
-                its new shape (obtained via self.get_output_shape_for).
+                its new shape (obtained via self.compute_output_shape).
                 This is done as part of _add_inbound_node().
             - We update the _keras_history of the output tensor(s)
                 with the current layer.
@@ -1413,7 +1413,7 @@ class Container(Layer):
         get_weights
         set_weights
         get_config
-        get_output_shape_for
+        compute_output_shape
 
     # Class Methods
         from_config
@@ -2010,7 +2010,7 @@ class Container(Layer):
             for i in range(len(input_shapes)):
                 layer = self.input_layers[i]
                 input_shape = input_shapes[i]
-                # It's an input layer: get_output_shape_for is identity,
+                # It's an input layer: compute_output_shape is identity,
                 # and there is only one node and one tensor output.
                 shape_key = layer.name + '_0_0'
                 layers_to_output_shapes[shape_key] = input_shape

--- a/keras/legacy/layers.py
+++ b/keras/legacy/layers.py
@@ -46,7 +46,7 @@ class Merge(Layer):
             (1:1 mapping to input tensors)
             and return a single shape tuple, including the
             batch size (same convention as the
-            `get_output_shape_for` method of layers).
+            `compute_output_shape` method of layers).
         node_indices: Optional list of integers containing
             the output node index for each input layer
             (in case some input layers have multiple output nodes).
@@ -417,7 +417,7 @@ def merge(inputs, mode='sum', concat_axis=-1,
             If the latter case, it should take as input a list of shape tuples
             (1:1 mapping to input tensors) and return a single shape tuple,
             including the batch size
-            (same convention as the `get_output_shape_for` method of layers).
+            (same convention as the `compute_output_shape` method of layers).
         node_indices: Optional list of integers containing
             the output node index for each input layer
             (in case some input layers have multiple output nodes).


### PR DESCRIPTION
Remove remaining references to `get_output_shape_for`. https://github.com/fchollet/keras/pull/5847 adds a warning if you define `get_output_shape_for` but not `compute_output_shape`.