### PR TITLE
Convert API in docs/templates to ver2 (Only Training, Losses & metrics)

### DIFF
--- a/docs/templates/getting-started/faq.md
+++ b/docs/templates/getting-started/faq.md
@@ -225,7 +225,7 @@ layer_output = get_3rd_layer_output([X, 1])[0]
 
 You can do batch training using `model.train_on_batch(X, y)` and `model.test_on_batch(X, y)`. See the [models documentation](/models/sequential).
 
-Alternatively, you can write a generator that yields batches of training data and use the method `model.fit_generator(data_generator, samples_per_epoch, epochs)`.
+Alternatively, you can write a generator that yields batches of training data and use the method `model.fit_generator(data_generator, steps_per_epoch, epochs)`.
 
 You can see batch training in action in our [CIFAR10 example](https://github.com/fchollet/keras/blob/master/examples/cifar10_cnn.py).
 

--- a/docs/templates/metrics.md
+++ b/docs/templates/metrics.md
@@ -17,7 +17,7 @@ model.compile(loss='mean_squared_error',
               metrics=[metrics.mae, metrics.categorical_accuracy])
 ```
 
-A metric function is similar to an [objective function](/objectives), except that the results from evaluating a metric are not used when training the model.
+A metric function is similar to an [loss function](/losses), except that the results from evaluating a metric are not used when training the model.
 
 You can either pass the name of an existing metric, or pass a Theano/TensorFlow symbolic function (see [Custom metrics](#custom-metrics)).
 

--- a/docs/templates/preprocessing/image.md
+++ b/docs/templates/preprocessing/image.md
@@ -116,7 +116,7 @@ datagen.fit(X_train)
 
 # fits the model on batches with real-time data augmentation:
 model.fit_generator(datagen.flow(X_train, Y_train, batch_size=32),
-                    samples_per_epoch=len(X_train), epochs=epochs)
+                    steps_per_epoch=len(X_train), epochs=epochs)
 
 # here's a more "manual" example
 for e in range(epochs):
@@ -156,7 +156,7 @@ validation_generator = test_datagen.flow_from_directory(
 
 model.fit_generator(
         train_generator,
-        samples_per_epoch=2000,
+        steps_per_epoch=2000,
         epochs=50,
         validation_data=validation_generator,
         validation_steps=800)
@@ -195,6 +195,6 @@ train_generator = zip(image_generator, mask_generator)
 
 model.fit_generator(
     train_generator,
-    samples_per_epoch=2000,
+    steps_per_epoch=2000,
     epochs=50)
 ```


### PR DESCRIPTION
Convert some API in docs/templates to ver2.
Based on [Keras 2.0 release notes](https://github.com/fchollet/keras/wiki/Keras-2.0-release-notes), the items in Training, Losses & metrics were converted.