### PR TITLE
Update docs and add contributing page

### DIFF
--- a/docs/autogen.py
+++ b/docs/autogen.py
@@ -8,9 +8,7 @@ Index
 - Getting started
     Getting started with the sequential model
     Getting started with the functional api
-    Examples
     FAQ
-    Installation guide
 
 - Models
     About Keras models
@@ -26,18 +24,23 @@ Index
         explain common layer functions: get_weights, set_weights, get_config
         explain input_shape
         explain usage on non-Keras tensors
-    Core layers
-    Convolutional
-    Recurrent
-    Embeddings
-    Normalization
-    Advanced activations
-    Noise
+    Core Layers
+    Convolutional Layers
+    Pooling Layers
+    Locally-connected Layers
+    Recurrent Layers
+    Embedding Layers
+    Merge Layers
+    Advanced Activations Layers
+    Normalization Layers
+    Noise Layers
+    Layer Wrappers
+    Writing your own Keras layers
 
 - Preprocessing
-    Image preprocessing
-    Text preprocessing
-    Sequence preprocessing
+    Sequence Preprocessing
+    Text Preprocessing
+    Image Preprocessing
 
 Losses
 Metrics
@@ -45,12 +48,15 @@ Optimizers
 Activations
 Callbacks
 Datasets
+Applications
 Backend
-Initializations
+Initializers
 Regularizers
 Constraints
 Visualization
 Scikit-learn API
+Utils
+Contributing
 
 '''
 from __future__ import print_function
@@ -509,3 +515,5 @@ for page_data in PAGES:
     if not os.path.exists(subdir):
         os.makedirs(subdir)
     open(path, 'w').write(mkdown)
+
+shutil.copyfile('../CONTRIBUTING.md','sources/contributing.md')

--- a/docs/autogen.py
+++ b/docs/autogen.py
@@ -516,4 +516,4 @@ for page_data in PAGES:
         os.makedirs(subdir)
     open(path, 'w').write(mkdown)
 
-shutil.copyfile('../CONTRIBUTING.md','sources/contributing.md')
+shutil.copyfile('../CONTRIBUTING.md', 'sources/contributing.md')

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -51,3 +51,4 @@ pages:
 - Visualization: visualization.md
 - Scikit-learn API: scikit-learn-api.md
 - Utils: utils.md
+- Contributing: contributing.md


### PR DESCRIPTION
I think it makes a lot of sense to mirror the [contributing page on GitHub](https://github.com/fchollet/keras/blob/master/CONTRIBUTING.md) on the doc site, as many other projects do. While we could simply copy `keras/CONTRIBUTING.md` to `keras/docs/templates/contributing.md` and be done with it, but we can also `shutil.copyfile()` at `autogen.py` runtime, so that any future changes to `keras/CONTRIBUTING.md` will be reflected on the doc site.  