### PR TITLE
mean_square_error => mean_squared_error

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -254,7 +254,7 @@ def _check_loss_and_target_compatibility(targets, loss_fns, output_shapes):
         ValueError: if a loss function or target array
             is incompatible with an output.
     """
-    key_losses = {'mean_square_error',
+    key_losses = {'mean_squared_error',
                   'binary_crossentropy',
                   'categorical_crossentropy'}
     for y, loss, shape in zip(targets, loss_fns, output_shapes):


### PR DESCRIPTION
training.py `'mean_squared_error'` was misspelled as `'mean_square_error'`.