### PR TITLE
fix saving models with Lambdas on Windows/python3 (replace backslash with forwardslash)

### DIFF
--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -170,7 +170,7 @@ def func_dump(func):
     # Returns
         A tuple `(code, defaults, closure)`.
     """
-    code = marshal.dumps(func.__code__).decode('raw_unicode_escape')
+    code = marshal.dumps(func.__code__).replace(b'\\',b'/').decode('raw_unicode_escape')
     defaults = func.__defaults__
     if func.__closure__:
         closure = tuple(c.cell_contents for c in func.__closure__)


### PR DESCRIPTION
On Windows/python3 models that use Lambdas cannot be saved because of backslash characters.

```
from keras.models import Sequential
from keras.layers import Lambda
model = Sequential()
model.add(Lambda(lambda x: (x/255.0)-0.5, input_shape = (2,2)))
model.save('model.h5')
```

Produces the following error:

```
Traceback (most recent call last):
  File "test.py", line 5, in <module>
    model.save('model.h5')
  File "keras\engine\topology.py", line 2416, in save
    save_model(self, filepath, overwrite)
  File "keras\models.py", line 101, in save_model
    'config': model.get_config()
  File "keras\models.py", line 1176, in get_config
    'config': layer.get_config()})
  File "keras\layers\core.py", line 668, in get_config
    function = func_dump(self.function)
  File "keras\utils\generic_utils.py", line 177, in func_dump
    code = marshal.dumps(func.__code__).decode('raw_unicode_escape')
UnicodeDecodeError: 'rawunicodeescape' codec can't decode bytes in position 89-93: truncated \uXXXX
```

This patch fixes the error.