### PR TITLE
DOCS: Slight rewording of description for input_dim in embeddings

### DIFF
--- a/keras/layers/embeddings.py
+++ b/keras/layers/embeddings.py
@@ -31,8 +31,8 @@ class Embedding(Layer):
     ```
 
     # Arguments
-      input_dim: int > 0. Size of the vocabulary, ie.
-          1 + maximum integer index occurring in the input data.
+      input_dim: int > 0. Size of the vocabulary
+          or maximum integer index + 1.
       output_dim: int >= 0. Dimension of the dense embedding.
       embeddings_initializer: Initializer for the `embeddings` matrix
           (see [initializers](../initializers.md)).
@@ -49,7 +49,8 @@ class Embedding(Layer):
           If this is `True` then all subsequent layers
           in the model need to support masking or an exception will be raised.
           If mask_zero is set to True, as a consequence, index 0 cannot be
-          used in the vocabulary (input_dim should equal `|vocabulary| + 2`).
+          used in the vocabulary (input_dim should equal size of
+          vocabulary + 1).
       input_length: Length of input sequences, when it is constant.
           This argument is required if you are going to connect
           `Flatten` then `Dense` layers upstream

--- a/keras/layers/embeddings.py
+++ b/keras/layers/embeddings.py
@@ -35,13 +35,13 @@ class Embedding(Layer):
           1 + maximum integer index occurring in the input data.
       output_dim: int >= 0. Dimension of the dense embedding.
       embeddings_initializer: Initializer for the `embeddings` matrix
-            (see [initializers](../initializers.md)).
+          (see [initializers](../initializers.md)).
       embeddings_regularizer: Regularizer function applied to
-            the `embeddings` matrix
-            (see [regularizer](../regularizers.md)).
+          the `embeddings` matrix
+          (see [regularizer](../regularizers.md)).
       embeddings_constraint: Constraint function applied to
-            the `embeddings` matrix
-            (see [constraints](../constraints.md)).
+          the `embeddings` matrix
+          (see [constraints](../constraints.md)).
       mask_zero: Whether or not the input value 0 is a special "padding"
           value that should be masked out.
           This is useful when using [recurrent layers](recurrent.md)

--- a/keras/layers/embeddings.py
+++ b/keras/layers/embeddings.py
@@ -31,8 +31,8 @@ class Embedding(Layer):
     ```
 
     # Arguments
-      input_dim: int > 0. Size of the vocabulary
-          or maximum integer index + 1.
+      input_dim: int > 0. Size of the vocabulary,
+          i.e. maximum integer index + 1.
       output_dim: int >= 0. Dimension of the dense embedding.
       embeddings_initializer: Initializer for the `embeddings` matrix
           (see [initializers](../initializers.md)).


### PR DESCRIPTION
The current description of the input arguments `input_dim` and `mask_zero` are a bit confusing:

> **input_dim**: int > 0. Size of the vocabulary, ie. 1 + maximum integer index occurring in the input data.
> ...
> **mask_zero**: ... If mask_zero is set to True, as a consequence, index 0 cannot be used in the vocabulary (input_dim should equal |vocabulary| + 2).

The first line seems correct, where I would understand

> Size of the vocabulary

as

    input_dim = len(vocabulary_indices)

and

> 1 + maximum integer index occurring in the input data.

as

    input_dim = max(vocabulary_indices) + 1

However the second line is confusing as you say

> input_dim should equal `|vocabulary| + 2`

I would interpret `|x|` as the cardinality of `x`, i.e. `len(x)`. So you are effectively saying

    input_dim = len(vocabulary_indices) + 2

which is not correct. It should be

    input_dim = len(vocabulary_indices) + 1

or

    input_dim = max(vocabulary_indices) + 2

### The Fix

This PR fixed that by reformulating the two lines to

> **input_dim**: int > 0. Size of the vocabulary or maximum integer index + 1.
> ...
> **mask_zero**: ... If mask_zero is set to True, as a consequence, index 0 cannot be used in the vocabulary (input_dim should equal size of vocabulary + 1).
