### PR TITLE
Change batch size back to None in reshape

### DIFF
--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -712,6 +712,8 @@ def concatenate(tensors, axis=-1):
 def reshape(x, shape):
     y = T.reshape(x, shape)
     if _is_explicit_shape(shape):
+        if -1 in shape:
+            shape = tuple(x if x != -1 else None for x in shape)
         y._keras_shape = shape
         if hasattr(x, '_uses_learning_phase'):
             y._uses_learning_phase = x._uses_learning_phase


### PR DESCRIPTION
When doing `K.reshape()`, you need to use `-1` instead of `None` for dimensions with unknown length.  The rest of the Keras code expects the shape to be `None` if the dimension has unknown length, and so setting `_keras_shape` without converting `-1` back to `None` leads to some bugs.  This fixes that.