### PR TITLE
Fix a bug when training with sparse matrices

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1462,7 +1462,10 @@ class Model(Container):
 
         elif validation_split and 0. < validation_split < 1.:
             do_validation = True
-            split_at = int(len(x[0]) * (1. - validation_split))
+            if hasattr(x[0], 'shape'):
+                split_at = int(x[0].shape[0] * (1. - validation_split))
+            else:
+                split_at = int(len(x[0]) * (1. - validation_split))
             x, val_x = (_slice_arrays(x, 0, split_at), _slice_arrays(x, split_at))
             y, val_y = (_slice_arrays(y, 0, split_at), _slice_arrays(y, split_at))
             sample_weights, val_sample_weights = (

--- a/tests/keras/engine/test_training.py
+++ b/tests/keras/engine/test_training.py
@@ -1,6 +1,7 @@
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose
+import scipy.sparse as sparse
 
 from keras.layers import Dense, Dropout
 from keras.engine.topology import Input
@@ -196,6 +197,18 @@ def test_model_methods():
     out = model.fit([input_a_np, input_b_np], [output_a_np, output_b_np], batch_size=4, epochs=1)
     out = model.evaluate([input_a_np, input_b_np], [output_a_np, output_b_np], batch_size=4)
     out = model.predict([input_a_np, input_b_np], batch_size=4)
+
+
+@pytest.mark.skipif(K.backend() != 'tensorflow', reason='sparse operations supported only by TF')
+@keras_test
+def test_sparse_input_validation_split():
+    test_input = sparse.random(6, 3, density=0.25).tocsr()
+    in1 = Input(shape=(3,), sparse=True)
+    out1 = Dense(4)(in1)
+    test_output = np.random.random((6, 4))
+    model = Model(in1, out1)
+    model.compile('rmsprop', 'mse')
+    model.fit(test_input, test_output, epochs=1, batch_size=2, validation_split=0.2)
 
 
 @keras_test


### PR DESCRIPTION
model.fit assumes it can figure out the size of the input.

A broader question: maybe I should replace all those `len(x[0])` in the file with `x[0].shape[0]`?