### PR TITLE
Fix failture of loading custom activation function with `keras.models.load_models(custom_objects=*)`

### DIFF
--- a/keras/models.py
+++ b/keras/models.py
@@ -12,6 +12,7 @@ import numpy as np
 from . import backend as K
 from . import optimizers
 from . import layers as layer_module
+from .utils.generic_utils import CustomObjectScope
 from .utils.io_utils import ask_to_proceed_with_overwrite
 from .engine.training import Model
 from .engine import topology
@@ -241,7 +242,13 @@ def load_model(filepath, custom_objects=None, compile=True):
     if model_config is None:
         raise ValueError('No model found in config file.')
     model_config = json.loads(model_config.decode('utf-8'))
-    model = model_from_config(model_config, custom_objects=custom_objects)
+
+    if custom_objects is None:
+        scope = CustomObjectScope({})
+    else:
+        scope = CustomObjectScope(custom_objects)
+    with scope:
+        model = model_from_config(model_config)
 
     # set weights
     topology.load_weights_from_hdf5_group(f['model_weights'], model.layers)

--- a/keras/models.py
+++ b/keras/models.py
@@ -12,7 +12,6 @@ import numpy as np
 from . import backend as K
 from . import optimizers
 from . import layers as layer_module
-from .utils.generic_utils import CustomObjectScope
 from .utils.io_utils import ask_to_proceed_with_overwrite
 from .engine.training import Model
 from .engine import topology
@@ -242,13 +241,7 @@ def load_model(filepath, custom_objects=None, compile=True):
     if model_config is None:
         raise ValueError('No model found in config file.')
     model_config = json.loads(model_config.decode('utf-8'))
-
-    if custom_objects is None:
-        scope = CustomObjectScope({})
-    else:
-        scope = CustomObjectScope(custom_objects)
-    with scope:
-        model = model_from_config(model_config)
+    model = model_from_config(model_config, custom_objects=custom_objects)
 
     # set weights
     topology.load_weights_from_hdf5_group(f['model_weights'], model.layers)

--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -133,16 +133,18 @@ def deserialize_keras_object(identifier, module_objects=None,
                                  ': ' + class_name)
         if hasattr(cls, 'from_config'):
             arg_spec = inspect.getargspec(cls.from_config)
+            custom_objects = custom_objects or {}
             if 'custom_objects' in arg_spec.args:
-                custom_objects = custom_objects or {}
                 return cls.from_config(config['config'],
                                        custom_objects=dict(list(_GLOBAL_CUSTOM_OBJECTS.items()) +
                                                            list(custom_objects.items())))
-            return cls.from_config(config['config'])
+            with CustomObjectScope(custom_objects):
+                return cls.from_config(config['config'])
         else:
             # Then `cls` may be a function returning a class.
             # in this case by convention `config` holds
             # the kwargs of the function.
+            custom_objects = custom_objects or {}
             with CustomObjectScope(custom_objects):
                 return cls(**config['config'])
     elif isinstance(identifier, six.string_types):

--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -143,7 +143,8 @@ def deserialize_keras_object(identifier, module_objects=None,
             # Then `cls` may be a function returning a class.
             # in this case by convention `config` holds
             # the kwargs of the function.
-            return cls(**config['config'])
+            with CustomObjectScope(custom_objects):
+                return cls(**config['config'])
     elif isinstance(identifier, six.string_types):
         function_name = identifier
         if custom_objects and function_name in custom_objects:

--- a/tests/test_model_saving.py
+++ b/tests/test_model_saving.py
@@ -4,7 +4,7 @@ import tempfile
 import numpy as np
 from numpy.testing import assert_allclose
 
-from keras import backend
+from keras import backend as K
 from keras.models import Model, Sequential
 from keras.layers import Dense, Lambda, RepeatVector, TimeDistributed
 from keras.layers import Input
@@ -296,7 +296,7 @@ def test_saving_lambda_custom_objects():
 @keras_test
 def test_saving_custom_activation_function():
     x = Input(shape=(3,))
-    output = Dense(3, activation=backend.cos)(x)
+    output = Dense(3, activation=K.cos)(x)
 
     model = Model(x, output)
     model.compile(loss=losses.MSE,
@@ -310,7 +310,7 @@ def test_saving_custom_activation_function():
     _, fname = tempfile.mkstemp('.h5')
     save_model(model, fname)
 
-    model = load_model(fname, custom_objects={'cos': backend.cos})
+    model = load_model(fname, custom_objects={'cos': K.cos})
     os.remove(fname)
 
     out2 = model.predict(x)

--- a/tests/test_model_saving.py
+++ b/tests/test_model_saving.py
@@ -14,6 +14,7 @@ from keras import metrics
 from keras.utils.test_utils import keras_test
 from keras.models import save_model, load_model
 
+
 @keras_test
 def test_sequential_model_saving():
     model = Sequential()
@@ -314,6 +315,6 @@ def test_saving_custom_activation_function():
 
     out2 = model.predict(x)
     assert_allclose(out, out2, atol=1e-05)
-    
+
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
Custom activation functon can't load with `keras.models.load_models(custom_objects=*)`, because given`custom_objects` doesn't bypass to `deserialize_keras_object()` through `keras.activations.get()`.

In initialization of layer (`Layer.__init__()`), the custom activation function is given as an `activation` argument as a string identifier, and deserialize it by calling `keras.activations.get()`. However, layers and `keras.activations.get()` don't take `custom_objects` as an argument. The deserialization of custom activation function is failed with `Unknown activation function` error.

To fix this bug,  use `CustomObjectScope` in `keras.models.load_models()`. By doing so, bypassing `custom_objects` over many function is not required.

Test code:
```python
import keras
import keras.backend as K
import keras.layers as L
import keras.engine import Input, Model

x = Input((28,))
y = L.Dense(10, activation=K.sin)(x)
model = Model(x, y)
model.save('model.h5')
```

Failed code
```python
import keras
import keras.backend as K

keras.models.load_models('model.h5', custom_objects={'sin': K.sin})
```
```
ValueError: ('Unknown activation function', ':sin')
```

Succeeded code
```python
import keras
import keras.backend as K
from keras.genetic_utils import CustomObjectScope

with CustomObjectScope({'sin': K.sin}):
  keras.models.load_models('model.h5')
```