### PR TITLE
Yield op tests

### DIFF
--- a/tests/keras/engine/test_training.py
+++ b/tests/keras/engine/test_training.py
@@ -27,6 +27,39 @@ class RandomSequence(Sequence):
             np.random.random((self.batch_size, 3))]
 
 
+def call_model_methods(model, input_np, output_np):
+
+    # train_on_batch
+    out = model.train_on_batch(input_np,
+                               output_np)
+    out = model.train_on_batch(input_np,
+                               output_np)
+
+    # test_on_batch
+    out = model.test_on_batch(input_np,
+                              output_np)
+
+    # predict_on_batch
+    out = model.predict_on_batch(input_np)
+
+    # fit
+    out = model.fit(input_np,
+                    output_np, epochs=1, batch_size=10)
+    out = model.fit(input_np,
+                    output_np, epochs=1, batch_size=10)
+
+    # evaluate
+    out = model.evaluate(input_np,
+                         output_np, batch_size=10)
+    out = model.evaluate(input_np,
+                         output_np, batch_size=10)
+
+    # predict
+    out = model.predict(input_np, batch_size=10)
+    out = model.predict(input_np, batch_size=10)
+    return out
+
+
 @keras_test
 def test_model_methods():
     a = Input(shape=(3,), name='input_a')
@@ -451,30 +484,7 @@ def test_model_with_input_feed_tensor():
                   loss_weights=loss_weights,
                   sample_weight_mode=None)
 
-    # test train_on_batch
-    out = model.train_on_batch(input_b_np,
-                               [output_a_np, output_b_np])
-    out = model.train_on_batch({'input_b': input_b_np},
-                               [output_a_np, output_b_np])
-    out = model.test_on_batch({'input_b': input_b_np},
-                              [output_a_np, output_b_np])
-    out = model.predict_on_batch({'input_b': input_b_np})
-
-    # test fit
-    out = model.fit({'input_b': input_b_np},
-                    [output_a_np, output_b_np], epochs=1, batch_size=10)
-    out = model.fit(input_b_np,
-                    [output_a_np, output_b_np], epochs=1, batch_size=10)
-
-    # test evaluate
-    out = model.evaluate({'input_b': input_b_np},
-                         [output_a_np, output_b_np], batch_size=10)
-    out = model.evaluate(input_b_np,
-                         [output_a_np, output_b_np], batch_size=10)
-
-    # test predict
-    out = model.predict({'input_b': input_b_np}, batch_size=10)
-    out = model.predict(input_b_np, batch_size=10)
+    out = call_model_methods(model, {'input_b': input_b_np}, [output_a_np, output_b_np])
     assert len(out) == 2
 
     # Now test a model with a single input
@@ -489,34 +499,7 @@ def test_model_with_input_feed_tensor():
     loss = 'mse'
     model.compile(optimizer, loss, metrics=['mean_squared_error'])
 
-    # test train_on_batch
-    out = model.train_on_batch(None,
-                               output_a_np)
-    out = model.train_on_batch(None,
-                               output_a_np)
-    out = model.test_on_batch(None,
-                              output_a_np)
-    out = model.predict_on_batch(None)
-    out = model.train_on_batch([],
-                               output_a_np)
-    out = model.train_on_batch({},
-                               output_a_np)
-
-    # test fit
-    out = model.fit(None,
-                    output_a_np, epochs=1, batch_size=10)
-    out = model.fit(None,
-                    output_a_np, epochs=1, batch_size=10)
-
-    # test evaluate
-    out = model.evaluate(None,
-                         output_a_np, batch_size=10)
-    out = model.evaluate(None,
-                         output_a_np, batch_size=10)
-
-    # test predict
-    out = model.predict(None, batch_size=10)
-    out = model.predict(None, batch_size=10)
+    out = call_model_methods(model, None, output_a_np)
     assert out.shape == (10, 4)
 
     # Same, without learning phase
@@ -530,34 +513,14 @@ def test_model_with_input_feed_tensor():
     loss = 'mse'
     model.compile(optimizer, loss, metrics=['mean_squared_error'])
 
-    # test train_on_batch
-    out = model.train_on_batch(None,
-                               output_a_np)
-    out = model.train_on_batch(None,
-                               output_a_np)
-    out = model.test_on_batch(None,
-                              output_a_np)
-    out = model.predict_on_batch(None)
+    # train_on_batch
     out = model.train_on_batch([],
                                output_a_np)
     out = model.train_on_batch({},
                                output_a_np)
 
-    # test fit
-    out = model.fit(None,
-                    output_a_np, epochs=1, batch_size=10)
-    out = model.fit(None,
-                    output_a_np, epochs=1, batch_size=10)
+    out = call_model_methods(model, None, output_a_np)
 
-    # test evaluate
-    out = model.evaluate(None,
-                         output_a_np, batch_size=10)
-    out = model.evaluate(None,
-                         output_a_np, batch_size=10)
-
-    # test predict
-    out = model.predict(None, batch_size=10)
-    out = model.predict(None, batch_size=10)
     assert out.shape == (10, 4)
 
 

--- a/tests/keras/engine/test_training.py
+++ b/tests/keras/engine/test_training.py
@@ -16,6 +16,7 @@ from keras import backend as K
 from keras.utils import Sequence
 from keras.utils.test_utils import keras_test
 from keras.callbacks import LambdaCallback
+from keras.callbacks import TensorBoard
 
 
 class RandomSequence(Sequence):
@@ -634,6 +635,9 @@ def input_label_tfrecord_model(input_a_tf, output_b_tf, img_batch_shape, classes
                   sample_weight_mode=None)
 
     call_model_methods(model, None, None, batch_size=img_batch_shape[0])
+
+    tensorboard = TensorBoard()
+    model.fit(None, None, callbacks=[tensorboard])
 
 
 def create_tfrecord_data(img_batch_shape, classes):


### PR DESCRIPTION
Add a first set of yield op tests where labels are a yield op too. These tests can be used for integration testing of new changes. 

- This PR first depends on #7060 to pass
- #7072 & deps should also cause this PR to pass.
- small part of #6928 and #7046 

Performance:
 - Note that this appears to run most efficiently in #6928, which has the `labels` parameter
    - the equivalent commit in #6928 is 9fae1b2193f006042ed6b7e0bef5d24ee4277b9e
 - It also runs in #7046, (equivalently #7072) but it may be slower.

Note: 9b4cb87 can be separated, because it tests additional cases, callbacks in particular, which not yet supported in master or #7046/#7072 with yield ops, but **callbacks are generally supported in #6928 (Yield Op support with `labels` param)**.