### PR TITLE
test_multiprocessing.py fix incorrect use of numpy.random.randint

### DIFF
--- a/tests/test_multiprocessing.py
+++ b/tests/test_multiprocessing.py
@@ -270,27 +270,26 @@ def test_multiprocessing_evaluate_error():
 
 @keras_test
 def test_multiprocessing_predict_error():
-    batch_size = 10
     good_batches = 3
 
     def custom_generator():
         """Raises an exception after a few good batches"""
         for i in range(good_batches):
-            yield (np.random.randint(batch_size, 256, (50, 2)),
-                   np.random.randint(batch_size, 2, 50))
+            yield (np.random.randint(1, 256, (2, 50)),
+                   np.random.randint(1, 256, (2, 50)))
         raise RuntimeError
 
     model = Sequential()
     model.add(Dense(1, input_shape=(2, )))
     model.compile(loss='mse', optimizer='adadelta')
 
-    with pytest.raises((ValueError, Exception)):
+    with pytest.raises((ValueError)):
         model.predict_generator(
             custom_generator(), good_batches + 1, 1,
             workers=4, pickle_safe=True,
         )
 
-    with pytest.raises((ValueError, Exception)):
+    with pytest.raises((ValueError)):
         model.predict_generator(
             custom_generator(), good_batches + 1, 1,
             pickle_safe=False,

--- a/tests/test_multiprocessing.py
+++ b/tests/test_multiprocessing.py
@@ -284,13 +284,13 @@ def test_multiprocessing_predict_error():
     model.add(Dense(1, input_shape=(2, )))
     model.compile(loss='mse', optimizer='adadelta')
 
-    with pytest.raises(ValueError):
+    with pytest.raises((ValueError, Exception)):
         model.predict_generator(
             custom_generator(), good_batches + 1, 1,
             workers=4, pickle_safe=True,
         )
 
-    with pytest.raises(ValueError):
+    with pytest.raises((ValueError, Exception)):
         model.predict_generator(
             custom_generator(), good_batches + 1, 1,
             pickle_safe=False,

--- a/tests/test_multiprocessing.py
+++ b/tests/test_multiprocessing.py
@@ -283,13 +283,13 @@ def test_multiprocessing_predict_error():
     model.add(Dense(1, input_shape=(2, )))
     model.compile(loss='mse', optimizer='adadelta')
 
-    with pytest.raises((ValueError)):
+    with pytest.raises(ValueError):
         model.predict_generator(
             custom_generator(), good_batches + 1, 1,
             workers=4, pickle_safe=True,
         )
 
-    with pytest.raises((ValueError)):
+    with pytest.raises(ValueError):
         model.predict_generator(
             custom_generator(), good_batches + 1, 1,
             pickle_safe=False,


### PR DESCRIPTION
There was a recent pull request that appeared to fix the problem, but actually it just ran into a different failure case. This actually fixes it. :-)