### PR TITLE
Fixed default header in RemoteMonitor callback.

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -523,8 +523,6 @@ class RemoteMonitor(Callback):
         path: String; path relative to `root` to which the events will be sent.
         field: String; JSON field under which the data will be stored.
         headers: Dictionary; optional custom HTTP headers.
-            Defaults to:
-            `{'Accept': 'application/json', 'Content-Type': 'application/x-www-form-urlencoded'}`
     """
 
     def __init__(self,
@@ -533,9 +531,7 @@ class RemoteMonitor(Callback):
                  field='data',
                  headers=None):
         super(RemoteMonitor, self).__init__()
-        if headers is None:
-            headers = {'Accept': 'application/json',
-                       'Content-Type': 'application/x-www-form-urlencoded'}
+        
         self.root = root
         self.path = path
         self.field = field

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -531,7 +531,7 @@ class RemoteMonitor(Callback):
                  field='data',
                  headers=None):
         super(RemoteMonitor, self).__init__()
-        
+
         self.root = root
         self.path = path
         self.field = field

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -524,7 +524,7 @@ class RemoteMonitor(Callback):
         field: String; JSON field under which the data will be stored.
         headers: Dictionary; optional custom HTTP headers.
             Defaults to:
-            `{'Accept': 'application/json', 'Content-Type': 'application/json'}`
+            `{'Accept': 'application/json', 'Content-Type': 'application/x-www-form-urlencoded'}`
     """
 
     def __init__(self,
@@ -535,7 +535,7 @@ class RemoteMonitor(Callback):
         super(RemoteMonitor, self).__init__()
         if headers is None:
             headers = {'Accept': 'application/json',
-                       'Content-Type': 'application/json'}
+                       'Content-Type': 'application/x-www-form-urlencoded'}
         self.root = root
         self.path = path
         self.field = field


### PR DESCRIPTION
When using the `RemoteMonitor` callback the headers sent with the request to the remote server defaulted to `{'Accept': 'application/json', 'Content-Type': 'application/json'}`. However, the request sent is not of type `application/json` but rather `application/x-www-form-urlencoded`. This led to some confusion when implementing a custom remote server.

Also, the [hualos](https://github.com/fchollet/hualos/) project breaks because of this bug.

This PR changes the default `Content-Type` header to `application/x-www-form-urlencoded`.