### PR TITLE
Fix in_top_k() for Theano when identical values appear in predictions

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -2729,13 +2729,14 @@ def in_top_k(predictions, targets, k):
     """Returns whether the `targets` are in the top `k` `predictions`.
 
     # Arguments
-        predictions: A tensor of shape `batch_size` x classes and type `float32`.
-        targets: A tensor of shape batch_size and type `int32` or `int64`.
+        predictions: A tensor of shape `(batch_size, classes)` and type `float32`.
+        targets: A 1D tensor of length `batch_size` and type `int32` or `int64`.
         k: An `int`, number of top elements to consider.
 
     # Returns
-        A tensor of shape `batch_size` and type `bool`. `output_i` is `True` if
-        `targets_i` is within top-k values of `predictions_i`
+        A 1D tensor of length `batch_size` and type `bool`.
+        `output[i]` is `True` if `predictions[i, targets[i]]` is within top-`k`
+        values of `predictions[i]`.
     """
     return tf.nn.in_top_k(predictions, targets, k)
 

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1497,14 +1497,29 @@ def in_top_k(predictions, targets, k):
     """Returns whether the `targets` are in the top `k` `predictions`.
 
     # Arguments
-        predictions: A tensor of shape `batch_size` x classes and type `float32`.
-        targets: A tensor of shape batch_size and type `int32` or `int64`.
+        predictions: A tensor of shape `(batch_size, classes)` and type `float32`.
+        targets: A 1D tensor of length `batch_size` and type `int32` or `int64`.
         k: An `int`, number of top elements to consider.
 
     # Returns
-        A tensor of shape `batch_size` and type `bool`. `output_i` is `True` if
-        `targets_i` is within top-k values of `predictions_i`
+        A 1D tensor of length `batch_size` and type `bool`.
+        `output[i]` is `True` if `predictions[i, targets[i]]` is within top-`k`
+        values of `predictions[i]`.
     """
+    # handle k < 1 and k >= predictions.shape[1] cases to match TF behavior
+    if k < 1:
+        # dtype='bool' is only available since Theano 0.9.0
+        try:
+            return T.zeros_like(targets, dtype='bool')
+        except TypeError:
+            return T.zeros_like(targets, dtype='int8')
+
+    if k >= int_shape(predictions)[1]:
+        try:
+            return T.ones_like(targets, dtype='bool')
+        except TypeError:
+            return T.ones_like(targets, dtype='int8')
+
     predictions_k = T.sort(predictions)[:, -k]
     targets_values = predictions[T.arange(targets.shape[0]), targets]
     return T.ge(targets_values, predictions_k)

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1494,20 +1494,20 @@ def l2_normalize(x, axis):
 
 
 def in_top_k(predictions, targets, k):
-    """Returns whether the `targets` are in the top `k` `predictions`
+    """Returns whether the `targets` are in the top `k` `predictions`.
 
     # Arguments
-        predictions: A tensor of shape batch_size x classess and type float32.
-        targets: A tensor of shape batch_size and type int32 or int64.
-        k: An int, number of top elements to consider.
+        predictions: A tensor of shape `batch_size` x classes and type `float32`.
+        targets: A tensor of shape batch_size and type `int32` or `int64`.
+        k: An `int`, number of top elements to consider.
 
     # Returns
-        A tensor of shape batch_size and type int. output_i is 1 if
-        targets_i is within top-k values of predictions_i
+        A tensor of shape `batch_size` and type `bool`. `output_i` is `True` if
+        `targets_i` is within top-k values of `predictions_i`
     """
-    predictions_top_k = T.argsort(predictions)[:, -k:]
-    result, _ = theano.map(lambda prediction, target: any(equal(prediction, target)), sequences=[predictions_top_k, targets])
-    return result
+    predictions_k = T.sort(predictions)[:, -k]
+    targets_values = predictions[T.arange(targets.shape[0]), targets]
+    return T.ge(targets_values, predictions_k)
 
 
 # CONVOLUTIONS


### PR DESCRIPTION
Fixes #6113 
The `in_top_k()` function in `theano_backend.py` gives incorrect result when there are identical values in the input tensor `predictions`.
Also with this PR, the return type becomes `bool`, so the same docstring as the TF version can be used now.