### PR TITLE
better keras2.0 back compat for serialized weights

### DIFF
--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -2799,7 +2799,7 @@ def preprocess_weights_for_loading(layer, weights,
             weights[0] = weights[0][:, 0, :, :]
 
         if layer.__class__.__name__ == 'Conv2D':
-            if layer.data_format == 'channels_first':
+            if layer.data_format == 'channels_first' or original_backend == 'theano':
                 # old: (filters, stack_size, kernel_rows, kernel_cols)
                 # new: (kernel_rows, kernel_cols, stack_size, filters)
                 weights[0] = np.transpose(weights[0], (2, 3, 1, 0))
@@ -2809,13 +2809,13 @@ def preprocess_weights_for_loading(layer, weights,
                 # old: (kernel_rows, kernel_cols, stack_size, filters)
                 # new: (kernel_rows, kernel_cols, filters, stack_size)
                 weights[0] = np.transpose(weights[0], (0, 1, 3, 2))
-            if layer.data_format == 'channels_first':
+            if original_backend == 'theano':
                 # old: (filters, stack_size, kernel_rows, kernel_cols)
                 # new: (kernel_rows, kernel_cols, filters, stack_size)
                 weights[0] = np.transpose(weights[0], (2, 3, 0, 1))
 
         if layer.__class__.__name__ == 'Conv3D':
-            if layer.data_format == 'channels_first':
+            if layer.data_format == 'channels_first' or original_backend == 'theano':
                 # old: (filters, stack_size, ...)
                 # new: (..., stack_size, filters)
                 weights[0] = np.transpose(weights[0], (2, 3, 4, 1, 0))
@@ -2932,7 +2932,7 @@ def load_weights_from_hdf5_group(f, layers):
     for k, name in enumerate(layer_names):
         g = f[name]
         weight_names = [n.decode('utf8') for n in g.attrs['weight_names']]
-        weight_values = [g[weight_name] for weight_name in weight_names]
+        weight_values = [g[weight_name][...] for weight_name in weight_names]
         layer = filtered_layers[k]
         symbolic_weights = layer.weights
         weight_values = preprocess_weights_for_loading(layer,


### PR DESCRIPTION
try to fix some errors that emerged when trying to load an old model in keras > 2.0