### PR TITLE
Fix hyperlink misrendering in documentation

### DIFF
--- a/docs/autogen.py
+++ b/docs/autogen.py
@@ -387,7 +387,7 @@ def process_class_docstring(docstring):
                        r'\n    __\1__\n\n',
                        docstring)
 
-    docstring = re.sub(r'    ([^\s\\]+):(.*)\n',
+    docstring = re.sub(r'    ([^\s\\\(]+):(.*)\n',
                        r'    - __\1__:\2\n',
                        docstring)
 
@@ -405,7 +405,7 @@ def process_function_docstring(docstring):
                        r'\n        __\1__\n\n',
                        docstring)
 
-    docstring = re.sub(r'    ([^\s\\]+):(.*)\n',
+    docstring = re.sub(r'    ([^\s\\\(]+):(.*)\n',
                        r'    - __\1__:\2\n',
                        docstring)
 


### PR DESCRIPTION
Two hyperlinks (namely `[here]` and `[details]`) are misrendered in TensorBoard callback documentation, see https://keras.io/callbacks/#tensorboard. PR excludes `(` in argument names, because otherwise `[link](http://` is rendered as a function/class argument.