### PR TITLE
Add verbose argument to predict_generator (Resolve #3793)

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -2021,7 +2021,8 @@ class Model(Container):
 
     @interfaces.legacy_generator_methods_support
     def predict_generator(self, generator, steps,
-                          max_q_size=10, workers=1, pickle_safe=False):
+                          max_q_size=10, workers=1,
+                          pickle_safe=False, verbose=0):
         """Generates predictions for the input samples from a data generator.
 
         The generator should return the same kind of data as accepted by
@@ -2041,6 +2042,7 @@ class Model(Container):
                 non picklable arguments to the generator
                 as they can't be passed
                 easily to children processes.
+            verbose: verbosity mode, 0 or 1.
 
         # Returns
             Numpy array(s) of predictions.
@@ -2059,6 +2061,9 @@ class Model(Container):
         try:
             enqueuer = GeneratorEnqueuer(generator, pickle_safe=pickle_safe)
             enqueuer.start(workers=workers, max_q_size=max_q_size)
+
+            if verbose == 1:
+                progbar = Progbar(target=steps)
 
             while steps_done < steps:
                 generator_output = None
@@ -2097,6 +2102,8 @@ class Model(Container):
                 for i, out in enumerate(outs):
                     all_outs[i].append(out)
                 steps_done += 1
+                if verbose == 1:
+                    progbar.update(steps_done)
 
         finally:
             if enqueuer is not None:

--- a/keras/models.py
+++ b/keras/models.py
@@ -1138,7 +1138,8 @@ class Sequential(Model):
 
     @interfaces.legacy_generator_methods_support
     def predict_generator(self, generator, steps,
-                          max_q_size=10, workers=1, pickle_safe=False):
+                          max_q_size=10, workers=1,
+                          pickle_safe=False, verbose=0):
         """Generates predictions for the input samples from a data generator.
 
         The generator should return the same kind of data as accepted by
@@ -1155,6 +1156,7 @@ class Sequential(Model):
                 relies on multiprocessing, you should not pass
                 non picklable arguments to the generator
                 as they can't be passed easily to children processes.
+            verbose: verbosity mode, 0 or 1.
 
         # Returns
             A Numpy array of predictions.
@@ -1164,7 +1166,8 @@ class Sequential(Model):
         return self.model.predict_generator(generator, steps,
                                             max_q_size=max_q_size,
                                             workers=workers,
-                                            pickle_safe=pickle_safe)
+                                            pickle_safe=pickle_safe,
+                                            verbose=verbose)
 
     def get_config(self):
         if isinstance(self.layers[0], legacy_layers.Merge):

--- a/tests/keras/test_sequential_model.py
+++ b/tests/keras/test_sequential_model.py
@@ -122,7 +122,7 @@ def test_sequential():
 
     loss = model.evaluate(x_test, y_test)
 
-    prediction = model.predict_generator(data_generator(x_test, y_test), 1, max_q_size=2)
+    prediction = model.predict_generator(data_generator(x_test, y_test), 1, max_q_size=2, verbose=1)
     gen_loss = model.evaluate_generator(data_generator(x_test, y_test, 50), 1, max_q_size=2)
     pred_loss = K.eval(K.mean(losses.get(model.loss)(K.variable(y_test), K.variable(prediction))))
 


### PR DESCRIPTION
This adds a verbose option to predict_generator and a progress bar when verbose=1. Verbose is 0 by default, matching current behavior and the predict method.

(link to related issue: #3793)