### PR TITLE
Changed name scope within bidirectional, fixing #5820

### DIFF
--- a/keras/layers/wrappers.py
+++ b/keras/layers/wrappers.py
@@ -229,8 +229,10 @@ class Bidirectional(Wrapper):
         self.backward_layer.reset_states()
 
     def build(self, input_shape):
-        self.forward_layer.build(input_shape)
-        self.backward_layer.build(input_shape)
+        with K.name_scope(self.forward_layer.name):
+            self.forward_layer.build(input_shape)
+        with K.name_scope(self.backward_layer.name):
+            self.backward_layer.build(input_shape)
         self.built = True
 
     def compute_mask(self, inputs, mask):


### PR DESCRIPTION
I don't feel like I understand what exactly name scopes do very well, so I might have done this incorrectly, but in my tests, this fixes #5820 (you can't save models with bidirectional layers, because there are overlapping names; I only ran into this with theano, incidentally; tensorflow worked fine).