### PR TITLE
Small fixes for Neural_Doodle example

### DIFF
--- a/examples/neural_doodle.py
+++ b/examples/neural_doodle.py
@@ -196,8 +196,8 @@ x = mask_input
 for layer in image_model.layers[1:]:
     name = 'mask_%s' % layer.name
     if 'conv' in layer.name:
-        x = AveragePooling2D((3, 3), strides=(
-            1, 1), name=name, border_mode='same')(x)
+        x = AveragePooling2D((3, 3), padding="same", strides=(
+            1, 1), name=name)(x)
     elif 'pool' in layer.name:
         x = AveragePooling2D((2, 2), name=name)(x)
 mask_model = Model(mask_input, x)

--- a/examples/neural_doodle.py
+++ b/examples/neural_doodle.py
@@ -196,7 +196,7 @@ x = mask_input
 for layer in image_model.layers[1:]:
     name = 'mask_%s' % layer.name
     if 'conv' in layer.name:
-        x = AveragePooling2D((3, 3), padding="same", strides=(
+        x = AveragePooling2D((3, 3), padding='same', strides=(
             1, 1), name=name)(x)
     elif 'pool' in layer.name:
         x = AveragePooling2D((2, 2), name=name)(x)

--- a/examples/neural_doodle.py
+++ b/examples/neural_doodle.py
@@ -238,6 +238,7 @@ def region_style_loss(style_image, target_image, style_mask, target_mask):
         masked_target = K.permute_dimensions(
             target_image, (2, 0, 1)) * target_mask
         num_channels = K.shape(style_image)[-1]
+    num_channels = K.cast(num_channels, dtype='float32')
     s = gram_matrix(masked_style) / K.mean(style_mask) / num_channels
     c = gram_matrix(masked_target) / K.mean(target_mask) / num_channels
     return K.mean(K.square(s - c))


### PR DESCRIPTION
1) Fixed type cast in region_style_loss() which prevented example to run: K.shape returns int32, but variable was immediately used in division operation which requires float32.

```
File "neural_doodle.py", line 241, in region_style_loss
    s = gram_matrix(masked_style) / K.mean(style_mask) / num_channels
ValueError: Tensor conversion requested dtype float32 for Tensor with dtype int32: 'Tensor("strided_slice_8:0", shape=(), dtype=int32)'
```

2) Also updated argument in AveragePooling2D usage to match Keras2 API. Put 'padding' instead of older 'border_mode'

```
neural_doodle.py:200: UserWarning: Update your `AveragePooling2D` call to the Keras 2 API: `AveragePooling2D((3, 3), padding="same", strides=(1, 1), name="mask_block1_conv1")`
  1, 1), name=name, border_mode='same')(x)
```
