### PR TITLE
get_file() progbar fix

### DIFF
--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -196,6 +196,8 @@ def get_file(fname,
 
         def dl_progress(count, block_size, total_size):
             if progress_tracker.progbar is None:
+                if total_size is -1:
+                    total_size = None
                 progress_tracker.progbar = Progbar(total_size)
             else:
                 progress_tracker.progbar.update(count * block_size)

--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -208,12 +208,14 @@ class Progbar(object):
     """Displays a progress bar.
 
     # Arguments
-        target: Total number of steps expected, -1 if unknown.
+        target: Total number of steps expected, either None or -1 if unknown.
         interval: Minimum visual progress update interval (in seconds).
     """
 
     def __init__(self, target, width=30, verbose=1, interval=0.05):
         self.width = width
+        if target is None:
+            target = -1
         self.target = target
         self.sum_values = {}
         self.unique_values = []

--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -208,7 +208,7 @@ class Progbar(object):
     """Displays a progress bar.
 
     # Arguments
-        target: Total number of steps expected, either None or -1 if unknown.
+        target: Total number of steps expected, None if unknown.
         interval: Minimum visual progress update interval (in seconds).
     """
 

--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -208,7 +208,7 @@ class Progbar(object):
     """Displays a progress bar.
 
     # Arguments
-        target: Total number of steps expected.
+        target: Total number of steps expected, -1 if unknown.
         interval: Minimum visual progress update interval (in seconds).
     """
 
@@ -253,21 +253,22 @@ class Progbar(object):
             sys.stdout.write('\b' * prev_total_width)
             sys.stdout.write('\r')
 
-            numdigits = int(np.floor(np.log10(self.target))) + 1
-            barstr = '%%%dd/%%%dd [' % (numdigits, numdigits)
-            bar = barstr % (current, self.target)
-            prog = float(current) / self.target
-            prog_width = int(self.width * prog)
-            if prog_width > 0:
-                bar += ('=' * (prog_width - 1))
-                if current < self.target:
-                    bar += '>'
-                else:
-                    bar += '='
-            bar += ('.' * (self.width - prog_width))
-            bar += ']'
-            sys.stdout.write(bar)
-            self.total_width = len(bar)
+            if self.target is not -1:
+                numdigits = int(np.floor(np.log10(self.target))) + 1
+                barstr = '%%%dd/%%%dd [' % (numdigits, numdigits)
+                bar = barstr % (current, self.target)
+                prog = float(current) / self.target
+                prog_width = int(self.width * prog)
+                if prog_width > 0:
+                    bar += ('=' * (prog_width - 1))
+                    if current < self.target:
+                        bar += '>'
+                    else:
+                        bar += '='
+                bar += ('.' * (self.width - prog_width))
+                bar += ']'
+                sys.stdout.write(bar)
+                self.total_width = len(bar)
 
             if current:
                 time_per_unit = (now - self.start) / current
@@ -275,7 +276,7 @@ class Progbar(object):
                 time_per_unit = 0
             eta = time_per_unit * (self.target - current)
             info = ''
-            if current < self.target:
+            if current < self.target and self.target is not -1:
                 info += ' - ETA: %ds' % eta
             else:
                 info += ' - %ds' % (now - self.start)


### PR DESCRIPTION
Includes fix get_file download progress bar #6535 with improvement to scoping clarity.

Additionally fixes bug in python 2.7 where `get_file()` crashes when downloading files where the response does not supply `'Content-Length'`:
```python
    from keras.utils import get_file
    listing_url = 'https://sites.google.com/site/brainrobotdata/home/grasping-dataset/grasp_listing.txt'
    grasp_listing_path = get_file('grasp_listing.txt', listing_url)
```