### PR TITLE
Fix fit_generator docs for validation_steps

### DIFF
--- a/keras/models.py
+++ b/keras/models.py
@@ -1043,7 +1043,7 @@ class Sequential(Model):
                 is a generator.
                 Number of steps to yield from validation generator
                 at the end of every epoch. It should typically
-                be equal to the number of unique samples of your 
+                be equal to the number of unique samples of your
                 validation dataset divided by the batch size.
             class_weight: Dictionary mapping class indices to a weight
                 for the class.

--- a/keras/models.py
+++ b/keras/models.py
@@ -1041,8 +1041,10 @@ class Sequential(Model):
                 - A tuple (inputs, targets, sample_weights).
             validation_steps: Only relevant if `validation_data`
                 is a generator.
-                Number of samples to use from validation generator
-                at the end of every epoch.
+                Number of steps to yield from validation generator
+                at the end of every epoch. It should typically
+                be equal to the number of unique samples of your 
+                validation dataset divided by the batch size.
             class_weight: Dictionary mapping class indices to a weight
                 for the class.
             max_q_size: Maximum size for the generator queue


### PR DESCRIPTION
I were reading the Keras2 API doc, and found that the fit_generator docs for validation_steps should be validation samples divided by batch_size but not the number of samples, so I made this change.