### PR TITLE
Add Chrome timeline support in Tensorflow

### DIFF
--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1201,7 +1201,7 @@ def function(inputs, outputs, updates=[], **kwargs):
         function_args = inspect.getargspec(theano.function)[0]
         for key in kwargs.keys():
             if key not in function_args:
-                msg = 'Invalid argument "%s" passed to K.function' % key
+                msg = 'Invalid argument "%s" passed to K.function with Theano backend' % key
                 raise ValueError(msg)
     return Function(inputs, outputs, updates=updates, **kwargs)
 

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -709,7 +709,8 @@ class Model(Container):
                 `sample_weight_mode` on each output by passing a
                 dictionary or a list of modes.
             **kwargs: when using the Theano backend, these arguments
-                are passed into K.function. Ignored for Tensorflow backend.
+                are passed into K.function. When using the Tensorflow backend,
+                these arguments are passed into `tf.Session.run`.
 
         # Raises
             ValueError: In case of invalid arguments for

--- a/keras/models.py
+++ b/keras/models.py
@@ -765,7 +765,8 @@ class Sequential(Model):
                 sample weighting (2D weights), set this to "temporal".
                 "None" defaults to sample-wise weights (1D).
             **kwargs: for Theano backend, these are passed into K.function.
-                Ignored for Tensorflow backend.
+                When using the Tensorflow backend, these are passed into
+                `tf.Session.run`.
 
         # Example
             ```python


### PR DESCRIPTION
Enables generating profiling data when using the Tensorflow backend, as requested by #6606

Passes all of the tests using the Tensorflow backend on my machine (I haven't changed anything in the Theano backend, so haven't run those tests).

It's a bit hacky how kwargs to `model.compile` are passed into `tf.Session.run` so understand if you don't want to merge this. If you're fine with this, I can update this with an example of how to generate trace files if you'd like?