### PR TITLE
Remove duplicated batch_set_value in cntk_backend

### DIFF
--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -798,11 +798,6 @@ def get_variable_shape(x):
     return x.shape
 
 
-def batch_set_value(tuples):
-    for p, v in tuples:
-        p.value = v.astype(np.float32)
-
-
 def update(x, new_x):
     return C.assign(x, new_x)
 


### PR DESCRIPTION
batch_set_value() is defined twice.

@souptc