### PR TITLE
Use loggers instead of `stderr` to inform progress or setting for users

### DIFF
--- a/docs/templates/backend.md
+++ b/docs/templates/backend.md
@@ -31,7 +31,8 @@ The default configuration file looks like this:
     "image_data_format": "channels_last",
     "epsilon": 1e-07,
     "floatx": "float32",
-    "backend": "tensorflow"
+    "backend": "tensorflow",
+    "logging_level": 30
 }
 ```
 
@@ -42,7 +43,8 @@ override what is defined in your config file :
 
 ```bash
 KERAS_BACKEND=tensorflow python -c "from keras import backend"
-Using TensorFlow backend.
+INFO:keras.backend:KERAS_BACKEND flag is set in the environment.
+INFO:keras.backend:Using TensorFlow backend.
 ```
 
 ----
@@ -55,18 +57,23 @@ Using TensorFlow backend.
     "image_data_format": "channels_last",
     "epsilon": 1e-07,
     "floatx": "float32",
-    "backend": "tensorflow"
+    "backend": "tensorflow",
+    "logging_level": 30
 }
 ```
 
-You can change these settings by editing `$HOME/.keras/keras.json`. 
+You can change these settings by editing `$HOME/.keras/keras.json`.
 
 * `image_data_format`: string, either `"channels_last"` or `"channels_first"`. It specifies which data format convention Keras will follow. (`keras.backend.image_data_format()` returns it.)
-  - For 2D data (e.g. image), `"channels_last"` assumes `(rows, cols, channels)` while `"channels_first"` assumes `(channels, rows, cols)`. 
+  - For 2D data (e.g. image), `"channels_last"` assumes `(rows, cols, channels)` while `"channels_first"` assumes `(channels, rows, cols)`.
   - For 3D data, `"channels_last"` assumes `(conv_dim1, conv_dim2, conv_dim3, channels)` while `"channels_first"` assumes `(channels, conv_dim1, conv_dim2, conv_dim3)`.
 * `epsilon`: float, a numeric fuzzing constant used to avoid dividing by zero in some operations.
 * `floatx`: string, `"float16"`, `"float32"`, or `"float64"`. Default float precision.
 * `backend`: string, `"tensorflow"`, `"theano"`, or `"cntk"`.
+* `logging_level`: int or string, following the conventions of the `logging` levels. Default level
+  is `"WARNING"` or `30`. If string, `"NOTSET`", `"DEBUG"`, `"INFO"`, `"WARNING"`,`"ERROR"`,
+  or `"CRITICIAL"`.
+
 
 ----
 

--- a/keras/__init__.py
+++ b/keras/__init__.py
@@ -20,4 +20,9 @@ from . import regularizers
 # Importable from root because it's technically not a layer
 from .layers import Input
 
+# Default logger settings for the whole module
+import logging
+from logging import (NOTSET as _notset, BASIC_FORMAT as _basic_fmt)
+logging.basicConfig(format=_basic_fmt, level=_notset)
+
 __version__ = '2.0.5'

--- a/keras/backend/__init__.py
+++ b/keras/backend/__init__.py
@@ -19,6 +19,12 @@ if not os.access(_keras_base_dir, os.W_OK):
 _keras_dir = os.path.join(_keras_base_dir, '.keras')
 
 # Default logger level settings for backend messages
+_LOG_LEVEL_NAMES = {'NOTSET': logging.NOTSET,      # 0
+                    'DEBUG': logging.DEBUG,        # 10
+                    'INFO': logging.INFO,          # 20
+                    'WARNING': logging.WARNING,    # 30
+                    'ERROR': logging.ERROR,        # 40
+                    'CRITICAL': logging.CRITICAL}  # 50
 _LOG_LEVEL = logging.WARNING
 logging.basicConfig(level=_LOG_LEVEL,
                     format=logging.BASIC_FORMAT,
@@ -48,8 +54,8 @@ if os.path.exists(_config_path):
                                      image_data_format())
     assert _image_data_format in {'channels_last', 'channels_first'}
     _user_logging_level = _config.get('logging_level', _LOG_LEVEL)
-    assert (_user_logging_level in logging._nameToLevel or
-            _user_logging_level in logging._levelToName)
+    assert (_user_logging_level in _LOG_LEVEL_NAMES or
+            isinstance(_user_logging_level, int))
 
     set_floatx(_floatx)
     set_epsilon(_epsilon)

--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -6,6 +6,11 @@ from collections import defaultdict
 from contextlib import contextmanager
 import warnings
 
+# Nothing interesting to log in this implementation
+# since it already raises appropriate errors when
+# the validations fail. Uncomment this if need to log.
+# import logging
+# logger = logging.getLogger(__name__)
 
 C.set_global_option('align_axis', 1)
 

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -496,7 +496,7 @@ def int_shape(x):
     try:
         return tuple([i.__int__() for i in shape])
     except ValueError:
