### PR TITLE
Fix for inputs without _keras_shape, allowing custom layers to use layer objects internally

### DIFF
--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -2256,7 +2256,7 @@ class Container(Layer):
             self._output_mask_cache[cache_key] = output_masks
 
         if output_shapes is not None:
-            input_shapes = [x._keras_shape for x in inputs]
+            input_shapes = [x._keras_shape if hasattr(x, '_keras_shape') else K.int_shape(x) for x in inputs]
             cache_key = ','.join([str(x) for x in input_shapes])
             if len(output_shapes) == 1:
                 output_shapes = output_shapes[0]


### PR DESCRIPTION
I tried to create a new custom layer that uses another layer object internally. But when I create a model with this layer and try to pass in a raw tensorflow tensor to the model, I get an exception. A minimal example is as follows:

```python
from keras.models import Sequential
from keras.layers import Conv2D, Layer
import tensorflow as tf


class CustomLayer(Layer):
    def __init__(self, **kwargs):
        super().__init__(**kwargs)
        self.conv_layer = None

    def build(self, batch_input_shape):
        self.conv_layer = Conv2D(filters=10, kernel_size=(3, 3),
                                 batch_input_shape=batch_input_shape)
        self.built = True

    def call(self, x):
        return self.conv_layer(x)


batch_input_shape = [16, 128, 128, 3]

model = Sequential()
model.add(CustomLayer(batch_input_shape=batch_input_shape))

x = tf.placeholder(shape=batch_input_shape, dtype=tf.float32)
model(x)
```

The call `model(x)` raises the following exception:

    Traceback (most recent call last):
      File "/home/sarandi/pose/pycharm/pose/minimal_example.py", line 26, in <module>
        model(x)
      File "/home/sarandi/anaconda3/lib/python3.6/site-packages/keras/engine/topology.py", line 585, in __call__
        output = self.call(inputs, **kwargs)
      File "/home/sarandi/anaconda3/lib/python3.6/site-packages/keras/models.py", line 523, in call
        return self.model.call(inputs, mask)
      File "/home/sarandi/anaconda3/lib/python3.6/site-packages/keras/engine/topology.py", line 2027, in call
        output_tensors, _, _ = self.run_internal_graph(inputs, masks)
      File "/home/sarandi/anaconda3/lib/python3.6/site-packages/keras/engine/topology.py", line 2260, in run_internal_graph
        input_shapes = [x._keras_shape for x in inputs]
      File "/home/sarandi/anaconda3/lib/python3.6/site-packages/keras/engine/topology.py", line 2260, in <listcomp>
        input_shapes = [x._keras_shape for x in inputs]
    AttributeError: 'Tensor' object has no attribute '_keras_shape'

The problem seems to be that the relevant part of `topology.py` assumes that just because the output tensors have their `_keras_shape`s defined, the `inputs` will also have them. However, in this case the inputs are raw tensorflow tensors and the outputs are the outputs of the internally used Conv2D layer.

The error goes away after appying the changes in this pull request.
