### PR TITLE
Add top_k_sparse_categorical_accuracy and test code

### DIFF
--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -36,6 +36,11 @@ def sparse_categorical_accuracy(y_true, y_pred):
 def top_k_categorical_accuracy(y_true, y_pred, k=5):
     return K.mean(K.in_top_k(y_pred, K.argmax(y_true, axis=-1), k), axis=-1)
 
+
+def top_k_sparse_categorical_accuracy(y_true, y_pred, k=5):
+    return K.mean(K.in_top_k(y_pred, K.cast(K.max(y_true, axis=-1), 'int32'), k), axis=-1)
+
+
 # Aliases
 
 mse = MSE = mean_squared_error

--- a/tests/keras/metrics_test.py
+++ b/tests/keras/metrics_test.py
@@ -56,5 +56,19 @@ def test_top_k_categorical_accuracy():
     assert failure_result == 0
 
 
+def test_top_k_sparse_categorical_accuracy():
+    y_pred = K.variable(np.array([[0.3, 0.2, 0.1], [0.1, 0.2, 0.7]]))
+    y_true = K.variable(np.array([[1], [0]]))
+    success_result = K.eval(metrics.top_k_sparse_categorical_accuracy(y_true, y_pred,
+                                                                      k=3))
+    assert success_result == 1
+    partial_result = K.eval(metrics.top_k_sparse_categorical_accuracy(y_true, y_pred,
+                                                                      k=2))
+    assert partial_result == 0.5
+    failure_result = K.eval(metrics.top_k_sparse_categorical_accuracy(y_true, y_pred,
+                                                                      k=1))
+    assert failure_result == 0
+
+
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
For sparse category, a top k metric may be helpful. I cited the code from [top_k_sparse_categorical_accuracy](https://stackoverflow.com/questions/43708510/implementing-top-k-sparse-categorical-accuracy-metric-for-keras) and tested it with my data.