### PR TITLE
fix rmsprop learning rate for convergence

### DIFF
--- a/examples/cifar10_cnn.py
+++ b/examples/cifar10_cnn.py
@@ -54,9 +54,12 @@ model.add(Dropout(0.5))
 model.add(Dense(num_classes))
 model.add(Activation('softmax'))
 
+# initiate RMSprop optimizer
+opt = keras.optimizers.rmsprop(lr=0.0001, decay=1e-6)
+
 # Let's train the model using RMSprop
 model.compile(loss='categorical_crossentropy',
-              optimizer='rmsprop',
+              optimizer=opt,
               metrics=['accuracy'])
 
 x_train = x_train.astype('float32')


### PR DESCRIPTION
Rmsprop with default learning rate (0.001) cannot converge in this example. 
Initialize learning rate to (0.0001) and add weight decay fix the problem.

https://github.com/fchollet/keras/issues/5239
As seen in this issue also, the loss will decrease at the begining but start increasing after few epochs due to too large learning rate.
Solution to this is decreasing the learning rate with rmsprop as I supposed or changing the optimizer like Adam or SGD.