### PR TITLE
More descriptive message when user specifies non-existing metric for early stopping

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -490,8 +490,11 @@ class EarlyStopping(Callback):
     def on_epoch_end(self, epoch, logs=None):
         current = logs.get(self.monitor)
         if current is None:
-            warnings.warn('Early stopping requires %s available!' %
-                          (self.monitor), RuntimeWarning)
+            warnings.warn(
+                'Early stopping conditioned on metric `%s` '
+                'which is not available. Available metrics are: %s' %
+                (self.monitor, ','.join(list(logs.keys()))), RuntimeWarning
+            )
 
         if self.monitor_op(current - self.min_delta, self.best):
             self.best = current


### PR DESCRIPTION
I tried to use "accuracy" for early stopping and got error `Early stopping requires accuracy available!` which was not immediately clear to me (the problem is that correct name should be "acc")

Now the message is going to be something like `Early stopping conditioned on metric 'accuracy' which is not available. Available metrics are: val_loss,acc,val_acc,loss` - more helpful IMO