### PR TITLE
Add skip_compile option to keras.models.load_model()

### DIFF
--- a/keras/models.py
+++ b/keras/models.py
@@ -175,6 +175,8 @@ def load_model(filepath, custom_objects=None, skip_compile=False):
         custom_objects: Optional dictionary mapping names
             (strings) to custom classes or functions to be
             considered during deserialization.
+        skip_compile: Boolean, whether to compile the model
+            after loading.
 
     # Returns
         A Keras model instance. If an optimizer was found

--- a/keras/models.py
+++ b/keras/models.py
@@ -167,7 +167,7 @@ def save_model(model, filepath, overwrite=True, include_optimizer=True):
     f.close()
 
 
-def load_model(filepath, custom_objects=None):
+def load_model(filepath, custom_objects=None, skip_compile=False):
     """Loads a model saved via `save_model`.
 
     # Arguments
@@ -241,6 +241,11 @@ def load_model(filepath, custom_objects=None):
 
     # set weights
     topology.load_weights_from_hdf5_group(f['model_weights'], model.layers)
+
+    # skip compile
+    if skip_compile:
+        f.close()
+        return model
 
     # instantiate optimizer
     training_config = f.attrs.get('training_config')

--- a/keras/models.py
+++ b/keras/models.py
@@ -167,7 +167,7 @@ def save_model(model, filepath, overwrite=True, include_optimizer=True):
     f.close()
 
 
-def load_model(filepath, custom_objects=None, skip_compile=False):
+def load_model(filepath, custom_objects=None, compile=True):
     """Loads a model saved via `save_model`.
 
     # Arguments
@@ -175,14 +175,16 @@ def load_model(filepath, custom_objects=None, skip_compile=False):
         custom_objects: Optional dictionary mapping names
             (strings) to custom classes or functions to be
             considered during deserialization.
-        skip_compile: Boolean, whether to compile the model
+        compile: Boolean, whether to compile the model
             after loading.
 
     # Returns
         A Keras model instance. If an optimizer was found
         as part of the saved model, the model is already
         compiled. Otherwise, the model is uncompiled and
-        a warning will be displayed.
+        a warning will be displayed. When `compile` is set
+        to False, the compilation is omitted without any
+        warning.
 
     # Raises
         ImportError: if h5py is not available.
@@ -244,8 +246,8 @@ def load_model(filepath, custom_objects=None, skip_compile=False):
     # set weights
     topology.load_weights_from_hdf5_group(f['model_weights'], model.layers)
 
-    # skip compile
-    if skip_compile:
+    # Early return if compilation is not required.
+    if not compile:
         f.close()
         return model
 


### PR DESCRIPTION
Under many scenarios, users **DO NOT** want to compile the `fit()` function during loading. For example, users might want to make predictions rather than continue training, or to make surgery on the loaded network to build a new one.
In theano, even the compiled model is cached in temporary files, the compilation of a `fit()` function of a complex network (e.g. ResNet-50) takes unbearable times (around 300 seconds). 
Therefore, I add a `skip_compile` option to the `load_model()` function, which can greatly reduce the deployment time of a network after pretrained, especially for those who are using Theano as a backend.