### PR TITLE
Update variational_autoencoder.py

### DIFF
--- a/examples/variational_autoencoder.py
+++ b/examples/variational_autoencoder.py
@@ -51,7 +51,7 @@ class CustomVariationalLayer(Layer):
     def vae_loss(self, x, x_decoded_mean):
         xent_loss = original_dim * metrics.binary_crossentropy(x, x_decoded_mean)
         kl_loss = - 0.5 * K.sum(1 + z_log_var - K.square(z_mean) - K.exp(z_log_var), axis=-1)
-        return K.mean(xent_loss + kl_loss)
+        return K.mean(xent_loss - kl_loss)
 
     def call(self, inputs):
         x = inputs[0]

--- a/examples/variational_autoencoder.py
+++ b/examples/variational_autoencoder.py
@@ -49,7 +49,7 @@ class CustomVariationalLayer(Layer):
         super(CustomVariationalLayer, self).__init__(**kwargs)
 
     def vae_loss(self, x, x_decoded_mean):
-        xent_loss = original_dim * metrics.binary_crossentropy(x, x_decoded_mean)
+        xent_loss = metrics.binary_crossentropy(x, x_decoded_mean)
         kl_loss = - 0.5 * K.sum(1 + z_log_var - K.square(z_mean) - K.exp(z_log_var), axis=-1)
         return K.mean(xent_loss - kl_loss)
 


### PR DESCRIPTION
In the paper, the first item of loss is -KL(q(z|x),p(z)) and -KL(q(z|x),p(z)) = 0.5 * K.sum(1 + z_log_var - K.square(z_mean) - K.exp(z_log_var), axis=-1), so I think if you define kl_loss = - 0.5 * K.sum(1 + z_log_var - K.square(z_mean) - K.exp(z_log_var), axis=-1), you should use loss = xent_loss - kl_loss