### PR TITLE
Bugfix: GeneratorEnqueuer should not change the generated batches' order when workers > 1

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -634,7 +634,9 @@ class GeneratorEnqueuer(object):
                         if self._pickle_safe or self.queue.qsize() < max_q_size:
                             generator_output = localPool.apply_async(next,
                                                                      (self._generator,))
+                            print("{} tries to enqueue with queue size {}...".format(multiprocessing.current_process()), self.queue.qsize(), end='')
                             self.queue.put(generator_output)
+                            print("OK")
                             should_wait = False
                     if should_wait:
                         time.sleep(wait_time)

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -581,6 +581,8 @@ def _standardize_weights(y, sample_weight=None, class_weight=None,
 
 
 generatorEnqueuerLock = multiprocessing.Lock()
+
+
 class GeneratorEnqueuer(object):
     """Builds a queue out of a data generator.
 
@@ -594,14 +596,14 @@ class GeneratorEnqueuer(object):
         """Wrapper that transparently stores future objects."""
         def get(self):
             future_object = super(GeneratorEnqueuer._FuturesQueueWrapper,
-                         self).get()
+                                  self).get()
             return future_object.get()
 
     class _FuturesQueueWrapperMultiprocessing(multiprocessing.queues.Queue):
         """Wrapper that transparently stores future objects."""
         def get(self):
             future_object = super(GeneratorEnqueuer._FuturesQueueWrapperMultiprocessing,
-                         self).get()
+                                  self).get()
             return future_object.get()
 
     def __init__(self, generator, pickle_safe=False):
@@ -622,7 +624,7 @@ class GeneratorEnqueuer(object):
 
         def data_generator_task():
             if self._pickle_safe:
-                localPool = multiprocessing.Pool(1) # used for apply_async
+                localPool = multiprocessing.Pool(1)
             else:
                 localPool = multiprocessing.pool.ThreadPool(1)
             while not self._stop_event.is_set():
@@ -630,8 +632,8 @@ class GeneratorEnqueuer(object):
                     should_wait = True
                     with generatorEnqueuerLock:
                         if self._pickle_safe or self.queue.qsize() < max_q_size:
-                            generator_output = localPool.apply_async(next, 
-                                                             (self._generator,))
+                            generator_output = localPool.apply_async(next,
+                                                                     (self._generator,))
                             self.queue.put(generator_output)
                             should_wait = False
                     if should_wait:
@@ -647,7 +649,7 @@ class GeneratorEnqueuer(object):
         try:
             if self._pickle_safe:
                 self.queue = GeneratorEnqueuer._FuturesQueueWrapperMultiprocessing(maxsize=max_q_size,
-                                           ctx=multiprocessing.get_context())
+                                                                                   ctx=multiprocessing.get_context())
                 self._stop_event = multiprocessing.Event()
             else:
                 self.queue = GeneratorEnqueuer._FuturesQueueWrapper(maxsize=max_q_size)
@@ -980,7 +982,7 @@ class Model(Container):
                     output_shape = self.internal_output_shapes[i]
                     acc_fn = None
                     if (output_shape[-1] == 1 or
-                       self.loss_functions[i] == losses.binary_crossentropy):
+                            self.loss_functions[i] == losses.binary_crossentropy):
                         # case: binary accuracy
                         acc_fn = metrics_module.binary_accuracy
                     elif self.loss_functions[i] == losses.sparse_categorical_crossentropy:

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -618,7 +618,7 @@ class GeneratorEnqueuer(object):
 
         # Arguments
             workers: number of worker threads
-            max_q_size: queue size (when full, threads could block on put())
+            max_q_size: queue size
             wait_time: time to sleep in-between calls to put()
         """
 


### PR DESCRIPTION
This is a proposed fix for the erroneous behaviour described in #6745.
I ran tests on Ubuntu 16.04 with python 3.5 and 2.7, all tests pass.
I also ran tests on Windows with python 3.5 (Tensorflow currently does not support python 2.7 on Windows) and all tests except those using multiprocessing pass.
The tests that fail are affected by the error mentioned in #5071.

**Description of the bug fix**: The idea is to exploit `multiprocessing`'s `Pool.apply_asynch` which does not block and immediately returns a `multiprocessing.pool.ApplyResult` object that is put in the queue.
The generator's batches order is kept by using a lock that guarantees that no thread can get a new batch until the last batch's `ApplyResult` object has been put in the queue.
Note that to keep the `GeneratorEnqueuer`'s external interface the same, I had to define two "private" classes that redefine the queues' `get()` method to actually return `ApplyResult.get()` (which may block if the result is not ready yet).

**NOTE**: Incidentally, fixing the original bug also led to the discovery and subsequent fix of a second bug.

**TL;DR**: The second bug would cause a `GeneratorEnqueuer` instance to stall potentially causing a deadlock. Now this cannot happen anymore.

**Second bug explanation:**
If:
1) the queue is full
2) a thread tries to `put()` and blocks until the queue has space again
3) the `GeneratorEnqueuer` instance calls `stop()`.

the thread calling `stop()` would block waiting for the thread waiting on `put()` to unblock. This would happen only if some thread calls `pop()` on the queue. This might lead to deadlock if the only thread popping from the queue is the thread calling `stop()`.

This behaviour is now prevented by the lock before the test on the queue length, which ensures no thread will ever try to `put()` when the queue is full.
