### PR TITLE
Add warning message for redundant outputs

### DIFF
--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -1493,12 +1493,18 @@ class Container(Layer):
             self.outputs = [outputs]
 
         # Check for redundancy in inputs.
-        inputs_set = set(self.inputs)
-        if len(inputs_set) != len(self.inputs):
+        if len(set(self.inputs)) != len(self.inputs):
             raise ValueError('The list of inputs passed to the model '
                              'is redundant. '
                              'All inputs should only appear once.'
                              ' Found: ' + str(self.inputs))
+
+        # Check for redundancy in outputs.
+        if len(set(self.outputs)) != len(self.outputs):
+            warnings.warn('The list of outputs passed to the model '
+                          'is redundant. '
+                          'All outputs should only appear once.'
+                          ' Found: ' + str(self.outputs))
 
         # List of initial layers (1 to 1 mapping with self.inputs,
         # hence the same layer might appear twice)

--- a/tests/keras/engine/test_topology.py
+++ b/tests/keras/engine/test_topology.py
@@ -439,12 +439,11 @@ def test_recursion():
     with pytest.raises(Exception) as e:
         Model([j], [m, n])
 
-    # redudant outputs
+    # redundant outputs
     j = Input(shape=(32,), name='input_j')
     k = Input(shape=(32,), name='input_k')
     m, n = model([j, k])
-    # this should work lol
-    # TODO: raise a warning
+    # this should work with a warning
     Model([j, k], [m, n, n])
 
     # redundant inputs


### PR DESCRIPTION
This PR proposes an warning message for redundant outputs when using functional API.