### PR TITLE
corrects #5868  import vis_utils to visualize_util

### DIFF
--- a/docs/templates/visualization.md
+++ b/docs/templates/visualization.md
@@ -1,16 +1,16 @@
 
 ## Model visualization
 
-The `keras.utils.vis_utils` module provides utility functions to plot
+The `keras.utils.visualize_util` module provides utility functions to plot
 a Keras model (using `graphviz`).
 
 This will plot a graph of the model and save it to a file:
 ```python
-from keras.utils import plot_model
-plot_model(model, to_file='model.png')
+from keras.utils.visualize_util import plot
+plot(model, to_file='model.png')
 ```
 
-`plot_model` takes two optional arguments:
+`plot` takes two optional arguments:
 
 - `show_shapes` (defaults to False) controls whether output shapes are shown in the graph.
 - `show_layer_names` (defaults to True) controls whether layer names are shown in the graph.


### PR DESCRIPTION
documentation was out of date on how to import data viz tools for models.

updated the documentation with the new import path and the method name

