### PR TITLE
Fix valid condition for TF <-> TH conversion of Conv1D

### DIFF
--- a/keras/utils/conv_utils.py
+++ b/keras/utils/conv_utils.py
@@ -70,7 +70,7 @@ def convert_kernel(kernel):
     Also works reciprocally, since the transformation is its own inverse.
 
     # Arguments
-        kernel: Numpy array (4D or 5D).
+        kernel: Numpy array (3D, 4D or 5D).
 
     # Returns
         The converted kernel.
@@ -79,7 +79,7 @@ def convert_kernel(kernel):
         ValueError: in case of invalid kernel shape or invalid data_format.
     """
     kernel = np.asarray(kernel)
-    if not 4 <= kernel.ndim <= 5:
+    if not 3 <= kernel.ndim <= 5:
         raise ValueError('Invalid kernel shape:', kernel.shape)
     slices = [slice(None, None, -1) for _ in range(kernel.ndim)]
     no_flip = (slice(None, None), slice(None, None))


### PR DESCRIPTION
This PR modifies a miscondition that can not make 3D kernels in `Conv1D` pass the `convert_kernel` function.