### PR TITLE
Add more meaningful message when cnkt can't handle variable length input

### DIFF
--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -1569,12 +1569,13 @@ class Function(object):
 
     @staticmethod
     def _is_input_shape_compatible(input, placeholder):
-        num_dynamic = get_num_dynamic_axis(placeholder)
-        input_shape = input.shape[num_dynamic:]
-        placeholder_shape = placeholder.shape
-        for i, p in zip(input_shape, placeholder_shape):
-            if i != p and p != C.InferredDimension:
-                return False
+        if hasattr(input, 'shape') and hasattr(placeholder, 'shape'):
+            num_dynamic = get_num_dynamic_axis(placeholder)
+            input_shape = input.shape[num_dynamic:]
+            placeholder_shape = placeholder.shape
+            for i, p in zip(input_shape, placeholder_shape):
+                if i != p and p != C.InferredDimension:
+                    return False
         return True
 
     def __call__(self, inputs):

--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -1567,6 +1567,16 @@ class Function(object):
         else:
             self.metrics_func = None
 
+    @staticmethod
+    def _is_input_shape_compatible(input, placeholder):
+        num_dynamic = get_num_dynamic_axis(placeholder)
+        input_shape = input.shape[num_dynamic:]
+        placeholder_shape = placeholder.shape
+        for i, p in zip(input_shape, placeholder_shape):
+            if i != p and p != C.InferredDimension:
+                return False
+        return True
+
     def __call__(self, inputs):
         assert type(inputs) in {list, tuple}
         feed_dict = {}
@@ -1576,6 +1586,14 @@ class Function(object):
                value.dtype != np.float32 and
                value.dtype != np.float64):
                 value = value.astype(np.float32)
+            # in current version cntk can't support input with variable
+            # length. Will support it in next release.
+            if not self._is_input_shape_compatible(value, tensor):
+                raise ValueError('CNTK backend: The placeholder has been resolved '
+                                 'to shape `%s`, but input shape is `%s`. Currently '
+                                 'CNTK can not take variable length inputs. Please '
+                                 'padding the inputs before fit the data.'
+                                 % (tensor.shape, value.shape))
             feed_dict[tensor] = value
 
         updated = []

--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -1593,7 +1593,7 @@ class Function(object):
                 raise ValueError('CNTK backend: The placeholder has been resolved '
                                  'to shape `%s`, but input shape is `%s`. Currently '
                                  'CNTK can not take variable length inputs. Please '
-                                 'padding the inputs before fit the data.'
+                                 'pass inputs that have a static shape.'
                                  % (tensor.shape, value.shape))
             feed_dict[tensor] = value
 


### PR DESCRIPTION
This pull request is for issue #7055 
In current version, cntk can't support variable length input, add more meaningful error message.
We are working on this feature and hopefully could support it in next release. 