### PR TITLE
Added weight name mapping for Tensorboard callback

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -603,6 +603,8 @@ class TensorBoard(Callback):
             [details](https://www.tensorflow.org/how_tos/embedding_viz/#metadata_optional)
             about metadata files format. In case if the same metadata file is
             used for all embedding layers, string can be passed.
+        weight_name_mapping: a function mapping from original weight names
+            to names to be displayed inside TensorBoard.
     """
 
     def __init__(self, log_dir='./logs',
@@ -612,7 +614,8 @@ class TensorBoard(Callback):
                  write_images=False,
                  embeddings_freq=0,
                  embeddings_layer_names=None,
-                 embeddings_metadata=None):
+                 embeddings_metadata=None,
+                 weight_name_mapping=lambda x: x.replace(":", "_")):
         super(TensorBoard, self).__init__()
         if K.backend() != 'tensorflow':
             raise RuntimeError('TensorBoard callback only works '
@@ -626,6 +629,7 @@ class TensorBoard(Callback):
         self.embeddings_freq = embeddings_freq
         self.embeddings_layer_names = embeddings_layer_names
         self.embeddings_metadata = embeddings_metadata or {}
+        self.weight_name_mapping = weight_name_mapping
 
     def set_model(self, model):
         self.model = model
@@ -634,11 +638,13 @@ class TensorBoard(Callback):
             for layer in self.model.layers:
 
                 for weight in layer.weights:
-                    tf.summary.histogram(weight.name, weight)
+                    tf.summary.histogram(self.weight_name_mapping(weight.name),
+                                         weight)
                     if self.write_grads:
                         grads = model.optimizer.get_gradients(model.total_loss,
                                                               weight)
-                        tf.summary.histogram('{}_grad'.format(weight.name), grads)
+                        tf.summary.histogram('{}_grad'.format(
+                            self.weight_name_mapping(weight.name)), grads)
                     if self.write_images:
                         w_img = tf.squeeze(weight)
                         shape = K.int_shape(w_img)
@@ -671,7 +677,8 @@ class TensorBoard(Callback):
 
                         shape = K.int_shape(w_img)
                         assert len(shape) == 4 and shape[-1] in [1, 3, 4]
-                        tf.summary.image(weight.name, w_img)
+                        tf.summary.image(self.weight_name_mapping(weight.name),
+                                         w_img)
 
                 if hasattr(layer, 'output'):
                     tf.summary.histogram('{}_out'.format(layer.name),


### PR DESCRIPTION
Should fix #5746 by providing a default mapping from ":" to "_" for weight names. Users can override the mapping to alter the display inside TensorBoard according to their liking.
