### PR TITLE
Fix dropout error in Bidirectional layer

### DIFF
--- a/keras/layers/wrappers.py
+++ b/keras/layers/wrappers.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import
 
 import copy
+import inspect
 from ..engine import Layer
 from ..engine import InputSpec
 from .. import backend as K
@@ -208,21 +209,36 @@ class Bidirectional(Wrapper):
         elif self.merge_mode is None:
             return [self.forward_layer.compute_output_shape(input_shape)] * 2
 
-    def call(self, inputs, mask=None):
-        y = self.forward_layer.call(inputs, mask)
-        y_rev = self.backward_layer.call(inputs, mask)
+    def call(self, inputs, training=None, mask=None):
+        func_args = inspect.signature(self.layer.call).parameters
+        kwargs = {}
+        for arg in ('training', 'mask'):
+            if arg in func_args:
+                kwargs[arg] = eval(arg)
+
+        y = self.forward_layer.call(inputs, **kwargs)
+        y_rev = self.backward_layer.call(inputs, **kwargs)
         if self.return_sequences:
             y_rev = K.reverse(y_rev, 1)
         if self.merge_mode == 'concat':
-            return K.concatenate([y, y_rev])
+            output = K.concatenate([y, y_rev])
         elif self.merge_mode == 'sum':
-            return y + y_rev
+            output = y + y_rev
         elif self.merge_mode == 'ave':
-            return (y + y_rev) / 2
+            output = (y + y_rev) / 2
         elif self.merge_mode == 'mul':
-            return y * y_rev
+            output = y * y_rev
         elif self.merge_mode is None:
-            return [y, y_rev]
+            output = [y, y_rev]
+
+        # Properly set learning phase
+        if 0 < self.layer.dropout + self.layer.recurrent_dropout:
+            if self.merge_mode is None:
+                for out in output:
+                    out._uses_learning_phase = True
+            else:
+                output._uses_learning_phase = True
+        return output
 
     def reset_states(self):
         self.forward_layer.reset_states()

--- a/keras/layers/wrappers.py
+++ b/keras/layers/wrappers.py
@@ -210,7 +210,7 @@ class Bidirectional(Wrapper):
             return [self.forward_layer.compute_output_shape(input_shape)] * 2
 
     def call(self, inputs, training=None, mask=None):
-        func_args = inspect.signature(self.layer.call).parameters
+        func_args = inspect.getargspec(self.layer.call).args
         kwargs = {}
         for arg in ('training', 'mask'):
             if arg in func_args:

--- a/tests/keras/layers/wrappers_test.py
+++ b/tests/keras/layers/wrappers_test.py
@@ -103,6 +103,7 @@ def test_Bidirectional():
     dim = 2
     timesteps = 2
     output_dim = 2
+    dropout_rate = 0.2
     for mode in ['sum', 'concat']:
         x = np.random.random((samples, timesteps, dim))
         target_dim = 2 * output_dim if mode == 'concat' else output_dim
@@ -110,7 +111,8 @@ def test_Bidirectional():
 
         # test with Sequential model
         model = Sequential()
-        model.add(wrappers.Bidirectional(rnn(output_dim),
+        model.add(wrappers.Bidirectional(rnn(output_dim, dropout=dropout_rate,
+                                             recurrent_dropout=dropout_rate),
                                          merge_mode=mode, input_shape=(timesteps, dim)))
         model.compile(loss='mse', optimizer='sgd')
         model.fit(x, y, epochs=1, batch_size=1)
@@ -130,7 +132,9 @@ def test_Bidirectional():
 
         # test with functional API
         input = Input((timesteps, dim))
-        output = wrappers.Bidirectional(rnn(output_dim), merge_mode=mode)(input)
+        output = wrappers.Bidirectional(rnn(output_dim, dropout=dropout_rate,
+                                            recurrent_dropout=dropout_rate),
+                                        merge_mode=mode)(input)
         model = Model(input, output)
         model.compile(loss='mse', optimizer='sgd')
         model.fit(x, y, epochs=1, batch_size=1)


### PR DESCRIPTION
For issue #5940 and #5975 
`Bidirectional` wrapper produces error with any `Recurrent` layer with `dropout` or `recurrent_dropout` argument.