### PR TITLE
Renamed one_hot function to hashing_trick, made hashing stable

### DIFF
--- a/docs/templates/preprocessing/text.md
+++ b/docs/templates/preprocessing/text.md
@@ -48,13 +48,11 @@ Converts a text to a sequence of indices in a fixed-size hashing space
         A list of integer word indices (unicity non-guaranteed).
 - __Arguments__: Same as `text_to_word_sequence` above.
     - __n__: Dimension of the hashing space.
-    - __hash_function__: The hash function to use. Takes in input a string,
-        returns a int. If argument is `None` the `hash` function is used.
-        Note that `hash` function is not a stable hashing function, so
-        it is not consistent across different run.
-        If a learned model that uses the hashing trick is meant to be
-        saved and reused a stable hashing function must be given as
-        argument.
+    - __hash_function__: one of 'hash', 'md5',  'mmh3' or any function
+            that takes in input a string and return a int.
+            Note that 'hash' is not a stable hashing function, so
+            it is not consistent across different runs, while 'md5' and 'mmh3'
+            are stable hashing functions.
 
 ## Tokenizer
 

--- a/docs/templates/preprocessing/text.md
+++ b/docs/templates/preprocessing/text.md
@@ -25,10 +25,36 @@ keras.preprocessing.text.one_hot(text, n,
 
 One-hot encode a text into a list of word indexes in a vocabulary of size n.
 
+This is a wrapper to the `hashing_trick` function using `hash` as the hashing function.
+
 - __Return__: List of integers in [1, n]. Each integer encodes a word (unicity non-guaranteed).
 
 - __Arguments__: Same as `text_to_word_sequence` above.
     - __n__: int. Size of vocabulary.
+    
+## hashing_trick
+
+```python
+keras.preprocessing.text.hashing_trick(text, n,
+                  hash_function=None,
+                  filters='!"#$%&()*+,-./:;<=>?@[\\]^_`{|}~\t\n',
+                  lower=True,
+                  split=' ')
+```
+
+Converts a text to a sequence of indices in a fixed-size hashing space
+
+- __Return__:
+        A list of integer word indices (unicity non-guaranteed).
+- __Arguments__: Same as `text_to_word_sequence` above.
+    - __n__: Dimension of the hashing space.
+    - __hash_function__: The hash function to use. Takes in input a string,
+        returns a int. If argument is `None` the `hash` function is used.
+        Note that `hash` function is not a stable hashing function, so
+        it is not consistent across different run.
+        If a learned model that uses the hashing trick is meant to be
+        saved and reused a stable hashing function must be given as
+        argument.
 
 ## Tokenizer
 

--- a/docs/templates/preprocessing/text.md
+++ b/docs/templates/preprocessing/text.md
@@ -2,8 +2,10 @@
 ## text_to_word_sequence
 
 ```python
-keras.preprocessing.text.text_to_word_sequence(text, 
-                                               filters='!"#$%&()*+,-./:;<=>?@[\\]^_`{|}~\t\n', lower=True, split=" ")
+keras.preprocessing.text.text_to_word_sequence(text,
+                                               filters='!"#$%&()*+,-./:;<=>?@[\\]^_`{|}~\t\n',
+                                               lower=True,
+                                               split=" ")
 ```
 
 Split a sentence into a list of words.
@@ -12,18 +14,23 @@ Split a sentence into a list of words.
 
 - __Arguments__:
     - __text__: str.
-    - __filters__: list (or concatenation) of characters to filter out, such as punctuation. Default: '!"#$%&()*+,-./:;<=>?@[\\]^_`{|}~\t\n' , includes basic punctuation, tabs, and newlines.
+    - __filters__: list (or concatenation) of characters to filter out, such as
+         punctuation. Default: '!"#$%&()*+,-./:;<=>?@[\\]^_`{|}~\t\n' , includes
+         basic punctuation, tabs, and newlines.
     - __lower__: boolean. Whether to set the text to lowercase.
     - __split__: str. Separator for word splitting.
 
 ## one_hot
 
 ```python
-keras.preprocessing.text.one_hot(text, n,
-                                 filters='!"#$%&()*+,-./:;<=>?@[\\]^_`{|}~\t\n', lower=True, split=" ")
+keras.preprocessing.text.one_hot(text,
+                                 n,
+                                 filters='!"#$%&()*+,-./:;<=>?@[\\]^_`{|}~\t\n',
+                                 lower=True,
+                                 split=" ")
 ```
 
-One-hot encode a text into a list of word indexes in a vocabulary of size n.
+One-hot encodes a text into a list of word indexes in a vocabulary of size n.
 
 This is a wrapper to the `hashing_trick` function using `hash` as the hashing function.
 
@@ -32,14 +39,17 @@ This is a wrapper to the `hashing_trick` function using `hash` as the hashing fu
 - __Arguments__:
     - __text__: str.
     - __n__: int. Size of vocabulary.
-    - __filters__: list (or concatenation) of characters to filter out, such as punctuation. Default: '!"#$%&()*+,-./:;<=>?@[\\]^_`{|}~\t\n' , includes basic punctuation, tabs, and newlines.
+    - __filters__: list (or concatenation) of characters to filter out, such as
+         punctuation. Default: '!"#$%&()*+,-./:;<=>?@[\\]^_`{|}~\t\n' , includes
+         basic punctuation, tabs, and newlines.
     - __lower__: boolean. Whether to set the text to lowercase.
     - __split__: str. Separator for word splitting.
     
 ## hashing_trick
 
 ```python
-keras.preprocessing.text.hashing_trick(text, n,
+keras.preprocessing.text.hashing_trick(text, 
+                                       n,
                                        hash_function=None,
                                        filters='!"#$%&()*+,-./:;<=>?@[\\]^_`{|}~\t\n',
                                        lower=True,
