### PR TITLE
Refactor and speedup local layer unit test

### DIFF
--- a/tests/keras/layers/local_test.py
+++ b/tests/keras/layers/local_test.py
@@ -12,63 +12,51 @@ def test_locallyconnected_1d():
     input_dim = 5
     filter_length = 3
     filters = 4
+    padding = 'valid'
+    strides = 1
 
-    for padding in ['valid']:
-        for strides in [1]:
-            if padding == 'same' and strides != 1:
-                continue
-            layer_test(local.LocallyConnected1D,
-                       kwargs={'filters': filters,
-                               'kernel_size': filter_length,
-                               'padding': padding,
-                               'strides': strides},
-                       input_shape=(num_samples, num_steps, input_dim))
-
-            layer_test(local.LocallyConnected1D,
-                       kwargs={'filters': filters,
-                               'kernel_size': filter_length,
-                               'padding': padding,
-                               'kernel_regularizer': 'l2',
-                               'bias_regularizer': 'l2',
-                               'activity_regularizer': 'l2',
-                               'strides': strides},
-                       input_shape=(num_samples, num_steps, input_dim))
+    layer_test(local.LocallyConnected1D,
+               kwargs={'filters': filters,
+                       'kernel_size': filter_length,
+                       'padding': padding,
+                       'kernel_regularizer': 'l2',
+                       'bias_regularizer': 'l2',
+                       'activity_regularizer': 'l2',
+                       'strides': strides},
+               input_shape=(num_samples, num_steps, input_dim))
 
 
 @keras_test
 def test_locallyconnected_2d():
-    num_samples = 8
+    num_samples = 5
     filters = 3
     stack_size = 4
     num_row = 6
-    num_col = 10
+    num_col = 8
+    padding = 'valid'
 
-    for padding in ['valid']:
-        for strides in [(1, 1), (2, 2)]:
-            if padding == 'same' and strides != (1, 1):
-                continue
+    for strides in [(1, 1), (2, 2)]:
+        layer_test(local.LocallyConnected2D,
+                   kwargs={'filters': filters,
+                           'kernel_size': 3,
+                           'padding': padding,
+                           'kernel_regularizer': 'l2',
+                           'bias_regularizer': 'l2',
+                           'activity_regularizer': 'l2',
+                           'strides': strides,
+                           'data_format': 'channels_last'},
+                   input_shape=(num_samples, num_row, num_col, stack_size))
 
-            layer_test(local.LocallyConnected2D,
-                       kwargs={'filters': filters,
-                               'kernel_size': 3,
-                               'padding': padding,
-                               'kernel_regularizer': 'l2',
-                               'bias_regularizer': 'l2',
-                               'activity_regularizer': 'l2',
-                               'strides': strides,
-                               'data_format': 'channels_last'},
-                       input_shape=(num_samples, num_row, num_col, stack_size))
-
-            layer_test(local.LocallyConnected2D,
-                       kwargs={'filters': filters,
-                               'kernel_size': (3, 3),
-                               'padding': padding,
-                               'kernel_regularizer': 'l2',
-                               'bias_regularizer': 'l2',
-                               'activity_regularizer': 'l2',
-                               'strides': strides,
-                               'data_format': 'channels_first'},
-                       input_shape=(num_samples, stack_size, num_row, num_col))
+        layer_test(local.LocallyConnected2D,
+                   kwargs={'filters': filters,
+                           'kernel_size': (3, 3),
+                           'padding': padding,
+                           'kernel_regularizer': 'l2',
+                           'bias_regularizer': 'l2',
+                           'activity_regularizer': 'l2',
+                           'strides': strides,
+                           'data_format': 'channels_first'},
+                   input_shape=(num_samples, stack_size, num_row, num_col))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
1. Remove unnecessary loop
2. Reduce weight size to speedup unit test