### PR TITLE
Add the function that read some gpu options from keras.json

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -168,12 +168,16 @@ def get_session():
                 try:
                     _config = json.load(open(_config_path))
                 except ValueError:
-                    pass
+                    _config = {}
             _options = _config.get('gpu_options', None)
             _allow_growth = _options.get('allow_growth', False)
             _mem_frac = _options.get('per_process_gpu_memory_fraction', 1.0)
+            _visible_device_list = _options.get('visible_device_list', None)
+            # Set gpu options
             _gpu_options = tf.GPUOptions(allow_growth=_allow_growth,
-                                         per_process_gpu_memory_fraction=_mem_frac)
+                                         per_process_gpu_memory_fraction=_mem_frac,
+                                         visible_device_list=_visible_device_list)
+
 
             if not os.environ.get('OMP_NUM_THREADS'):
                 config = tf.ConfigProto(allow_soft_placement=True,

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -158,11 +158,11 @@ def get_session():
             _keras_base_dir = os.path.expanduser('~')
             if not os.access(_keras_base_dir, os.W_OK):
                 _keras_base_dir = '/tmp'
-                
+
             _keras_dir = os.path.join(_keras_base_dir, '.keras')
             _config_path = os.path.expanduser(os.path.join(_keras_dir,
                                                            'keras.json'))
-            
+
             if os.path.exists(_config_path):
                 try:
                     _config = json.load(open(_config_path))

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -156,7 +156,6 @@ def get_session():
     else:
         if _SESSION is None:
             _keras_base_dir = os.path.expanduser('~')
-            
             if not os.access(_keras_base_dir, os.W_OK):
                 _keras_base_dir = '/tmp'
                 
@@ -178,12 +177,10 @@ def get_session():
                                          per_process_gpu_memory_fraction=_mem_frac,
                                          visible_device_list=_visible_device_list)
 
-
             if not os.environ.get('OMP_NUM_THREADS'):
                 config = tf.ConfigProto(allow_soft_placement=True,
                                         gpu_options=_gpu_options)
             else:
-
                 num_thread = int(os.environ.get('OMP_NUM_THREADS'))
                 config = tf.ConfigProto(intra_op_parallelism_threads=num_thread,
                                         allow_soft_placement=True,

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -168,7 +168,7 @@ def get_session():
                     _config = json.load(open(_config_path))
                 except ValueError:
                     _config = {}
-            _options = _config.get('gpu_options', None)
+            _options = _config.get('gpu_options', {})
             _allow_growth = _options.get('allow_growth', False)
             _mem_frac = _options.get('per_process_gpu_memory_fraction', 1.0)
             _visible_device_list = _options.get('visible_device_list', None)


### PR DESCRIPTION
This PR can solve #1538.
Add the function that read `gpu_options` from keras.json in the `tensorflow_backend.py` .

・json example:
```json
{
    "epsilon": 1e-07,
    "floatx": "float32",
    "image_data_format": "channels_last",
    "backend": "tensorflow",
    "gpu_options": {
        "allow_growth": false,
        "per_process_gpu_memory_fraction": 0.5,
        "visible_device_list": "0,1"
    }
}
```

This PR supports only `allow_growth, per_process_gpu_memory_fraction, visible_device_list`.
