### PR TITLE
Add a directory iterator option to allow to work easily with autoencoders (issue #4260)

### DIFF
--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -838,7 +838,8 @@ class DirectoryIterator(Iterator):
             `"binary"`: binary targets (if there are only two classes),
             `"categorical"`: categorical targets,
             `"sparse"`: integer targets,
-            `"identical"`: image targets identical to input images,
+            `"input"`: targets are images identical to input images (mainly
+                used to work with autoencoders),
             `None`: no targets get yielded (only input images are yielded).
         batch_size: Integer, size of a batch.
         shuffle: Boolean, whether to shuffle the data between epochs.
@@ -883,10 +884,10 @@ class DirectoryIterator(Iterator):
                 self.image_shape = (1,) + self.target_size
         self.classes = classes
         if class_mode not in {'categorical', 'binary', 'sparse',
-                              'identical', None}:
+                              'input', None}:
             raise ValueError('Invalid class_mode:', class_mode,
                              '; expected one of "categorical", '
-                             '"binary", "sparse", "identical"'
+                             '"binary", "sparse", "input"'
                              ' or None.')
         self.class_mode = class_mode
         self.save_to_dir = save_to_dir
@@ -975,7 +976,7 @@ class DirectoryIterator(Iterator):
                                                                   format=self.save_format)
                 img.save(os.path.join(self.save_to_dir, fname))
         # build batch of labels
-        if self.class_mode == 'identical':
+        if self.class_mode == 'input':
             batch_y = batch_x.copy()
         elif self.class_mode == 'sparse':
             batch_y = self.classes[index_array]

--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -838,6 +838,7 @@ class DirectoryIterator(Iterator):
             `"binary"`: binary targets (if there are only two classes),
             `"categorical"`: categorical targets,
             `"sparse"`: integer targets,
+            `"identical"`: image targets identical to input images,
             `None`: no targets get yielded (only input images are yielded).
         batch_size: Integer, size of a batch.
         shuffle: Boolean, whether to shuffle the data between epochs.
@@ -881,10 +882,12 @@ class DirectoryIterator(Iterator):
             else:
                 self.image_shape = (1,) + self.target_size
         self.classes = classes
-        if class_mode not in {'categorical', 'binary', 'sparse', None}:
+        if class_mode not in {'categorical', 'binary', 'sparse',
+                              'identical', None}:
             raise ValueError('Invalid class_mode:', class_mode,
                              '; expected one of "categorical", '
-                             '"binary", "sparse", or None.')
+                             '"binary", "sparse", "identical"'
+                             ' or None.')
         self.class_mode = class_mode
         self.save_to_dir = save_to_dir
         self.save_prefix = save_prefix
@@ -972,7 +975,9 @@ class DirectoryIterator(Iterator):
                                                                   format=self.save_format)
                 img.save(os.path.join(self.save_to_dir, fname))
         # build batch of labels
-        if self.class_mode == 'sparse':
+        if self.class_mode == 'identical':
+            batch_y = batch_x.copy()
+        elif self.class_mode == 'sparse':
             batch_y = self.classes[index_array]
         elif self.class_mode == 'binary':
             batch_y = self.classes[index_array].astype(K.floatx())

--- a/tests/keras/preprocessing/image_test.py
+++ b/tests/keras/preprocessing/image_test.py
@@ -160,6 +160,32 @@ class TestImage:
         assert(sorted(dir_iterator.filenames) == sorted(filenames))
         shutil.rmtree(tmp_folder)
 
+    def test_directory_iterator_class_mode_identical(self):
+        tmp_folder = tempfile.mkdtemp(prefix='test_images')
+        os.mkdir(os.path.join(tmp_folder, 'class-1'))
+
+        # save the images in the paths
+        count = 0
+        for test_images in self.all_test_images:
+            for im in test_images:
+                filename = os.path.join(tmp_folder, 'class-1', 'image-{}.jpg'.format(count))
+                im.save(os.path.join(tmp_folder, filename))
+                count += 1
+
+        # create iterator
+        generator = image.ImageDataGenerator()
+        dir_iterator = generator.flow_from_directory(tmp_folder, class_mode='identical')
+        batch = next(dir_iterator)
+
+        # check if input and output have the same shape
+        assert(batch[0].shape == batch[1].shape)
+        # check if the input and output images are not the same numpy array
+        input_img = batch[0][0]
+        output_img = batch[1][0]
+        output_img[0][0][0] += 1
+        assert(input_img[0][0][0] != output_img[0][0][0])
+        shutil.rmtree(tmp_folder)
+
     def test_img_utils(self):
         height, width = 10, 8
 

--- a/tests/keras/preprocessing/image_test.py
+++ b/tests/keras/preprocessing/image_test.py
@@ -160,7 +160,7 @@ class TestImage:
         assert(sorted(dir_iterator.filenames) == sorted(filenames))
         shutil.rmtree(tmp_folder)
 
-    def test_directory_iterator_class_mode_identical(self):
+    def test_directory_iterator_class_mode_input(self):
         tmp_folder = tempfile.mkdtemp(prefix='test_images')
         os.mkdir(os.path.join(tmp_folder, 'class-1'))
 
@@ -174,7 +174,7 @@ class TestImage:
 
         # create iterator
         generator = image.ImageDataGenerator()
-        dir_iterator = generator.flow_from_directory(tmp_folder, class_mode='identical')
+        dir_iterator = generator.flow_from_directory(tmp_folder, class_mode='input')
         batch = next(dir_iterator)
 
         # check if input and output have the same shape


### PR DESCRIPTION
This patch adds a new class_mode to keras.preprocessing.image.ImageDataGenerator.flow_from_directory method. 

This new class_mode is 'identical' and it allows to generate minibatches where the target values are identical to input values. It makes working with autoencoders trivial. This issue has been described in #4260. The patch also contains tests that ensure that the input images are not the same numpy array as target images. 