### PR TITLE
Fix error in test_saving_without_compilation

### DIFF
--- a/tests/test_model_saving.py
+++ b/tests/test_model_saving.py
@@ -76,7 +76,7 @@ def test_sequential_model_saving_2():
 
 
 @keras_test
-def test_fuctional_model_saving():
+def test_functional_model_saving():
     input = Input(shape=(3,))
     x = Dense(2)(input)
     output = Dense(3)(x)
@@ -131,10 +131,12 @@ def test_saving_multiple_metrics_outputs():
 
 @keras_test
 def test_saving_without_compilation():
+    """
+    test saving model without compiling
+    """
     model = Sequential()
     model.add(Dense(2, input_shape=(3,)))
     model.add(Dense(3))
-    model.compile(loss='mse', optimizer='sgd', metrics=['acc'])
 
     _, fname = tempfile.mkstemp('.h5')
     save_model(model, fname)

--- a/tests/test_model_saving.py
+++ b/tests/test_model_saving.py
@@ -131,8 +131,7 @@ def test_saving_multiple_metrics_outputs():
 
 @keras_test
 def test_saving_without_compilation():
-    """
-    test saving model without compiling
+    """Test saving model without compiling.
     """
     model = Sequential()
     model.add(Dense(2, input_shape=(3,)))


### PR DESCRIPTION
Small fix to test_saving_without_compilation. Currently the test calls compile before saving which does not appear to be the intended behavior of the test.