### PR TITLE
Fix load_model for multiple output metrics in dictionary

### DIFF
--- a/keras/models.py
+++ b/keras/models.py
@@ -213,7 +213,14 @@ def load_model(filepath, custom_objects=None):
         if isinstance(obj, dict):
             deserialized = {}
             for key, value in obj.items():
-                if value in custom_objects:
+                deserialized[key] = []
+                if isinstance(value, list):
+                    for element in value:
+                        if element in custom_objects:
+                            deserialized[key].append(custom_objects[element])
+                        else:
+                            deserialized[key].append(element)
+                elif value in custom_objects:
                     deserialized[key] = custom_objects[value]
                 else:
                     deserialized[key] = value

--- a/tests/test_model_saving.py
+++ b/tests/test_model_saving.py
@@ -101,6 +101,35 @@ def test_fuctional_model_saving():
 
 
 @keras_test
+def test_saving_multiple_metrics_outputs():
+    input = Input(shape=(5,))
+    x = Dense(5)(input)
+    output1 = Dense(1, name='output1')(x)
+    output2 = Dense(1, name='output2')(x)
+
+    model = Model(inputs=input, outputs=[output1, output2])
+
+    metrics = {'output1': ['mse', 'binary_accuracy'],
+               'output2': ['mse', 'binary_accuracy']
+               }
+    loss = {'output1': 'mse', 'output2': 'mse'}
+
+    model.compile(loss=loss, optimizer='sgd', metrics=metrics)
+
+    # assure that model is working
+    x = np.array([[1, 1, 1, 1, 1]])
+    out = model.predict(x)
+    _, fname = tempfile.mkstemp('.h5')
+    save_model(model, fname)
+
+    model = load_model(fname)
+    os.remove(fname)
+
+    out2 = model.predict(x)
+    assert_allclose(out, out2, atol=1e-05)
+
+
+@keras_test
 def test_saving_without_compilation():
     model = Sequential()
     model.add(Dense(2, input_shape=(3,)))


### PR DESCRIPTION
load_model fails when a model has multiple output layers that have more
than one metric. Solve this problem by adding a clause that checks if
metrics are a list.
For more elaborate description see issue #3958