### PR TITLE
Raise a descriptive error if `inputs` are not inputs

### DIFF
--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -1467,6 +1467,9 @@ class Container(Layer):
 
     # Class Methods
         from_config
+
+    # Raises
+        TypeError: if input tensors are not Keras tensors from InputLayer objects
     """
 
     @interfaces.legacy_model_constructor_support
@@ -1607,12 +1610,13 @@ class Container(Layer):
         self._feed_inputs = []
         self._feed_input_shapes = []
         for i, layer in enumerate(self.input_layers):
+            # Check that layer is an InputLayer.
+            if not isinstance(layer, InputLayer):
+                raise TypeError(('Input layers to a `{}` must be `InputLayer` objects. ' +
+                                'Input {} (0-based) is a `{}` object.').format(
+                                    self.__class__.__name__, i, layer.__class__.__name__
+                                ))
             self.input_names.append(layer.name)
-            if not hasattr(layer, 'is_placeholder'):
-                raise ValueError(
-                    'Input {} (0-indexed) `{}` has no attribute `is_placeholder`. Is it an Input layer?'.format(
-                        i, layer
-                    ))
             if layer.is_placeholder:
                 self._feed_input_names.append(layer.name)
                 self._feed_inputs.append(layer.input)

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -1612,11 +1612,13 @@ class Container(Layer):
         for i, layer in enumerate(self.input_layers):
             # Check that layer is an InputLayer.
             if not isinstance(layer, InputLayer):
-                raise TypeError(('Input layers to a `{}` must be `InputLayer` objects. ' +
-                                 'Input {} (0-based) is a `{}` object.').format(
-                    self.__class__.__name__, i, layer.__class__.__name__
-                )
-                )
+                raise TypeError(
+                    'Input layers to a `Model` must be `InputLayer` objects. '
+                    'Received inputs: {}. '
+                    'Input {} (0-based) originates '
+                    'from layer type `{}`.'.format(i,
+                                                   inputs,
+                                                   layer.__class__.__name__))
             self.input_names.append(layer.name)
             if layer.is_placeholder:
                 self._feed_input_names.append(layer.name)

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -1616,8 +1616,8 @@ class Container(Layer):
                     'Input layers to a `Model` must be `InputLayer` objects. '
                     'Received inputs: {}. '
                     'Input {} (0-based) originates '
-                    'from layer type `{}`.'.format(i,
-                                                   inputs,
+                    'from layer type `{}`.'.format(inputs,
+                                                   i,
                                                    layer.__class__.__name__))
             self.input_names.append(layer.name)
             if layer.is_placeholder:

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -1614,8 +1614,9 @@ class Container(Layer):
             if not isinstance(layer, InputLayer):
                 raise TypeError(('Input layers to a `{}` must be `InputLayer` objects. ' +
                                  'Input {} (0-based) is a `{}` object.').format(
-                        self.__class__.__name__, i, layer.__class__.__name__
-                        ))
+                    self.__class__.__name__, i, layer.__class__.__name__
+                )
+                )
             self.input_names.append(layer.name)
             if layer.is_placeholder:
                 self._feed_input_names.append(layer.name)

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -1613,9 +1613,9 @@ class Container(Layer):
             # Check that layer is an InputLayer.
             if not isinstance(layer, InputLayer):
                 raise TypeError(('Input layers to a `{}` must be `InputLayer` objects. ' +
-                                'Input {} (0-based) is a `{}` object.').format(
-                                    self.__class__.__name__, i, layer.__class__.__name__
-                                ))
+                                 'Input {} (0-based) is a `{}` object.').format(
+                        self.__class__.__name__, i, layer.__class__.__name__
+                    ))
             self.input_names.append(layer.name)
             if layer.is_placeholder:
                 self._feed_input_names.append(layer.name)

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -1608,6 +1608,11 @@ class Container(Layer):
         self._feed_input_shapes = []
         for i, layer in enumerate(self.input_layers):
             self.input_names.append(layer.name)
+            if not hasattr(layer, 'is_placeholder'):
+                raise ValueError(
+                    'Input {} (0-indexed) `{}` has no attribute `is_placeholder`. Is it an Input layer?'.format(
+                        i, layer
+                    ))
             if layer.is_placeholder:
                 self._feed_input_names.append(layer.name)
                 self._feed_inputs.append(layer.input)

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -1615,7 +1615,7 @@ class Container(Layer):
                 raise TypeError(('Input layers to a `{}` must be `InputLayer` objects. ' +
                                  'Input {} (0-based) is a `{}` object.').format(
                         self.__class__.__name__, i, layer.__class__.__name__
-                    ))
+                        ))
             self.input_names.append(layer.name)
             if layer.is_placeholder:
                 self._feed_input_names.append(layer.name)


### PR DESCRIPTION
Raise a descriptive error if `Model` constructor `inputs` are not inputs.

I had a typo where I swapped the inputs and outputs and the resulting error was a little weird.

> AttributeError: 'Dense' object has no attribute 'is_placeholder'

PR adds a check for `is_placeholder` just before that line so I get a message like this.

> ValueError: Input 0 (0-indexed) `<keras.layers.core.Dense object at 0x000000003C445128>` has no attribute `is_placeholder`. Is it an Input layer?

Cheers