### PR TITLE
Visualize grad distributions in TensorBoard

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -724,8 +724,8 @@ class TensorBoard(Callback):
 
                 val_data = self.validation_data
                 tensors = self.model.inputs + \
-                          self.model.targets + \
-                          self.model.sample_weights
+                    self.model.targets + \
+                    self.model.sample_weights
 
                 if self.model.uses_learning_phase:
                     tensors += [K.learning_phase()]

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -630,6 +630,9 @@ class TensorBoard(Callback):
 
                 for weight in layer.weights:
                     tf.summary.histogram(weight.name, weight)
+                    grads = model.optimizer.get_gradients(model.total_loss,
+                                                          weight)
+                    tf.summary.histogram('{}_grad'.format(weight.name), grads)
                     if self.write_images:
                         w_img = tf.squeeze(weight)
                         shape = K.int_shape(w_img)
@@ -720,8 +723,11 @@ class TensorBoard(Callback):
                 # (current call will likely go OOM on GPU)
                 if self.model.uses_learning_phase:
                     cut_v_data = len(self.model.inputs)
-                    val_data = self.validation_data[:cut_v_data] + [0]
-                    tensors = self.model.inputs + [K.learning_phase()]
+                    val_data = self.validation_data
+                    tensors = self.model.inputs + \
+                              self.model.targets + \
+                              self.model.sample_weights + \
+                              [K.learning_phase()]
                 else:
                     val_data = self.validation_data
                     tensors = self.model.inputs

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -584,11 +584,14 @@ class TensorBoard(Callback):
         log_dir: the path of the directory where to save the log
             files to be parsed by Tensorboard.
         histogram_freq: frequency (in epochs) at which to compute activation
-            histograms for the layers of the model. If set to 0,
-            histograms won't be computed.
+            and weight histograms for the layers of the model. If set to 0,
+            histograms won't be computed. Validation data (or split) must be
+            specified for histogram visualizations.
         write_graph: whether to visualize the graph in Tensorboard.
             The log file can become quite large when
             write_graph is set to True.
+        write_grads: whether to visualize gradient histograms in Tensorboard.
+            histogram_freq must be greater than 0.
         write_images: whether to write model weights to visualize as
             image in Tensorboard.
         embeddings_freq: frequency (in epochs) at which selected embedding
@@ -605,6 +608,7 @@ class TensorBoard(Callback):
     def __init__(self, log_dir='./logs',
                  histogram_freq=0,
                  write_graph=True,
+                 write_grads=False,
                  write_images=False,
                  embeddings_freq=0,
                  embeddings_layer_names=None,
@@ -617,6 +621,7 @@ class TensorBoard(Callback):
         self.histogram_freq = histogram_freq
         self.merged = None
         self.write_graph = write_graph
+        self.write_grads = write_grads
         self.write_images = write_images
         self.embeddings_freq = embeddings_freq
         self.embeddings_layer_names = embeddings_layer_names
@@ -630,9 +635,10 @@ class TensorBoard(Callback):
 
                 for weight in layer.weights:
                     tf.summary.histogram(weight.name, weight)
-                    grads = model.optimizer.get_gradients(model.total_loss,
-                                                          weight)
-                    tf.summary.histogram('{}_grad'.format(weight.name), grads)
+                    if self.write_grads:
+                        grads = model.optimizer.get_gradients(model.total_loss,
+                                                              weight)
+                        tf.summary.histogram('{}_grad'.format(weight.name), grads)
                     if self.write_images:
                         w_img = tf.squeeze(weight)
                         shape = K.int_shape(w_img)

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -721,16 +721,16 @@ class TensorBoard(Callback):
             if epoch % self.histogram_freq == 0:
                 # TODO: implement batched calls to sess.run
                 # (current call will likely go OOM on GPU)
+
+                val_data = self.validation_data
+                tensors = self.model.inputs + \
+                          self.model.targets + \
+                          self.model.sample_weights
+
                 if self.model.uses_learning_phase:
-                    cut_v_data = len(self.model.inputs)
-                    val_data = self.validation_data
-                    tensors = self.model.inputs + \
-                              self.model.targets + \
-                              self.model.sample_weights + \
-                              [K.learning_phase()]
-                else:
-                    val_data = self.validation_data
-                    tensors = self.model.inputs
+                    tensors += [K.learning_phase()]
+
+                assert len(val_data) == len(tensors)
                 feed_dict = dict(zip(tensors, val_data))
                 result = self.sess.run([self.merged], feed_dict=feed_dict)
                 summary_str = result[0]

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -582,18 +582,18 @@ class TensorBoard(Callback):
 
     # Arguments
         log_dir: the path of the directory where to save the log
-            files to be parsed by Tensorboard.
+            files to be parsed by TensorBoard.
         histogram_freq: frequency (in epochs) at which to compute activation
             and weight histograms for the layers of the model. If set to 0,
             histograms won't be computed. Validation data (or split) must be
             specified for histogram visualizations.
-        write_graph: whether to visualize the graph in Tensorboard.
+        write_graph: whether to visualize the graph in TensorBoard.
             The log file can become quite large when
             write_graph is set to True.
-        write_grads: whether to visualize gradient histograms in Tensorboard.
-            histogram_freq must be greater than 0.
+        write_grads: whether to visualize gradient histograms in TensorBoard.
+            `histogram_freq` must be greater than 0.
         write_images: whether to write model weights to visualize as
-            image in Tensorboard.
+            image in TensorBoard.
         embeddings_freq: frequency (in epochs) at which selected embedding
             layers will be saved.
         embeddings_layer_names: a list of names of layers to keep eye on. If
@@ -729,9 +729,9 @@ class TensorBoard(Callback):
                 # (current call will likely go OOM on GPU)
 
                 val_data = self.validation_data
-                tensors = self.model.inputs + \
-                    self.model.targets + \
-                    self.model.sample_weights
+                tensors = (self.model.inputs +
+                           self.model.targets +
+                           self.model.sample_weights)
 
                 if self.model.uses_learning_phase:
                     tensors += [K.learning_phase()]

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1839,8 +1839,12 @@ class Model(Container):
                                  str(validation_data))
             val_x, val_y, val_sample_weights = self._standardize_user_data(
                 val_x, val_y, val_sample_weight)
