### PR TITLE
Fix ImageNet weight loading for ResNet50 with channels_first

### DIFF
--- a/keras/applications/inception_v3.py
+++ b/keras/applications/inception_v3.py
@@ -384,8 +384,6 @@ def InceptionV3(include_top=True,
                 cache_subdir='models',
                 md5_hash='bcbd6486424b2319ff4ef7d526e38f63')
         model.load_weights(weights_path)
-        if K.backend() == 'theano':
-            convert_all_kernels_in_model(model)
     return model
 
 

--- a/keras/applications/resnet50.py
+++ b/keras/applications/resnet50.py
@@ -264,21 +264,19 @@ def ResNet50(include_top=True, weights='imagenet',
         model.load_weights(weights_path)
         if K.backend() == 'theano':
             layer_utils.convert_all_kernels_in_model(model)
-
-        if K.image_data_format() == 'channels_first':
             if include_top:
                 maxpool = model.get_layer(name='avg_pool')
                 shape = maxpool.output_shape[1:]
                 dense = model.get_layer(name='fc1000')
                 layer_utils.convert_dense_weights_data_format(dense, shape, 'channels_first')
 
-            if K.backend() == 'tensorflow':
-                warnings.warn('You are using the TensorFlow backend, yet you '
-                              'are using the Theano '
-                              'image data format convention '
-                              '(`image_data_format="channels_first"`). '
-                              'For best performance, set '
-                              '`image_data_format="channels_last"` in '
-                              'your Keras config '
-                              'at ~/.keras/keras.json.')
+        if K.image_data_format() == 'channels_first' and K.backend() == 'tensorflow':
+            warnings.warn('You are using the TensorFlow backend, yet you '
+                          'are using the Theano '
+                          'image data format convention '
+                          '(`image_data_format="channels_first"`). '
+                          'For best performance, set '
+                          '`image_data_format="channels_last"` in '
+                          'your Keras config '
+                          'at ~/.keras/keras.json.')
     return model

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -2905,16 +2905,20 @@ def preprocess_weights_for_loading(layer, weights,
                                                     (2, 3, 1, 0))
                 weights = [kernel, recurrent_kernel, bias]
 
-    if original_backend and K.backend() != original_backend:
-        conv_layers = ['Conv1D',
-                       'Conv2D',
-                       'Conv3D',
-                       'Conv2DTranspose']
-        if layer.__class__.__name__ in conv_layers:
+    conv_layers = ['Conv1D',
+                   'Conv2D',
+                   'Conv3D',
+                   'Conv2DTranspose',
+                   'ConvLSTM2D']
+    if layer.__class__.__name__ in conv_layers:
+        if original_backend and K.backend() != original_backend:
             weights[0] = conv_utils.convert_kernel(weights[0])
-        if layer.__class__.__name__ == 'ConvLSTM2D':
-            weights[0] = conv_utils.convert_kernel(weights[0])
-            weights[1] = conv_utils.convert_kernel(weights[1])
+            if layer.__class__.__name__ == 'ConvLSTM2D':
+                weights[1] = conv_utils.convert_kernel(weights[1])
+        if K.int_shape(layer.weights[0]) != weights[0].shape:
+            weights[0] = np.transpose(weights[0], (3, 2, 0, 1))
+            if layer.__class__.__name__ == 'ConvLSTM2D':
+                weights[1] = np.transpose(weights[1], (3, 2, 0, 1))
     return weights
 
 


### PR DESCRIPTION
This PR fixes ImageNet weight loading for ResNet50 with channels_first described in "Requests for Contributions". I explored some possible solutions, and think this might be a concise solution.

First of all, `load_weights()` should be able to load weights even if `K.image_data_format()` and `image_data_format` of weight files are different. For loading weights saved with `channels_last` under `channels_first` runtime setting (and vice versa), `load_weights()` must be able to detects the difference of `image_data_format` between saved files and runtime setting. Because `image_data_format` is not saved as an hdf5-attribute of weight files, this PR used `K.int_shape(layer.weights[0]) != weights[0].shape` as a condition for dim-ordering conversion. Note that the `layer.weights[0]` is a constructed tensor under runtime setting, and the `weights[0]` is restored values from weight files saved. Now, `load_weights()` can load weights even if `K.image_data_format()` and `image_data_format` of weight files are different. Then, all we need to do is just converting with `convert_all_kernels_in_model` and `convert_dense_weights_data_format ` in case of Theano backend.

In results, users can always get the same results of `ResNet50(weights='imagenet')` under the following 4 cases without errors:

- "image_data_format": "channels_last", "backend": "theano"
- "image_data_format": "channels_first", "backend": "theano"
- "image_data_format": "channels_last", "backend": "tensorflow"
- "image_data_format": "channels_first", "backend": "tensorflow"