### PR TITLE
Call self.executor.join() in OrderedEnqueuer to prevent zombie worker processes

### DIFF
--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -515,6 +515,7 @@ class OrderedEnqueuer(SequenceEnqueuer):
             self.queue.unfinished_tasks = 0
             self.queue.not_full.notify()
         self.executor.close()
+        self.executor.join()
         self.run_thread.join(timeout)
 
 


### PR DESCRIPTION
This refers to https://github.com/fchollet/keras/pull/6891#issuecomment-309889683