### PR TITLE
Add arbitrary tensor output during training/testing

### DIFF
--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -1470,7 +1470,7 @@ class Container(Layer):
     """
 
     @interfaces.legacy_model_constructor_support
-    def __init__(self, inputs, outputs, name=None):
+    def __init__(self, inputs, outputs, extra_output=None, name=None):
         # Handle `name` argument.
         if not name:
             prefix = self.__class__.__name__.lower()
@@ -1491,6 +1491,12 @@ class Container(Layer):
             self.outputs = list(outputs)
         else:
             self.outputs = [outputs]
+        if extra_output is None:
+            self.extra_output = []
+        elif isinstance(extra_output, (list, tuple)):
+            self.extra_output = list(extra_output)
+        else:
+            self.extra_output = [extra_output]
 
         # Check for redundancy in inputs.
         inputs_set = set(self.inputs)

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1015,7 +1015,8 @@ class Model(Container):
             updates = self.updates + training_updates
             # Gets loss and metrics. Updates weights at each call.
             self.train_function = K.function(inputs,
-                                             [self.total_loss] + self.metrics_tensors,
+                                             [self.total_loss] + self.metrics_tensors +
+                                             self.extra_output,
                                              updates=updates,
                                              name='train_function',
                                              **self._function_kwargs)
@@ -1030,7 +1031,8 @@ class Model(Container):
             # Return loss and metrics, no gradient updates.
             # Does update the network states.
             self.test_function = K.function(inputs,
-                                            [self.total_loss] + self.metrics_tensors,
+                                            [self.total_loss] + self.metrics_tensors +
+                                            self.extra_output,
                                             updates=self.state_updates,
                                             name='test_function',
                                             **self._function_kwargs)
@@ -1270,6 +1272,8 @@ class Model(Container):
                 ins_batch = _slice_arrays(ins, batch_ids)
 
             batch_outs = f(ins_batch)
+            if len(self.extra_output) > 0:
+                batch_outs = batch_outs[:-len(self.extra_output)]
             if isinstance(batch_outs, list):
                 if batch_index == 0:
                     for batch_out in enumerate(batch_outs):

--- a/tests/keras/engine/test_training.py
+++ b/tests/keras/engine/test_training.py
@@ -20,7 +20,7 @@ def test_model_methods():
     dp = Dropout(0.5, name='dropout')
     b_2 = dp(b)
 
-    model = Model([a, b], [a_2, b_2])
+    model = Model([a, b], [a_2, b_2], extra_output=[b_2])
 
     optimizer = 'rmsprop'
     loss = 'mse'
@@ -114,16 +114,21 @@ def test_model_methods():
                               [output_a_np, output_b_np],
                               sample_weight=sample_weight)
 
+    # test that extra_output works
+    assert out[-1].shape == output_b_np.shape
+    not_dropped = out[-1] != 0.0
+    assert np.allclose(out[-1][not_dropped], input_b_np[not_dropped])
+
     # test accuracy metric
     model.compile(optimizer, loss, metrics=['acc'],
                   sample_weight_mode=None)
 
     out = model.train_on_batch([input_a_np, input_b_np],
                                [output_a_np, output_b_np])
-    assert len(out) == 5
+    assert len(out) == 6
     out = model.test_on_batch([input_a_np, input_b_np],
                               [output_a_np, output_b_np])
-    assert len(out) == 5
+    assert len(out) == 6
 
     # this should also work
     model.compile(optimizer, loss, metrics={'dense_1': 'acc'},
@@ -131,10 +136,10 @@ def test_model_methods():
 
     out = model.train_on_batch([input_a_np, input_b_np],
                                [output_a_np, output_b_np])
-    assert len(out) == 4
+    assert len(out) == 5
     out = model.test_on_batch([input_a_np, input_b_np],
                               [output_a_np, output_b_np])
-    assert len(out) == 4
+    assert len(out) == 5
 
     # and this as well
     model.compile(optimizer, loss, metrics={'dense_1': ['acc']},
@@ -142,10 +147,10 @@ def test_model_methods():
 
     out = model.train_on_batch([input_a_np, input_b_np],
                                [output_a_np, output_b_np])
-    assert len(out) == 4
+    assert len(out) == 5
     out = model.test_on_batch([input_a_np, input_b_np],
                               [output_a_np, output_b_np])
-    assert len(out) == 4
+    assert len(out) == 5
 
     # test starting from non-zero initial epoch
     trained_epochs = []
@@ -181,7 +186,7 @@ def test_model_methods():
 
     out = model.train_on_batch([input_a_np, input_b_np],
                                [output_a_np, output_b_np])
-    out_len = 1 + 2 * (1 + 1)  # total loss + 2 outputs * (loss + metric)
+    out_len = 1 + 2 * (1 + 1) + 1  # total loss + 2 outputs * (loss + metric) + extra_output
     assert len(out) == out_len
     out = model.test_on_batch([input_a_np, input_b_np],
                               [output_a_np, output_b_np])


### PR DESCRIPTION
This PR is in reference to issue #6414. The purpose is to provide with a view under the hood for people who want to evaluate what is happening during training. I will showcase in the following code snippet what is proposed but the main goal is to create a discussion because nobody seemed interested to counter-argue with the issue.

```python
# Let's say I want to count how many values are negative before relu.
# It is currently not possible in keras during training. We could use a metric but we
# would not be able to access the values and we would have to add an output
# not used during prediction.
from keras.layers import Activation, Dense, Dropout, Input
from keras.models import Model
import numpy as np

x0 = Input(shape=(10,))
x = Dense(10, activation="relu")(x0)
x = Dropout(0.5)(x)
y_extra = x = Dense(10)(x)
x = Activation("relu")(x)
x = Dropout(0.5)(x)
y = Dense(1)

m = Model(inputs=[x0], outputs=[y], extra_output=[y_extra])
m.compile(optimizer="sgd", loss="mse")

loss, y_extra = m.train_on_batch(np.random.rand(128, 10), np.random.rand(128, 1))
loss = m.evaluate(np.random.rand(128, 10), np.random.rand(128), batch_size=10)
y = m.predict(np.random.rand(128, 10), batch_size=10)
```

So, I am waiting to hear your thoughts on the matter.