### PR TITLE
Add `include_optimizer` argument to `save_model`

### DIFF
--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -2393,7 +2393,7 @@ class Container(Layer):
             output_tensors.append(layer_output_tensors[tensor_index])
         return cls(inputs=input_tensors, outputs=output_tensors, name=name)
 
-    def save(self, filepath, overwrite=True):
+    def save(self, filepath, overwrite=True, exclude_optimizer=False):
         """Save the model to a single HDF5 file.
 
         The savefile includes:
@@ -2414,6 +2414,7 @@ class Container(Layer):
             filepath: String, path to the file to save the weights to.
             overwrite: Whether to silently overwrite any existing file at the
                 target location, or provide the user with a manual prompt.
+            exclude_optimizer: If True, exclude optimizer's state.
 
         # Example
 
@@ -2429,7 +2430,7 @@ class Container(Layer):
         ```
         """
         from ..models import save_model
-        save_model(self, filepath, overwrite)
+        save_model(self, filepath, overwrite, exclude_optimizer)
 
     def save_weights(self, filepath, overwrite=True):
         """Dumps all layer weights to a HDF5 file.

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -2393,7 +2393,7 @@ class Container(Layer):
             output_tensors.append(layer_output_tensors[tensor_index])
         return cls(inputs=input_tensors, outputs=output_tensors, name=name)
 
-    def save(self, filepath, overwrite=True, exclude_optimizer=False):
+    def save(self, filepath, overwrite=True, include_optimizer=True):
         """Save the model to a single HDF5 file.
 
         The savefile includes:
@@ -2414,7 +2414,7 @@ class Container(Layer):
             filepath: String, path to the file to save the weights to.
             overwrite: Whether to silently overwrite any existing file at the
                 target location, or provide the user with a manual prompt.
-            exclude_optimizer: If True, exclude optimizer's state.
+            include_optimizer: If True, save optimizer's state together.
 
         # Example
 
@@ -2430,7 +2430,7 @@ class Container(Layer):
         ```
         """
         from ..models import save_model
-        save_model(self, filepath, overwrite, exclude_optimizer)
+        save_model(self, filepath, overwrite, include_optimizer)
 
     def save_weights(self, filepath, overwrite=True):
         """Dumps all layer weights to a HDF5 file.

--- a/keras/models.py
+++ b/keras/models.py
@@ -27,7 +27,7 @@ except ImportError:
     h5py = None
 
 
-def save_model(model, filepath, overwrite=True, exclude_optimizer=False):
+def save_model(model, filepath, overwrite=True, include_optimizer=True):
     """Save a model to a HDF5 file.
 
     The saved model contains:
@@ -45,7 +45,7 @@ def save_model(model, filepath, overwrite=True, exclude_optimizer=False):
         overwrite: Whether we should overwrite any existing
             model at the target location, or instead
             ask the user with a manual prompt.
-        exclude_optimizer: If True, exclude optimizer's state.
+        include_optimizer: If True, save optimizer's state together.
 
     # Raises
         ImportError: if h5py is not available.
@@ -109,7 +109,7 @@ def save_model(model, filepath, overwrite=True, exclude_optimizer=False):
         model_layers = model.layers
     topology.save_weights_to_hdf5_group(model_weights_group, model_layers)
 
-    if hasattr(model, 'optimizer') and not exclude_optimizer:
+    if include_optimizer and hasattr(model, 'optimizer'):
         if isinstance(model.optimizer, optimizers.TFOptimizer):
             warnings.warn(
                 'TensorFlow optimizers do not '

--- a/keras/models.py
+++ b/keras/models.py
@@ -27,7 +27,7 @@ except ImportError:
     h5py = None
 
 
-def save_model(model, filepath, overwrite=True):
+def save_model(model, filepath, overwrite=True, exclude_optimizer=False):
     """Save a model to a HDF5 file.
 
     The saved model contains:
@@ -45,6 +45,7 @@ def save_model(model, filepath, overwrite=True):
         overwrite: Whether we should overwrite any existing
             model at the target location, or instead
             ask the user with a manual prompt.
+        exclude_optimizer: If True, exclude optimizer's state.
 
     # Raises
         ImportError: if h5py is not available.
@@ -108,7 +109,7 @@ def save_model(model, filepath, overwrite=True):
         model_layers = model.layers
     topology.save_weights_to_hdf5_group(model_weights_group, model_layers)
 
-    if hasattr(model, 'optimizer'):
+    if hasattr(model, 'optimizer') and not exclude_optimizer:
         if isinstance(model.optimizer, optimizers.TFOptimizer):
             warnings.warn(
                 'TensorFlow optimizers do not '


### PR DESCRIPTION
`save_model` saves the model with optimizer's state.
If output model is used only for predicting, optimizer's state is useless.

This PR make it possible to save model without optimizer's state.
(It also helps avoiding #6046.)