### PR TITLE
Fix doc: an obsolete code example

### DIFF
--- a/docs/templates/initializers.md
+++ b/docs/templates/initializers.md
@@ -39,5 +39,5 @@ from keras import backend as K
 def my_init(shape, dtype=None):
     return K.random_normal(shape, dtype=dtype)
 
-model.add(Dense(64, init=my_init))
+model.add(Dense(64, kernel_initializer=my_init))
 ```


### PR DESCRIPTION
`init` parameter is a v1 API.