### PR TITLE
Bugfix: mistakes in 2 Glorot initializers

### DIFF
--- a/keras/initializers.py
+++ b/keras/initializers.py
@@ -319,7 +319,7 @@ def glorot_normal(seed=None):
         Glorot & Bengio, AISTATS 2010
         http://jmlr.org/proceedings/papers/v9/glorot10a/glorot10a.pdf
     """
-    return VarianceScaling(scale=1.,
+    return VarianceScaling(scale=2.,
                            mode='fan_avg',
                            distribution='normal',
                            seed=seed)
@@ -343,7 +343,7 @@ def glorot_uniform(seed=None):
         Glorot & Bengio, AISTATS 2010
         http://jmlr.org/proceedings/papers/v9/glorot10a/glorot10a.pdf
     """
-    return VarianceScaling(scale=1.,
+    return VarianceScaling(scale=2.,
                            mode='fan_avg',
                            distribution='uniform',
                            seed=seed)


### PR DESCRIPTION
In 2 Glorot initializers `glorot_uniform()` and `glorot_normal()`, `VarianceScaling` object is returned. 
Parameter `scale` passed to create `VarianceScaling` object in function . 

When `distribution` is `normal`, `stddev` of `VarianceScaling` object is `sqrt(scale / n)`. 
But for Glorot normal initializer, `stddev` equals to  `sqrt(2 / n)`. So scale should be `2.` at L322.

When `distribution` is `uniform`, `limit` of `VarianceScaling` object is `sqrt(3 * scale / n)`. 
But for Glorot uniform initializer, `stddev` equals to  `sqrt(6 / n)`. So scale should be `2.` at L346.