### PR TITLE
Add exception handling when attempting to write keras config file

### DIFF
--- a/keras/backend/__init__.py
+++ b/keras/backend/__init__.py
@@ -44,23 +44,27 @@ if os.path.exists(_config_path):
     _BACKEND = _backend
 
 # Save config file, if possible.
-if os.access(_keras_base_dir, os.W_OK):
-    if not os.path.exists(_keras_dir):
-        try:
-            os.makedirs(_keras_dir)
-        except OSError:
-            pass
-    if not os.path.exists(_config_path):
-        _config = {'floatx': floatx(),
-                   'epsilon': epsilon(),
-                   'backend': _BACKEND,
-                   'image_data_format': image_data_format()}
-        try:
-            with open(_config_path, 'w') as f:
-                f.write(json.dumps(_config, indent=4))
-        except IOError:
-            # Except permission denied.
-            pass
+if not os.path.exists(_keras_dir):
+    try:
+        os.makedirs(_keras_dir)
+    except OSError:
+        # Except permission denied and potential race conditions
+        # in multi-threaded environments.
+        pass
+
+if not os.path.exists(_config_path):
+    _config = {
+        'floatx': floatx(),
+        'epsilon': epsilon(),
+        'backend': _BACKEND,
+        'image_data_format': image_data_format()
+    }
+    try:
+        with open(_config_path, 'w') as f:
+            f.write(json.dumps(_config, indent=4))
+    except IOError:
+        # Except permission denied.
+        pass
 
 # Set backend based on KERAS_BACKEND flag, if applicable.
 if 'KERAS_BACKEND' in os.environ:

--- a/keras/backend/__init__.py
+++ b/keras/backend/__init__.py
@@ -55,8 +55,12 @@ if os.access(_keras_base_dir, os.W_OK):
                    'epsilon': epsilon(),
                    'backend': _BACKEND,
                    'image_data_format': image_data_format()}
-        with open(_config_path, 'w') as f:
-            f.write(json.dumps(_config, indent=4))
+        try:
+            with open(_config_path, 'w') as f:
+                f.write(json.dumps(_config, indent=4))
+        except IOError:
+            # Except permission denied.
+            pass
 
 # Set backend based on KERAS_BACKEND flag, if applicable.
 if 'KERAS_BACKEND' in os.environ:


### PR DESCRIPTION
Add exception handling when attempting to write keras config file to disk to match tf.contrib.keras implementation.
Basically trying to match:
https://github.com/tensorflow/tensorflow/blob/master/tensorflow/contrib/keras/python/keras/backend.py#L3648
My understanding is that writing the config file is only an "attempt" and should be treated as such?