+            val_data = val_x + val_y + val_sample_weights
+            if self.uses_learning_phase and not isinstance(K.learning_phase(),
+                                                           int):
+                val_data += [0.]
             for cbk in callbacks:
-                cbk.validation_data = val_x + val_y + val_sample_weights
+                cbk.validation_data = val_data
         enqueuer = None
 
         try:

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1840,7 +1840,7 @@ class Model(Container):
             val_x, val_y, val_sample_weights = self._standardize_user_data(
                 val_x, val_y, val_sample_weight)
             for cbk in callbacks:
-                cbk.validation_data = val_x + [val_y, val_sample_weights]
+                cbk.validation_data = val_x + val_y + val_sample_weights
         enqueuer = None
 
         try:

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1840,8 +1840,7 @@ class Model(Container):
             val_x, val_y, val_sample_weights = self._standardize_user_data(
                 val_x, val_y, val_sample_weight)
             val_data = val_x + val_y + val_sample_weights
-            if self.uses_learning_phase and not isinstance(K.learning_phase(),
-                                                           int):
+            if self.uses_learning_phase and not isinstance(K.learning_phase(), int):
                 val_data += [0.]
             for cbk in callbacks:
                 cbk.validation_data = val_data

--- a/keras/models.py
+++ b/keras/models.py
@@ -786,11 +786,14 @@ class Sequential(Model):
                            **kwargs)
         self.optimizer = self.model.optimizer
         self.loss = self.model.loss
+        self.total_loss = self.model.total_loss
         self.loss_weights = self.model.loss_weights
         self.metrics = self.model.metrics
         self.metrics_tensors = self.model.metrics_tensors
         self.metrics_names = self.model.metrics_names
         self.sample_weight_mode = self.model.sample_weight_mode
+        self.sample_weights = self.model.sample_weights
+        self.targets = self.model.targets
 
     def fit(self, x, y, batch_size=32, epochs=10, verbose=1, callbacks=None,
             validation_split=0., validation_data=None, shuffle=True,

--- a/tests/keras/test_callbacks.py
+++ b/tests/keras/test_callbacks.py
@@ -381,7 +381,7 @@ def test_TensorBoard_convnet():
                   optimizer='rmsprop',
                   metrics=['accuracy'])
     tsb = callbacks.TensorBoard(log_dir=filepath, histogram_freq=1,
-                                write_images=True)
+                                write_images=True, write_grads=True)
     cbks = [tsb]
     model.summary()
     history = model.fit(x_train, y_train, epochs=2, batch_size=16,

--- a/tests/keras/test_callbacks.py
+++ b/tests/keras/test_callbacks.py
@@ -438,7 +438,7 @@ def test_CallbackValData():
     assert len(cbk.validation_data) == len(cbk2.validation_data) == 3
     assert cbk.validation_data[0] is cbk2.validation_data[0]
     assert cbk.validation_data[1] is cbk2.validation_data[1]
-    assert cbk.validation_data[2] is cbk2.validation_data[2]
+    assert cbk.validation_data[2].shape == cbk2.validation_data[2].shape
 
 
 @keras_test

--- a/tests/keras/test_callbacks.py
+++ b/tests/keras/test_callbacks.py
@@ -317,7 +317,7 @@ def test_TensorBoard():
                   metrics=['accuracy'])
 
     tsb = callbacks.TensorBoard(log_dir=filepath, histogram_freq=1,
-                                write_images=True)
+                                write_images=True, write_grads=True)
     cbks = [tsb]
 
     # fit with validation data

