### PR TITLE
Added test coverage check to pytest script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,5 +62,5 @@ script:
     elif [[ "$TEST_MODE" == "PEP8" ]]; then
        PYTHONPATH=$PWD:$PYTHONPATH py.test --pep8 -m pep8 -n0;
     else
-       PYTHONPATH=$PWD:$PYTHONPATH py.test tests/ --ignore=tests/integration_tests;
+       PYTHONPATH=$PWD:$PYTHONPATH py.test tests/ --ignore=tests/integration_tests --cov=keras tests/ --cov-fail-under 78 --cov-report term-missing;
     fi

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(name='Keras',
           'visualize': ['pydot-ng'],
           'tests': ['pytest',
                     'pytest-pep8',
-                    'pytest-xdist'],
+                    'pytest-xdist',
+                    'pytest-cov'],
       },
       packages=find_packages())


### PR DESCRIPTION
Added test coverage check as part of pytest execution. `py.test tests/` return code will be 1 if test coverage is less than 80% or 0 if it is over 80%. 