### PR TITLE
Fix docstring relating to stacked recurrent layers

### DIFF
--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -82,7 +82,8 @@ class Recurrent(Layer):
         model = Sequential()
         model.add(LSTM(32, input_dim=64, input_length=10))
 
-        # to stack recurrent layers, you must use return_sequences=True on any recurrent layer that feeds into another recurrent layer:
+        # to stack recurrent layers, you must use return_sequences=True on any recurrent layer that feeds into another recurrent layer.
+        # note that you only need to specify the input size on the first layer.
         model = Sequential()
         model.add(LSTM(64, input_dim=64, input_length=10, return_sequences=True))
         model.add(LSTM(32, return_sequences=True))

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -82,8 +82,11 @@ class Recurrent(Layer):
         model = Sequential()
         model.add(LSTM(32, input_dim=64, input_length=10))
 
-        # for subsequent layers, not need to specify the input size:
-        model.add(LSTM(16))
+        # to stack recurrent layers, you must use return_sequences=True on any recurrent layer that feeds into another recurrent layer:
+        model = Sequential()
+        model.add(LSTM(64, input_dim=64, input_length=10, return_sequences=True))
+        model.add(LSTM(32, return_sequences=True))
+        model.add(LSTM(10))
     ```
 
     # Arguments

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -78,9 +78,8 @@ class Recurrent(Layer):
         # now model.output_shape == (None, 32)
         # note: `None` is the batch dimension.
 
-        # the following is identical:
-        model = Sequential()
-        model.add(LSTM(32, input_dim=64, input_length=10))
+        # for subsequent layers, no need to specify the input size:
+        model.add(LSTM(16))
 
         # to stack recurrent layers, you must use return_sequences=True on any recurrent layer that feeds into another recurrent layer.
         # note that you only need to specify the input size on the first layer.


### PR DESCRIPTION
The docstring did not specify the need to use return_sequences=True when creating a stacked recurrent network. I have replaced the original example with a more descriptive one.