### PR TITLE
Fix the issue that when n can be mod by batch_size, the shuffle never happened

### DIFF
--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -708,7 +708,7 @@ class Iterator(object):
                     index_array = np.random.permutation(n)
 
             current_index = (self.batch_index * batch_size) % n
-            if n >= current_index + batch_size:
+            if n > current_index + batch_size:
                 current_batch_size = batch_size
                 self.batch_index += 1
             else:


### PR DESCRIPTION
The data generator function '_flow_index' has some issue, that when n can be mod by batch_size, the shuffle never happened.

The code has already  been tested.