### PR TITLE
Prediction dtype fix

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1205,7 +1205,8 @@ class Model(Container):
             if batch_index == 0:
                 for batch_out in batch_outs:
                     shape = (samples,) + batch_out.shape[1:]
-                    outs.append(np.zeros(shape, dtype=batch_out.dtype))
+                    dtype = K.floatx() if batch_out.dtype in (np.float32, np.float64) else batch_out.dtype
+                    outs.append(np.zeros(shape, dtype=dtype))
 
             for i, batch_out in enumerate(batch_outs):
                 outs[i][batch_start:batch_end] = batch_out

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1205,7 +1205,7 @@ class Model(Container):
             if batch_index == 0:
                 for batch_out in batch_outs:
                     shape = (samples,) + batch_out.shape[1:]
-                    outs.append(np.zeros(shape, dtype=K.floatx()))
+                    outs.append(np.zeros(shape, dtype=batch_out.dtype))
 
             for i, batch_out in enumerate(batch_outs):
                 outs[i][batch_start:batch_end] = batch_out

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1205,7 +1205,7 @@ class Model(Container):
             if batch_index == 0:
                 for batch_out in batch_outs:
                     shape = (samples,) + batch_out.shape[1:]
-                    dtype = K.floatx() if batch_out.dtype in (np.float32, np.float64) else batch_out.dtype
+                    dtype = K.floatx() if batch_out.dtype in (np.float16, np.float32, np.float64) else batch_out.dtype
                     outs.append(np.zeros(shape, dtype=dtype))
 
             for i, batch_out in enumerate(batch_outs):


### PR DESCRIPTION
Alternative logic to https://github.com/fchollet/keras/pull/5903. Convert to floatx if dtype is float32 or float64, otherwise keep dtype. Only affects predict loop.

Most people are probably using float outputs and are unaffected. If you have int outputs, they will now be predicted as ints.

Cheers