### PR TITLE
Adding backwards compatibility for old models by converting input_dtype to dtype

### DIFF
--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -1263,6 +1263,7 @@ class InputLayer(Layer):
         name: Name of the layer (string).
     """
 
+    @interfaces.legacy_input_support
     def __init__(self, input_shape=None, batch_size=None,
                  batch_input_shape=None,
                  dtype=None, input_tensor=None, sparse=False, name=None):

--- a/keras/legacy/interfaces.py
+++ b/keras/legacy/interfaces.py
@@ -602,3 +602,7 @@ legacy_model_constructor_support = generate_legacy_interface(
     allowed_positional_args=None,
     conversions=[('input', 'inputs'),
                  ('output', 'outputs')])
+
+legacy_input_support = generate_legacy_interface(
+    allowed_positional_args=None,
+    conversions=[('input_dtype', 'dtype')])


### PR DESCRIPTION
On Keras 2, loading ResNet50 models saved with Keras 1.2.2 throws a "got an unexpected keyword argument 'input_dtype'" exception. Possibly the same problem appears with other models. This is because we are missing a legacy support interface for the input layer. This PR fixes the problem by adding a new legacy support interface that converts the input_dtype parameter to dtype.

Here is how to reproduce the bug:
```
$ pip install keras==1.2.2 tensorflow==0.12.1
$ python
>>> import keras.applications
>>> model = keras.applications.resnet50.ResNet50()
>>> model.save("model.h5")
>>> exit()
$ pip install -U keras tensorflow
$ python
>>> from keras.models import load_model
>>> model = load_model("model.h5")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python2.7/dist-packages/keras/models.py", line 240, in load_model
    model = model_from_config(model_config, custom_objects=custom_objects)
  File "/usr/local/lib/python2.7/dist-packages/keras/models.py", line 301, in model_from_config
    return layer_module.deserialize(config, custom_objects=custom_objects)
  File "/usr/local/lib/python2.7/dist-packages/keras/layers/__init__.py", line 46, in deserialize
    printable_module_name='layer')
  File "/usr/local/lib/python2.7/dist-packages/keras/utils/generic_utils.py", line 140, in deserialize_keras_object
    list(custom_objects.items())))
  File "/usr/local/lib/python2.7/dist-packages/keras/engine/topology.py", line 2378, in from_config
    process_layer(layer_data)
  File "/usr/local/lib/python2.7/dist-packages/keras/engine/topology.py", line 2347, in process_layer
    custom_objects=custom_objects)
  File "/usr/local/lib/python2.7/dist-packages/keras/layers/__init__.py", line 46, in deserialize
    printable_module_name='layer')
  File "/usr/local/lib/python2.7/dist-packages/keras/utils/generic_utils.py", line 141, in deserialize_keras_object
    return cls.from_config(config['config'])
  File "/usr/local/lib/python2.7/dist-packages/keras/engine/topology.py", line 1210, in from_config
    return cls(**config)
TypeError: __init__() got an unexpected keyword argument 'input_dtype'
```