### PR TITLE
Serializing/Desrializing numpy arrays in Lambda layer arguments

### DIFF
--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -729,9 +729,6 @@ class Lambda(Layer):
                     if 'type' in arg_dict and arg_dict['type'] == 'ndarray':
                         # Overwrite the argument with its numpy translation
                         config['arguments'][key] = np.array(arg_dict['value'])
-                    else:
-                        warnings.warn('Unhandled dictionnary data in arguments {}'
-                                      .format(arg_dict))
 
         config['function'] = function
         config['output_shape'] = output_shape

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -723,12 +723,10 @@ class Lambda(Layer):
         # If arguments were numpy array, they have been saved as
         # list. We need to recover the ndarray
         if 'arguments' in config:
-            for k in config['arguments']:
-                if isinstance(config['arguments'][k], dict) and \
-                   ('type' in config['arguments'][k]) and \
-                   (config['arguments'][k]['type'] == 'ndarray'):
+            for key in config['arguments']:
+                if isinstance(config['arguments'][k], dict) and ('type' in config['arguments'][k]) and (config['arguments'][k]['type'] == 'ndarray'):
                     config['arguments'][k] = np.array(config['arguments'][k]['value'])
-            
+
         config['function'] = function
         config['output_shape'] = output_shape
         return cls(**config)

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -724,8 +724,14 @@ class Lambda(Layer):
         # list. We need to recover the ndarray
         if 'arguments' in config:
             for key in config['arguments']:
-                if isinstance(config['arguments'][k], dict) and ('type' in config['arguments'][k]) and (config['arguments'][k]['type'] == 'ndarray'):
-                    config['arguments'][k] = np.array(config['arguments'][k]['value'])
+                if isinstance(config['arguments'][key], dict):
+                    arg_dict = config['arguments'][key]
+                    if 'type' in arg_dict and arg_dict['type'] == 'ndarray':
+                        # Overwrite the argument with its numpy translation
+                        config['arguments'][key] = np.array(arg_dict['value'])
+                    else:
+                        warnings.warn('Unhandled dictionnary data in arguments {}'
+                                      .format(arg_dict))
 
         config['function'] = function
         config['output_shape'] = output_shape

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -720,6 +720,15 @@ class Lambda(Layer):
         else:
             output_shape = config['output_shape']
 
+        # If arguments were numpy array, they have been saved as
+        # list. We need to recover the ndarray
+        if 'arguments' in config:
+            for k in config['arguments']:
+                if isinstance(config['arguments'][k], dict) and \
+                   ('type' in config['arguments'][k]) and \
+                   (config['arguments'][k]['type'] == 'ndarray'):
+                    config['arguments'][k] = np.array(config['arguments'][k]['value'])
+            
         config['function'] = function
         config['output_shape'] = output_shape
         return cls(**config)

--- a/keras/models.py
+++ b/keras/models.py
@@ -77,7 +77,6 @@ def save_model(model, filepath, overwrite=True):
                 return {'type': type(obj),
                         'value': obj.tolist()}
             else:
-                print("Have to serialize np type other than array ...")
                 return obj.item()
 
         # misc functions (e.g. loss function)

--- a/keras/models.py
+++ b/keras/models.py
@@ -73,7 +73,12 @@ def save_model(model, filepath, overwrite=True):
 
         # if obj is any numpy type
         if type(obj).__module__ == np.__name__:
-            return obj.item()
+            if isinstance(obj, np.ndarray):
+                return {'type': type(obj),
+                        'value': obj.tolist()}
+            else:
+                print("Have to serialize np type other than array ...")
+                return obj.item()
 
         # misc functions (e.g. loss function)
         if callable(obj):

--- a/tests/test_model_saving.py
+++ b/tests/test_model_saving.py
@@ -292,15 +292,17 @@ def test_saving_lambda_custom_objects():
     out2 = model.predict(x)
     assert_allclose(out, out2, atol=1e-05)
 
+
 @keras_test
 def test_saving_lambda_numpy_array_arguments():
-    mean = np.random.random((4,2,3))
-    std = np.abs(np.random.random((4,2,3))) + 1e-5
-    input = Input(shape=(4,2,3))
-    output = Lambda(lambda image, mu, std: (image - mu)/std, arguments={'mu':mean, 'std': std})(input)
+    mean = np.random.random((4, 2, 3))
+    std = np.abs(np.random.random((4, 2, 3))) + 1e-5
+    input = Input(shape=(4, 2, 3))
+    output = Lambda(lambda image, mu, std: (image - mu) / std,
+                    arguments={'mu': mean, 'std': std})(input)
     model = Model(input, output)
     model.compile(loss='mse', optimizer='sgd', metrics=['acc'])
-    
+
     _, fname = tempfile.mkstemp('.h5')
     save_model(model, fname)
 
@@ -309,7 +311,7 @@ def test_saving_lambda_numpy_array_arguments():
 
     assert_allclose(mean, model.layers[1].arguments['mu'])
     assert_allclose(std, model.layers[1].arguments['std'])
-    
+
 
 @keras_test
 def test_saving_custom_activation_function():

--- a/tests/test_model_saving.py
+++ b/tests/test_model_saving.py
@@ -261,6 +261,23 @@ def test_saving_lambda_custom_objects():
     out2 = model.predict(x)
     assert_allclose(out, out2, atol=1e-05)
 
+@keras_test
+def test_saving_lambda_numpy_array_arguments():
+    mean = np.random.random((4,2,3))
+    std = np.abs(np.random.random((4,2,3))) + 1e-5
+    input = Input(shape=(4,2,3))
+    output = Lambda(lambda image, mu, std: (image - mu)/std, arguments={'mu':mean, 'std': std})(input)
+    model = Model(input, output)
+    model.compile(loss='mse', optimizer='sgd', metrics=['acc'])
+    
+    _, fname = tempfile.mkstemp('.h5')
+    save_model(model, fname)
 
+    model = load_model(fname)
+    os.remove(fname)
+
+    assert_allclose(mean, model.layers[1].arguments['mu'])
+    assert_allclose(std, model.layers[1].arguments['std'])
+    
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
When we use numpy arrays in arguments of Lambda layers, they cannot be serialized with model.save.

For example, running 

```
from keras.layers import Input, Lambda
from keras.models import Model
import numpy as np

mean = np.zeros((2,2,1))
xi = Input(shape=(2,2,1), name="input")
p = Lambda(lambda image, mu: image - mu, arguments={'mu':mean})(xi)
model = Model(inputs=[xi], outputs=[p])

print("Arguments to save : {}".format(model.layers[1].arguments))
model.save("titi.h5")
```

fails with "ValueError: can only convert an array of size 1 to a Python scalar"

The issue comes from models.py:get_json_type which invokes obj.item in case of a numpy object but this fails if the object is indeed a numpy array. 

This pull requests propose to handle specifically the case the serialized object is a ndarray by converting it into a list. Deserialization is done only in from_config of Lambda layers. This is a proposal, I do not master the API of Keras so guidelines for improving this PR are welcomed.