### PR TITLE
Fix depth calculation for shared layers

### DIFF
--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -1690,6 +1690,14 @@ class Container(Layer):
             # If the depth is not set, the node has no outbound nodes (depth 0).
             depth = nodes_depths.setdefault(node, 0)
 
+            # Update the depth of the corresponding layer
+            previous_depth = layers_depths.get(node.outbound_layer, 0)
+            # If we've seen this layer before at a higher depth, we should use that depth instead
+            # of the node depth.  This is necessary for shared layers that have inputs at different
+            # depth levels in the graph.
+            depth = max(depth, previous_depth)
+            layers_depths[node.outbound_layer] = depth
+
             # Update the depth of inbound nodes.
             for i in range(len(node.inbound_layers)):
                 inbound_layer = node.inbound_layers[i]
@@ -1697,10 +1705,6 @@ class Container(Layer):
                 inbound_node = inbound_layer.inbound_nodes[node_index]
                 previous_depth = nodes_depths.get(inbound_node, 0)
                 nodes_depths[inbound_node] = max(depth + 1, previous_depth)
-
-            # Update the depth of the corresponding layer
-            previous_depth = layers_depths.get(node.outbound_layer, 0)
-            layers_depths[node.outbound_layer] = max(depth, previous_depth)
 
         # Build a dict {depth: list of nodes with this depth}
         nodes_by_depth = {}

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -1697,6 +1697,7 @@ class Container(Layer):
             # depth levels in the graph.
             depth = max(depth, previous_depth)
             layers_depths[node.outbound_layer] = depth
+            nodes_depths[node] = depth
 
             # Update the depth of inbound nodes.
             for i in range(len(node.inbound_layers)):


### PR DESCRIPTION
This PR fixes a bug where model serialization and loading is broken when a shared layer is used at several different depths in a model (issue found here: https://github.com/allenai/deep_qa/pull/357).  I first added a test that failed on master, then fixed the test.  Hopefully the test and the comments around the test and the fix are enough to explain what's going on.