-        log.warning("""Couldn't parse the provided shape tensor.
+        logger.warning("""Couldn't parse the provided shape tensor.
                        It is neither has the supported shape nor
                        values that can be converted to integers.""")
         return None

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -20,6 +20,9 @@ from ..utils.generic_utils import has_arg
 from .common import set_image_dim_ordering
 from .common import image_dim_ordering
 
+import logging
+logger = logging.getLogger(__name__)
+
 py_all = all
 py_sum = sum
 
@@ -493,6 +496,9 @@ def int_shape(x):
     try:
         return tuple([i.__int__() for i in shape])
     except ValueError:
+        log.warning("""Couldn't parse the provided shape tensor.
+                       It is neither has the supported shape nor
+                       values that can be converted to integers.""")
         return None
 
 

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -21,6 +21,9 @@ from ..utils.generic_utils import has_arg
 # Legacy functions
 from .common import set_image_dim_ordering, image_dim_ordering
 
+import logging
+logger = logging.getLogger(__name__)
+
 py_all = all
 py_sum = sum
 
@@ -1647,6 +1650,8 @@ def _preprocess_padding(padding):
         raise ValueError('Border mode not supported:', str(padding))
     return th_padding
 
+def _log_unsupported_shape_type():
+    logger.warning('Theano does not support long types for shape.')
 
 def _preprocess_conv2d_image_shape(image_shape, data_format):
     # Theano might not accept long type
@@ -1654,6 +1659,7 @@ def _preprocess_conv2d_image_shape(image_shape, data_format):
         try:
             return int(value)
         except TypeError:
+            _log_unsupported_shape_type()
             return None
     if data_format == 'channels_last':
         if image_shape:
@@ -1670,6 +1676,7 @@ def _preprocess_conv3d_volume_shape(volume_shape, data_format):
         try:
             return int(value)
         except TypeError:
+            _log_unsupported_shape_type()
             return None
     if data_format == 'channels_last':
         if volume_shape:
@@ -1686,6 +1693,7 @@ def _preprocess_conv2d_filter_shape(filter_shape, data_format):
         try:
             return int(value)
         except TypeError:
+            _log_unsupported_shape_type()
             return None
     if filter_shape:
         filter_shape = (filter_shape[3], filter_shape[2],
@@ -1701,6 +1709,7 @@ def _preprocess_conv3d_filter_shape(filter_shape, data_format):
         try:
             return int(value)
         except TypeError:
+            _log_unsupported_shape_type()
             return None
     if filter_shape:
         filter_shape = (filter_shape[4], filter_shape[3],

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1650,8 +1650,10 @@ def _preprocess_padding(padding):
         raise ValueError('Border mode not supported:', str(padding))
     return th_padding
 
+
 def _log_unsupported_shape_type():
     logger.warning('Theano does not support long types for shape.')
+
 
 def _preprocess_conv2d_image_shape(image_shape, data_format):
     # Theano might not accept long type


### PR DESCRIPTION
Previously, the backend part was *always* writing the final choice of the backend to the the `stderr` (`Now using Theano....`) and since this decision process was happening at the initiation time, every single Python package or library or tool that makes use of Keras was also printing it out -- and eventually these messages start populating regular logs (such as a prediction webserver writing it out to web logs, or an image recognizer tool writing on the terminals, ...) at various times and places.

Since it was not configurable (but it should be), I switched to the core logging utility for such messages and give the user an option to set the level. See this:

```shell
$  KERAS_BACKEND="theano" python -c 'import keras'
$  KERAS_BACKEND="tensorflow" python -c 'import keras'
$  cat ~/.keras/keras.json
{
    "floatx": "float32",
    "epsilon": 1e-07,
    "backend": "tensorflow",
    "image_data_format": "channels_last",
    "logging_level": 30
}
$  rm -f ~/.keras/keras.json
$  KERAS_BACKEND="tensorflow" python -c 'import keras'
$  cat ~/.keras/keras.json
{
    "floatx": "float32",
    "epsilon": 1e-07,
    "backend": "tensorflow",
    "image_data_format": "channels_last",
    "logging_level": 30
}
$ vi ~/.keras/keras.json
$  sed -i.bak -e 's/30/10/g' ~/.keras/keras.json
$  KERAS_BACKEND="tensorflow" python -c 'import keras'
INFO:keras.backend:KERAS_BACKEND flag is set in the environment.
INFO:keras.backend:Using TensorFlow backend.
$  KERAS_BACKEND="tensorflow" python -c 'import keras' > /dev/null
INFO:keras.backend:KERAS_BACKEND flag is set in the environment.
INFO:keras.backend:Using TensorFlow backend.
$  KERAS_BACKEND="tensorflow" python -c 'import keras' 2> /dev/null
$                                                      
```
