### PR TITLE
Fixed error when using linear activation as first layer, added identity op

### DIFF
--- a/keras/activations.py
+++ b/keras/activations.py
@@ -57,7 +57,7 @@ def hard_sigmoid(x):
 
 
 def linear(x):
-    return x
+    return K.identity(x)
 
 
 def serialize(activation):

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -969,6 +969,18 @@ def gather(reference, indices):
 
 # ELEMENT-WISE OPERATIONS
 
+def identity(x):
+    """Returns a tensor with the same shape, type and content as the input tensor.
+
+    # Arguments
+        x: The input tensor.
+
+    # Returns
+        A tensor of the same shape, type and content.
+    """
+    return tf.identity(x)
+
+
 def _normalize_axis(axis, ndim):
     """Converts negative axes to positive values.
 

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -409,6 +409,11 @@ def gather(reference, indices):
 
 # ELEMENT-WISE OPERATIONS
 
+def identity(x):
+    """Returns a tensor with the same shape, type and content as the input tensor.
+    """
+    return x.copy()
+
 
 def max(x, axis=None, keepdims=False):
     return T.max(x, axis=axis, keepdims=keepdims)


### PR DESCRIPTION
Fixes #6129 

This PR fixes the issue where using `Activation('linear')` as your first layer throws an error. This adds an identity op to both the theano and tensorflow backend, and uses the op in `Activation('linear')`.