### PR TITLE
Minor fix for visualization documentation.

### DIFF
--- a/docs/templates/visualization.md
+++ b/docs/templates/visualization.md
@@ -19,7 +19,7 @@ You can also directly obtain the `pydot.Graph` object and render it yourself,
 for example to show it in an ipython notebook :
 ```python
 from IPython.display import SVG
-from keras.utils.visualize_util import model_to_dot
+from keras.utils.vis_utils import model_to_dot
 
 SVG(model_to_dot(model).create(prog='dot', format='svg'))
 ```


### PR DESCRIPTION
Visualization documentation missed one renaming of `keras.utils.visualize_util` and the old one still does not work:

```
>>> import keras.utils.visualize_util
Using Theano backend.
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: No module named visualize_util
```