### PR TITLE
Add callback to terminate training if NaN loss encountered. (Update to #4849)

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -229,14 +229,17 @@ class BaseLogger(Callback):
 
 class TerminateOnNaN(Callback):
     """Callback that terminates training when a NaN loss is encountered."""
+
     def __init__(self):
         super(TerminateOnNaN, self).__init__()
 
     def on_batch_end(self, batch, logs=None):
-        current = logs.get('loss')
-        if np.isnan(current) or np.isinf(current):
-            print('Batch %05d: Invalid loss, terminating training' % (batch))
-            self.model.stop_training = True
+        logs = logs or {}
+        loss = logs.get('loss')
+        if loss is not None:
+            if np.isnan(loss) or np.isinf(loss):
+                print('Batch %d: Invalid loss, terminating training' % (batch))
+                self.model.stop_training = True
 
 
 class ProgbarLogger(Callback):

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -227,6 +227,18 @@ class BaseLogger(Callback):
                     logs[k] = self.totals[k] / self.seen
 
 
+class TerminateOnNaN(Callback):
+    """Callback that terminates training when a NaN loss is encountered."""
+    def __init__(self):
+        super(TerminateOnNaN, self).__init__()
+
+    def on_batch_end(self, batch, logs=None):
+        current = logs.get('loss')
+        if np.isnan(current) or np.isinf(current):
+            print('Batch %05d: Invalid loss, terminating training' % (batch))
+            self.model.stop_training = True
+
+
 class ProgbarLogger(Callback):
     """Callback that prints metrics to stdout.
 

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1159,6 +1159,8 @@ class Model(Container):
                     batch_logs[l] = o
 
                 callbacks.on_batch_end(batch_index, batch_logs)
+                if callback_model.stop_training:
+                    break
 
                 if batch_index == len(batches) - 1:  # Last batch.
                     if do_validation:

--- a/tests/keras/test_callbacks.py
+++ b/tests/keras/test_callbacks.py
@@ -6,6 +6,7 @@ import pytest
 from csv import Sniffer
 import shutil
 from keras import optimizers
+from keras import initializers
 from keras import callbacks
 from keras.models import Sequential
 from keras.layers.core import Dense
@@ -20,6 +21,34 @@ num_class = 2
 batch_size = 5
 train_samples = 20
 test_samples = 20
+
+
+@keras_test
+def test_TerminateOnNaN():
+    np.random.seed(1337)
+    (X_train, y_train), (X_test, y_test) = get_test_data(num_train=train_samples,
+                                                         num_test=test_samples,
+                                                         input_shape=(input_dim,),
+                                                         classification=True,
+                                                         num_classes=num_class)
+
+    y_test = np_utils.to_categorical(y_test)
+    y_train = np_utils.to_categorical(y_train)
+    cbks = [callbacks.TerminateOnNaN()]
+    model = Sequential()
+    initializer = initializers.Constant(value=1e5)
+    for _ in range(5):
+        model.add(Dense(num_hidden, input_dim=input_dim, activation='relu',
+                        kernel_initializer=initializer))
+    model.add(Dense(num_class, activation='linear'))
+    model.compile(loss='mean_squared_error',
+                  optimizer='rmsprop')
+
+    history = model.fit(X_train, y_train, batch_size=batch_size,
+                        validation_data=(X_test, y_test), callbacks=cbks, epochs=20)
+    loss = history.history['loss']
+    assert len(loss) == 1
+    assert loss[0] == np.inf
 
 
 @keras_test


### PR DESCRIPTION
In cases where jobs are submitted to a queue, it would be helpful to have training terminated automatically when NaN loss is encountered, as stated in issue #4848. This PR uses a callback to stop training at the end of a batch if the loss is NaN.