### PR TITLE
Don't rate limit final Progbar update

### DIFF
--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -246,7 +246,7 @@ class Progbar(object):
 
         now = time.time()
         if self.verbose == 1:
-            if not force and (now - self.last_update) < self.interval:
+            if not force and (now - self.last_update) < self.interval and current < self.target:
                 return
 
             prev_total_width = self.total_width


### PR DESCRIPTION
This PR fixes the case when using small batch sizes in `evaluate` and `predict`, the final update may be randomly throttled and the total elapsed time is not displayed. 
Note that `fit` does not suffer from this problem because it uses the `ProgbarLogger` and forces the update `on_epoch_end`.