### PR TITLE
generic_utils.py fix progbar crash batched data

### DIFF
--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -288,7 +288,7 @@ class Progbar(object):
             for k in self.unique_values:
                 info += ' - %s:' % k
                 if isinstance(self.sum_values[k], list):
-                    avg = self.sum_values[k][0] / max(1, self.sum_values[k][1])
+                    avg = np.mean(self.sum_values[k][0] / max(1, self.sum_values[k][1]))
                     if abs(avg) > 1e-3:
                         info += ' %.4f' % avg
                     else:
@@ -311,7 +311,7 @@ class Progbar(object):
                 info = '%ds' % (now - self.start)
                 for k in self.unique_values:
                     info += ' - %s:' % k
-                    avg = self.sum_values[k][0] / max(1, self.sum_values[k][1])
+                    avg = np.mean(self.sum_values[k][0] / max(1, self.sum_values[k][1]))
                     if avg > 1e-3:
                         info += ' %.4f' % avg
                     else:

--- a/tests/keras/utils/generic_utils_test.py
+++ b/tests/keras/utils/generic_utils_test.py
@@ -1,7 +1,20 @@
 import pytest
+import numpy as np
 from keras.utils.generic_utils import custom_object_scope
 from keras import activations
 from keras import regularizers
+from keras.utils.test_utils import keras_test
+from keras.utils.generic_utils import Progbar
+
+
+@keras_test
+def test_progbar():
+    n = 2
+    input_arr = np.random.random((n, n, n))
+    bar = Progbar(n)
+
+    for i, arr in enumerate(input_arr):
+        bar.update(i, list(arr))
 
 
 def test_custom_objects_scope():

--- a/tests/keras/utils/generic_utils_test.py
+++ b/tests/keras/utils/generic_utils_test.py
@@ -3,10 +3,10 @@ import pytest
 import numpy as np
 from keras.utils.generic_utils import custom_object_scope
 from keras.utils.generic_utils import has_arg
+from keras.utils.generic_utils import Progbar
+from keras.utils.test_utils import keras_test
 from keras import activations
 from keras import regularizers
-from keras.utils.test_utils import keras_test
-from keras.utils.generic_utils import Progbar
 
 
 @keras_test


### PR DESCRIPTION
This lets the progbar handle batches of data by taking the average if there is more than one element. #7075 is an example & depends on this PR.