### PR TITLE
Switched mask from uint8 to bool in concat layers

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1136,8 +1136,7 @@ def any(x, axis=None, keepdims=False):
     """
     axis = _normalize_axis(axis, ndim(x))
     x = tf.cast(x, tf.bool)
-    x = tf.reduce_any(x, reduction_indices=axis, keep_dims=keepdims)
-    return tf.cast(x, tf.uint8)
+    return tf.reduce_any(x, reduction_indices=axis, keep_dims=keepdims)
 
 
 def all(x, axis=None, keepdims=False):
@@ -1153,8 +1152,7 @@ def all(x, axis=None, keepdims=False):
     """
     axis = _normalize_axis(axis, ndim(x))
     x = tf.cast(x, tf.bool)
-    x = tf.reduce_all(x, reduction_indices=axis, keep_dims=keepdims)
-    return tf.cast(x, tf.uint8)
+    return tf.reduce_all(x, reduction_indices=axis, keep_dims=keepdims)
 
 
 def argmax(x, axis=-1):

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -56,7 +56,7 @@ class Masking(Layer):
         self.mask_value = mask_value
 
     def compute_mask(self, inputs, mask=None):
-        return K.cast(K.any(K.not_equal(inputs, self.mask_value), axis=-1), 'bool')
+        return K.any(K.not_equal(inputs, self.mask_value), axis=-1)
 
     def call(self, inputs):
         boolean_mask = K.any(K.not_equal(inputs, self.mask_value),

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -56,7 +56,7 @@ class Masking(Layer):
         self.mask_value = mask_value
 
     def compute_mask(self, inputs, mask=None):
-        return K.any(K.not_equal(inputs, self.mask_value), axis=-1)
+        return K.cast(K.any(K.not_equal(inputs, self.mask_value), axis=-1), 'bool')
 
     def call(self, inputs):
         boolean_mask = K.any(K.not_equal(inputs, self.mask_value),

--- a/keras/layers/merge.py
+++ b/keras/layers/merge.py
@@ -197,8 +197,8 @@ class Concatenate(_Merge):
         for input_i, mask_i in zip(inputs, mask):
             if mask_i is None:
                 # Input is unmasked. Append all 1s to masks,
-                # but cast it to uint8 first
-                masks.append(K.cast(K.ones_like(input_i), 'uint8'))
+                # but cast it to bool first
+                masks.append(K.cast(K.ones_like(input_i), 'bool'))
             elif K.ndim(mask_i) < K.ndim(input_i):
                 # Mask is smaller than the input, expand it
                 masks.append(K.expand_dims(mask_i))

--- a/keras/legacy/layers.py
+++ b/keras/legacy/layers.py
@@ -297,8 +297,8 @@ class Merge(Layer):
             for input_i, mask_i in zip(inputs, mask):
                 if mask_i is None:
                     # Input is unmasked. Append all 1s to masks,
-                    # but cast it to uint8 first
-                    masks.append(K.cast(K.ones_like(input_i), 'uint8'))
+                    # but cast it to bool first
+                    masks.append(K.cast(K.ones_like(input_i), 'bool'))
                 elif K.ndim(mask_i) < K.ndim(input_i):
                     # Mask is smaller than the input, expand it
                     masks.append(K.expand_dims(mask_i))


### PR DESCRIPTION
Addresses #5867.  It looks like everywhere else in the code, masks are of type `bool`.  The cast to `uint8` causes a problem when one of the concated inputs has a mask and one doesn't, because you can't concat a `bool` tensor and a `uint8` tensor.