### PR TITLE
get_file() with tar, tgz, tar.bz, zip and sha256, resolves #5861.

### DIFF
--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -280,7 +280,7 @@ def get_file(fname, origin, untar=False,
     return fpath
 
 
-def validate_file(fpath, file_hash, algorithm='auto'):
+def validate_file(fpath, file_hash, algorithm='auto', chunk_size=65535):
     """Validates a file against a SHA256 or MD5 hash.
 
     Python example of how to get the sha256 hash:
@@ -298,6 +298,7 @@ def validate_file(fpath, file_hash, algorithm='auto'):
         algorithm: hash algorithm, one of 'auto', 'sha256',
                    or the insecure 'md5'.
                    The default 'auto' detects the hash algorithm in use.
+        chunk_size: Bytes to read at a time, important for large files.
     # Returns
         Whether the file is valid
     """
@@ -306,9 +307,9 @@ def validate_file(fpath, file_hash, algorithm='auto'):
     else:
         hasher = hashlib.md5()
 
-    with open(fpath, 'rb') as file:
-        buf = file.read()
-        hasher.update(buf)
+    with open(fpath, 'rb') as fpath_file:
+        for chunk in iter(lambda: fpath_file.read(chunk_size), b''):
+            hasher.update(chunk)
     if str(hasher.hexdigest()) == str(file_hash):
         return True
     else:

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 
 import functools
 import tarfile
+import zipfile
 import os
 import sys
 import shutil
@@ -55,23 +56,171 @@ else:
     from six.moves.urllib.request import urlretrieve
 
 
+class Archive(object):
+    """ Defines an inteface to extract archive files like tar and zip files.
+    """
+    signature = None
+    offset = 0
+    file_type = None
+    mime_type = None
+    file_path = None
+
+    def __init__(self, file_path):
+        self.file_path = file_path
+
+    @classmethod
+    def is_match(cls, fpath):
+        """ Returns True if the file's signature matches the supported archive format.
+        """
+        match = False
+        if cls.signature is None:
+            return match
+        with open(fpath, 'rb') as f:
+            f.seek(cls.offset)
+            match = f.read(len(cls.signature)).startswith(cls.signature)
+        return match
+
+    def open(self, mode='rb'):
+        """ Open the file, or archive object in subclasses.
+        """
+        return open(self.file_path, mode)
+
+    def extractall(self, archive, path="."):
+        """ Extract all archive contents if available.
+        """
+        return None
+
+    def extractall_if_match(self, path="."):
+        if (self.file_type is None) or not self.is_match(self.file_path):
+            return False
+        with self.open() as archive:
+            try:
+                self.extractall(archive, path=path)
+            except (Exception, KeyboardInterrupt) as e:
+                if os.path.exists(path):
+                    if os.path.isfile(path):
+                        os.remove(path)
+                    else:
+                        shutil.rmtree(path)
+                raise
+        return True
+
+
+class TarArchive(Archive):
+    """ Tar file Archive, wraps python tarfile module.
+    """
+    signature = '\x75\x73\x74\x61\x72'
+    offset = 0x101
+    file_type = 'tar'
+    mime_type = 'application/x-tar'
+
+    @classmethod
+    def is_match(cls, fpath):
+        """ Returns True if the file's signature matches supported tar archive format.
+        """
+        return tarfile.is_tarfile(fpath)
+
+    def open(self, mode='r'):
+        """ Opens a tarfile.TarFile object at the file path.
+        """
+        return tarfile.open(self.file_path, mode)
+
+    def extractall(self, archive, path="."):
+        return None
+
+
+class ZipArchive(Archive):
+    """ Zip file Archive, wraps python zipfile module.
+    """
+    signature = '\x50\x4b\x03\x04'
+    offset = 0
+    file_type = 'zip'
+    mime_type = 'compressed/zip'
+
+    @classmethod
+    def is_match(cls, fpath):
+        """ Returns True if the file's signature matches that of a zip formatted file.
+        """
+        return zipfile.is_zipfile(fpath)
+
+    def open(self):
+        """ Returns True if the file's signature matches the supported archive format.
+        """
+        return zipfile.ZipFile(self.file_path, 'r')
+
+    def extractall(self, archive, path="."):
+        return archive.extractall(path)
+
+
+def extract_archive(file_path, path='.', archive_formats='auto'):
+    """Extracts an archive file if it matches one of the recognized formats
+
+    # Arguments
+        file_path: path to the archive file
+        path: path to extract the archive file
+        archive_formats: List of Archive formats to try extracting the file.
+                         The default 'auto' is [TarArchive, ZipArchive].
+                         Options are subclasses of the Archive class.
+                         None or an empty list will return no matches found.
+    """
+    match_found = False
+    if archive_formats is 'auto':
+        archive_formats = [TarArchive, ZipArchive]
+    if not isinstance(archive_formats, basestring):
+        return False
+    for archive_type in archive_formats:
+        archive = archive_type(file_path)
+        match_found = archive.extractall_if_match(path)
+        if match_found:
+            return match_found
+    return match_found
+
+
 def get_file(fname, origin, untar=False,
-             md5_hash=None, cache_subdir='datasets'):
+             md5_hash=None, cache_subdir='datasets',
+             file_hash=None,
+             hash_algorithm='auto',
+             extract=False,
+             archive_formats='auto'):
     """Downloads a file from a URL if it not already in the cache.
 
-    Passing the MD5 hash will verify the file after download
-    as well as if it is already present in the cache.
+    Passing the hash will verify the file after download which also
+    means it will skip re-downloading if it is already present in the cache.
+    Python example of how to get the sha256 hash:
+
+    ```python
+       >>> import os, hashlib
+       >>> print hashlib.sha256(open('/path/to/file').read()).hexdigest()
+       'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+    ```
 
     # Arguments
         fname: name of the file
         origin: original URL of the file
-        untar: boolean, whether the file should be decompressed
-        md5_hash: MD5 hash of the file for verification
-        cache_subdir: directory being used as the cache
+        untar: Deprecated in favor of 'extract'.
+               boolean, whether the file should be decompressed
+        md5_hash: Deprecated in favor of 'file_hash'.
+                  MD5 hash of the file for verification
+        file_hash: The expected hash string of the file after download,
+                   preferably sha256, but md5 is also supported.
+        cache_subdir: Directory where the file is saved,
+                      ~/.keras/ is the default and /tmp/.keras
+                      is a backup default if the first does not work.
+        hash_algorithm: Select the hash algorithm to verify the file.
+                        options are 'md5', 'sha256', and 'auto'
+                        The default 'auto' detects the hash algorithm in use.
+        extract: True tries extracting the file as an Archive, like tar or zip.
+        archive_formats: List of Archive formats to try extracting the file.
+                  The default 'auto' tries [TarArchive, ZipArchive].
+                  Options are subclasses of the Archive class.
+                  None or an empty list will return no matches found.
 
     # Returns
         Path to the downloaded file
     """
