### PR TITLE
Bug fix in recurrent layer

### DIFF
--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -362,9 +362,9 @@ class Recurrent(Layer):
             if len(states) != len(self.states):
                 raise ValueError('Layer ' + self.name + ' expects ' +
                                  str(len(self.states)) + ' states, '
-                                 'but it received ' + str(len(values)) +
+                                 'but it received ' + str(len(states)) +
                                  ' state values. Input received: ' +
-                                 str(values))
+                                 str(states))
             for index, (value, state) in enumerate(zip(states, self.states)):
                 if value.shape != (batch_size, self.units):
                     raise ValueError('State ' + str(index) +

--- a/tests/keras/layers/recurrent_test.py
+++ b/tests/keras/layers/recurrent_test.py
@@ -240,6 +240,10 @@ def test_reset_states_with_values(layer_class):
                                np.ones(K.int_shape(layer.states[0])),
                                atol=1e-4)
 
+    # Test fit with invalid data
+    with pytest.raises(ValueError):
+        layer.reset_states([1] * (len(layer.states) + 1))
+
 
 @rnn_test
 def test_specify_state_with_masking(layer_class):


### PR DESCRIPTION
The variable `values` is not defined in the file, 

@Joshua-Chin: Could you check that this is correct?