@@ -58,15 +68,20 @@ Converts a text to a sequence of indices in a fixed-size hashing space
             Note that 'hash' is not a stable hashing function, so
             it is not consistent across different runs, while 'md5'
             is a stable hashing function.
-    - __filters__: list (or concatenation) of characters to filter out, such as punctuation. Default: '!"#$%&()*+,-./:;<=>?@[\\]^_`{|}~\t\n' , includes basic punctuation, tabs, and newlines.
+    - __filters__: list (or concatenation) of characters to filter out, such as
+         punctuation. Default: '!"#$%&()*+,-./:;<=>?@[\\]^_`{|}~\t\n' , includes
+         basic punctuation, tabs, and newlines.
     - __lower__: boolean. Whether to set the text to lowercase.
     - __split__: str. Separator for word splitting.
 
 ## Tokenizer
 
 ```python
-keras.preprocessing.text.Tokenizer(num_words=None, filters='!"#$%&()*+,-./:;<=>?@[\\]^_`{|}~\t\n', 
-                                   lower=True, split=" ", char_level=False)
+keras.preprocessing.text.Tokenizer(num_words=None,
+                                   filters='!"#$%&()*+,-./:;<=>?@[\\]^_`{|}~\t\n',
+                                   lower=True,
+                                   split=" ",
+                                   char_level=False)
 ```
 
 Class for vectorizing texts, or/and turning texts into sequences (=list of word indexes, where the word of rank i in the dataset (starting at 1) has index i).

--- a/docs/templates/preprocessing/text.md
+++ b/docs/templates/preprocessing/text.md
@@ -3,7 +3,7 @@
 
 ```python
 keras.preprocessing.text.text_to_word_sequence(text, 
-    filters='!"#$%&()*+,-./:;<=>?@[\\]^_`{|}~\t\n', lower=True, split=" ")
+                                               filters='!"#$%&()*+,-./:;<=>?@[\\]^_`{|}~\t\n', lower=True, split=" ")
 ```
 
 Split a sentence into a list of words.
@@ -20,7 +20,7 @@ Split a sentence into a list of words.
 
 ```python
 keras.preprocessing.text.one_hot(text, n,
-    filters='!"#$%&()*+,-./:;<=>?@[\\]^_`{|}~\t\n', lower=True, split=" ")
+                                 filters='!"#$%&()*+,-./:;<=>?@[\\]^_`{|}~\t\n', lower=True, split=" ")
 ```
 
 One-hot encode a text into a list of word indexes in a vocabulary of size n.
@@ -29,36 +29,44 @@ This is a wrapper to the `hashing_trick` function using `hash` as the hashing fu
 
 - __Return__: List of integers in [1, n]. Each integer encodes a word (unicity non-guaranteed).
 
-- __Arguments__: Same as `text_to_word_sequence` above.
+- __Arguments__:
+    - __text__: str.
     - __n__: int. Size of vocabulary.
+    - __filters__: list (or concatenation) of characters to filter out, such as punctuation. Default: '!"#$%&()*+,-./:;<=>?@[\\]^_`{|}~\t\n' , includes basic punctuation, tabs, and newlines.
+    - __lower__: boolean. Whether to set the text to lowercase.
+    - __split__: str. Separator for word splitting.
     
 ## hashing_trick
 
 ```python
 keras.preprocessing.text.hashing_trick(text, n,
-                  hash_function=None,
-                  filters='!"#$%&()*+,-./:;<=>?@[\\]^_`{|}~\t\n',
-                  lower=True,
-                  split=' ')
+                                       hash_function=None,
+                                       filters='!"#$%&()*+,-./:;<=>?@[\\]^_`{|}~\t\n',
+                                       lower=True,
+                                       split=' ')
 ```
 
 Converts a text to a sequence of indices in a fixed-size hashing space
 
 - __Return__:
         A list of integer word indices (unicity non-guaranteed).
-- __Arguments__: Same as `text_to_word_sequence` above.
+- __Arguments__:
+    - __text__: str.
     - __n__: Dimension of the hashing space.
-    - __hash_function__: one of 'hash', 'md5',  'mmh3' or any function
-            that takes in input a string and return a int.
+    - __hash_function__: defaults to python `hash` function, can be 'md5' or
+            any function that takes in input a string and returns a int.
             Note that 'hash' is not a stable hashing function, so
-            it is not consistent across different runs, while 'md5' and 'mmh3'
-            are stable hashing functions.
+            it is not consistent across different runs, while 'md5'
+            is a stable hashing function.
+    - __filters__: list (or concatenation) of characters to filter out, such as punctuation. Default: '!"#$%&()*+,-./:;<=>?@[\\]^_`{|}~\t\n' , includes basic punctuation, tabs, and newlines.
+    - __lower__: boolean. Whether to set the text to lowercase.
+    - __split__: str. Separator for word splitting.
 
 ## Tokenizer
 
 ```python
 keras.preprocessing.text.Tokenizer(num_words=None, filters='!"#$%&()*+,-./:;<=>?@[\\]^_`{|}~\t\n', 
