### PR TITLE
Better error message for invalid functional api inputs (#6589)

### DIFF
--- a/keras/backend/__init__.py
+++ b/keras/backend/__init__.py
@@ -10,7 +10,6 @@ from .common import set_floatx
 from .common import cast_to_floatx
 from .common import image_data_format
 from .common import set_image_data_format
-from .common import is_keras_tensor
 
 # Obtain Keras base dir path: either ~/.keras or /tmp.
 _keras_base_dir = os.path.expanduser('~')

--- a/keras/backend/common.py
+++ b/keras/backend/common.py
@@ -145,35 +145,6 @@ def set_image_data_format(data_format):
     _IMAGE_DATA_FORMAT = str(data_format)
 
 
-def is_keras_tensor(x):
-    """Returns whether `x` is a Keras tensor.
-
-    # Arguments
-        x: a potential tensor.
-
-    # Returns
-        A boolean: whether the argument is a Keras tensor.
-
-    # Examples
-    ```python
-        >>> from keras import backend as K
-        >>> np_var = numpy.array([1, 2])
-        >>> K.is_keras_tensor(np_var)
-        False
-        >>> keras_var = K.variable(np_var)
-        >>> K.is_keras_tensor(keras_var)  # A variable is not a Tensor.
-        False
-        >>> keras_placeholder = K.placeholder(shape=(2, 4, 5))
-        >>> K.is_keras_tensor(keras_placeholder)  # A placeholder is a Tensor.
-        True
-    ```
-    """
-    if hasattr(x, '_keras_shape'):
-        return True
-    else:
-        return False
-
-
 # Legacy methods
 
 def set_image_dim_ordering(dim_ordering):

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -4,6 +4,7 @@ from tensorflow.python.ops import tensor_array_ops
 from tensorflow.python.ops import control_flow_ops
 from tensorflow.python.ops import functional_ops
 from tensorflow.python.ops import ctc_ops as ctc
+from tensorflow.python.ops import variables
 
 from collections import defaultdict
 import numpy as np
@@ -364,13 +365,16 @@ def is_keras_tensor(x):
         A boolean: whether the argument is a Keras tensor.
 
     # Raises
-        ValueError: in case `x` is not a supported tensor type.
+        ValueError: in case `x` is not a symbolic tensor.
 
     # Examples
     ```python
         >>> from keras import backend as K
         >>> np_var = numpy.array([1, 2])
         >>> K.is_keras_tensor(np_var)
+        ValueError
+        >>> k_var = tf.placeholder('float32', shape=(1,1))
+        >>> K.is_keras_tensor(k_var)
         False
         >>> keras_var = K.variable(np_var)
         >>> K.is_keras_tensor(keras_var)  # A variable is not a Tensor.
@@ -381,11 +385,10 @@ def is_keras_tensor(x):
     ```
     """
     if not isinstance(x, (tf.Tensor,
-                          tf.python.ops.variables.Variable)):
-        raise ValueError('Unexpectedly found an instance of type `' + str(type(x)) + '`.' +
-                         'Expected an instance of keras Tensor.')
-
-    return hasattr(x, '_keras_shape')
+                          variables.Variable)):
+        raise ValueError('Unexpectedly found an instance of type `' + str(type(x)) + '`. '
+                         'Expected a symbolic tensor instance.')
+    return hasattr(x, '_keras_history')
 
 
 def placeholder(shape=None, ndim=None, dtype=None, sparse=False, name=None):

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -353,6 +353,7 @@ def constant(value, dtype=None, shape=None, name=None):
         dtype = floatx()
     return tf.constant(value, dtype=dtype, shape=shape, name=name)
 
+
 def is_keras_tensor(x):
     """Returns whether `x` is a Keras tensor.
 
@@ -376,10 +377,11 @@ def is_keras_tensor(x):
         True
     ```
     """
-    if hasattr(x, '_keras_shape') or isinstance(x, tf.Tensor):
-        return True
-    else:
-        return False
+    if not isinstance(x, tf.Tensor):
+        raise ValueError('Unexpectedly found an instance of type `' + str(type(x)) + '`.' +
+                    'Expected an instance of keras Tensor.')
+
+    return hasattr(x, '_keras_shape')
 
 
 def placeholder(shape=None, ndim=None, dtype=None, sparse=False, name=None):

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -363,6 +363,9 @@ def is_keras_tensor(x):
     # Returns
         A boolean: whether the argument is a Keras tensor.
 
+    # Raises
+        ValueError: in case `x` is not a supported tensor type.
+
     # Examples
     ```python
         >>> from keras import backend as K
@@ -377,9 +380,10 @@ def is_keras_tensor(x):
         True
     ```
     """
-    if not isinstance(x, tf.Tensor):
+    if not isinstance(x, (tf.Tensor,
+                          tf.python.ops.variables.Variable)):
         raise ValueError('Unexpectedly found an instance of type `' + str(type(x)) + '`.' +
-                    'Expected an instance of keras Tensor.')
+                         'Expected an instance of keras Tensor.')
 
     return hasattr(x, '_keras_shape')
 

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -353,6 +353,34 @@ def constant(value, dtype=None, shape=None, name=None):
         dtype = floatx()
     return tf.constant(value, dtype=dtype, shape=shape, name=name)
 
+def is_keras_tensor(x):
+    """Returns whether `x` is a Keras tensor.
+
+    # Arguments
+        x: a potential tensor.
+
+    # Returns
+        A boolean: whether the argument is a Keras tensor.
+
+    # Examples
+    ```python
+        >>> from keras import backend as K
+        >>> np_var = numpy.array([1, 2])
+        >>> K.is_keras_tensor(np_var)
+        False
+        >>> keras_var = K.variable(np_var)
+        >>> K.is_keras_tensor(keras_var)  # A variable is not a Tensor.
+        True
+        >>> keras_placeholder = K.placeholder(shape=(2, 4, 5))
+        >>> K.is_keras_tensor(keras_placeholder)  # A placeholder is a Tensor.
+        True
+    ```
+    """
+    if hasattr(x, '_keras_shape') or isinstance(x, tf.Tensor):
+        return True
+    else:
+        return False
+
 
 def placeholder(shape=None, ndim=None, dtype=None, sparse=False, name=None):
     """Instantiates a placeholder tensor and returns it.

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -371,16 +371,16 @@ def is_keras_tensor(x):
     ```python
         >>> from keras import backend as K
         >>> np_var = numpy.array([1, 2])
-        >>> K.is_keras_tensor(np_var)
+        >>> K.is_keras_tensor(np_var) # A numpy array is not a symbolic yensor.
         ValueError
         >>> k_var = tf.placeholder('float32', shape=(1,1))
-        >>> K.is_keras_tensor(k_var)
+        >>> K.is_keras_tensor(k_var) # A variable created directly from tensorflow/theano is not a Keras tensor.
         False
         >>> keras_var = K.variable(np_var)
-        >>> K.is_keras_tensor(keras_var)  # A variable is not a Tensor.
+        >>> K.is_keras_tensor(keras_var)  # A variable created with the keras backend is a Keras tensor.
         True
         >>> keras_placeholder = K.placeholder(shape=(2, 4, 5))
-        >>> K.is_keras_tensor(keras_placeholder)  # A placeholder is a Tensor.
+        >>> K.is_keras_tensor(keras_placeholder)  # A placeholder is a Keras tensor.
         True
     ```
     """

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -167,9 +167,10 @@ def constant(value, dtype=None, shape=None, name=None):
 def is_keras_tensor(x):
     """Returns whether `x` is a Keras tensor.
     """
-    if not isinstance(x, theano.tensor.TensorVariable):
+    if not isinstance(x, (T.TensorVariable,
+                          T.sharedvar.TensorSharedVariable)):
         raise ValueError('Unexpectedly found an instance of type `' + str(type(x)) + '`.' +
-                    'Expected an instance of keras Tensor.')
+                         'Expected an instance of keras Tensor.')
 
     return hasattr(x, '_keras_shape')
 

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -164,6 +164,15 @@ def constant(value, dtype=None, shape=None, name=None):
     return const
 
 
+def is_keras_tensor(x):
+    """Returns whether `x` is a Keras tensor.
+    """
+    if hasattr(x, '_keras_shape') or isinstance(x, theano.tensor.TensorVariable):
+        return True
+    else:
+        return False
+
+
 def placeholder(shape=None, ndim=None, dtype=None, sparse=False, name=None):
     """Instantiate an input data placeholder variable.
     """

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -180,16 +180,16 @@ def is_keras_tensor(x):
     ```python
         >>> from keras import backend as K
         >>> np_var = numpy.array([1, 2])
-        >>> K.is_keras_tensor(np_var)
+        >>> K.is_keras_tensor(np_var) # A numpy array is not a symbolic tensor.
         ValueError
         >>> k_var = theano.shared(value=np.array([1,2,3]))
-        >>> K.is_keras_tensor(k_var)
+        >>> K.is_keras_tensor(k_var) # A variable created directly from tensorflow/theano is not a Keras tensor.
         False
         >>> keras_var = K.variable(np_var)
-        >>> K.is_keras_tensor(keras_var)  # A variable is not a Tensor.
+        >>> K.is_keras_tensor(keras_var) # A variable created with the keras backend is a Keras tensor.
         True
         >>> keras_placeholder = K.placeholder(shape=(2, 4, 5))
-        >>> K.is_keras_tensor(keras_placeholder)  # A placeholder is a Tensor.
+        >>> K.is_keras_tensor(keras_placeholder)  # A placeholder is a Keras tensor.
         True
     ```
     """

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -167,10 +167,11 @@ def constant(value, dtype=None, shape=None, name=None):
 def is_keras_tensor(x):
     """Returns whether `x` is a Keras tensor.
     """
-    if hasattr(x, '_keras_shape') or isinstance(x, theano.tensor.TensorVariable):
-        return True
-    else:
-        return False
+    if not isinstance(x, theano.tensor.TensorVariable):
+        raise ValueError('Unexpectedly found an instance of type `' + str(type(x)) + '`.' +
+                    'Expected an instance of keras Tensor.')
+
+    return hasattr(x, '_keras_shape')
 
 
 def placeholder(shape=None, ndim=None, dtype=None, sparse=False, name=None):

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -166,13 +166,38 @@ def constant(value, dtype=None, shape=None, name=None):
 
 def is_keras_tensor(x):
     """Returns whether `x` is a Keras tensor.
+
+    # Arguments
+        x: a potential tensor.
+
+    # Returns
+        A boolean: whether the argument is a Keras tensor.
+
+    # Raises
+        ValueError: in case `x` is not a symbolic tensor.
+
+    # Examples
+    ```python
+        >>> from keras import backend as K
+        >>> np_var = numpy.array([1, 2])
+        >>> K.is_keras_tensor(np_var)
+        ValueError
+        >>> k_var = theano.shared(value=np.array([1,2,3]))
+        >>> K.is_keras_tensor(k_var)
+        False
+        >>> keras_var = K.variable(np_var)
+        >>> K.is_keras_tensor(keras_var)  # A variable is not a Tensor.
+        True
+        >>> keras_placeholder = K.placeholder(shape=(2, 4, 5))
+        >>> K.is_keras_tensor(keras_placeholder)  # A placeholder is a Tensor.
+        True
+    ```
     """
     if not isinstance(x, (T.TensorVariable,
                           T.sharedvar.TensorSharedVariable)):
-        raise ValueError('Unexpectedly found an instance of type `' + str(type(x)) + '`.' +
-                         'Expected an instance of keras Tensor.')
-
-    return hasattr(x, '_keras_shape')
+        raise ValueError('Unexpectedly found an instance of type `' + str(type(x)) + '`. '
+                         'Expected a symbolic tensor instance.')
+    return hasattr(x, '_keras_history')
 
 
 def placeholder(shape=None, ndim=None, dtype=None, sparse=False, name=None):

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -413,13 +413,20 @@ class Layer(object):
             ValueError: in case of mismatch between
                 the provided inputs and the expectations of the layer.
         """
+        inputs = _to_list(inputs)
+        for i in inputs:
+            if K.is_keras_tensor(i): continue
+            elif K._BACKEND == 'tensorflow':
+                import tensorflow as tf
+                if isinstance(i, tf.Tensor): continue
+            raise ValueError('Unexpectedly found an instance of type `' + str(type(i)) + '`.' +
+                    'Expected an instance of keras Tensor.')
         if not self.input_spec:
             return
         if not isinstance(self.input_spec, (list, tuple)):
             input_spec = _to_list(self.input_spec)
         else:
             input_spec = self.input_spec
-        inputs = _to_list(inputs)
         if len(inputs) != len(input_spec):
             raise ValueError('Layer ' + self.name + ' expects ' +
                              str(len(input_spec)) + ' inputs, '

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -414,12 +414,9 @@ class Layer(object):
                 the provided inputs and the expectations of the layer.
         """
         inputs = _to_list(inputs)
-        for i in inputs:
-            if K.is_keras_tensor(i): continue
-            elif K._BACKEND == 'tensorflow':
-                import tensorflow as tf
-                if isinstance(i, tf.Tensor): continue
-            raise ValueError('Unexpectedly found an instance of type `' + str(type(i)) + '`.' +
+        for x in inputs:
+            if not K.is_keras_tensor(x):
+                raise ValueError('Unexpectedly found an instance of type `' + str(type(x)) + '`.' +
                     'Expected an instance of keras Tensor.')
         if not self.input_spec:
             return

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -414,7 +414,8 @@ class Layer(object):
                 the provided inputs and the expectations of the layer.
         """
         inputs = _to_list(inputs)
-        for x in inputs: K.is_keras_tensor(x)
+        for x in inputs:
+            K.is_keras_tensor(x)
 
         if not self.input_spec:
             return

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -414,10 +414,8 @@ class Layer(object):
                 the provided inputs and the expectations of the layer.
         """
         inputs = _to_list(inputs)
-        for x in inputs:
-            if not K.is_keras_tensor(x):
-                raise ValueError('Unexpectedly found an instance of type `' + str(type(x)) + '`.' +
-                    'Expected an instance of keras Tensor.')
+        for x in inputs: K.is_keras_tensor(x)
+
         if not self.input_spec:
             return
         if not isinstance(self.input_spec, (list, tuple)):

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -415,7 +415,13 @@ class Layer(object):
         """
         inputs = _to_list(inputs)
         for x in inputs:
-            K.is_keras_tensor(x)
+            try:
+                K.is_keras_tensor(x)
+            except ValueError:
+                raise ValueError('Layer ' + self.name + ' expects '
+                                 'an input of a symbolic tensor but '
+                                 'it received an instance of ' +
+                                 str(type(x)) + ".")
 
         if not self.input_spec:
             return

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -77,6 +77,21 @@ def check_composed_tensor_operations(first_function_name, first_function_args,
 
 class TestBackend(object):
 
+    def test_is_keras_tensor(self):
+        for K in [KTH, KTF]:
+            np_var = np.array([1, 2])
+            try:
+                K.is_keras_tensor(np_var)
+                assert True == False
+            except ValueError:
+                # This is the expected behavior
+                continue
+
+            keras_var = K.variable(np_var)
+            assert K.is_keras_tensor(keras_var) == True
+            keras_placeholder = K.placeholder(shape=(2, 4, 5))
+            assert K.is_keras_tensor(keras_placeholder) == True
+
     def test_linear_operations(self):
         check_two_tensor_operation('dot', (4, 2), (2, 4))
         check_two_tensor_operation('dot', (4, 2), (5, 2, 3))

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -82,15 +82,15 @@ class TestBackend(object):
             np_var = np.array([1, 2])
             try:
                 K.is_keras_tensor(np_var)
-                assert True == False
+                assert True is False
             except ValueError:
                 # This is the expected behavior
                 continue
 
             keras_var = K.variable(np_var)
-            assert K.is_keras_tensor(keras_var) == True
+            assert K.is_keras_tensor(keras_var) is True
             keras_placeholder = K.placeholder(shape=(2, 4, 5))
-            assert K.is_keras_tensor(keras_placeholder) == True
+            assert K.is_keras_tensor(keras_placeholder) is True
 
     def test_linear_operations(self):
         check_two_tensor_operation('dot', (4, 2), (2, 4))


### PR DESCRIPTION
* raise ValueError if `inputs` is not a Keras tensor