### PR TITLE
Fix error message in `deserialize_keras_objects`

### DIFF
--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -153,8 +153,8 @@ def deserialize_keras_object(identifier, module_objects=None,
         else:
             fn = module_objects.get(function_name)
             if fn is None:
-                raise ValueError('Unknown ' + printable_module_name,
-                                 ':' + function_name)
+                raise ValueError('Unknown ' + printable_module_name + ': ',
+                                  + function_name)
         return fn
     else:
         raise ValueError('Could not interpret serialized ' +


### PR DESCRIPTION
The error message included a colon in the name of the
custom loss. e.g Unknown loss function ':customized_loss'.
This could confuse users since that is not the name they provided.