### PR TITLE
Fix AttributeError in HDF5Matrix 

### DIFF
--- a/keras/utils/io_utils.py
+++ b/keras/utils/io_utils.py
@@ -62,8 +62,8 @@ class HDF5Matrix(object):
         return self.end - self.start
 
     def __getitem__(self, key):
-        start, stop = key.start, key.stop
         if isinstance(key, slice):
+            start, stop = key.start, key.stop
             if start is None:
                 start = 0
             if stop is None:


### PR DESCRIPTION
In #6299 better support for slicing was added in HDF5Matrix. I experienced an AttributeError in my code caused by line 65 in this commit, where the `start` and `stop` attributes would be requested for inputs that can include integers and lists. This line was moved to the slice `if` block.