--- a/tests/keras/test_callbacks.py
+++ b/tests/keras/test_callbacks.py
@@ -393,6 +393,55 @@ def test_TensorBoard_convnet():
 
 
 @keras_test
+def test_CallbackValData():
+    np.random.seed(1337)
+    (X_train, y_train), (X_test, y_test) = get_test_data(num_train=train_samples,
+                                                         num_test=test_samples,
+                                                         input_shape=(input_dim,),
+                                                         classification=True,
+                                                         num_classes=num_class)
+    y_test = np_utils.to_categorical(y_test)
+    y_train = np_utils.to_categorical(y_train)
+    model = Sequential()
+    model.add(Dense(num_hidden, input_dim=input_dim, activation='relu'))
+    model.add(Dense(num_class, activation='softmax'))
+    model.compile(loss='categorical_crossentropy',
+                  optimizer='sgd',
+                  metrics=['accuracy'])
+
+    cbk = callbacks.LambdaCallback(on_train_end=lambda x: 1)
+    model.fit(X_train, y_train, batch_size=batch_size,
+              validation_data=(X_test, y_test), callbacks=[cbk], epochs=1)
+
+    def data_generator(train):
+        if train:
+            max_batch_index = len(X_train) // batch_size
+        else:
+            max_batch_index = len(X_test) // batch_size
+        i = 0
+        while 1:
+            if train:
+                yield (X_train[i * batch_size: (i + 1) * batch_size],
+                       y_train[i * batch_size: (i + 1) * batch_size])
+            else:
+                yield (X_test[i * batch_size: (i + 1) * batch_size],
+                       y_test[i * batch_size: (i + 1) * batch_size])
+            i += 1
+            i = i % max_batch_index
+
+    cbk2 = callbacks.LambdaCallback(on_train_end=lambda x: 1)
+    model.fit_generator(data_generator(True), len(X_train), epochs=1,
+                        validation_data=(X_test, y_test),
+                        callbacks=[cbk2])
+
+    # callback validation data should always have x, y, and sample weights
+    assert len(cbk.validation_data) == len(cbk2.validation_data) == 3
+    assert cbk.validation_data[0] is cbk2.validation_data[0]
+    assert cbk.validation_data[1] is cbk2.validation_data[1]
+    assert cbk.validation_data[2] is cbk2.validation_data[2]
+
+
+@keras_test
 def test_LambdaCallback():
     np.random.seed(1337)
     (X_train, y_train), (X_test, y_test) = get_test_data(num_train=train_samples,

--- a/tests/keras/test_callbacks.py
+++ b/tests/keras/test_callbacks.py
@@ -8,7 +8,7 @@ import shutil
 from keras import optimizers
 from keras import callbacks
 from keras.models import Sequential
-from keras.layers.core import Dense
+from keras.layers.core import Dense, Dropout
 from keras.layers.convolutional import Conv2D
 from keras.layers.pooling import MaxPooling2D, GlobalAveragePooling2D
 from keras.utils.test_utils import get_test_data
@@ -311,6 +311,7 @@ def test_TensorBoard():
     # case 1 Sequential
     model = Sequential()
     model.add(Dense(num_hidden, input_dim=input_dim, activation='relu'))
+    model.add(Dropout(0.1))
     model.add(Dense(num_class, activation='softmax'))
     model.compile(loss='categorical_crossentropy',
                   optimizer='sgd',


### PR DESCRIPTION
Adds gradient distribution visualizations to TensorBoard callback. Here is how it looks like in MNIST MLP training:

![image](https://cloud.githubusercontent.com/assets/1140359/25154945/098285d0-2493-11e7-9757-4d532eec7ed2.png)

Fixes #6215.

I'm not sure about two things: 

1. ~I couldn't figure out why self.validation_data includes only the inputs if self.model.uses_learning_phase is False. So I didn't change this part, you can help me out on that.~ I'm not sure whether the only difference between `self.model.uses_learning_phase==True` and `self.model.uses_learning_phase==False` is `K.learning_phase()` element in feed_dict.

2. `model.{targets,sample_weights,total_loss}` is required for this PR. It's fine for the models using the functional API since these are available as class members but for the `Sequential` class objects, this is not the case, so I added them as members for `Sequential` as well. Another option would be to check  `isinstance(self.model, Sequential)` and use `model.model.total_loss` instead of `model.total_loss` for `Sequential` instances but this seemed dirtier to me.

Feedback is welcome, looking forward to seeing this in Keras.