### PR TITLE
Update the value of steps_per_epoch of fit_generator to be divided by batch_size

### DIFF
--- a/docs/templates/preprocessing/image.md
+++ b/docs/templates/preprocessing/image.md
@@ -122,7 +122,7 @@ datagen.fit(X_train)
 
 # fits the model on batches with real-time data augmentation:
 model.fit_generator(datagen.flow(X_train, Y_train, batch_size=32),
-                    steps_per_epoch=len(X_train)/32, epochs=epochs)
+                    steps_per_epoch=len(X_train) / 32, epochs=epochs)
 
 # here's a more "manual" example
 for e in range(epochs):

--- a/docs/templates/preprocessing/image.md
+++ b/docs/templates/preprocessing/image.md
@@ -122,7 +122,7 @@ datagen.fit(X_train)
 
 # fits the model on batches with real-time data augmentation:
 model.fit_generator(datagen.flow(X_train, Y_train, batch_size=32),
-                    steps_per_epoch=len(X_train), epochs=epochs)
+                    steps_per_epoch=len(X_train)/32, epochs=epochs)
 
 # here's a more "manual" example
 for e in range(epochs):

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1719,7 +1719,7 @@ class Model(Container):
                 - a tuple (inputs, targets, sample_weights).
                 All arrays should contain the same number of samples.
                 The generator is expected to loop over its data
-                indefinitely. An epoch finishes when `steps_per_epoch`
+                indefinitely. An epoch finishes when `steps_per_epoch * batch_size`
                 samples have been seen by the model.
             steps_per_epoch: Total number of steps (batches of samples)
                 to yield from `generator` before declaring one epoch

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1719,8 +1719,8 @@ class Model(Container):
                 - a tuple (inputs, targets, sample_weights).
                 All arrays should contain the same number of samples.
                 The generator is expected to loop over its data
-                indefinitely. An epoch finishes when `steps_per_epoch * batch_size`
-                samples have been seen by the model.
+                indefinitely. An epoch finishes when `steps_per_epoch`
+                batches have been seen by the model.
             steps_per_epoch: Total number of steps (batches of samples)
                 to yield from `generator` before declaring one epoch
                 finished and starting the next epoch. It should typically


### PR DESCRIPTION
According to the official document and my experience of training process,
I found out that the value of "steps_per_epoch" should equal to the value of
`Total # of samples of training dataset / batch_size`.
(it's same with the api documentation [here](https://keras.io/models/model/#fit_generator))

So I think the following parts of files should be modified.