### PR TITLE
New LSTM Layer, TimeStepLSTM

### DIFF
--- a/examples/timesteplstm.py
+++ b/examples/timesteplstm.py
@@ -1,21 +1,21 @@
 """
 This example shows how to use TimeStepLSTM in model.
 
-This particular example does the exact same thing as an LSTM with "return_states = True" because 
-input to the RNN was not changed as the states were evaluated but hopefully this will give you an 
+This particular example does the exact same thing as an LSTM with "return_states = True" because
+input to the RNN was not changed as the states were evaluated but hopefully this will give you an
 idea of what you can do with this new Layer
 """
 
-from keras.models import Model 
+from keras.models import Model
 from keras.layers import Input, TimeDistributed, Dense, TimeStepLSTM, LSTM, Masking
 from keras.layers.merge import concatenate
 import keras.backend as K
-import numpy as np 
+import numpy as np
 
 np.random.seed(111)
 
 # create model
-i1 = Input(shape=(10,16))
+i1 = Input(shape=(10, 16))
 lstm1 = TimeStepLSTM(32)
 lstm2 = LSTM(32, return_sequences=True)(i1)
 predict_layer = Dense(1, activation='sigmoid')
@@ -23,16 +23,16 @@ predict_layer = Dense(1, activation='sigmoid')
 predictions = []
 # evaluate states individually
 for t in range(K.int_shape(i1)[1]):
-	if t > 0:
-		# i1 can be updated here before calling RNN at next timepoint
-		ht = lstm1(i1, prev_state=ht[-2:], timepoint=t)
-	else:
-		ht = lstm1(i1, timepoint=t)
+    if t > 0:
+        # i1 can be updated here before calling RNN at next timepoint
+        ht = lstm1(i1, prev_state=ht[-2:], timepoint=t)
+    else:
+        ht = lstm1(i1, timepoint=t)
 
-	# can act on the individual states here before continuing in RNN
-	# in this example, prediction based on the current state was made 
-	prediction = predict_layer(ht[0])
-	predictions.append(prediction)
+    # can act on the individual states here before continuing in RNN
+    # in this example, prediction based on the current state was made
+    prediction = predict_layer(ht[0])
+    predictions.append(prediction)
 
 out1 = concatenate(predictions)
 out2 = TimeDistributed(Dense(1, activation='sigmoid'))(lstm2)
@@ -43,18 +43,18 @@ model2 = Model(i1, out2)
 model2.compile(optimizer='adam', loss='binary_crossentropy')
 
 # train and compare outputs from both LSTM networks
-train1 = np.ones((3,10,16))
-train2 = np.zeros((2,10,16))
-labels1 = np.zeros((3,10,1))
-labels2 = np.ones((2,10,1))
+train1 = np.ones((3, 10, 16))
+train2 = np.zeros((2, 10, 16))
+labels1 = np.zeros((3, 10, 1))
+labels2 = np.ones((2, 10, 1))
 
 train_data = np.concatenate([train1, train2], axis=0)
 train_labels = np.concatenate([labels1, labels2], axis=0)
 
-test_data1 = np.ones((1,10,16))
-test_data2 = np.zeros((1,10,16))
+test_data1 = np.ones((1, 10, 16))
+test_data2 = np.zeros((1, 10, 16))
 
-model1.fit(train_data, train_labels[:,:,0], epochs=1000, batch_size=1)
+model1.fit(train_data, train_labels[:, :, 0], epochs=1000, batch_size=1)
 model2.fit(train_data, train_labels, epochs=1000, batch_size=1)
 
 preds11 = model1.predict(test_data1)
@@ -66,4 +66,3 @@ print('Preds11: ', preds11)
 print('Preds12: ', preds12)
 print('Preds21: ', preds21)
 print('Preds22: ', preds22)
-

--- a/examples/timesteplstm.py
+++ b/examples/timesteplstm.py
@@ -1,3 +1,11 @@
+"""
+This example shows how to use TimeStepLSTM in model.
+
+This particular example does the exact same thing as an LSTM with "return_states = True" because 
+input to the RNN was not changed as the states were evaluated but hopefully this will give you an 
+idea of what you can do with this new Layer
+"""
+
 from keras.models import Model 
 from keras.layers import Input, TimeDistributed, Dense, TimeStepLSTM, LSTM, Masking
 from keras.layers.merge import concatenate
