### PR TITLE
Fix bug in EarlyStopping to reset stopped_epoch

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -482,7 +482,9 @@ class EarlyStopping(Callback):
             self.min_delta *= -1
 
     def on_train_begin(self, logs=None):
-        self.wait = 0  # Allow instances to be re-used
+        # Allow instances to be re-used
+        self.wait = 0
+        self.stopped_epoch = 0
         self.best = np.Inf if self.monitor_op == np.less else -np.Inf
 
     def on_epoch_end(self, epoch, logs=None):


### PR DESCRIPTION
Fix bug in EarlyStopping to reset stopped_epoch in on_train_begin to allow it to be re-used. This code change allows me to know check EarlyStopping.stopped_epoch after each train to figure out if this callback triggered and at which epoch.

My exact use case is I have created a custom callback which may also trigger self.model.stop_training, just like EarlyStopping . If my custom callback triggers self.model.stop_training then the EarlyStopping callback will have stopped_epoch set to some value from a previous train.