### PR TITLE
Fix model saving/loading for LeakyReLU layer

### DIFF
--- a/keras/layers/advanced_activations.py
+++ b/keras/layers/advanced_activations.py
@@ -41,7 +41,7 @@ class LeakyReLU(Layer):
         return K.relu(inputs, alpha=self.alpha)
 
     def get_config(self):
-        config = {'alpha': self.alpha}
+        config = {'alpha': float(self.alpha)}
         base_config = super(LeakyReLU, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
 


### PR DESCRIPTION
For models containing a `LeakyReLU` layer, saving and loading the model will result in a `TypeError`.
```
TypeError: float() argument must be a string or a number, not 'dict'
```

The reason is that the scalar argument `alpha` is converted to and saved as a `numpy.array`, instead of a `float`, in the following lines:
```python
    self.alpha = K.cast_to_floatx(alpha)
```
```python
    config = {'alpha': self.alpha}
```

The issue can be reproduced by the following code:
```python
from keras.models import Sequential, load_model
from keras.layers import Dense, LeakyReLU
model = Sequential()
model.add(Dense(1, input_shape=(10,)))
model.add(LeakyReLU())
model.save('1.h5')
model = load_model('1.h5')
```

The solution to this problem is already implemented in the `ELU` layer:
```python
    config = {'alpha': float(self.alpha)}
```