### PR TITLE
Added scan to backends

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -2315,6 +2315,39 @@ def stop_gradient(variables):
     return tf.stop_gradient(variables)
 
 
+def scan(fn, sequences, outputs_info=None, non_sequences=None, go_backwards=False):
+    """Symbolic loop
+    # Arguments
+        Same as correspondent arguments in `theano.scan`, except that sequences cannot be `None`
+
+    # Return
+        Same as the first element of the return of `theano.scan`, i.e., no update.
+    """
+    if not isinstance(sequences, list):
+        sequences = [sequences]
+    if go_backwards:
+        sequences = [tf.reverse(e, [0]) for e in sequences]
+    if non_sequences is None:
+        non_sequences = []
+    if not isinstance(non_sequences, list):
+        non_sequences = [non_sequences]
+
+    if outputs_info is None:
+        def tf_fn(initializer, elems):
+            args = elems + non_sequences
+            return fn(*args)
+        outputs_info = tf_fn([], [e[0] for e in sequences])
+    else:
+        def tf_fn(initializer, elems):
+            if not isinstance(initializer, list):
+                initializer = [initializer]
+            args = elems + initializer + non_sequences
+            return fn(*args)
+
+    res = functional_ops.scan(tf_fn, sequences, outputs_info)
+    return res
+
+
 # CONTROL FLOW
 
 def rnn(step_function, inputs, initial_states,

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1217,6 +1217,18 @@ def stop_gradient(variables):
     return theano.gradient.disconnected_grad(variables)
 
 
+def scan(fn, sequences, outputs_info=None, non_sequences=None, go_backwards=False):
+    """Symbolic loop
+    # Arguments
+        Same as correspondent arguments in `theano.scan`, except that sequences cannot be `None`
+
+    # Return
+        Same as the first element of the return of `theano.scan`, i.e., no update.
+    """
+    res, _ = theano.scan(fn, sequences, outputs_info, non_sequences, go_backwards=go_backwards)
+    return res
+
+
 # CONTROL FLOW
 
 def rnn(step_function, inputs, initial_states,

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -397,6 +397,49 @@ class TestBackend(object):
         assert new_val_th.shape == new_val_tf.shape
         assert_allclose(new_val_th, new_val_tf, atol=1e-05)
 
+    def test_scan(self):
+        # test 1
+        init = KTF.zeros((3,))
+        seq = KTF.variable(np.arange(12).reshape((4, 3)))
+        cumsum = KTF.scan(lambda s, o: s + o, seq, init)
+        tf_res = KTF.eval(cumsum)
+
+        init = KTH.zeros((3,))
+        seq = KTH.variable(np.arange(12).reshape((4, 3)))
+        cumsum = KTH.scan(lambda s, o: s + o, [seq], init)
+        th_res = KTH.eval(cumsum)
+
+        assert_allclose(tf_res, th_res, atol=1e-05)
+
+        # test 2
+        def func(s, o1, o2, ns):
+            return [o1 + s + ns, o2 * s + ns]
+
+        init = KTF.zeros((3,))
+        seq = KTF.variable(np.arange(12, dtype='float32').reshape((4, 3)))
+        non_seq = KTF.variable(np.array([0.1, 0.2, 0.3]))
+        cumsum = KTF.scan(func, seq, [init, init], non_seq)
+        tf_res = KTF.eval(cumsum[0]), KTF.eval(cumsum[1])
+
+        init = KTH.zeros((3,))
+        seq = KTH.variable(np.arange(12, dtype='float32').reshape((4, 3)))
+        non_seq = KTH.variable(np.array([0.1, 0.2, 0.3], dtype='float32'))
+        cumsum = KTH.scan(func, seq, [init, init], non_seq)
+        th_res = KTH.eval(cumsum[0]), KTH.eval(cumsum[1])
+
+        assert_allclose(tf_res, th_res, atol=1e-05)
+
+        # test 3
+        seq = KTF.variable(np.arange(12).reshape((4, 3)))
+        cumsum = KTF.scan(lambda s1, s2: [s1 + s2, s1 * s2], [seq, seq], None, go_backwards=True)
+        tf_res = KTF.eval(cumsum[0]), KTF.eval(cumsum[1])
+
+        seq = KTH.variable(np.arange(12).reshape((4, 3)))
+        cumsum = KTH.scan(lambda s1, s2: [s1 + s2, s1 * s2], [seq, seq], None, go_backwards=True)
+        th_res = KTH.eval(cumsum[0]), KTH.eval(cumsum[1])
+
+        assert_allclose(tf_res, th_res, atol=1e-05)
+
     def test_rnn(self):
         # implement a simple RNN
         input_dim = 8


### PR DESCRIPTION
`scan` is powerful symbolic loop in `theano` and `tensorflow`. It is more general than `K.rnn`.
The implementation here adapts the well known `theano` interface for `K.scan`. 

`rnn` does not support to slices on a list of sequences and does not return a list of sequences. Plus, `rnn` is handle things like an RNN, but you may need a loop for something like, compute cumulative sum, or sliding windows, or even a new tensor operation that saves memory.