### PR TITLE
Modify embedding to accept arbitrary input dim

### DIFF
--- a/keras/layers/embeddings.py
+++ b/keras/layers/embeddings.py
@@ -51,7 +51,7 @@ class Embedding(Layer):
           If mask_zero is set to True, as a consequence, index 0 cannot be
           used in the vocabulary (input_dim should equal size of
           vocabulary + 1).
-      input_length: Lengths of input sequences, when it is constant.
+      input_length: Length of input sequences, when it is constant.
           This argument is required if you are going to connect
           `Flatten` then `Dense` layers upstream
           (without it, the shape of the dense outputs cannot be computed).
@@ -112,7 +112,7 @@ class Embedding(Layer):
             return input_shape + (self.output_dim,)
         else:
             # input_length can be tuple if input is 3D or higher
-            if hasattr(self.input_length, '__len__'):
+            if isinstance(self.input_length, (list, tuple)):
                 in_lens = list(self.input_length)
             else:
                 in_lens = [self.input_length]

--- a/keras/layers/embeddings.py
+++ b/keras/layers/embeddings.py
@@ -108,11 +108,7 @@ class Embedding(Layer):
             return K.not_equal(inputs, 0)
 
     def compute_output_shape(self, input_shape):
-        if not self.input_length:
-            input_length = input_shape[1]
-        else:
-            input_length = self.input_length
-        return (input_shape[0], input_length, self.output_dim)
+        return input_shape + (self.output_dim,)
 
     def call(self, inputs):
         if K.dtype(inputs) != 'int32':

--- a/tests/keras/layers/embeddings_test.py
+++ b/tests/keras/layers/embeddings_test.py
@@ -16,6 +16,11 @@ def test_embedding():
                input_shape=(3, 2),
                input_dtype='int32',
                expected_output_dtype=K.floatx())
+    layer_test(Embedding,
+               kwargs={'output_dim': 4, 'input_dim': 10, 'mask_zero': True},
+               input_shape=(3, 2, 5),
+               input_dtype='int32',
+               expected_output_dtype=K.floatx())
 
 
 if __name__ == '__main__':

--- a/tests/keras/layers/embeddings_test.py
+++ b/tests/keras/layers/embeddings_test.py
@@ -21,6 +21,11 @@ def test_embedding():
                input_shape=(3, 2, 5),
                input_dtype='int32',
                expected_output_dtype=K.floatx())
+    layer_test(Embedding,
+               kwargs={'output_dim': 4, 'input_dim': 10, 'mask_zero': True, 'input_length': (None, 5)},
+               input_shape=(3, 2, 5),
+               input_dtype='int32',
+               expected_output_dtype=K.floatx())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
1. Support high dimension input, e.g., in NLP, input could have shape like `(n_batch, n_sentences, n_words)`. 
2. No need to use `input_length` at all, but left for back compatibility. 