### PR TITLE
Remove requirement that batch_size divides len(x_train) in VAE example

### DIFF
--- a/examples/variational_autoencoder.py
+++ b/examples/variational_autoencoder.py
@@ -20,7 +20,7 @@ epochs = 50
 epsilon_std = 1.0
 
 
-x = Input(batch_shape=(batch_size, original_dim))
+x = Input(shape=(original_dim,))
 h = Dense(intermediate_dim, activation='relu')(x)
 z_mean = Dense(latent_dim)(h)
 z_log_var = Dense(latent_dim)(h)
@@ -28,7 +28,7 @@ z_log_var = Dense(latent_dim)(h)
 
 def sampling(args):
     z_mean, z_log_var = args
-    epsilon = K.random_normal(shape=(batch_size, latent_dim), mean=0.,
+    epsilon = K.random_normal(shape=(latent_dim,), mean=0.,
                               stddev=epsilon_std)
     return z_mean + K.exp(z_log_var / 2) * epsilon
 


### PR DESCRIPTION
Currently the Variational Auto Encoder example fails when the training set size is not a multiple of the batch size (related to #5255, and in a way to #3332).

This PR changes the input shape of the layers where batch_size was explicit, to allow any number of examples thus removing the problem.

The [blog quoting this code](https://blog.keras.io/building-autoencoders-in-keras.html) should probably also be updated.

Bug reproducibility steps:
- change the batch size (examples/variational_autoencoder.py line 15) to something that doesn't divide mnist train set size, for instance 51
- run examples/variational_autoencoder.py

