### PR TITLE
throw an error when receiving empty batch, instead of returning nans

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -2030,6 +2030,9 @@ class Model(Container):
                     batch_size = len(list(x.values())[0])
                 else:
                     batch_size = len(x)
+                if batch_size == 0:
+                    raise ValueError('Received an empty batch. '
+                                     'Batches should at least contain one item.')
                 all_outs.append(outs)
 
                 steps_done += 1

--- a/tests/keras/engine/test_training.py
+++ b/tests/keras/engine/test_training.py
@@ -203,6 +203,12 @@ def test_model_methods():
     out = model.evaluate([input_a_np, input_b_np], [output_a_np, output_b_np], batch_size=4)
     out = model.predict([input_a_np, input_b_np], batch_size=4)
 
+    # empty batch
+    with pytest.raises(ValueError):
+        def gen_data():
+            yield (np.asarray([]), np.asarray([]))
+        out = model.evaluate_generator(gen_data(), steps=1)
+
     # x is not a list of numpy arrays.
     with pytest.raises(ValueError):
         out = model.predict([None])


### PR DESCRIPTION
Currently, when `evaluate_generator` receives an empty batch, it will return nans because of the `np.average` at the end.

When I encountered a bug in my code that triggered this, I thought that my network was overflowing somewhere, resulting in hours of debugging the network.

I therefore propose throwing an exception when this happens.

