### PR TITLE
Keras 2 _*generator displaying warning always about semantic changes from Keras 1

### DIFF
--- a/keras/legacy/interfaces.py
+++ b/keras/legacy/interfaces.py
@@ -582,9 +582,15 @@ def generator_methods_args_preprocessor(args, kwargs):
 
     keras1_args = {'samples_per_epoch', 'val_samples', 'nb_epoch', 'nb_val_samples', 'nb_worker'}
     if keras1_args.intersection(kwargs.keys()):
-        warnings.warn('Note Keras 2 *_generator arguments `steps_per_epoch`, `validation_steps` '
-                      'and `steps` semantics are not the same as in Keras 1. Basically '
-                      'steps_per_epoch = samples_per_epoch/batch_size.', stacklevel=3)
+        warnings.warn('The semantics of the Keras 2 argument '
+                      '`steps_per_epoch` is not the same as the '		
+                      'Keras 1 argument `samples_per_epoch`. '
+                      '`steps_per_epoch` is the number of batches '		
+                      'to draw from the generator at each epoch. '
+                      'Basically steps_per_epoch = samples_per_epoch/batch_size. '
+                      'Similarly `nb_val_samples`->`validation_steps` and '
+                      '`val_samples`->`steps` arguments have changed. '
+                      'Update your method calls accordingly.', stacklevel=3)
 
     return args, kwargs, converted
 

--- a/keras/legacy/interfaces.py
+++ b/keras/legacy/interfaces.py
@@ -583,9 +583,9 @@ def generator_methods_args_preprocessor(args, kwargs):
     keras1_args = {'samples_per_epoch', 'val_samples', 'nb_epoch', 'nb_val_samples', 'nb_worker'}
     if keras1_args.intersection(kwargs.keys()):
         warnings.warn('The semantics of the Keras 2 argument '
-                      '`steps_per_epoch` is not the same as the '		
+                      '`steps_per_epoch` is not the same as the '
                       'Keras 1 argument `samples_per_epoch`. '
-                      '`steps_per_epoch` is the number of batches '		
+                      '`steps_per_epoch` is the number of batches '
                       'to draw from the generator at each epoch. '
                       'Basically steps_per_epoch = samples_per_epoch/batch_size. '
                       'Similarly `nb_val_samples`->`validation_steps` and '

--- a/keras/legacy/interfaces.py
+++ b/keras/legacy/interfaces.py
@@ -577,14 +577,15 @@ def generator_methods_args_preprocessor(args, kwargs):
             if hasattr(generator, 'batch_size'):
                 kwargs['steps_per_epoch'] = samples_per_epoch // generator.batch_size
             else:
-                warnings.warn('The semantics of the Keras 2 argument '
-                              ' `steps_per_epoch` is not the same as the '
-                              'Keras 1 argument `samples_per_epoch`. '
-                              '`steps_per_epoch` is the number of batches '
-                              'to draw from the generator at each epoch. '
-                              'Update your method calls accordingly.', stacklevel=3)
                 kwargs['steps_per_epoch'] = samples_per_epoch
             converted.append(('samples_per_epoch', 'steps_per_epoch'))
+
+    keras1_args = {'samples_per_epoch', 'val_samples', 'nb_epoch', 'nb_val_samples', 'nb_worker'}
+    if keras1_args.intersection(kwargs.keys()):
+        warnings.warn('Note Keras 2 *_generator arguments `steps_per_epoch`, `validation_steps` '
+                      'and `steps` semantics are not the same as in Keras 1. Basically '
+                      'steps_per_epoch = samples_per_epoch/batch_size.', stacklevel=3)
+
     return args, kwargs, converted
 
 

--- a/tests/keras/legacy/interface_test.py
+++ b/tests/keras/legacy/interface_test.py
@@ -799,6 +799,11 @@ def test_generator_methods_interface():
                         validation_data=val_generator(),
                         nb_val_samples=1,
                         nb_worker=1)
+    model.fit_generator(train_generator(),
+                        10,
+                        1,
+                        nb_val_samples=1,
+                        nb_worker=1)
     model.evaluate_generator(generator=train_generator(),
                              val_samples=2,
                              nb_worker=1)


### PR DESCRIPTION
I was going from Keras1 to Keras2 and had call like 

`model.fit_generator(gen, gen.n, verbose=1, validation_data=gen, nb_val_samples=10) `

I got an warning: 

```
UserWarning: Update your 'fit_generator' call to the Keras 2 API: 'fit_generator(<ssd_gener..., 10, 1, verbose=1, validation_data=None, validation_steps=1, workers=1)
```

but no information about other changes. So I changed nb_val_samples quickly and I got the exact same output/information as before. Quite much later I noticed that it was 30 times slower. Keras2 changed *_generator arguments (and seems like a smarter way to do things) but I didn't notice it. I should have used named arguments at everything would been fine :P Quick googling resulted that maybe others have done the same mistake but its hard to know if its about this or something else:

https://github.com/fchollet/keras/issues/6445 , https://github.com/fchollet/keras/issues/6117 , https://github.com/fchollet/keras/issues/2730#issuecomment-290204054 , https://github.com/fchollet/keras/issues/6406

A better warning in my case could have helped a bit. Now the notice would be a bit longer if anything in the *_generator call references to Keras1:
```
UserWarning: Note Keras 2 *_generator arguments `steps_per_epoch`, `validation_steps` and `steps` semantics are not the same as in Keras 1. Basically steps_per_epoch = samples_per_epoch/batch_size.
UserWarning: Update your `fit_generator` call to the Keras 2 API: `fit_generator(<ssd_gener..., 10, 1, verbose=1, validation_data=None, validation_steps=1, workers=1)`
```

I was also thinking of adding an example to https://github.com/fchollet/keras/wiki/Keras-2.0-release-notes and maybe the warning could be a link there instead of trying to explain what has changed.
