### PR TITLE
Update LICENSE dates for all other contributors

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -9,7 +9,7 @@ Copyright (c) 2015, Google, Inc.
 All rights reserved.
 
 All other contributions:
-Copyright (c) 2015, the respective contributors.
+Copyright (c) 2015 - 2017, the respective contributors.
 All rights reserved.
 
 Each contributor holds copyright over their respective contributions.


### PR DESCRIPTION
Correction at https://github.com/fchollet/keras/pull/6800/files/8a93935d99fae4b8dc2ce0ea1a169906da0a165d#r120219133 also applies to all other contributers. It probably applies François Chollet and Google too, but I'm only a member of "All other contributors" so I figured the other changes should be made by those respective rightsholders. :-)