### PR TITLE
HDF5Matrix support for inferred slice indexing #6297

### DIFF
--- a/keras/utils/io_utils.py
+++ b/keras/utils/io_utils.py
@@ -62,9 +62,14 @@ class HDF5Matrix(object):
         return self.end - self.start
 
     def __getitem__(self, key):
+        start, stop = key.start, key.stop
         if isinstance(key, slice):
-            if key.stop + self.start <= self.end:
-                idx = slice(key.start + self.start, key.stop + self.start)
+            if start is None:
+                start = 0
+            if stop is None:
+                stop = self.data.shape[0]
+            if stop + self.start <= self.end:
+                idx = slice(start + self.start, stop + self.start)
             else:
                 raise IndexError
         elif isinstance(key, int):


### PR DESCRIPTION
Slight addition to the implementation of the `HDF5Matrix` class to support support inferred slices (e.g. `data[:10]`).

This is a small issue, but it can get annoying when inferring the end index (e.g. data[_start_:]), as one has to get the shape of the data set each time.