-    lower=True, split=" ", char_level=False)
+                                   lower=True, split=" ", char_level=False)
 ```
 
 Class for vectorizing texts, or/and turning texts into sequences (=list of word indexes, where the word of rank i in the dataset (starting at 1) has index i).

--- a/keras/preprocessing/text.py
+++ b/keras/preprocessing/text.py
@@ -53,14 +53,14 @@ def one_hot(text, n,
     hashing function, unicity of word to index mapping non-guaranteed.
     """
     return hashing_trick(text, n,
-                         hash_function='hash',
+                         hash_function=hash,
                          filters=filters,
                          lower=lower,
                          split=split)
 
 
 def hashing_trick(text, n,
-                  hash_function='hash',
+                  hash_function=None,
                   filters='!"#$%&()*+,-./:;<=>?@[\\]^_`{|}~\t\n',
                   lower=True,
                   split=' '):
@@ -69,9 +69,9 @@ def hashing_trick(text, n,
     # Arguments
         text: Input text (string).
         n: Dimension of the hashing space.
-        hash_function: defaults to python `hash` function, can be 'md5' or
+        hash_function: if `None` uses python `hash` function, can be 'md5' or
             any function that takes in input a string and returns a int.
-            Note that 'hash' is not a stable hashing function, so
+            Note that `hash` is not a stable hashing function, so
             it is not consistent across different runs, while 'md5'
             is a stable hashing function.
         filters: Sequence of characters to filter out.

--- a/keras/preprocessing/text.py
+++ b/keras/preprocessing/text.py
@@ -51,8 +51,8 @@ def hashing_trick(text, n,
     # Arguments
         text: Input text (string).
         n: Dimension of the hashing space.
-        hash_function: The hash function to use. Takes in input a string, 
-            returns a int. If None md5 is used.            
+        hash_function: The hash function to use. Takes in input a string,
+            returns a int. If None md5 is used.
         filters: Sequence of characters to filter out.
         lower: Whether to convert the input to lowercase.
         split: Sentence split marker (string).

--- a/keras/preprocessing/text.py
+++ b/keras/preprocessing/text.py
@@ -47,7 +47,7 @@ def one_hot(text, n,
             filters='!"#$%&()*+,-./:;<=>?@[\\]^_`{|}~\t\n',
             lower=True,
             split=' '):
-    """One-hot encode a text into a list of word indexes of size n.
+    """One-hot encodes a text into a list of word indexes of size n.
 
     This is a wrapper to the `hashing_trick` function using `hash` as the
     hashing function, unicity of word to index mapping non-guaranteed.

--- a/keras/preprocessing/text.py
+++ b/keras/preprocessing/text.py
@@ -41,15 +41,41 @@ def text_to_word_sequence(text,
     return [i for i in seq if i]
 
 
-def one_hot(text, n,
-            filters='!"#$%&()*+,-./:;<=>?@[\\]^_`{|}~\t\n',
-            lower=True,
-            split=' '):
+def hashing_trick(text, n,
+                  hash_function=None,
+                  filters='!"#$%&()*+,-./:;<=>?@[\\]^_`{|}~\t\n',
+                  lower=True,
+                  split=' '):
+    """Converts a text to a sequence of indices in a fixed-size hashing space
+
+    # Arguments
+        text: Input text (string).
+        n: Dimension of the hashing space.
+        hash_function: The hash function to use. Takes in input a string, 
+            returns a int. If None md5 is used.            
+        filters: Sequence of characters to filter out.
+        lower: Whether to convert the input to lowercase.
+        split: Sentence split marker (string).
+
+    # Returns
+        A list of integer word indices.
+
+    `0` is a reserved index that won't be assigned to any word.
+
+    Two or more words may be assigned to the same index, due to possible
+    collisions by the hashing function.
+    The probability of a collision is in relation to the dimension of
+    the hashing space and the number of distinct objects, see
+    https://en.wikipedia.org/wiki/Birthday_problem#Probability_table
+    """
+    if hash_function is None:
+        hash_function = lambda w: int(md5(w.encode()).hexdigest(), 16)
+
     seq = text_to_word_sequence(text,
                                 filters=filters,
                                 lower=lower,
                                 split=split)
-    return [(abs(hash(w)) % (n - 1) + 1) for w in seq]
+    return [(hash_function(w) % (n - 1) + 1) for w in seq]
 
 
 class Tokenizer(object):

--- a/keras/preprocessing/text.py
+++ b/keras/preprocessing/text.py
@@ -9,6 +9,7 @@ from __future__ import division
 import string
 import sys
 import numpy as np
+from hashlib import md5
 from six.moves import range
 from six.moves import zip
 from collections import OrderedDict

--- a/keras/preprocessing/text.py
+++ b/keras/preprocessing/text.py
@@ -12,11 +12,6 @@ import warnings
 from collections import OrderedDict
 from hashlib import md5
 
-try:
-    import mmh3
-except ImportError:
-    mmh3 = None
-
 import numpy as np
 from six.moves import range
 from six.moves import zip
@@ -74,21 +69,17 @@ def hashing_trick(text, n,
     # Arguments
         text: Input text (string).
         n: Dimension of the hashing space.
-        hash_function: one of 'hash', 'md5',  'mmh3' or any function
-            that takes in input a string and return a int.
-            Note that `hash` function is not a stable hashing function, so
-            it is not consistent across different runs, while 'md5' and 'mmh3'
-            are stable hashing functions.
+        hash_function: defaults to python `hash` function, can be 'md5' or
+            any function that takes in input a string and returns a int.
+            Note that 'hash' is not a stable hashing function, so
+            it is not consistent across different runs, while 'md5'
+            is a stable hashing function.
         filters: Sequence of characters to filter out.
         lower: Whether to convert the input to lowercase.
         split: Sentence split marker (string).
 
     # Returns
         A list of integer word indices (unicity non-guaranteed).
-
-    # Raises
-        ImportError: if mmh3 is not available when 'mmh3' is passed to
-        `hash_function`.
 
     `0` is a reserved index that won't be assigned to any word.
 
@@ -98,14 +89,10 @@ def hashing_trick(text, n,
     of a collision is in relation to the dimension of the hashing space and
     the number of distinct objects.
     """
-    if hash_function == 'hash':
+    if hash_function is None:
         hash_function = hash
     elif hash_function == 'md5':
         hash_function = lambda w: int(md5(w.encode()).hexdigest(), 16)
-    elif hash_function == 'mmh3':
-        if mmh3 is None:
-            raise ImportError('`hashing_trick` requires mmh3.')
-        hash_function = mmh3.hash
 
     seq = text_to_word_sequence(text,
                                 filters=filters,

--- a/tests/keras/preprocessing/text_test.py
+++ b/tests/keras/preprocessing/text_test.py
@@ -1,6 +1,7 @@
-from keras.preprocessing.text import Tokenizer, one_hot, hashing_trick
-import pytest
 import numpy as np
+import pytest
+
+from keras.preprocessing.text import Tokenizer, one_hot, hashing_trick
 
 
 def test_one_hot():
@@ -25,19 +26,6 @@ def test_hashing_trick_md5():
     assert len(encoded) == 6
     assert np.max(encoded) <= 4
     assert np.min(encoded) >= 1
-
-
-def test_hashing_trick_mmh3():
-    text = 'The cat sat on the mat.'
-    try:
-        import mmh3
-    except ImportError:
-        mmh3 = None
-    if mmh3 is not None:
-        encoded = hashing_trick(text, 5, hash_function='mmh3')
-        assert len(encoded) == 6
-        assert np.max(encoded) <= 4
-        assert np.min(encoded) >= 1
 
 
 def test_tokenizer():

--- a/tests/keras/preprocessing/text_test.py
+++ b/tests/keras/preprocessing/text_test.py
@@ -1,14 +1,14 @@
-from keras.preprocessing.text import Tokenizer, one_hot
+from keras.preprocessing.text import Tokenizer, hashing_trick
 import pytest
 import numpy as np
 
 
-def test_one_hot():
+def test_hashing_trick():
     text = 'The cat sat on the mat.'
-    encoded = one_hot(text, 5)
+    encoded = hashing_trick(text, 5)
     assert len(encoded) == 6
     assert np.max(encoded) <= 4
-    assert np.min(encoded) >= 0
+    assert np.min(encoded) >= 1
 
 
 def test_tokenizer():

--- a/tests/keras/preprocessing/text_test.py
+++ b/tests/keras/preprocessing/text_test.py
@@ -1,6 +1,14 @@
-from keras.preprocessing.text import Tokenizer, hashing_trick
+from keras.preprocessing.text import Tokenizer, one_hot, hashing_trick
 import pytest
 import numpy as np
+
+
+def test_one_hot():
+    text = 'The cat sat on the mat.'
+    encoded = one_hot(text, 5)
+    assert len(encoded) == 6
+    assert np.max(encoded) <= 4
+    assert np.min(encoded) >= 0
 
 
 def test_hashing_trick():

--- a/tests/keras/preprocessing/text_test.py
+++ b/tests/keras/preprocessing/text_test.py
@@ -11,12 +11,31 @@ def test_one_hot():
     assert np.min(encoded) >= 0
 
 
-def test_hashing_trick():
+def test_hashing_trick_hash():
     text = 'The cat sat on the mat.'
     encoded = hashing_trick(text, 5)
     assert len(encoded) == 6
     assert np.max(encoded) <= 4
     assert np.min(encoded) >= 1
+
+def test_hashing_trick_md5():
+    text = 'The cat sat on the mat.'
+    encoded = hashing_trick(text, 5, hash_function='md5')
+    assert len(encoded) == 6
+    assert np.max(encoded) <= 4
+    assert np.min(encoded) >= 1
+
+def test_hashing_trick_mmh3():
+    text = 'The cat sat on the mat.'
+    try:
+        import mmh3
+    except ImportError:
+        mmh3 = None
+    if mmh3 is not None:
+        encoded = hashing_trick(text, 5, hash_function='mmh3')
+        assert len(encoded) == 6
+        assert np.max(encoded) <= 4
+        assert np.min(encoded) >= 1
 
 
 def test_tokenizer():

--- a/tests/keras/preprocessing/text_test.py
+++ b/tests/keras/preprocessing/text_test.py
@@ -18,12 +18,14 @@ def test_hashing_trick_hash():
     assert np.max(encoded) <= 4
     assert np.min(encoded) >= 1
 
+
 def test_hashing_trick_md5():
     text = 'The cat sat on the mat.'
     encoded = hashing_trick(text, 5, hash_function='md5')
     assert len(encoded) == 6
     assert np.max(encoded) <= 4
     assert np.min(encoded) >= 1
+
 
 def test_hashing_trick_mmh3():
     text = 'The cat sat on the mat.'


### PR DESCRIPTION
As pointed out in #2294 the one_hot function does not really implement a one hot encoding, but a hashing-based encoding, with possible collisions between words.
This method is a well-known indexing method, a.k.a. the hashing trick.
For this reason I propose to rename the function from one_hot to hashing_trick.
I also changed the implementation, as the original one_hot function used the hash() function that is not implemented as a stable hashing function (due to security concerns), and replaced it with md5() from hashlib, which is stable.
The use of md5 is not as straightforward and fast as using a dedicated hashing function, such as murmurhash, but using it as default avoids adding new dependencies to keras.
A custom hashing function can be eventually passed as a parameter to the hashing_trick function.