### PR TITLE
add new Activation function: selu

### DIFF
--- a/keras/activations.py
+++ b/keras/activations.py
@@ -33,9 +33,13 @@ def softmax(x, axis=-1):
 def elu(x, alpha=1.0):
     return K.elu(x, alpha)
 
+def selu(x):
+    return K.selu(x)
 
 def softplus(x):
     return K.softplus(x)
+
+
 
 
 def softsign(x):

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -2670,6 +2670,24 @@ def relu(x, alpha=0., max_value=None):
         x -= alpha * negative_part
     return x
 
+def selu(x):
+    """Keras Implementation of the Scaled ELU function
+        #read paper to know more detail:
+            Self-Normalizing Neural Networks:https : //arxiv.org/abs/1706.02515
+        #discussion:
+            https://www.reddit.com/r/MachineLearning/comments/6g5tg1/r_selfnormalizing_neural_networks_improved_elu/
+    #usage:
+        just like relu:
+        relu : model.add(Dense(64, activation='relu'))
+        selu : model.add(Dense(64, activation='selu'))
+    # Arguments
+        x: A tenor or variable to compute the activation function for.
+    # Returns
+        A tensor.
+    """    
+    alpha = 1.6732632423543772848170429916717
+    scale = 1.0507009873554804934193349852946
+    return scale*tf.where(x>=0.0, x, alpha*tf.nn.elu(x))
 
 def elu(x, alpha=1.):
     """Exponential linear unit.


### PR DESCRIPTION
add new Activation function :  selu

#read paper to know more detail:
    Self-Normalizing Neural Networks:https : //arxiv.org/abs/1706.02515
#discussion:
    https://www.reddit.com/r/MachineLearning/comments/6g5tg1/r_selfnormalizing_neural_networks_improved_elu/

#usage:
just like relu:
model.add(Dense(64, activation='relu'))
---model.add(Dense(64, activation='selu'))

experiment on mnist：（run keras-master\examples\mnist_cnn.py）：
with relu：
    Test loss: 0.025632923909
    Test accuracy: 0.9915
replace relu in network with selu:
    Test loss: 0.052635348707
    Test accuracy: 0.9837
