### PR TITLE
TensorBoard: Embed only given layers

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -707,7 +707,7 @@ class TensorBoard(Callback):
 
             config = projector.ProjectorConfig()
             self.embeddings_ckpt_path = os.path.join(self.log_dir,
-                                                    'keras_embedding.ckpt')
+                                                     'keras_embedding.ckpt')
 
             for layer_name, tensor in embeddings.items():
                 embedding = config.embeddings.add()

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -685,8 +685,6 @@ class TensorBoard(Callback):
             self.writer = tf.summary.FileWriter(self.log_dir)
 
         if self.embeddings_freq:
-            self.saver = tf.train.Saver()
-
             embeddings_layer_names = self.embeddings_layer_names
 
             if not embeddings_layer_names:
@@ -697,6 +695,8 @@ class TensorBoard(Callback):
                           for layer in self.model.layers
                           if layer.name in embeddings_layer_names}
 
+            self.saver = tf.train.Saver(list(embeddings.values()))
+
             embeddings_metadata = {}
 
             if not isinstance(self.embeddings_metadata, str):
@@ -706,14 +706,12 @@ class TensorBoard(Callback):
                                        for layer_name in embeddings.keys()}
 
             config = projector.ProjectorConfig()
-            self.embeddings_logs = []
+            self.embeddings_ckpt_path = os.path.join(self.log_dir,
+                                                    'keras_embedding.ckpt')
 
             for layer_name, tensor in embeddings.items():
                 embedding = config.embeddings.add()
                 embedding.tensor_name = tensor.name
-
-                self.embeddings_logs.append(os.path.join(self.log_dir,
-                                                         layer_name + '.ckpt'))
 
                 if layer_name in embeddings_metadata:
                     embedding.metadata_path = embeddings_metadata[layer_name]
@@ -742,10 +740,11 @@ class TensorBoard(Callback):
                 summary_str = result[0]
                 self.writer.add_summary(summary_str, epoch)
 
-        if self.embeddings_freq and self.embeddings_logs:
+        if self.embeddings_freq and self.embeddings_ckpt_path:
             if epoch % self.embeddings_freq == 0:
-                for log in self.embeddings_logs:
-                    self.saver.save(self.sess, log, epoch)
+                self.saver.save(self.sess,
+                                self.embeddings_ckpt_path,
+                                epoch)
 
         for name, value in logs.items():
             if name in ['batch', 'size']:

--- a/tests/keras/test_callbacks.py
+++ b/tests/keras/test_callbacks.py
@@ -318,7 +318,9 @@ def test_TensorBoard():
                   metrics=['accuracy'])
 
     tsb = callbacks.TensorBoard(log_dir=filepath, histogram_freq=1,
-                                write_images=True, write_grads=True)
+                                write_images=True, write_grads=True,
+                                embeddings_freq=1,
+                                embeddings_layer_names=['dense_1'])
     cbks = [tsb]
 
     # fit with validation data


### PR DESCRIPTION
As @smyskoff diagnosed in https://github.com/fchollet/keras/pull/5247, tensorboard callback records weights of __all layers__ by default and does not respect the `embeddings_layer_names` parameter since `tf.train.Saver()` is instantiated without arguments. This PR fixes that.

I also replaced the self.embeddings_logs list with a string, so that variables are serialized to only one file, which is sufficient. Test case is also added.