### PR TITLE
Bug fix : Error when applying layer recursively on a list in Keras 2

### DIFF
--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -503,6 +503,8 @@ class Layer(object):
             ValueError: in case the layer is missing shape information
                 for its `build` call.
         """
+        if type(inputs) is list:
+            inputs = inputs[:]
         with K.name_scope(self.name):
             # Handle laying building (weight creating, input spec locking).
             if not self.built:


### PR DESCRIPTION
Simple script to reproduce:

```python
from keras.layers import*
from keras.models import *

a = Input((None, None))
x = [a, a]
b = concatenate(x, 1)
x += [b]  # This changes b._keras_history[0].input
b = concatenate(x, 1)
model = Model(a, b)
```

Works with legacy merge layer. See #5972
