### PR TITLE
Update check for sequential models

### DIFF
--- a/keras/utils/layer_utils.py
+++ b/keras/utils/layer_utils.py
@@ -19,7 +19,7 @@ def print_summary(model, line_length=None, positions=None):
     else:
         sequential_like = True
         for v in model.nodes_by_depth.values():
-            if len(v) > 1:
+            if (len(v) > 1) or (len(v) == 1 and len(v[0].inbound_layers) > 1):
                 sequential_like = False
                 break
 

--- a/keras/utils/layer_utils.py
+++ b/keras/utils/layer_utils.py
@@ -20,6 +20,8 @@ def print_summary(model, line_length=None, positions=None):
         sequential_like = True
         for v in model.nodes_by_depth.values():
             if (len(v) > 1) or (len(v) == 1 and len(v[0].inbound_layers) > 1):
+                # if the model has multiple nodes or if the nodes have multiple inbound_layers
+                # the model is no longer sequential
                 sequential_like = False
                 break
 


### PR DESCRIPTION
Model is not sequential if there is a "merge" layer somewhere in the graph. So if a layer has multiple input layers ("inbound_layers"), the entire model is in my opinion no longer sequential...
Updated the check for sequential models in the print_summary() function in layer_utils.py and commented the check for sequentiality.
