### PR TITLE
Fix CSV formatting for Windows with Python 2

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -863,7 +863,7 @@ class CSVLogger(Callback):
         self.writer = None
         self.keys = None
         self.append_header = True
-        self.file_flags = 'b' if six.PY2 and os.name == "nt" else ''
+        self.file_flags = 'b' if six.PY2 and os.name == 'nt' else ''
         super(CSVLogger, self).__init__()
 
     def on_train_begin(self, logs=None):

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 
 import os
 import csv
+import six
 
 import numpy as np
 import time
@@ -862,16 +863,17 @@ class CSVLogger(Callback):
         self.writer = None
         self.keys = None
         self.append_header = True
+        self.file_flags = 'b' if six.PY2 and os.name == "nt" else ''
         super(CSVLogger, self).__init__()
 
     def on_train_begin(self, logs=None):
         if self.append:
             if os.path.exists(self.filename):
-                with open(self.filename) as f:
+                with open(self.filename, 'r'+self.file_flags) as f:
                     self.append_header = not bool(len(f.readline()))
-            self.csv_file = open(self.filename, 'a')
+            self.csv_file = open(self.filename, 'a'+self.file_flags)
         else:
-            self.csv_file = open(self.filename, 'w')
+            self.csv_file = open(self.filename, 'w'+self.file_flags)
 
     def on_epoch_end(self, epoch, logs=None):
         logs = logs or {}

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -869,11 +869,11 @@ class CSVLogger(Callback):
     def on_train_begin(self, logs=None):
         if self.append:
             if os.path.exists(self.filename):
-                with open(self.filename, 'r'+self.file_flags) as f:
+                with open(self.filename, 'r' + self.file_flags) as f:
                     self.append_header = not bool(len(f.readline()))
-            self.csv_file = open(self.filename, 'a'+self.file_flags)
+            self.csv_file = open(self.filename, 'a' + self.file_flags)
         else:
-            self.csv_file = open(self.filename, 'w'+self.file_flags)
+            self.csv_file = open(self.filename, 'w' + self.file_flags)
 
     def on_epoch_end(self, epoch, logs=None):
         logs = logs or {}


### PR DESCRIPTION
Esoteric issue with CSVs. With Windows and Python 2 you need to open in binary mode. Text mode works for all other OS and for Windows with Python 3. Only one configuration but probably a large user base.

With this patch, I get "0d 0a" line endings on Windows. Without it, I get "0d 0d 0a". If you open in something like Excel, every other line will be blank.

I implemented as an attribute. If someone has an odd setup where they need something else they could overwrite it easily enough.

Any fellow Keras on Windows people out there? No real way to test this on our Travis setup. Can anyone confirm or test on Windows? This is a known issue in native windows Python 2. I haven't tested this in cygwin or the new bash on Windows.

Cheers