### PR TITLE
Make accuracy metrics work with masked outputs

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -481,6 +481,7 @@ def _masked_objective(fn):
             # Cast the mask to floatX to avoid float64 upcasting in theano
             mask = K.cast(mask, K.floatx())
             # mask should have the same shape as score_array
+            score_array = K.cast(score_array, K.floatx())
             score_array *= mask
             #  the loss per batch should be proportional
             #  to the number of unmasked samples.

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -481,7 +481,6 @@ def _masked_objective(fn):
             # Cast the mask to floatX to avoid float64 upcasting in theano
             mask = K.cast(mask, K.floatx())
             # mask should have the same shape as score_array
-            score_array = K.cast(score_array, K.floatx())
             score_array *= mask
             #  the loss per batch should be proportional
             #  to the number of unmasked samples.

--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -21,13 +21,15 @@ def binary_accuracy(y_true, y_pred):
 
 
 def categorical_accuracy(y_true, y_pred):
-    return K.equal(K.argmax(y_true, axis=-1),
-                   K.argmax(y_pred, axis=-1))
+    return K.cast(K.equal(K.argmax(y_true, axis=-1),
+                          K.argmax(y_pred, axis=-1)),
+                  K.floatx())
 
 
 def sparse_categorical_accuracy(y_true, y_pred):
-    return K.equal(K.max(y_true, axis=-1),
-                   K.cast(K.argmax(y_pred, axis=-1), K.floatx()))
+    return K.cast(K.equal(K.max(y_true, axis=-1),
+                          K.cast(K.argmax(y_pred, axis=-1), K.floatx())),
+                  K.floatx())
 
 
 def top_k_categorical_accuracy(y_true, y_pred, k=5):


### PR DESCRIPTION
Several accuracy metrics end in a call to `K.equal()`, which gives a tensor with dtype `bool`.  The multiplication with a float mask then crashes.  This fixes that crash.