### PR TITLE
Fix off by 1 errors in datasets.imdb.load_data

### DIFF
--- a/keras/datasets/imdb.py
+++ b/keras/datasets/imdb.py
@@ -70,37 +70,37 @@ def load_data(path='imdb.npz', num_words=None, skip_top=0,
     labels = np.concatenate([labels_train, labels_test])
 
     if start_char is not None:
-        xs = [[start_char] + [w + index_from for w in x] for x in xs]
+        xs = [[start_char] + [w + index_from - 1 for w in x] for x in xs]
     elif index_from:
-        xs = [[w + index_from for w in x] for x in xs]
+        xs = [[w + index_from - 1 for w in x] for x in xs]
 
     if maxlen:
         new_xs = []
         new_labels = []
         for x, y in zip(xs, labels):
-            if len(x) < maxlen:
+            if len(x) <= maxlen:
                 new_xs.append(x)
                 new_labels.append(y)
         xs = new_xs
         labels = new_labels
     if not xs:
-        raise ValueError('After filtering for sequences shorter than maxlen=' +
+        raise ValueError('After filtering out sequences longer than maxlen=' +
                          str(maxlen) + ', no sequence was kept. '
                          'Increase maxlen.')
     if not num_words:
-        num_words = max([max(x) for x in xs])
+        num_words = max([max(x) for x in xs]) + 1
 
     # by convention, use 2 as OOV word
     # reserve 'index_from' (=3 by default) characters:
     # 0 (padding), 1 (start), 2 (OOV)
     if oov_char is not None:
-        xs = [[oov_char if (w >= num_words or w < skip_top) else w for w in x] for x in xs]
+        xs = [[oov_char if ((w >= num_words or w < skip_top) and w != start_char) else w for w in x] for x in xs]
     else:
         new_xs = []
         for x in xs:
             nx = []
             for w in x:
-                if w >= num_words or w < skip_top:
+                if skip_top <= w < num_words or w == start_char:
                     nx.append(w)
             new_xs.append(nx)
         xs = new_xs


### PR DESCRIPTION
- in `imdb.npz` word indexes start from 1, `index_from` should account for that;
- `maxlen` test should be inclusive;
- if `num_words` is None, word with maximum index should not be replaced with `oov_char`;
- `start_char` should not be replaced with `oov_char` when `skip_top` is given.