### PR TITLE
[Documentation] Fine-tuning InceptionV3

### DIFF
--- a/docs/templates/applications.md
+++ b/docs/templates/applications.md
@@ -130,10 +130,10 @@ for i, layer in enumerate(base_model.layers):
    print(i, layer.name)
 
 # we chose to train the top 2 inception blocks, i.e. we will freeze
-# the first 172 layers and unfreeze the rest:
-for layer in model.layers[:172]:
+# the first 249 layers and unfreeze the rest:
+for layer in model.layers[:249]:
    layer.trainable = False
-for layer in model.layers[172:]:
+for layer in model.layers[249:]:
    layer.trainable = True
 
 # we need to recompile the model for these modifications to take effect


### PR DESCRIPTION
The documentation wrongly states that the 2 last inception blocks consist of layers `model.layers[172:]`. Fixes #6910.

This PR corrects the number of layers for two last inception blocks in the documentation.