### PR TITLE
Adds requirements for testing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,12 @@ setup(name='Keras',
       extras_require={
           'h5py': ['h5py'],
           'visualize': ['pydot-ng'],
-          'tests': ['pytest',
+          'tests': ['h5py',
+                    'pillow',
+                    'pytest',
                     'pytest-pep8',
                     'pytest-xdist',
-                    'pytest-cov'],
+                    'pytest-cov',
+                    'tensorflow']
       },
       packages=find_packages())


### PR DESCRIPTION
I've experienced some weird issue with testing `keras` -- despite couple of `.mark.skipif` marks over tests, running
```bash
pip install .[tests] && pytest tests/
```
ends up with
 - 42 errors with `ModuleNotFoundError: No module named 'tensorflow'`
 - 16 errors with `ImportError: `save_weights` requires h5py`
 - 1 error with `ModuleNotFoundError: No module named 'PIL'`

Personally, I believe in "sane defaults" idea. So, clean setup with defaults should pass tests, IMO. According to this, I propose either add extra requirements for testing (I guess, vast majority of devs already has this anyway), or tune tests skipping with respect to available modules.