### PR TITLE
Add error message for Conv2DTranspose on Theano

### DIFF
--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1858,7 +1858,10 @@ def conv2d_transpose(x, kernel, output_shape, strides=(1, 1),
         padding: string, "same" or "valid".
         data_format: "channels_last" or "channels_first".
             Whether to use Theano or TensorFlow data format
-        in inputs/kernels/ouputs.
+        in inputs/kernels/outputs.
+
+    # Raises
+        ValueError: if using an even kernel size with padding 'same'.
     """
     flip_filters = False
     if data_format is None:
@@ -1877,6 +1880,12 @@ def conv2d_transpose(x, kernel, output_shape, strides=(1, 1),
     else:
         # Will only work if `kernel` is a shared variable.
         kernel_shape = kernel.eval().shape
+
+    if padding == 'same' and kernel_shape[0] % 2 == 0:
+        raise ValueError('In `Conv2DTranspose`, with padding mode `same`, '
+                         'even kernel sizes are only supported with Tensorflow. '
+                         'With Theano, set `kernel_size` to an odd number.')
+
     kernel_shape = _preprocess_conv2d_filter_shape(kernel_shape, data_format)
 
     x = _preprocess_conv2d_input(x, data_format)


### PR DESCRIPTION
This PR proposes an error message for Conv2DTranspose on Theano backend. The problem is originally described in #6302. Following is a minimum code snippet, which runs on Tensorflow but not on Theano:
```python
from keras.models import Sequential
from keras.layers import Conv2DTranspose
model = Sequential([
        Conv2DTranspose(5, kernel_size=4, strides=1,
                        input_shape=(3,10,10),
                        padding='same',
                        data_format='channels_first')])
```

Main reason is that the padding behavior for `Conv2DTranspose` is different between `TF` and `TH` in case of the `same` padding mode with even kernel sizes.

For implementation of the `same` mode with the even sizes, padding pixels should be asymmetric. For example, when the number of padding pixels along height is 5, `TF` correctly pads 2 and 3 pixels at top and bottom, respectively. But `AbstractConv2d_gradInputs` in `TH` pads 3 pixels at both top and bottom. In the example in #6302, Keras expects `(1, 1, 18, 18)` but Theano produces `(1, 1, 19, 19)`.

As far as I know, Theano owner knows this issue but won't implement the asymmetric padding:

- https://github.com/Theano/Theano/issues/2118#issuecomment-282332804.
- http://deeplearning.net/software/theano/library/tensor/nnet/conv.html#theano.tensor.nnet.conv2d

Thus, I propose the error message.