@@ -6,18 +14,23 @@ import numpy as np
 
 np.random.seed(111)
 
+# create model
 i1 = Input(shape=(10,16))
-# mask1 = Masking(mask_value=2.)(i1)
 lstm1 = TimeStepLSTM(32)
 lstm2 = LSTM(32, return_sequences=True)(i1)
 predict_layer = Dense(1, activation='sigmoid')
 
 predictions = []
+# evaluate states individually
 for t in range(K.int_shape(i1)[1]):
 	if t > 0:
+		# i1 can be updated here before calling RNN at next timepoint
 		ht = lstm1(i1, prev_state=ht[-2:], timepoint=t)
 	else:
 		ht = lstm1(i1, timepoint=t)
+
+	# can act on the individual states here before continuing in RNN
+	# in this example, prediction based on the current state was made 
 	prediction = predict_layer(ht[0])
 	predictions.append(prediction)
 

--- a/examples/timesteplstm.py
+++ b/examples/timesteplstm.py
@@ -32,7 +32,7 @@ for t in range(K.int_shape(i1)[1]):
     # can act on the individual states here before continuing in RNN
     # in this example, prediction based on the current state was made
     prediction = predict_layer(ht[0])
-    predictions.append(Reshape((1,1))(prediction))
+    predictions.append(Reshape((1, 1))(prediction))
 
 out1 = concatenate(predictions, axis=1)
 out2 = TimeDistributed(Dense(1, activation='sigmoid'))(lstm2)

--- a/examples/timesteplstm.py
+++ b/examples/timesteplstm.py
@@ -7,7 +7,7 @@ idea of what you can do with this new Layer
 """
 
 from keras.models import Model
-from keras.layers import Input, TimeDistributed, Dense, TimeStepLSTM, LSTM, Masking
+from keras.layers import Input, TimeDistributed, Dense, TimeStepLSTM, LSTM, Masking, Reshape
 from keras.layers.merge import concatenate
 import keras.backend as K
 import numpy as np
@@ -32,9 +32,9 @@ for t in range(K.int_shape(i1)[1]):
     # can act on the individual states here before continuing in RNN
     # in this example, prediction based on the current state was made
     prediction = predict_layer(ht[0])
-    predictions.append(prediction)
+    predictions.append(Reshape((1,1))(prediction))
 
-out1 = concatenate(predictions)
+out1 = concatenate(predictions, axis=1)
 out2 = TimeDistributed(Dense(1, activation='sigmoid'))(lstm2)
 
 model1 = Model(i1, out1)
@@ -54,7 +54,7 @@ train_labels = np.concatenate([labels1, labels2], axis=0)
 test_data1 = np.ones((1, 10, 16))
 test_data2 = np.zeros((1, 10, 16))
 
-model1.fit(train_data, train_labels[:, :, 0], epochs=1000, batch_size=1)
+model1.fit(train_data, train_labels, epochs=1000, batch_size=1)
 model2.fit(train_data, train_labels, epochs=1000, batch_size=1)
 
 preds11 = model1.predict(test_data1)

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1329,9 +1329,9 @@ def rnn(step_function, inputs, initial_states,
 
 def single_step_rnn(step_function, cur_data, prev_states, timepoint, mask=None, constants=None):
     """
-    Iterates over time dimension of a tensor, 1 timepoint at a time. 
+    Iterates over time dimension of a tensor, 1 timepoint at a time.
 
