### PR TITLE
Update mnist_siamese_graph example

### DIFF
--- a/examples/mnist_siamese_graph.py
+++ b/examples/mnist_siamese_graph.py
@@ -24,7 +24,7 @@ from keras import backend as K
 
 def euclidean_distance(vects):
     x, y = vects
-    return K.sqrt(K.sum(K.square(x - y), axis=1, keepdims=True))
+    return K.sqrt(K.maximum(K.sum(K.square(x - y), axis=1, keepdims=True), K.epsilon()))
 
 
 def eucl_dist_output_shape(shapes):


### PR DESCRIPTION
Take max of squared distance and `K.epsilon()` because some data points will throw `nan`s for euclidean distance due to numerical stability issues.