### PR TITLE
Display current percentage in Progbar

### DIFF
--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -265,7 +265,7 @@ class Progbar(object):
                 else:
                     bar += '='
             bar += ('.' * (self.width - prog_width))
-            bar += ']'
+            bar += '] %6.2f%%' % (prog * 100, )
             sys.stdout.write(bar)
             self.total_width = len(bar)
 


### PR DESCRIPTION
This PR adds a current percentage display to the right of the progress bar, I would say this improves the user experience since most users are accustomed to seeing a percentage number besides a progress bar.
Example:
` 348928/1071643 [========>.....................]  `**`32.56%`**` - ETA: 149s - loss: 0.1342 - acc: 0.9549`