### PR TITLE
Correct add_weight parameters

### DIFF
--- a/docs/templates/layers/writing-your-own-keras-layers.md
+++ b/docs/templates/layers/writing-your-own-keras-layers.md
@@ -21,7 +21,8 @@ class MyLayer(Layer):
 
     def build(self, input_shape):
         # Create a trainable weight variable for this layer.
-        self.kernel = self.add_weight(shape=(input_shape[1], self.output_dim),
+        self.kernel = self.add_weight(name='kernel',
+                                      shape=(input_shape[1], self.output_dim),
                                       initializer='uniform',
                                       trainable=True)
         super(MyLayer, self).build(input_shape)  # Be sure to call this somewhere!


### PR DESCRIPTION
Added the missing `name` parameter in the example call of `add_weight`.