### PR TITLE
Fixing the input for Inception v3

### DIFF
--- a/keras/applications/inception_v3.py
+++ b/keras/applications/inception_v3.py
@@ -157,7 +157,10 @@ def InceptionV3(include_top=True,
     if input_tensor is None:
         img_input = Input(shape=input_shape)
     else:
-        img_input = Input(tensor=input_tensor, shape=input_shape)
+        if not K.is_keras_tensor(input_tensor):
+            img_input = Input(tensor=input_tensor, shape=input_shape)
+        else:
+            img_input = input_tensor
 
     if K.image_data_format() == 'channels_first':
         channel_axis = 1


### PR DESCRIPTION
There is a missing IF statement on the Inception v3 model of Keras 2.0 which causes an exception to be thrown if an Input layer is provided. 

Here is how to reproduce the error:
```python
import keras.applications
from keras.preprocessing import image
from keras.models import Model
from keras.layers import Input

g=image.ImageDataGenerator().flow_from_directory('/path/to/data', target_size=(299, 299), batch_size=32, class_mode='categorical', shuffle=True)
x = g.next()[0]

base_model = keras.applications.InceptionV3(weights='imagenet', include_top=False, input_shape=(299, 299, 3))
model = Model(inputs=base_model.input, outputs=base_model.layers[310].output)
features = model.predict(x) # Works!

base_model = keras.applications.InceptionV3(weights='imagenet', include_top=False, input_tensor=Input(shape=(299, 299, 3)))
model = Model(inputs=base_model.input, outputs=base_model.layers[310].output)
features = model.predict(x) # Throws exception
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python2.7/dist-packages/keras/engine/training.py", line 1554, in predict
    check_batch_axis=False)
  File "/usr/local/lib/python2.7/dist-packages/keras/engine/training.py", line 100, in _standardize_input_data
    'Found: array with shape ' + str(data.shape))
ValueError: The model expects 0 input arrays, but only received one array. Found: array with shape (32, 299, 299, 3)

This PR solves the problem by using the same logic as in all other Keras models.