-    Arguments: 
+    Arguments:
         cur_data: subtensor for current timepoint (samples, ...)
             (at least 2D)
         step_function:

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1328,7 +1328,7 @@ def rnn(step_function, inputs, initial_states,
     return last_output, outputs, states
 
 
-def single_step_rnn(step_function, cur_data, prev_states, timepoint, mask=None, constants=None):
+def single_step_rnn(step_function, cur_data, prev_states, timepoint, mask=None, constants=None, go_backwards=False):
     """
     Iterates over time dimension of a tensor, 1 timepoint at a time.
 

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -595,9 +595,13 @@ class Layer(object):
             # Infering the output shape is only relevant for Theano.
             if all([s is not None for s in _to_list(input_shape)]):
                 output_shape = self.compute_output_shape(input_shape)
+                # output can contain states if used with TimeStepLSTM
+                if isinstance(output, list):
+                    output_shape = [output_shape for i in range(len(output))]
             else:
                 if isinstance(input_shape, list):
                     output_shape = [None for _ in input_shape]
+                    
                 else:
                     output_shape = None
 
@@ -2676,8 +2680,13 @@ def _collect_previous_mask(input_tensors):
         if hasattr(x, '_keras_history'):
             inbound_layer, node_index, tensor_index = x._keras_history
             node = inbound_layer.inbound_nodes[node_index]
-            mask = node.output_masks[tensor_index]
-            masks.append(mask)
+            # if TimeStepLSTM is previous node and no Masking layers are used
+            # tensor_index can be larger than number of output_masks
+            if tensor_index >= len(node.output_masks):
+                masks.append(None)
+            else:
+                mask = node.output_masks[tensor_index]
+                masks.append(mask)
         else:
             masks.append(None)
     if len(masks) == 1:

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -595,9 +595,6 @@ class Layer(object):
             # Infering the output shape is only relevant for Theano.
             if all([s is not None for s in _to_list(input_shape)]):
                 output_shape = self.compute_output_shape(input_shape)
-                # output can contain states if used with TimeStepLSTM
-                if isinstance(output, list):
-                    output_shape = [output_shape for i in range(len(output))]
             else:
                 if isinstance(input_shape, list):
                     output_shape = [None for _ in input_shape]

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -601,7 +601,6 @@ class Layer(object):
             else:
                 if isinstance(input_shape, list):
                     output_shape = [None for _ in input_shape]
-                    
                 else:
                     output_shape = None
 

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -1204,11 +1204,11 @@ class TimeStepLSTM(LSTM):
 
         # this outputs the state for the current RNN LSTM block
         current_output, states = K.single_step_rnn(self.step,
-                                                    cur_data,
-                                                    prev_states,
-                                                    timepoint,
-                                                    mask=mask,
-                                                    constants=constants)
+                                                   cur_data,
+                                                   prev_states,
+                                                   timepoint,
+                                                   mask=mask,
+                                                   constants=constants)
 
         if self.stateful:
             updates = []

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -1139,3 +1139,96 @@ class LSTM(Recurrent):
                   'recurrent_dropout': self.recurrent_dropout}
         base_config = super(LSTM, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
+
+
+"""
+An adapted version of the LSTM to allow you to act on the individual states immediately after they are evaluated. Allows 
+you to build more types of RNN architectures (i.e. One to Many, Many to Many [https://deeplearning4j.org/usingrnns])
+
+    # Arguments:
+    units: Positive integer, dimensionality of the output space.
+
+    This function can take in all other parameters used by the LSTM Layer. States are evaluated by K.single_step_rnn().
+    Network is always unrolled, so passing unroll = False has no effect.
+
+    Note1: **ONLY IMPLEMENTED WITH THEANO BACKEND CURRENTLY**
+
+    Note2: As of now, TimeStepLSTM Layer is not json serializable, use cPickle to save model containing this layer
+
+    Note3: This Layer needs to be called interatively within a loop to be able to access and act on the states as 
+        they are evaluated (functioning example provided in 'examples/timesteplstm.py'. 
+    i.e.    input1 = Input(batch_shape=(20, 32, 16)) # 32 timesteps, 16 dims
+            time_step_lstm1 = TimeStepLSTM(32)
+            for t in range(K.int_shape(input1)[1]):
+                if t > 0:
+                    <**CODE TO UPDATE INPUT1 BEFORE PASSING BACK INTO RNN**>
+                    ht = time_step_lstm1(input1, prev_state=ht[-2:], timepoint=t)
+                else:
+                    ht = time_step_lstm1(input1, timepoint=t)
+                <**CODE TO ACT ON INDIVIDUAL STATE EVALUATED**>
+"""
+class TimeStepLSTM(LSTM):
+    def __init__(self, units, **kwargs):
+        super(TimeStepLSTM, self).__init__(units, **kwargs)
+
+
+    def call(self, inputs, timepoint, mask=None, prev_state=None, training=None):
+        # input shape: `(samples, time (padded with zeros), input_dim)`
+        # note that the .build() method of subclasses MUST define
+        # self.input_spec and self.state_spec with complete input shapes.
+        
+        # changed initial_state to prev_state (using separate overriding __call__() statement)
+        if prev_state is not None:
+            if not isinstance(prev_state, (list, tuple)):
+                prev_states = [prev_state]
+            else:
+                prev_states = list(prev_state)
+        elif self.stateful:
+            prev_states = self.states
+        else:
+            prev_states = self.get_initial_states(inputs)
+
+        if len(prev_states) != len(self.states):
+            raise ValueError('Layer has ' + str(len(self.states)) +
+                             ' states but was passed ' +
+                             str(len(prev_states)) +
+                             ' initial states.')
+        input_shape = K.int_shape(inputs)
+        if input_shape[1] is None:
+            raise ValueError('Cannot evaluate RNN states for each timestep without providing number of timesteps in input shape (input_shape[1])')
+        constants = self.get_constants(inputs, training=None)
+        preprocessed_input = self.preprocess_input(inputs, training=None)
+
+        if self.go_backwards:
+            cur_data = preprocessed_input[:, input_shape[1] - timepoint - 1, :]
+        else:
+            cur_data = preprocessed_input[:, timepoint, :]
+
+        # this outputs the state for the current RNN LSTM block
+        current_output, states = K.single_step_rnn(self.step, 
+                                                        cur_data, 
+                                                        prev_states,
+                                                        timepoint,
+                                                        mask=mask, 
+                                                        constants=constants)
+
+        if self.stateful:
+            updates = []
+            for i in range(len(states)):
+                updates.append((self.states[i], states[i]))
+            self.add_update(updates, inputs)
+
+        # Properly set learning phase
+        if 0 < self.dropout + self.recurrent_dropout:
+            current_output._uses_learning_phase = True
+
+        return [current_output] + states 
+
+
+    def __call__(self, inputs, **kwargs):
+        """ Bypass Recurrent __call__
+
+        This implementation does not use initial_state, replaced with prev_state in call() function
+        """
+        return super(Recurrent, self).__call__(inputs, **kwargs)
+        

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -1148,8 +1148,8 @@ you to build more types of RNN architectures (i.e. One to Many, Many to Many [ht
     # Arguments:
     units: Positive integer, dimensionality of the output space.
 
-    This function can take in all other parameters used by the LSTM Layer. States are evaluated by K.single_step_rnn().
-    Network is always unrolled, so passing unroll = False has no effect.
+    This function can take in all other parameters used by the LSTM Layer (except initial_state). States are evaluated by 
+    K.single_step_rnn(). Network is always unrolled, so passing unroll = False has no effect.
 
     Note1: **ONLY IMPLEMENTED WITH THEANO BACKEND CURRENTLY**
 

--- a/tests/keras/layers/recurrent_test.py
+++ b/tests/keras/layers/recurrent_test.py
@@ -57,6 +57,14 @@ def test_dropout(layer_class):
                        'dropout': 0.1,
                        'recurrent_dropout': 0.1},
                input_shape=(num_samples, timesteps, embedding_dim))
+    # Test that dropout is not applied during testing
+    x = np.random.random((num_samples, timesteps, embedding_dim))
+    layer = layer_class(units, dropout=0.5, recurrent_dropout=0.5,
+                        input_shape=(timesteps, embedding_dim))
+    model = Sequential([layer])
+    y1 = model.predict(x)
+    y2 = model.predict(x)
+    assert_allclose(y1, y2)
 
 
 @rnn_test

--- a/tests/keras/layers/timestep_recurrent_test.py
+++ b/tests/keras/layers/timestep_recurrent_test.py
@@ -14,7 +14,7 @@ def test_timesteplstm():
 
     state_list1 = lstm1(i1, timepoint=0)
     assert state_list1[0]._keras_shape == (None, 32)
-    assert len(state_list) == 3
+    assert len(state_list1) == 3
 
     state_list = []
     for t in range(K.int_shape(i1)[1]):

--- a/tests/keras/layers/timestep_recurrent_test.py
+++ b/tests/keras/layers/timestep_recurrent_test.py
@@ -9,20 +9,20 @@ from keras.utils.test_utils import keras_test
 
 @keras_test
 def test_timesteplstm():
-	i1 = Input(shape=(10, 16))
-	lstm1 = TimeStepLSTM(32)
+    i1 = Input(shape=(10, 16))
+    lstm1 = TimeStepLSTM(32)
 
-	state_list1 = lstm1(i1, timepoint=0)
-	assert state_list1[0]._keras_shape == (None, 32)
-	assert len(state_list) == 3
+    state_list1 = lstm1(i1, timepoint=0)
+    assert state_list1[0]._keras_shape == (None, 32)
+    assert len(state_list) == 3
 
-	state_list = []
-	for t in range(K.int_shape(i1)[1]):
-		cur_state_list = lstm1(i1, timepoint=t)
-		state_list.append(Reshape((1, 32))(cur_state_list[0]))
+    state_list = []
+    for t in range(K.int_shape(i1)[1]):
+        cur_state_list = lstm1(i1, timepoint=t)
+        state_list.append(Reshape((1, 32))(cur_state_list[0]))
 
-	states = concatenate(state_list, axis=1)
-	assert states._keras_shape == (None, 10, 32)
+    states = concatenate(state_list, axis=1)
+    assert states._keras_shape == (None, 10, 32)
 
-	lstm2 = LSTM(32, return_sequences=True)(i1)
-	assert lstm2._keras_shape == (None, 10, 32)
+    lstm2 = LSTM(32, return_sequences=True)(i1)
+    assert lstm2._keras_shape == (None, 10, 32)

--- a/tests/keras/layers/timestep_recurrent_test.py
+++ b/tests/keras/layers/timestep_recurrent_test.py
@@ -1,0 +1,28 @@
+import pytest
+import numpy as np
+from keras.layers import Input, LSTM, TimeStepLSTM, Reshape
+from keras.layers.merge import concatenate
+from keras.models import Model
+import keras.backend as K
+from keras.utils.test_utils import keras_test
+
+
+@keras_test
+def test_timesteplstm():
+	i1 = Input(shape=(10, 16))
+	lstm1 = TimeStepLSTM(32)
+
+	state_list1 = lstm1(i1, timepoint=0)
+	assert state_list1[0]._keras_shape == (None, 32)
+	assert len(state_list) == 3
+
+	state_list = []
+	for t in range(K.int_shape(i1)[1]):
+		cur_state_list = lstm1(i1, timepoint=t)
+		state_list.append(Reshape((1, 32))(cur_state_list[0]))
+
+	states = concatenate(state_list, axis=1)
+	assert states._keras_shape == (None, 10, 32)
+
+	lstm2 = LSTM(32, return_sequences=True)(i1)
+	assert lstm2._keras_shape == (None, 10, 32)

--- a/tests/keras/layers/timestep_recurrent_test.py
+++ b/tests/keras/layers/timestep_recurrent_test.py
@@ -26,4 +26,3 @@ def test_timesteplstm():
 
     lstm2 = LSTM(32, return_sequences=True)(i1)
     assert lstm2._keras_shape == (None, 10, 32)
-    

--- a/tests/keras/layers/timestep_recurrent_test.py
+++ b/tests/keras/layers/timestep_recurrent_test.py
@@ -26,3 +26,4 @@ def test_timesteplstm():
 
     lstm2 = LSTM(32, return_sequences=True)(i1)
     assert lstm2._keras_shape == (None, 10, 32)
+    


### PR DESCRIPTION
This PR is adds a new layer to Keras to allow people to build more complicated LSTM networks where someone may want to adjust the input to the network at a later step and/or act on the states returned by the LSTM immediately. With this layer it is possible to build more types of RNN architectures (one-to-many, many-to-one, many-to-many, etc) Examples of networks can be found here: https://deeplearning4j.org/usingrnns

This PR includes documentation to describe the Layer's usage (above function in recurrent.py), an example to illustrate its usage, and a test case file to make sure that the compatibility does not get broken in the future.

Hope this Layer helps the community, I needed this for a very particular network that I was working on based on one found in literature. 