### PR TITLE
Use batch_input_shape in input layer even if input_tensor is set

### DIFF
--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -1298,7 +1298,8 @@ class InputLayer(Layer):
             raise ValueError('Only provide the input_shape OR '
                              'batch_input_shape argument to '
                              'InputLayer, not both at the same time.')
-        if input_tensor is not None:
+        if input_tensor is not None and batch_input_shape is None:
+            # If input_tensor is set, and batch_input_shape is not set:
             # Attempt automatic input shape inference.
             try:
                 batch_input_shape = K.int_shape(input_tensor)


### PR DESCRIPTION
If an input layer is supplied an input_tensor among its arguments, it will try to determine the batch_input_shape based on this tensor. 

I am using a separate pre-trained network inside a keras custom loss function, and sending the y_pred and y_true through a network. This resulted in the shape (None, None, None, None), which eventually leads to the program failing. I know the shape beforehand, however, setting the batch_input_shape didn't help. In this PR, I made it so that the input layer will always use batch_input_shape if it is set.