### PR TITLE
Enable 2-D input length tensor with second dimension 1

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -3529,6 +3529,10 @@ def ctc_decode(y_pred, input_length, greedy=True, beam_width=100,
                 the log probability of each decoded sequence.
     """
     y_pred = tf.log(tf.transpose(y_pred, perm=[1, 0, 2]) + 1e-8)
+
+    if len(input_length.shape) == 2 and input_length.shape[1] == 1:
+        input_length = tf.reshape(input_length, [-1])
+
     input_length = tf.to_int32(input_length)
 
     if greedy:


### PR DESCRIPTION
Since the input length tensor provided by users is typically a 2-D tensor of dimension (nsamples, 1) when training with mini-batches, this modification simplifies client code by flattening the second dimension to avoid rank mismatch errors down the chain. 