### PR TITLE
Add more numpy-style attributes to HDF5Matrix

### DIFF
--- a/keras/utils/io_utils.py
+++ b/keras/utils/io_utils.py
@@ -96,23 +96,22 @@ class HDF5Matrix(object):
 
     @property
     def shape(self):
-        """Numpy-style shape tuple giving dataset dimensions"""
+        """Get a numpy-style shape tuple giving the dataset dimensions."""
         return (self.end - self.start,) + self.data.shape[1:]
-    
+
     @property
     def dtype(self):
-        """Numpy dtype representing the datatype"""
+        """Get the datatype of the dataset"""
         return self.data.dtype
-    
+
     @property
     def ndim(self):
-        """Numpy-style attribute giving the number of dimensions"""
-        self.data.size
+        """Get the number of dimensions (rank) of the dataset"""
         return self.data.ndim
-    
+
     @property
     def size(self):
-        """Numpy-style attribute giving the total dataset size"""
+        """Get the total dataset size (number of elements)"""
         return np.prod(self.shape)
 
 

--- a/keras/utils/io_utils.py
+++ b/keras/utils/io_utils.py
@@ -96,7 +96,24 @@ class HDF5Matrix(object):
 
     @property
     def shape(self):
+        """Numpy-style shape tuple giving dataset dimensions"""
         return (self.end - self.start,) + self.data.shape[1:]
+    
+    @property
+    def dtype(self):
+        """Numpy dtype representing the datatype"""
+        return self.data.dtype
+    
+    @property
+    def ndim(self):
+        """Numpy-style attribute giving the number of dimensions"""
+        self.data.size
+        return self.data.ndim
+    
+    @property
+    def size(self):
+        """Numpy-style attribute giving the total dataset size"""
+        return np.prod(self.shape)
 
 
 def ask_to_proceed_with_overwrite(filepath):

--- a/keras/utils/io_utils.py
+++ b/keras/utils/io_utils.py
@@ -96,22 +96,35 @@ class HDF5Matrix(object):
 
     @property
     def shape(self):
-        """Get a numpy-style shape tuple giving the dataset dimensions."""
+        """Get a numpy-style shape tuple giving the dataset dimensions.
+
+        # Returns
+            A numpy-style shape tuple.
+        """
         return (self.end - self.start,) + self.data.shape[1:]
 
     @property
     def dtype(self):
-        """Get the datatype of the dataset"""
+        """Get the datatype of the dataset.
+
+        # Returns
+            A numpy dtype string."""
         return self.data.dtype
 
     @property
     def ndim(self):
-        """Get the number of dimensions (rank) of the dataset"""
+        """Get the number of dimensions (rank) of the dataset.
+
+        # Returns
+            An integer denoting the number of dimensions (rank) of the dataset."""
         return self.data.ndim
 
     @property
     def size(self):
-        """Get the total dataset size (number of elements)"""
+        """Get the total dataset size (number of elements).
+
+        # Returns
+            An integer denoting the number of elements in the dataset."""
         return np.prod(self.shape)
 
 

--- a/keras/utils/io_utils.py
+++ b/keras/utils/io_utils.py
@@ -96,7 +96,7 @@ class HDF5Matrix(object):
 
     @property
     def shape(self):
-        """Get a numpy-style shape tuple giving the dataset dimensions.
+        """Gets a numpy-style shape tuple giving the dataset dimensions.
 
         # Returns
             A numpy-style shape tuple.
@@ -105,26 +105,29 @@ class HDF5Matrix(object):
 
     @property
     def dtype(self):
-        """Get the datatype of the dataset.
+        """Gets the datatype of the dataset.
 
         # Returns
-            A numpy dtype string."""
+            A numpy dtype string.
+        """
         return self.data.dtype
 
     @property
     def ndim(self):
-        """Get the number of dimensions (rank) of the dataset.
+        """Gets the number of dimensions (rank) of the dataset.
 
         # Returns
-            An integer denoting the number of dimensions (rank) of the dataset."""
+            An integer denoting the number of dimensions (rank) of the dataset.
+        """
         return self.data.ndim
 
     @property
     def size(self):
-        """Get the total dataset size (number of elements).
+        """Gets the total dataset size (number of elements).
 
         # Returns
-            An integer denoting the number of elements in the dataset."""
+            An integer denoting the number of elements in the dataset.
+        """
         return np.prod(self.shape)
 
 

--- a/tests/keras/utils/io_utils_test.py
+++ b/tests/keras/utils/io_utils_test.py
@@ -52,7 +52,7 @@ def test_io_utils(in_tmpdir):
     # HDF5Matrix behave more or less like Numpy matrices with regards to indexing
     assert y_train.shape == (150, 1), 'HDF5Matrix shape should match input array'
     # But they do not support negative indices, so don't try print(X_train[-1])
-    
+
     assert y_train.dtype == np.dtype('i'), 'HDF5Matrix dtype should match input array'
     assert y_train.ndim == 2, 'HDF5Matrix ndim should match input array'
     assert y_train.size == 150, 'HDF5Matrix ndim should match input array'

--- a/tests/keras/utils/io_utils_test.py
+++ b/tests/keras/utils/io_utils_test.py
@@ -52,6 +52,10 @@ def test_io_utils(in_tmpdir):
     # HDF5Matrix behave more or less like Numpy matrices with regards to indexing
     assert y_train.shape == (150, 1), 'HDF5Matrix shape should match input array'
     # But they do not support negative indices, so don't try print(X_train[-1])
+    
+    assert y_train.dtype == np.dtype('i'), 'HDF5Matrix dtype should match input array'
+    assert y_train.ndim == 2, 'HDF5Matrix ndim should match input array'
+    assert y_train.size == 150, 'HDF5Matrix ndim should match input array'
 
     model = Sequential()
     model.add(Dense(64, input_shape=(10,), activation='relu'))


### PR DESCRIPTION
When replacing a numpy array with HDF5Matrix, certain attributes are required. I added `dtype`, `ndim` and `size` and updated these including `shape` with the corresponding doc strings from h5py.Dataset.