### PR TITLE
Implement general ImprovementBasedAction callback (update to #4858)

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -806,8 +806,6 @@ class TensorBoard(Callback):
         self.writer.close()
 
 
-<<<<<<< HEAD
-<<<<<<< 664412ae86c04966ac0f10ed81c96d1b7bccfecf
 class ReduceLROnPlateau(Callback):
     """Reduce learning rate when a metric has stopped improving.
 
@@ -919,10 +917,6 @@ class ReduceLROnPlateau(Callback):
         return self.cooldown_counter > 0
 
 
-=======
->>>>>>> Bug fixes, update ImprovementBasedLRScheduler to replace ReduceLROnPlateau
-=======
->>>>>>> 6d1816295a2989a44d4e9427a87fed1f0d76f884
 class CSVLogger(Callback):
     """Callback that streams epoch results to a csv file.
 

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -551,7 +551,7 @@ class ImprovementBasedLRScheduler(ImprovementBasedAction):
         lr = self.schedule(epoch)
         assert type(lr) == float, 'The output of the "schedule" function should be float.'
         K.set_value(self.model.optimizer.lr, lr)
-        print('Epoch %05d: Updating learning rate to %.2E' % (epoch,lr))
+        print('Epoch %05d: Updating learning rate to %.2E' % (epoch, lr))
 
 
 class RemoteMonitor(Callback):


### PR DESCRIPTION
This PR combines implements a general `ImprovementBasedAction` callback that draws on the current implementations of the `EarlyStopping` and `ReduceLROnPlateau` callbacks . The general callback monitors a metric of interest and calls an action() function after some epochs of no improvement, as mentioned in issue #4857. `EarlyStopping` and `ReduceLROnPlateau` are implemented as subclasses.