### PR TITLE
bug fix, cast batch_sizes as a list to support indexing

### DIFF
--- a/keras/layers/merge.py
+++ b/keras/layers/merge.py
@@ -160,7 +160,7 @@ class _Merge(Layer):
         batch_sizes = set(batch_sizes)
         batch_sizes -= set([None])
         if len(batch_sizes) == 1:
-            output_shape = (batch_sizes[0],) + output_shape
+            output_shape = (list(batch_sizes)[0],) + output_shape
         else:
             output_shape = (None,) + output_shape
         return output_shape


### PR DESCRIPTION
Cannot index a set, so batch_sizes must be cast back as a list or a tuple.