### PR TITLE
Fix memory leak in tensorflow backend

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -67,6 +67,7 @@ def clear_session():
     reset_uids()
     _SESSION = None
     phase = tf.placeholder(dtype='bool', name='keras_learning_phase')
+    _GRAPH_LEARNING_PHASES = {}
     _GRAPH_LEARNING_PHASES[tf.get_default_graph()] = phase
 
 


### PR DESCRIPTION
Hi, I do a lot of `clear_session()` in my code (distributed processing) and noticed a memory leak.  Tracked it down to `_GRAPH_LEARNING_PHASES` not being cleared in clear_session, which meant a lot of graph data was not being properly garbage collected.