### PR TITLE
Fixed no attribute 'ifelse'

### DIFF
--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 from contextlib import contextmanager
 import theano
+from theano import ifelse
 from theano import tensor as T
 from theano.sandbox.rng_mrg import MRG_RandomStreams as RandomStreams
 from theano.tensor.signal import pool


### PR DESCRIPTION
Imported `ifelse` explicitly... without this it raised the exception `"theano.ifelse.ifelse" keras no attribute 'ifelse'` in this [line](https://github.com/fchollet/keras/blob/master/keras/backend/theano_backend.py#L1373)

The exception was raising for example for `Dropout` or `BatchNormalization` layers.