### PR TITLE
Improve descriptions of go_backwards parameters.

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -2174,8 +2174,8 @@ def rnn(step_function, inputs, initial_states,
             (no time dimension),
             containing the initial values for the states used in
             the step function.
-        go_backwards: boolean. If True, do the iteration over
-            the time dimension in reverse order.
+        go_backwards: boolean. If True, do the iteration over the time
+            dimension in reverse order and return the reversed sequence.
         mask: binary tensor with shape `(samples, time, 1)`,
             with a zero for every element that is masked.
         constants: a list of constant values passed at each step.

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1166,8 +1166,8 @@ def rnn(step_function, inputs, initial_states,
         initial_states: tensor with shape (samples, ...) (no time dimension),
             containing the initial values for the states used in
             the step function.
-        go_backwards: boolean. If True, do the iteration over
-            the time dimension in reverse order.
+        go_backwards: boolean. If True, do the iteration over the time
+            dimension in reverse order and return the reversed sequence.
         mask: binary tensor with shape (samples, time),
             with a zero for every element that is masked.
         constants: a list of constant values passed at each step.

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -93,7 +93,8 @@ class Recurrent(Layer):
         return_sequences: Boolean. Whether to return the last output
             in the output sequence, or the full sequence.
         go_backwards: Boolean (default False).
-            If True, process the input sequence backwards.
+            If True, process the input sequence backwards and return the
+            reversed sequence.
         stateful: Boolean (default False). If True, the last state
             for each sample at index i in a batch will be used as initial
             state for the sample of index i in the following batch.


### PR DESCRIPTION
If I understand the backend code correctly, Keras reverses the input order when producing an output sequence with `go_backwards=True`. This means that the first element in the input sequence (`input[0]`) is positioned as the last element of the output sequence (`output[last]`) after being processed by a backward RNN. This is correctly used in `Bidirectional` layer. Unfortunately general documentation is a bit misleading about this, so this is the PR to fix this.

Anyway, to see what effect does a wrong implementation have, I have modified the example `imdb_bidirectional_lstm.py` to use the following model:

```py
model = Sequential()
model.add(Embedding(max_features, 128, input_length=maxlen))
model.add(Bidirectional(LSTM(20, return_sequences=True), merge_mode='sum'))
model.add(Bidirectional(LSTM(20), merge_mode='sum'))
model.add(Dropout(0.5))
model.add(Dense(1, activation='sigmoid'))
```

With `Bidirectional` layer from *master*:

```
$ python imdb_bidirectional_lstm.py
Train on 25000 samples, validate on 25000 samples
Epoch 1/4
25000/25000 [==============================] - 245s - loss: 0.4119 - acc: 0.8083 - val_loss: 0.3401 - val_acc: 0.8526
Epoch 2/4
25000/25000 [==============================] - 150s - loss: 0.2182 - acc: 0.9189 - val_loss: 0.3683 - val_acc: 0.8480
Epoch 3/4
25000/25000 [==============================] - 150s - loss: 0.1138 - acc: 0.9612 - val_loss: 0.5108 - val_acc: 0.8435
Epoch 4/4
25000/25000 [==============================] - 150s - loss: 0.0546 - acc: 0.9836 - val_loss: 0.6518 - val_acc: 0.8329
```

With `Bidirectional` layer without reversing of the backward sequence:

```
$ python imdb_bidirectional_lstm.py
Train on 25000 samples, validate on 25000 samples
Epoch 1/4
25000/25000 [==============================] - 154s - loss: 0.4102 - acc: 0.8059 - val_loss: 0.3231 - val_acc: 0.8593
Epoch 2/4
25000/25000 [==============================] - 155s - loss: 0.2048 - acc: 0.9261 - val_loss: 0.3503 - val_acc: 0.8518
Epoch 3/4
25000/25000 [==============================] - 154s - loss: 0.0959 - acc: 0.9693 - val_loss: 0.5068 - val_acc: 0.8457
Epoch 4/4
25000/25000 [==============================] - 153s - loss: 0.0446 - acc: 0.9870 - val_loss: 0.6779 - val_acc: 0.8334
```

Although a far too small example, the metrics seem to remain comparable.