### PR TITLE
Make image_data_format consistent

### DIFF
--- a/docs/templates/backend.md
+++ b/docs/templates/backend.md
@@ -60,12 +60,12 @@ Using TensorFlow backend.
 
 You can change these settings by editing `$HOME/.keras/keras.json`. 
 
-* `image_data_format`: string, either `"channels_last"` or `"channels_first"`. It specifies which data format convention Keras will follow. (`keras.backend.image_data_format()` returns it.)
-  - For 2D data (e.g. image), `"channels_last"` assumes `(rows, cols, channels)` while `"channels_first"` assumes `(channels, rows, cols)`. 
-  - For 3D data, `"channels_last"` assumes `(conv_dim1, conv_dim2, conv_dim3, channels)` while `"channels_first"` assumes `(channels, conv_dim1, conv_dim2, conv_dim3)`.
+* `image_data_format`: string, either "channels_last" or "channels_first". It specifies which data format convention Keras will follow. (`keras.backend.image_data_format()` returns it.)
+  - For 2D data (e.g. image), "channels_last" assumes `(rows, cols, channels)` while "channels_first" assumes `(channels, rows, cols)`. 
+  - For 3D data, "channels_last" assumes `(conv_dim1, conv_dim2, conv_dim3, channels)` while "channels_first" assumes `(channels, conv_dim1, conv_dim2, conv_dim3)`.
 * `epsilon`: float, a numeric fuzzing constant used to avoid dividing by zero in some operations.
-* `floatx`: string, `"float16"`, `"float32"`, or `"float64"`. Default float precision.
-* `backend`: string, `"tensorflow"` or `"theano"`.
+* `floatx`: string, "float16", "float32", or "float64". Default float precision.
+* `backend`: string, "tensorflow" or "theano".
 
 ----
 

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -1086,16 +1086,16 @@ class UpSampling2D(Layer):
 
     # Input shape
         4D tensor with shape:
-        - If `data_format` is `"channels_last"`:
+        - If `data_format` is "channels_last":
             `(batch, rows, cols, channels)`
-        - If `data_format` is `"channels_first"`:
+        - If `data_format` is "channels_first":
             `(batch, channels, rows, cols)`
 
     # Output shape
         4D tensor with shape:
-        - If `data_format` is `"channels_last"`:
+        - If `data_format` is "channels_last":
             `(batch, upsampled_rows, upsampled_cols, channels)`
-        - If `data_format` is `"channels_first"`:
+        - If `data_format` is "channels_first":
             `(batch, channels, upsampled_rows, upsampled_cols)`
     """
 
@@ -1155,16 +1155,16 @@ class UpSampling3D(Layer):
 
     # Input shape
         5D tensor with shape:
-        - If `data_format` is `"channels_last"`:
+        - If `data_format` is "channels_last":
             `(batch, dim1, dim2, dim3, channels)`
-        - If `data_format` is `"channels_first"`:
+        - If `data_format` is "channels_first":
             `(batch, channels, dim1, dim2, dim3)`
 
     # Output shape
         5D tensor with shape:
-        - If `data_format` is `"channels_last"`:
+        - If `data_format` is "channels_last":
             `(batch, upsampled_dim1, upsampled_dim2, upsampled_dim3, channels)`
-        - If `data_format` is `"channels_first"`:
+        - If `data_format` is "channels_first":
             `(batch, channels, upsampled_dim1, upsampled_dim2, upsampled_dim3)`
     """
 
@@ -1279,16 +1279,16 @@ class ZeroPadding2D(Layer):
 
     # Input shape
         4D tensor with shape:
-        - If `data_format` is `"channels_last"`:
+        - If `data_format` is "channels_last":
             `(batch, rows, cols, channels)`
-        - If `data_format` is `"channels_first"`:
+        - If `data_format` is "channels_first":
             `(batch, channels, rows, cols)`
 
     # Output shape
         4D tensor with shape:
-        - If `data_format` is `"channels_last"`:
+        - If `data_format` is "channels_last":
             `(batch, padded_rows, padded_cols, channels)`
-        - If `data_format` is `"channels_first"`:
+        - If `data_format` is "channels_first":
             `(batch, channels, padded_rows, padded_cols)`
     """
 
@@ -1386,16 +1386,16 @@ class ZeroPadding3D(Layer):
 
     # Input shape
         5D tensor with shape:
-        - If `data_format` is `"channels_last"`:
+        - If `data_format` is "channels_last":
             `(batch, first_axis_to_pad, second_axis_to_pad, third_axis_to_pad, depth)`
-        - If `data_format` is `"channels_first"`:
+        - If `data_format` is "channels_first":
             `(batch, depth, first_axis_to_pad, second_axis_to_pad, third_axis_to_pad)`
 
     # Output shape
         5D tensor with shape:
-        - If `data_format` is `"channels_last"`:
+        - If `data_format` is "channels_last":
             `(batch, first_padded_axis, second_padded_axis, third_axis_to_pad, depth)`
-        - If `data_format` is `"channels_first"`:
+        - If `data_format` is "channels_first":
             `(batch, depth, first_padded_axis, second_padded_axis, third_axis_to_pad)`
     """
 
@@ -1551,16 +1551,16 @@ class Cropping2D(Layer):
 
     # Input shape
         4D tensor with shape:
-        - If `data_format` is `"channels_last"`:
+        - If `data_format` is "channels_last":
             `(batch, rows, cols, channels)`
-        - If `data_format` is `"channels_first"`:
+        - If `data_format` is "channels_first":
             `(batch, channels, rows, cols)`
 
     # Output shape
         4D tensor with shape:
-        - If `data_format` is `"channels_last"`:
+        - If `data_format` is "channels_last":
             `(batch, cropped_rows, cropped_cols, channels)`
-        - If `data_format` is `"channels_first"`:
+        - If `data_format` is "channels_first":
             `(batch, channels, cropped_rows, cropped_cols)`
 
     # Examples
@@ -1692,16 +1692,16 @@ class Cropping3D(Layer):
 
     # Input shape
         5D tensor with shape:
-        - If `data_format` is `"channels_last"`:
+        - If `data_format` is "channels_last":
             `(batch, first_axis_to_crop, second_axis_to_crop, third_axis_to_crop, depth)`
-        - If `data_format` is `"channels_first"`:
+        - If `data_format` is "channels_first":
             `(batch, depth, first_axis_to_crop, second_axis_to_crop, third_axis_to_crop)`
 
     # Output shape
         5D tensor with shape:
-        - If `data_format` is `"channels_last"`:
+        - If `data_format` is "channels_last":
             `(batch, first_cropped_axis, second_cropped_axis, third_cropped_axis, depth)`
-        - If `data_format` is `"channels_first"`:
+        - If `data_format` is "channels_first":
             `(batch, depth, first_cropped_axis, second_cropped_axis, third_cropped_axis)`
     """
 


### PR DESCRIPTION
In comments, strings for `image_data_format` are expressed in three different ways. The frequencies are as follows:
- \`channels_first\`: 76
- "channels_first": 26
- \`"channels_first"\`: 15

It is hard to choose a standard form between \`xxx\` and "xxx". However, I think \`"xxx"\` looks a bit strange. This PR makes \`"channels_first"\` to "channels_first"; thus the frequencies are now:
- \`channels_first\`: 76
- "channels_first": 41
- \`"channels_first"\`: 0

I would like to get feedback on this.