### PR TITLE
Fix issue where TimeDistributed doesn't pass uses_learning_phase

### DIFF
--- a/tests/keras/layers/wrappers_test.py
+++ b/tests/keras/layers/wrappers_test.py
@@ -86,6 +86,12 @@ def test_TimeDistributed():
     outer_model.compile(optimizer='rmsprop', loss='mse')
     outer_model.fit(np.random.random((10, 3, 2)), np.random.random((10, 3, 3)), epochs=1, batch_size=10)
 
+    # test layers that need learning_phase to be set
+    model = Sequential()
+    model.add(wrappers.TimeDistributed(core.Dropout(.5), input_shape=(3, 2)))
+    model.compile(optimizer='rmsprop', loss='mse')
+    model.predict(np.random.random((10, 3, 2)))
+
 
 @keras_test
 def test_regularizers():


### PR DESCRIPTION
It seems that the `TimeDistributed` layer has a similar issue as the `Bidirectional` layer when passed a layer that requires the learning phase as described in:

* https://github.com/fchollet/keras/issues/5940
* https://github.com/fchollet/keras/issues/5975
* https://github.com/fchollet/keras/pull/5985

This simple example reproduces the problem and is included in the unit tests in the PR. This was tested on a clean copy of the master branch on the commit prior to the PR.

```python
from keras.layers import core, wrappers
from keras.models import Sequential
import numpy as np

model = Sequential()
model.add(wrappers.TimeDistributed(core.Dropout(.5), input_shape=(3, 2)))
model.compile(optimizer='rmsprop', loss='mse')
model.predict(np.random.random((10, 3, 2)))
```

The error output is longish so I put it in this gist: https://gist.github.com/EntilZha/06a8bbd2279d01a61a1c7a5e61d882b4

My proposed fix mimics this section of code from `Bidirectional`, but applies it to `TimeDistributed`: https://github.com/fchollet/keras/blob/master/keras/layers/wrappers.py#L257-L285

I tested my changes locally using `py.test tests` before my changes and after my changes and all tests pass. `py.test --pep8 -m pep8` also passes without errors. The machines I am using use tensorflow `1.0.0-rc0` and `1.0.0`.

Thanks!