### PR TITLE
Added dice_coef

### DIFF
--- a/keras/losses.py
+++ b/keras/losses.py
@@ -73,6 +73,12 @@ def cosine_proximity(y_true, y_pred):
     return -K.mean(y_true * y_pred, axis=-1)
 
 
+def dice_coef(y_true, y_pred):
+    flat_y_true = K.flatten(y_true)
+    flat_y_pred_f = K.flatten(y_pred)
+    return -(2.*K.sum(y_true_f*y_pred_f))/(K.sum(flat_y_true)+K.sum(flat_y_pred_f))
+
+
 # Aliases.
 
 mse = MSE = mean_squared_error

--- a/keras/losses.py
+++ b/keras/losses.py
@@ -75,8 +75,8 @@ def cosine_proximity(y_true, y_pred):
 
 def dice_coef_loss(y_true, y_pred):
     flat_y_true = K.flatten(y_true)
-    flat_y_pred_f = K.flatten(y_pred)
-    return -(2.*K.sum(y_true_f*y_pred_f))/(K.sum(flat_y_true)+K.sum(flat_y_pred_f))
+    flat_y_pred = K.flatten(y_pred)
+    return -(2.*K.sum(flat_y_true*flat_y_pred))/(K.sum(flat_y_true)+K.sum(flat_y_pred))
 
 
 # Aliases.

--- a/keras/losses.py
+++ b/keras/losses.py
@@ -73,7 +73,7 @@ def cosine_proximity(y_true, y_pred):
     return -K.mean(y_true * y_pred, axis=-1)
 
 
-def dice_coef(y_true, y_pred):
+def dice_coef_loss(y_true, y_pred):
     flat_y_true = K.flatten(y_true)
     flat_y_pred_f = K.flatten(y_pred)
     return -(2.*K.sum(y_true_f*y_pred_f))/(K.sum(flat_y_true)+K.sum(flat_y_pred_f))

--- a/keras/losses.py
+++ b/keras/losses.py
@@ -76,7 +76,7 @@ def cosine_proximity(y_true, y_pred):
 def dice_coef_loss(y_true, y_pred):
     flat_y_true = K.flatten(y_true)
     flat_y_pred = K.flatten(y_pred)
-    return -(2.*K.sum(flat_y_true*flat_y_pred))/(K.sum(flat_y_true)+K.sum(flat_y_pred))
+    return -2. * K.sum(flat_y_true * flat_y_pred) / (K.sum(flat_y_true) + K.sum(flat_y_pred))
 
 
 # Aliases.

--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -14,7 +14,7 @@ from .losses import binary_crossentropy
 from .losses import kullback_leibler_divergence
 from .losses import poisson
 from .losses import cosine_proximity
-from .losses import dice_coef
+from .losses import dice_coef_loss
 from .utils.generic_utils import deserialize_keras_object
 
 

--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -44,8 +44,8 @@ def sparse_top_k_categorical_accuracy(y_true, y_pred, k=5):
 
 def dice_coef(y_true, y_pred):
     flat_y_true = K.flatten(y_true)
-    flat_y_pred_f = K.flatten(y_pred)
-    return (2.*K.sum(y_true_f*y_pred_f))/(K.sum(flat_y_true)+K.sum(flat_y_pred_f))
+    flat_y_pred = K.flatten(y_pred)
+    return (2.*K.sum(flat_y_true*flat_y_pred))/(K.sum(flat_y_true)+K.sum(flat_y_pred))
 
 
 # Aliases

--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -14,6 +14,7 @@ from .losses import binary_crossentropy
 from .losses import kullback_leibler_divergence
 from .losses import poisson
 from .losses import cosine_proximity
+from .losses import dice_coef
 from .utils.generic_utils import deserialize_keras_object
 
 
@@ -39,6 +40,12 @@ def top_k_categorical_accuracy(y_true, y_pred, k=5):
 
 def sparse_top_k_categorical_accuracy(y_true, y_pred, k=5):
     return K.mean(K.in_top_k(y_pred, K.cast(K.max(y_true, axis=-1), 'int32'), k), axis=-1)
+
+
+def dice_coef(y_true, y_pred):
+    flat_y_true = K.flatten(y_true)
+    flat_y_pred_f = K.flatten(y_pred)
+    return (2.*K.sum(y_true_f*y_pred_f))/(K.sum(flat_y_true)+K.sum(flat_y_pred_f))
 
 
 # Aliases

--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -45,7 +45,7 @@ def sparse_top_k_categorical_accuracy(y_true, y_pred, k=5):
 def dice_coef(y_true, y_pred):
     flat_y_true = K.flatten(y_true)
     flat_y_pred = K.flatten(y_pred)
-    return (2.*K.sum(flat_y_true*flat_y_pred))/(K.sum(flat_y_true)+K.sum(flat_y_pred))
+    return 2. * K.sum(flat_y_true * flat_y_pred) / (K.sum(flat_y_true) + K.sum(flat_y_pred))
 
 
 # Aliases

--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -43,9 +43,7 @@ def sparse_top_k_categorical_accuracy(y_true, y_pred, k=5):
 
 
 def dice_coef(y_true, y_pred):
-    flat_y_true = K.flatten(y_true)
-    flat_y_pred = K.flatten(y_pred)
-    return 2. * K.sum(flat_y_true * flat_y_pred) / (K.sum(flat_y_true) + K.sum(flat_y_pred))
+    return - dice_coef_loss(y_true, y_pred)
 
 
 # Aliases


### PR DESCRIPTION
For segmantation dice_coef function so important.
If we want to segmantate image to classes, other functions will look all image area(with background so other functions look remaining background will behaving like higher accuracy.) but dice_coef look only segmantatin area matching, **not background**.
In this way, we can estimate the correct error rate.

`dice_coef = (2*intersection) / ((first area) + (second area))`

Example: 
(White: Segamantation, Black: Background)
Label: 
![label](https://user-images.githubusercontent.com/12643233/27264320-b6fb56b2-5484-11e7-845b-01d9f786499f.jpg)


Predict:
![predict](https://user-images.githubusercontent.com/12643233/27264330-c6b1db30-5484-11e7-87b4-b4f85ef99a89.jpg)

Computer's say true segments area is big (Only little area(according to white areas) is wrong **but not**):
![computers say true](https://user-images.githubusercontent.com/12643233/27264337-f1d37558-5484-11e7-9a14-c4cac3ed6394.jpg)

True segments areas must be like(So prediction is wrong):
![true](https://user-images.githubusercontent.com/12643233/27264332-da38dd48-5484-11e7-81b8-1b9bac20c286.jpg)