+    if md5_hash is not None and file_hash is None:
+        file_hash = md5_hash
+        hash_algorithm = 'md5'
     datadir_base = os.path.expanduser(os.path.join('~', '.keras'))
     if not os.access(datadir_base, os.W_OK):
         datadir_base = os.path.join('/tmp', '.keras')
@@ -88,10 +237,12 @@ def get_file(fname, origin, untar=False,
     download = False
     if os.path.exists(fpath):
         # File found; verify integrity if a hash was provided.
-        if md5_hash is not None:
-            if not validate_file(fpath, md5_hash):
+        if file_hash is not None:
+            if not validate_file(fpath, file_hash, algorithm=hash_algorithm):
                 print('A local file was found, but it seems to be '
-                      'incomplete or outdated.')
+                      'incomplete or outdated because the ' + hash_algorithm +
+                      ' file hash does not match the original value of ' +
+                      file_hash + ' so we will re-download the data.')
                 download = True
     else:
         download = True
@@ -123,38 +274,42 @@ def get_file(fname, origin, untar=False,
 
     if untar:
         if not os.path.exists(untar_fpath):
-            print('Untaring file...')
-            tfile = tarfile.open(fpath, 'r:gz')
-            try:
-                tfile.extractall(path=datadir)
-            except (Exception, KeyboardInterrupt) as e:
-                if os.path.exists(untar_fpath):
-                    if os.path.isfile(untar_fpath):
-                        os.remove(untar_fpath)
-                    else:
-                        shutil.rmtree(untar_fpath)
-                raise
-            tfile.close()
+            extract_archive(fpath, datadir, archive_formats=[TarArchive])
         return untar_fpath
 
     return fpath
 
 
-def validate_file(fpath, md5_hash):
-    """Validates a file against a MD5 hash.
+def validate_file(fpath, file_hash, algorithm='auto'):
+    """Validates a file against a SHA256 or MD5 hash.
+
+    Python example of how to get the sha256 hash:
+
+    ```python
+       >>> import os, hashlib
+       >>> print hashlib.sha256(open('/path/to/file').read()).hexdigest()
+       'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+    ```
 
     # Arguments
         fpath: path to the file being validated
-        md5_hash: the MD5 hash being validated against
-
+        file_hash:  The expected hash string of the file,
+                    preferably sha256, but md5 is also supported.
+        algorithm: hash algorithm, one of 'auto', 'sha256',
+                   or the insecure 'md5'.
+                   The default 'auto' detects the hash algorithm in use.
     # Returns
         Whether the file is valid
     """
-    hasher = hashlib.md5()
-    with open(fpath, 'rb') as f:
-        buf = f.read()
+    if (algorithm is 'sha256') or (algorithm is 'auto' and len(hash) is 64):
+        hasher = hashlib.sha256()
+    else:
+        hasher = hashlib.md5()
+
+    with open(fpath, 'rb') as file:
+        buf = file.read()
         hasher.update(buf)
-    if str(hasher.hexdigest()) == str(md5_hash):
+    if str(hasher.hexdigest()) == str(file_hash):
         return True
     else:
         return False

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -126,7 +126,7 @@ class TarArchive(Archive):
         return tarfile.open(self.file_path, mode)
 
     def extractall(self, archive, path="."):
-        return None
+        return archive.extractall(path)
 
 
 class ZipArchive(Archive):

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -110,7 +110,7 @@ def get_file(fname, origin, untar=False,
              hash_algorithm='auto',
              extract=False,
              archive_format='auto',
-             cache_dir='~/.keras'):
+             cache_dir=None):
     """Downloads a file from a URL if it not already in the cache.
 
     By default the file at the url `origin` is downloaded to the
@@ -144,12 +144,15 @@ def get_file(fname, origin, untar=False,
             'tar' includes tar, tar.gz, and tar.bz files.
             The default 'auto' is ['tar', 'zip'].
             None or an empty list will return no matches found.
-        cache_dir: Location to store cached files, defaults to the
-            [Keras Directory](/backend/#switching-from-one-backend-to-another).
+        cache_dir: Location to store cached files, when None it
+            defaults to the [Keras Directory]
+            (/faq/#where-is-the-keras-configuration-filed-stored).
 
     # Returns
         Path to the downloaded file
     """
+    if cache_dir is None:
+        cache_dir = os.path.expanduser(os.path.join('~', '.keras'))
     if md5_hash is not None and file_hash is None:
         file_hash = md5_hash
         hash_algorithm = 'md5'

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -114,9 +114,9 @@ def get_file(fname, origin, untar=False,
     """Downloads a file from a URL if it not already in the cache.
 
     By default the file at the url `origin` is downloaded to the
-    cach_dir `~/.keras`, placed in the cache_subdir `datasets`,
+    cache_dir `~/.keras`, placed in the cache_subdir `datasets`,
     and given the filename `fname`. The final location of a file
-    `example.txt` would therefore be `~/keras/datasets/example.txt`.
+    `example.txt` would therefore be `~/.keras/datasets/example.txt`.
 
     Files in tar, tar.gz, tar.bz, and zip formats can also be extracted.
     Passing a hash will verify the file after download. The command line
@@ -145,8 +145,7 @@ def get_file(fname, origin, untar=False,
             The default 'auto' is ['tar', 'zip'].
             None or an empty list will return no matches found.
         cache_dir: Location to store cached files, when None it
-            defaults to the [Keras Directory]
-            (/faq/#where-is-the-keras-configuration-filed-stored).
+            defaults to the [Keras Directory](/faq/#where-is-the-keras-configuration-filed-stored).
 
     # Returns
         Path to the downloaded file

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -166,8 +166,6 @@ def extract_archive(file_path, path='.', archive_formats='auto'):
     match_found = False
     if archive_formats is 'auto':
         archive_formats = [TarArchive, ZipArchive]
-    if not isinstance(archive_formats, basestring):
-        return False
     for archive_type in archive_formats:
         archive = archive_type(file_path)
         match_found = archive.extractall_if_match(path)

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -144,9 +144,8 @@ def get_file(fname, origin, untar=False,
             'tar' includes tar, tar.gz, and tar.bz files.
             The default 'auto' is ['tar', 'zip'].
             None or an empty list will return no matches found.
-        cache_dir: Location to store cached files. `~/.keras/` is the default
-            cache dir, and `/tmp/.keras` is a backup default if there is a
-            permissions problem.
+        cache_dir: Location to store cached files, defaults to the
+            [Keras Directory](/backend/#switching-from-one-backend-to-another).
 
     # Returns
         Path to the downloaded file

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -277,6 +277,9 @@ def get_file(fname, origin, untar=False,
             extract_archive(fpath, datadir, archive_formats=[TarArchive])
         return untar_fpath
 
+    if extract:
+        extract_archive(fpath, datadir)
+
     return fpath
 
 

--- a/tests/keras/utils/data_utils_test.py
+++ b/tests/keras/utils/data_utils_test.py
@@ -1,0 +1,51 @@
+import os
+import pytest
+import tarfile
+import zipfile
+from six.moves.urllib.request import pathname2url
+from six.moves.urllib.parse import urljoin
+from keras.utils.data_utils import get_file
+from keras.utils.data_utils import validate_file
+from keras.utils.data_utils import _hash_file
+from keras import activations
+from keras import regularizers
+
+
+def test_data_utils():
+    dirname = 'data_utils'
+
+    with open("test.txt", "w") as text_file:
+        text_file.write('Float like a butterfly, sting like a bee.')
+
+    with tarfile.open('test.tar.gz', 'w:gz') as tar_file:
+        tar_file.add('test.txt')
+
+    with zipfile.ZipFile('test.zip', 'w') as zip_file:
+        zip_file.write('test.txt')
+
+
+    origin = urljoin("file://", pathname2url(os.path.abspath('test.tar.gz')))
+
+    path = get_file(dirname, origin, untar=True)
+    filepath = path + '.tar.gz'
+    hashval_sha256 = _hash_file(filepath)
+    hashval_md5 = _hash_file(filepath, algorithm='md5')
+    path = get_file(dirname, origin, md5_hash=hashval_md5, untar=True)
+    path = get_file(filepath, origin, file_hash=hashval_sha256, extract=True)
+    assert os.path.exists(path)
+    assert validate_file(filepath, hashval_sha256)
+    assert validate_file(filepath, hashval_md5)
+
+
+    origin = urljoin("file://", pathname2url(os.path.abspath('test.zip')))
+
+    hashval_sha256 = _hash_file('test.zip')
+    hashval_md5 = _hash_file('test.zip', algorithm='md5')
+    path = get_file(dirname, origin, md5_hash=hashval_md5, extract=True)
+    path = get_file(dirname, origin, file_hash=hashval_sha256, extract=True)
+    assert os.path.exists(path)
+    assert validate_file(path, hashval_sha256)
+    assert validate_file(path, hashval_md5)
+
+if __name__ == '__main__':
+    pytest.main([__file__])

--- a/tests/keras/utils/data_utils_test.py
+++ b/tests/keras/utils/data_utils_test.py
@@ -1,3 +1,5 @@
+"""Tests for functions in data_utils.py.
+"""
 import os
 import pytest
 import tarfile
@@ -12,9 +14,11 @@ from keras import regularizers
 
 
 def test_data_utils():
+    """Tests get_file from a url, plus extraction and validation.
+    """
     dirname = 'data_utils'
 
-    with open("test.txt", "w") as text_file:
+    with open('test.txt', 'w') as text_file:
         text_file.write('Float like a butterfly, sting like a bee.')
 
     with tarfile.open('test.tar.gz', 'w:gz') as tar_file:
@@ -23,8 +27,7 @@ def test_data_utils():
     with zipfile.ZipFile('test.zip', 'w') as zip_file:
         zip_file.write('test.txt')
 
-
-    origin = urljoin("file://", pathname2url(os.path.abspath('test.tar.gz')))
+    origin = urljoin('file://', pathname2url(os.path.abspath('test.tar.gz')))
 
     path = get_file(dirname, origin, untar=True)
     filepath = path + '.tar.gz'
@@ -32,12 +35,13 @@ def test_data_utils():
     hashval_md5 = _hash_file(filepath, algorithm='md5')
     path = get_file(dirname, origin, md5_hash=hashval_md5, untar=True)
     path = get_file(filepath, origin, file_hash=hashval_sha256, extract=True)
-    assert os.path.exists(path)
+    assert os.path.exists(filepath)
     assert validate_file(filepath, hashval_sha256)
     assert validate_file(filepath, hashval_md5)
+    os.remove(filepath)
+    os.remove('test.tar.gz')
 
-
-    origin = urljoin("file://", pathname2url(os.path.abspath('test.zip')))
+    origin = urljoin('file://', pathname2url(os.path.abspath('test.zip')))
 
     hashval_sha256 = _hash_file('test.zip')
     hashval_md5 = _hash_file('test.zip', algorithm='md5')
@@ -46,6 +50,10 @@ def test_data_utils():
     assert os.path.exists(path)
     assert validate_file(path, hashval_sha256)
     assert validate_file(path, hashval_md5)
+
+    os.remove(path)
+    os.remove('test.txt')
+    os.remove('test.zip')
 
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
The changes were designed to preserve backwards compatibility while adding support
for .tar.gz, .tgz, .tar.bz, and .zip files.
sha256 hash is now supported in addition to md5.

This should resolve #5861