### PR TITLE
Bugfix to ConvLSTM2D in channels_first image_data_format mode.

### DIFF
--- a/keras/layers/convolutional_recurrent.py
+++ b/keras/layers/convolutional_recurrent.py
@@ -340,7 +340,7 @@ class ConvLSTM2D(ConvRecurrent2D):
             self.states = [None, None]
 
         if self.data_format == 'channels_first':
-            channel_axis = 1
+            channel_axis = 2
         else:
             channel_axis = -1
         if input_shape[channel_axis] is None:


### PR DESCRIPTION
### Problem

In Keras master (`3382c0bb894b2ecaac2562238f34c2a46bf413c9`), when using `ConvLSTM2D` with `image_data_format == channels_first` mode, the wrong axis is selected as the channel axis.

```python
>>> import keras as K, keras.layers as KL, keras.engine as KE, keras.backend as KB, numpy as np
Using Theano backend.
NVIDIA: no NVIDIA devices found
>>> input = KL.Input(shape=(100,1,32,1))                                   
>>> convlayer = KL.ConvLSTM2D(32, (3,1), activation="relu", padding="same")
>>> fseq = convlayer(input)
>>> model = KE.Model(inputs=input, outputs=fseq)        
>>> model.predict(np.random.normal(size=(5,100,1,32,1)))
Traceback (most recent call last):

[snip]

Apply node that caused the error: CorrMM{half, (1, 1), (1, 1)}(Alloc.0, Subtensor{::, ::, ::int64, ::int64}.0)
Toposort index: 37
Inputs types: [TensorType(float32, 4D), TensorType(float32, 4D)]
Inputs shapes: [(5, 1, 32, 1), (32, 100, 3, 1)]
Inputs strides: [(128, 9223372036854775807, 4, 9223372036854775807), (4, 128, -12800, -4)]
Inputs values: ['not shown', 'not shown']
Outputs clients: [[InplaceDimShuffle{x,0,1,2,3}(CorrMM{half, (1, 1), (1, 1)}.0)]]

[snip]
```

### Solution

The cause of the problem is that in `keras/layers/convolutional_recurrent.py:342`, when `self.data_format == 'channels_first'`, the channel axis selected is 1 instead of 2. The solution is simple:

```diff
diff --git a/keras/layers/convolutional_recurrent.py b/keras/layers/convolutional_recurrent.py
index e95b7918..00b69c6d 100644
--- a/keras/layers/convolutional_recurrent.py
+++ b/keras/layers/convolutional_recurrent.py
@@ -340,7 +340,7 @@ class ConvLSTM2D(ConvRecurrent2D):
             self.states = [None, None]
 
         if self.data_format == 'channels_first':
-            channel_axis = 1
+            channel_axis = 2
         else:
             channel_axis = -1
         if input_shape[channel_axis] is None:
```