### PR TITLE
Fix get_file download progress bar

### DIFF
--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -186,6 +186,9 @@ def get_file(fname,
 
     if download:
         print('Downloading data from', origin)
+
+        # Closures: Use a dictionary workaround To support python2, 
+        # since `nonlocal` is only support in python3.
         enclosed = {'progbar': None}
 
         def dl_progress(count, block_size, total_size):

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -186,19 +186,18 @@ def get_file(fname,
 
     if download:
         print('Downloading data from', origin)
-        progbar = None
+        enclosed = {'progbar': None}
 
-        def dl_progress(count, block_size, total_size, progbar=None):
-            if progbar is None:
-                progbar = Progbar(total_size)
+        def dl_progress(count, block_size, total_size):
+            if enclosed['progbar'] is None:
+                enclosed['progbar'] = Progbar(total_size)
             else:
-                progbar.update(count * block_size)
+                enclosed['progbar'].update(count * block_size)
 
         error_msg = 'URL fetch failure on {}: {} -- {}'
         try:
             try:
-                urlretrieve(origin, fpath,
-                            functools.partial(dl_progress, progbar=progbar))
+                urlretrieve(origin, fpath, dl_progress)
             except URLError as e:
                 raise Exception(error_msg.format(origin, e.errno, e.reason))
             except HTTPError as e:

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -187,7 +187,7 @@ def get_file(fname,
     if download:
         print('Downloading data from', origin)
 
-        # Closures: Use a dictionary workaround To support python2, 
+        # Closures: Use a dictionary workaround To support python2,
         # since `nonlocal` is only support in python3.
         enclosed = {'progbar': None}
 


### PR DESCRIPTION
get_file doesn't currently display the progress bar because the if statement on line 192 is always true.
Since the `nonlocal` statement is only supported in Python 3, I used the [dictionary workaround](https://technotroph.wordpress.com/2012/10/01/python-closures-and-the-python-2-7-nonlocal-solution/) to support Python 2.