### PR TITLE
Added support for new pydot versions to fix find_graphviz error

### DIFF
--- a/keras/utils/vis_utils.py
+++ b/keras/utils/vis_utils.py
@@ -16,9 +16,7 @@ def _check_pydot():
     try:
         # Attempt to create an image of a blank graph to check the pydot/graphviz installation.
         pydot.Dot.create(pydot.Dot())
-    except Exception as e:  # pydot raises a generic Exception here.
-        if not isinstance(e, AttributeError) and 'not found in path' not in str(e):
-            raise  # Re-raise previous exception if it's not what was expected.
+    except Exception:  # pydot raises a generic Exception here, so no specific class can be caught.
         raise ImportError('Failed to import pydot. You must install pydot'
                           ' and graphviz for `pydotprint` to work.')
 

--- a/keras/utils/vis_utils.py
+++ b/keras/utils/vis_utils.py
@@ -13,7 +13,13 @@ except ImportError:
 
 
 def _check_pydot():
-    if not (pydot and pydot.find_graphviz()):
+    try:
+        if hasattr(pydot, 'find_graphviz'):
+            if not pydot.find_graphviz():
+                raise ImportError()
+        else:
+            pydot.Dot.create(pydot.Dot())
+    except:
         raise ImportError('Failed to import pydot. You must install pydot'
                           ' and graphviz for `pydotprint` to work.')
 

--- a/keras/utils/vis_utils.py
+++ b/keras/utils/vis_utils.py
@@ -16,7 +16,9 @@ def _check_pydot():
     try:
         # Attempt to create an image of a blank graph to check the pydot/graphviz installation.
         pydot.Dot.create(pydot.Dot())
-    except:
+    except Exception as e:  # pydot raises a generic Exception here.
+        if not isinstance(e, AttributeError) and 'not found in path' not in str(e):
+            raise  # Re-raise previous exception if it's not what was expected.
         raise ImportError('Failed to import pydot. You must install pydot'
                           ' and graphviz for `pydotprint` to work.')
 

--- a/keras/utils/vis_utils.py
+++ b/keras/utils/vis_utils.py
@@ -14,11 +14,8 @@ except ImportError:
 
 def _check_pydot():
     try:
-        if hasattr(pydot, 'find_graphviz'):
-            if not pydot.find_graphviz():
-                raise ImportError()
-        else:
-            pydot.Dot.create(pydot.Dot())
+        # Attempt to create an image of a blank graph to check the pydot/graphviz installation.
+        pydot.Dot.create(pydot.Dot())
     except:
         raise ImportError('Failed to import pydot. You must install pydot'
                           ' and graphviz for `pydotprint` to work.')


### PR DESCRIPTION
I was having difficulties with the `keras.utils.plot_model` function, specifically that pydot no longer supports the `find_graphviz` function, and installing `pydot-ng` instead does not seem to fix it. This pull request should solve [issue #3210](https://github.com/fchollet/keras/issues/3210).