### PR TITLE
Fix for weight loading bug with `channels_first`

### DIFF
--- a/keras/applications/vgg16.py
+++ b/keras/applications/vgg16.py
@@ -166,9 +166,7 @@ def VGG16(include_top=True, weights='imagenet',
             weights_path = get_file('vgg16_weights_tf_dim_ordering_tf_kernels_notop.h5',
                                     WEIGHTS_PATH_NO_TOP,
                                     cache_subdir='models')
-        model.load_weights(weights_path)
-        if K.backend() == 'theano':
-            layer_utils.convert_all_kernels_in_model(model)
+        model.load_weights(weights_path, original_backend='tensorflow')
 
         if K.image_data_format() == 'channels_first':
             if include_top:

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -2785,6 +2785,9 @@ def preprocess_weights_for_loading(layer, weights,
         A list of weights values (Numpy arrays).
     """
     if original_keras_version == '1':
+        if original_backend is None:
+            raise ValueError('Please specify original_backend')
+
         if layer.__class__.__name__ == 'Bidirectional':
             num_weights_per_layer = len(weights) // 2
 

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -2504,7 +2504,7 @@ class Container(Layer):
         f.flush()
         f.close()
 
-    def load_weights(self, filepath, by_name=False):
+    def load_weights(self, filepath, by_name=False, original_backend=None):
         """Loads all layer weights from a HDF5 save file.
 
         If `by_name` is False (default) weights are loaded
@@ -2533,9 +2533,9 @@ class Container(Layer):
         if 'layer_names' not in f.attrs and 'model_weights' in f:
             f = f['model_weights']
         if by_name:
-            load_weights_from_hdf5_group_by_name(f, self.layers)
+            load_weights_from_hdf5_group_by_name(f, self.layers, original_backend)
         else:
-            load_weights_from_hdf5_group(f, self.layers)
+            load_weights_from_hdf5_group(f, self.layers, original_backend)
 
         if hasattr(f, 'close'):
             f.close()
@@ -2815,7 +2815,7 @@ def preprocess_weights_for_loading(layer, weights,
             weights[0] = weights[0][:, 0, :, :]
 
         if layer.__class__.__name__ == 'Conv2D':
-            if layer.data_format == 'channels_first':
+            if layer.data_format == 'channels_first' and original_backend in {'th', 'theano'}:
                 # old: (filters, stack_size, kernel_rows, kernel_cols)
                 # new: (kernel_rows, kernel_cols, stack_size, filters)
                 weights[0] = np.transpose(weights[0], (2, 3, 1, 0))
@@ -2831,7 +2831,7 @@ def preprocess_weights_for_loading(layer, weights,
                 weights[0] = np.transpose(weights[0], (2, 3, 0, 1))
 
         if layer.__class__.__name__ == 'Conv3D':
-            if layer.data_format == 'channels_first':
+            if layer.data_format == 'channels_first' and original_backend in {'th', 'theano'}:
                 # old: (filters, stack_size, ...)
                 # new: (..., stack_size, filters)
                 weights[0] = np.transpose(weights[0], (2, 3, 4, 1, 0))
@@ -2902,7 +2902,7 @@ def preprocess_weights_for_loading(layer, weights,
     return weights
 
 
-def load_weights_from_hdf5_group(f, layers):
+def load_weights_from_hdf5_group(f, layers, original_backend=None):
     """Implements topological (order-based) weight loading.
 
     # Arguments
@@ -2919,8 +2919,9 @@ def load_weights_from_hdf5_group(f, layers):
         original_keras_version = '1'
     if 'backend' in f.attrs:
         original_backend = f.attrs['backend'].decode('utf8')
-    else:
-        original_backend = None
+
+    if original_backend is None:
+        raise ValueError('Please specify original_backend')
 
     filtered_layers = []
     for layer in layers:
@@ -2970,7 +2971,7 @@ def load_weights_from_hdf5_group(f, layers):
     K.batch_set_value(weight_value_tuples)
 
 
-def load_weights_from_hdf5_group_by_name(f, layers):
+def load_weights_from_hdf5_group_by_name(f, layers, original_backend=None):
     """Implements name-based weight loading.
 
     (instead of topological weight loading).
@@ -2991,8 +2992,9 @@ def load_weights_from_hdf5_group_by_name(f, layers):
         original_keras_version = '1'
     if 'backend' in f.attrs:
         original_backend = f.attrs['backend'].decode('utf8')
-    else:
-        original_backend = None
+
+    if original_backend is None:
+        raise ValueError('Please specify original_backend')
 
     # New file format.
     layer_names = [n.decode('utf8') for n in f.attrs['layer_names']]

--- a/keras/models.py
+++ b/keras/models.py
@@ -708,7 +708,7 @@ class Sequential(Model):
             self.build()
         self.model.set_weights(weights)
 
-    def load_weights(self, filepath, by_name=False):
+    def load_weights(self, filepath, by_name=False, original_backend=None):
         if h5py is None:
             raise ImportError('`load_weights` requires h5py.')
         f = h5py.File(filepath, mode='r')
@@ -721,9 +721,9 @@ class Sequential(Model):
         else:
             layers = self.layers
         if by_name:
-            topology.load_weights_from_hdf5_group_by_name(f, layers)
+            topology.load_weights_from_hdf5_group_by_name(f, layers, original_backend)
         else:
-            topology.load_weights_from_hdf5_group(f, layers)
+            topology.load_weights_from_hdf5_group(f, layers, original_backend)
         if hasattr(f, 'close'):
             f.close()
 

--- a/tests/keras/engine/test_topology.py
+++ b/tests/keras/engine/test_topology.py
@@ -516,7 +516,8 @@ def test_load_layers():
     td_conv_layer.layer.data_format = 'channels_first'
     weight_tensor_td_conv_new = preprocess_weights_for_loading(td_conv_layer,
                                                                weight_tensor_td_conv_old,
-                                                               original_keras_version='1')
+                                                               original_keras_version='1',
+                                                               original_backend='theano')
     symbolic_weights = td_conv_layer.weights
     assert (len(symbolic_weights) == len(weight_tensor_td_conv_new))
     weight_value_tuples += zip(symbolic_weights, weight_tensor_td_conv_new)
@@ -533,7 +534,8 @@ def test_load_layers():
     bi_convlstm_layer = model.layers[2]
     weight_tensor_bi_convlstm_new = preprocess_weights_for_loading(bi_convlstm_layer,
                                                                    weight_tensor_bi_convlstm_old,
-                                                                   original_keras_version='1')
+                                                                   original_keras_version='1',
+                                                                   original_backend='tensorflow')
 
     symbolic_weights = bi_convlstm_layer.weights
     assert (len(symbolic_weights) == len(weight_tensor_bi_convlstm_new))


### PR DESCRIPTION
@fchollet This is the start of a fix for the `channels_first` weight loading bug. The bug is due to loading weights from Keras 1 models that used the Tensorflow backend. The current weight loading code assumes all Keras 1 models have Theano dim ordering and so things get messed up. Also the `original_backend` is not found automatically in the old models and so is set to `None`, which makes it difficult or impossible to always convert correctly. Thus I made it so the user can specify the `original_backend` so things can be appropriately converted. Note that I removed `layer_utils.convert_all_kernels_in_model(model)` from the vgg16 example since the weight loading code takes care of the kernel flipping already.

TODO:
1) Properly handle `Conv1D ` and `Conv2DTranspose`. I wasn't sure exactly what to do here so I left it alone, but the same issues probably apply.
2) Fix other applications where weight loading is a problem.