### PR TITLE
Use dtype of first batch for dtype of predicted outputs

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1205,7 +1205,7 @@ class Model(Container):
             if batch_index == 0:
                 for batch_out in batch_outs:
                     shape = (samples,) + batch_out.shape[1:]
-                    outs.append(np.zeros(shape, dtype=K.floatx()))
+                    outs.append(np.zeros(shape, dtype=batch_out.dtype))
 
             for i, batch_out in enumerate(batch_outs):
                 outs[i][batch_start:batch_end] = batch_out


### PR DESCRIPTION
When predicting in a loop, this PR uses the dtype of the first batch to create the container instead of always converting to floatX.

@fchollet any thoughts on the best way to implement this behavior? I have models that output integers and I would like to avoid casting back and forth.
 
* If there are some programs that rely on floats being cast, I could do this logic: Cast to floatx if it is float32 or float64, otherwise do not change dtype.
* If you want to keep current behavior, maybe we could add a flag to switch between casting to float32 or using the returned dtype.

Cheers