### PR TITLE
stale bot specifies 30 days when it posts

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -15,5 +15,5 @@ staleLabel: stale
 # Comment to post when marking as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because it has not had
-  recent activity. It will be closed if no further activity occurs, but
-  feel free to re-open it if needed.
+  recent activity. It will be closed after 30 days if no further activity 
+  occurs, but feel free to re-open a closed issue if needed.


### PR DESCRIPTION
Got notified about some stale threads, but realized I forgot to put the number of days in the post's string.