### PR TITLE
better error message when ReduceLROnPlateau conditioned on non-existing metric

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -873,8 +873,12 @@ class ReduceLROnPlateau(Callback):
         logs['lr'] = K.get_value(self.model.optimizer.lr)
         current = logs.get(self.monitor)
         if current is None:
-            warnings.warn('Learning Rate Plateau Reducing requires %s available!' %
-                          self.monitor, RuntimeWarning)
+            warnings.warn(
+                'Reduce LR on plateau conditioned on metric `%s` '
+                'which is not available. Available metrics are: %s' %
+                (self.monitor, ','.join(list(logs.keys()))), RuntimeWarning
+            )
+
         else:
             if self.in_cooldown():
                 self.cooldown_counter -= 1


### PR DESCRIPTION
Same as #6954 but for callback `ReduceLROnPlateau`