### PR TITLE
Count number of floating point operations per layer

### DIFF
--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -1246,30 +1246,17 @@ class Layer(object):
             if self.__class__.__name__ == 'Sequential':
                 self.build()
             else:
-                raise RuntimeError('You tried to call `count_params` on ' +
+                raise RuntimeError('You tried to call `count_ops` on ' +
                                    self.name + ', but the layer isn\'t built. '
                                    'You can build it manually via: `' +
                                    self.name + '.build(batch_input_shape)`.')
-        flops = None
+        ops = None
         if K.image_data_format() == 'channels_last':
-            input_filters = self.input_shape[-1]
-            output_filters = self.output_shape[-1]
-            output_area = None
-            if self.__class__.__name__ == 'Dense':
-                output_area = 1
-                filter_area = 1
-            elif self.__class__.__name__ == 'Conv1D':
-                output_area = np.prod(self.output_shape[1:-1])
-                filter_area = np.prod(self.kernel_size)
-            elif self.__class__.__name__ == 'Conv2D':
-                output_area = np.prod(self.output_shape[1:-1])
-                filter_area = np.prod(self.kernel_size)
-            elif self.__class__.__name__ == 'Conv3D':
-                output_area = np.prod(self.output_shape[1:-1])
-                filter_area = np.prod(self.kernel_size)
-            if output_area is not None:
-                flops = input_filters * output_filters * filter_area * output_area
-        return flops
+            output_area = np.prod(self.output_shape[1:-1])
+            output_area = int(output_area)
+            if hasattr(self, 'kernel'):
+                ops = np.prod(self.kernel._keras_shape) * output_area
+        return ops
 
 
 class InputLayer(Layer):

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -1230,11 +1230,13 @@ class Layer(object):
         return sum([K.count_params(p) for p in self.weights])
 
     def count_ops(self):
-        """Count the total number of floating point operations for a _forward_ calculation of this layer.
+        """Count the total number of floating point operations for a
+           _forward_ calculation of this layer.
 
         # Returns
             An integer count.  A multiply-add counts as one flop.
-            (None if the layer does not yet support counting operations. Supported layers are Conv1D/2D/3D and Dense.)
+            (None if the layer does not yet support counting operations.
+            Supported layers are Conv1D/2D/3D and Dense.)
 
         # Raises
             RuntimeError: if the layer isn't yet built
@@ -1257,17 +1259,18 @@ class Layer(object):
                 output_area = 1
                 filter_area = 1
             elif self.__class__.__name__ == 'Conv1D':
-                output_area = np.prod( self.output_shape[1:-1] )
-                filter_area = np.prod( self.kernel_size )
+                output_area = np.prod(self.output_shape[1:-1])
+                filter_area = np.prod(self.kernel_size)
             elif self.__class__.__name__ == 'Conv2D':
-                output_area = np.prod( self.output_shape[1:-1] )
-                filter_area = np.prod( self.kernel_size )
+                output_area = np.prod(self.output_shape[1:-1])
+                filter_area = np.prod(self.kernel_size)
             elif self.__class__.__name__ == 'Conv3D':
-                output_area = np.prod( self.output_shape[1:-1] )
-                filter_area = np.prod( self.kernel_size )
+                output_area = np.prod(self.output_shape[1:-1])
+                filter_area = np.prod(self.kernel_size)
             if output_area is not None:
                 flops = input_filters * output_filters * filter_area * output_area
         return flops
+
 
 class InputLayer(Layer):
     """Layer to be used as an entry point into a graph.

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -1229,7 +1229,7 @@ class Layer(object):
                                    self.name + '.build(batch_input_shape)`.')
         return sum([K.count_params(p) for p in self.weights])
 
-    def count_flops(self):
+    def count_ops(self):
         """Count the total number of floating point operations for a _forward_ calculation of this layer.
 
         # Returns

--- a/keras/utils/layer_utils.py
+++ b/keras/utils/layer_utils.py
@@ -23,19 +23,19 @@ def print_summary(model, line_length=None, positions=None):
                 sequential_like = False
 
     if sequential_like:
-        line_length = line_length or 65
-        positions = positions or [.45, .85, 1.]
+        line_length = line_length or 80
+        positions = positions or [.40, .72, .85, 1.]
         if positions[-1] <= 1:
             positions = [int(line_length * p) for p in positions]
         # header names for the different log elements
-        to_display = ['Layer (type)', 'Output Shape', 'Param #']
+        to_display = ['Layer (type)', 'Output Shape', 'Param #', 'Flops #']
     else:
         line_length = line_length or 100
-        positions = positions or [.33, .55, .67, 1.]
+        positions = positions or [.33, .55, .67, .77, 1.]
         if positions[-1] <= 1:
             positions = [int(line_length * p) for p in positions]
         # header names for the different log elements
-        to_display = ['Layer (type)', 'Output Shape', 'Param #', 'Connected to']
+        to_display = ['Layer (type)', 'Output Shape', 'Param #', 'Flops #', 'Connected to']
         relevant_nodes = []
         for v in model.nodes_by_depth.values():
             relevant_nodes += v
@@ -61,7 +61,7 @@ def print_summary(model, line_length=None, positions=None):
             output_shape = 'multiple'
         name = layer.name
         cls_name = layer.__class__.__name__
-        fields = [name + ' (' + cls_name + ')', output_shape, layer.count_params()]
+        fields = [name + ' (' + cls_name + ')', output_shape, layer.count_params(), layer.count_flops()]
         print_row(fields, positions)
 
     def print_layer_summary_with_connections(layer):
@@ -112,10 +112,12 @@ def print_summary(model, line_length=None, positions=None):
             print('_' * line_length)
 
     trainable_count, non_trainable_count = count_total_params(layers, layer_set=None)
+    flops_count = count_total_flops(layers)
 
     print('Total params: {:,}'.format(trainable_count + non_trainable_count))
     print('Trainable params: {:,}'.format(trainable_count))
     print('Non-trainable params: {:,}'.format(non_trainable_count))
+    print('Total flops: {:,}'.format(flops_count))
     print('_' * line_length)
 
 
@@ -146,6 +148,24 @@ def count_total_params(layers, layer_set=None):
             trainable_count += np.sum([K.count_params(p) for p in layer.trainable_weights])
             non_trainable_count += np.sum([K.count_params(p) for p in layer.non_trainable_weights])
     return int(trainable_count), int(non_trainable_count)
+
+
+def count_total_flops(layers):
+    """Counts the number of floating point operations in a list of layers.
+
+    # Arguments
+        layers: list of layers.
+
+    # Returns
+        An integer count.
+        (layers which do not support a count are not included in the total)
+    """
+    count = 0
+    for layer in layers:
+        flops = layer.count_flops()
+        if flops is not None:
+            count += flops
+    return count
 
 
 def convert_all_kernels_in_model(model):

--- a/keras/utils/layer_utils.py
+++ b/keras/utils/layer_utils.py
@@ -28,14 +28,14 @@ def print_summary(model, line_length=None, positions=None):
         if positions[-1] <= 1:
             positions = [int(line_length * p) for p in positions]
         # header names for the different log elements
-        to_display = ['Layer (type)', 'Output Shape', 'Param #', 'Flops #']
+        to_display = ['Layer (type)', 'Output Shape', 'Param #', 'Ops #']
     else:
         line_length = line_length or 100
         positions = positions or [.33, .55, .67, .77, 1.]
         if positions[-1] <= 1:
             positions = [int(line_length * p) for p in positions]
         # header names for the different log elements
-        to_display = ['Layer (type)', 'Output Shape', 'Param #', 'Flops #', 'Connected to']
+        to_display = ['Layer (type)', 'Output Shape', 'Param #', 'Ops #', 'Connected to']
         relevant_nodes = []
         for v in model.nodes_by_depth.values():
             relevant_nodes += v
@@ -61,7 +61,7 @@ def print_summary(model, line_length=None, positions=None):
             output_shape = 'multiple'
         name = layer.name
         cls_name = layer.__class__.__name__
-        fields = [name + ' (' + cls_name + ')', output_shape, layer.count_params(), layer.count_flops()]
+        fields = [name + ' (' + cls_name + ')', output_shape, layer.count_params(), layer.count_ops()]
         print_row(fields, positions)
 
     def print_layer_summary_with_connections(layer):
@@ -112,12 +112,12 @@ def print_summary(model, line_length=None, positions=None):
             print('_' * line_length)
 
     trainable_count, non_trainable_count = count_total_params(layers, layer_set=None)
-    flops_count = count_total_flops(layers)
+    ops_count = count_total_ops(layers)
 
     print('Total params: {:,}'.format(trainable_count + non_trainable_count))
     print('Trainable params: {:,}'.format(trainable_count))
     print('Non-trainable params: {:,}'.format(non_trainable_count))
-    print('Total flops: {:,}'.format(flops_count))
+    print('Total floating point operations: {:,}'.format(ops_count))
     print('_' * line_length)
 
 
@@ -150,7 +150,7 @@ def count_total_params(layers, layer_set=None):
     return int(trainable_count), int(non_trainable_count)
 
 
-def count_total_flops(layers):
+def count_total_ops(layers):
     """Counts the number of floating point operations in a list of layers.
 
     # Arguments
@@ -162,9 +162,9 @@ def count_total_flops(layers):
     """
     count = 0
     for layer in layers:
-        flops = layer.count_flops()
-        if flops is not None:
-            count += flops
+        ops = layer.count_ops()
+        if ops is not None:
+            count += ops
     return count
 
 


### PR DESCRIPTION
This PR partially implements the feature requested in #5625.

Opening it here for feedback on the implementation strategy.

Supported layers: Conv1D, Conv2D, Conv3D, Dense.  Other layers return None, and don't count towards the total.

Behavior with different padding and strides seems okay. 

Questions:
- Should this go in the Layer class (as here), or in each individual layer implementation?
- Should this rely on some knowledge about the layers (as here), or on backend features for counting flops?  If backend, how?
- Should a multiply-add be counted as one flop (as here) or two?  Common usage seems to be one flop, eg ResNet paper.
- Should layers like pooling or activations even be counted at all?  (How many flops is an ELU?)  It seems that these are not usually counted at all, in any case typically a few convolutions account for the bulk of the calculation.