### PR TITLE
close the opened hdf5 file in load model in case of error

### DIFF
--- a/keras/models.py
+++ b/keras/models.py
@@ -246,7 +246,6 @@ def load_model(filepath, custom_objects=None, compile=True):
 
         # Early return if compilation is not required.
         if not compile:
-            f.close()
             return model
 
         # instantiate optimizer
@@ -254,7 +253,6 @@ def load_model(filepath, custom_objects=None, compile=True):
         if training_config is None:
             warnings.warn('No training configuration found in save file: '
                           'the model was *not* compiled. Compile it manually.')
-            f.close()
             return model
         training_config = json.loads(training_config.decode('utf-8'))
         optimizer_config = training_config['optimizer_config']

--- a/keras/models.py
+++ b/keras/models.py
@@ -233,9 +233,7 @@ def load_model(filepath, custom_objects=None, compile=True):
         if obj in custom_objects:
             return custom_objects[obj]
         return obj
-    try:
-        f = h5py.File(filepath, mode='r')
-
+    with h5py.File(filepath, mode='r') as f:
         # instantiate model
         model_config = f.attrs.get('model_config')
         if model_config is None:
@@ -289,10 +287,6 @@ def load_model(filepath, custom_objects=None, compile=True):
             optimizer_weight_values = [optimizer_weights_group[n] for n in
                                        optimizer_weight_names]
             model.optimizer.set_weights(optimizer_weight_values)
-    except:
-        f.close()
-        raise
-    f.close()
     return model
 
 

--- a/keras/models.py
+++ b/keras/models.py
@@ -233,60 +233,65 @@ def load_model(filepath, custom_objects=None, compile=True):
         if obj in custom_objects:
             return custom_objects[obj]
         return obj
+    try:
+        f = h5py.File(filepath, mode='r')
 
-    f = h5py.File(filepath, mode='r')
+        # instantiate model
+        model_config = f.attrs.get('model_config')
+        if model_config is None:
+            raise ValueError('No model found in config file.')
+        model_config = json.loads(model_config.decode('utf-8'))
+        model = model_from_config(model_config, custom_objects=custom_objects)
 
-    # instantiate model
-    model_config = f.attrs.get('model_config')
-    if model_config is None:
-        raise ValueError('No model found in config file.')
-    model_config = json.loads(model_config.decode('utf-8'))
-    model = model_from_config(model_config, custom_objects=custom_objects)
+        # set weights
+        topology.load_weights_from_hdf5_group(f['model_weights'], model.layers)
 
-    # set weights
-    topology.load_weights_from_hdf5_group(f['model_weights'], model.layers)
+        # Early return if compilation is not required.
+        if not compile:
+            f.close()
+            return model
 
-    # Early return if compilation is not required.
-    if not compile:
+        # instantiate optimizer
+        training_config = f.attrs.get('training_config')
+        if training_config is None:
+            warnings.warn('No training configuration found in save file: '
+                          'the model was *not* compiled. Compile it manually.')
+            f.close()
+            return model
+        training_config = json.loads(training_config.decode('utf-8'))
+        optimizer_config = training_config['optimizer_config']
+        optimizer = optimizers.deserialize(optimizer_config,
+                                           custom_objects=custom_objects)
+
+        # Recover loss functions and metrics.
+        loss = convert_custom_objects(training_config['loss'])
+        metrics = convert_custom_objects(training_config['metrics'])
+        sample_weight_mode = training_config['sample_weight_mode']
+        loss_weights = training_config['loss_weights']
+
+        # Compile model.
+        model.compile(optimizer=optimizer,
+                      loss=loss,
+                      metrics=metrics,
+                      loss_weights=loss_weights,
+                      sample_weight_mode=sample_weight_mode)
+
+        # Set optimizer weights.
+        if 'optimizer_weights' in f:
+            # Build train function (to get weight updates).
+            if isinstance(model, Sequential):
+                model.model._make_train_function()
+            else:
+                model._make_train_function()
+            optimizer_weights_group = f['optimizer_weights']
+            optimizer_weight_names = [n.decode('utf8') for n in
+                                      optimizer_weights_group.attrs['weight_names']]
+            optimizer_weight_values = [optimizer_weights_group[n] for n in
+                                       optimizer_weight_names]
+            model.optimizer.set_weights(optimizer_weight_values)
+    except:
         f.close()
-        return model
-
-    # instantiate optimizer
-    training_config = f.attrs.get('training_config')
-    if training_config is None:
-        warnings.warn('No training configuration found in save file: '
-                      'the model was *not* compiled. Compile it manually.')
-        f.close()
-        return model
-    training_config = json.loads(training_config.decode('utf-8'))
-    optimizer_config = training_config['optimizer_config']
-    optimizer = optimizers.deserialize(optimizer_config,
-                                       custom_objects=custom_objects)
-
-    # Recover loss functions and metrics.
-    loss = convert_custom_objects(training_config['loss'])
-    metrics = convert_custom_objects(training_config['metrics'])
-    sample_weight_mode = training_config['sample_weight_mode']
-    loss_weights = training_config['loss_weights']
-
-    # Compile model.
-    model.compile(optimizer=optimizer,
-                  loss=loss,
-                  metrics=metrics,
-                  loss_weights=loss_weights,
-                  sample_weight_mode=sample_weight_mode)
-
-    # Set optimizer weights.
-    if 'optimizer_weights' in f:
-        # Build train function (to get weight updates).
-        if isinstance(model, Sequential):
-            model.model._make_train_function()
-        else:
-            model._make_train_function()
-        optimizer_weights_group = f['optimizer_weights']
-        optimizer_weight_names = [n.decode('utf8') for n in optimizer_weights_group.attrs['weight_names']]
-        optimizer_weight_values = [optimizer_weights_group[n] for n in optimizer_weight_names]
-        model.optimizer.set_weights(optimizer_weight_values)
+        raise
     f.close()
     return model
 


### PR DESCRIPTION
One problem that I had with the current load_model function defined in keras.models, is that, when an error is raised somewhere in the body of that function, the hdf5 opened at the beginning of the function is never closed. So say I want, after having caught the exception, to modify the content of the hdf5 to solve the error, I cannot reopen it in write mode since it is already opened in read mode, and the reference to that file is lost.

Full disclosure, I got this error when trying to load hdf5 models created with keras 1, with keras 2. A problem stems from incompatible format for optimizer wieghts. Since I only care about inference in my code, a simple solution is to delete the optimizer weights from the hdf5. I only do that when I detect that load_model raised a ValueError (which happens at the ```model.optimizer.set_weights(optimizer_weight_values)``` line), and that the hdf5 had a keras version < 2.0.0. For the reasons I explained above, I cannot do that because the hdf5 file opened in load_model is never closed. In practice I redefined load_model in my own code, but still I think it might be a non absurd addition to the code.