### PR TITLE
Enable recursive setting of the trainable parameter

### DIFF
--- a/docs/templates/applications.md
+++ b/docs/templates/applications.md
@@ -111,8 +111,7 @@ model = Model(inputs=base_model.input, outputs=predictions)
 
 # first: train only the top layers (which were randomly initialized)
 # i.e. freeze all convolutional InceptionV3 layers
-for layer in base_model.layers:
-    layer.trainable = False
+base_model.set_trainable(False)
 
 # compile the model (should be done *after* setting layers to non-trainable)
 model.compile(optimizer='rmsprop', loss='categorical_crossentropy')
@@ -132,9 +131,9 @@ for i, layer in enumerate(base_model.layers):
 # we chose to train the top 2 inception blocks, i.e. we will freeze
 # the first 249 layers and unfreeze the rest:
 for layer in model.layers[:249]:
-   layer.trainable = False
+    layer.set_trainable(False)
 for layer in model.layers[249:]:
-   layer.trainable = True
+    layer.set_trainable(True)
 
 # we need to recompile the model for these modifications to take effect
 # we use SGD with a low learning rate

--- a/docs/templates/getting-started/faq.md
+++ b/docs/templates/getting-started/faq.md
@@ -284,19 +284,19 @@ You can pass a `trainable` argument (boolean) to a layer constructor to set a la
 frozen_layer = Dense(32, trainable=False)
 ```
 
-Additionally, you can set the `trainable` property of a layer to `True` or `False` after instantiation. For this to take effect, you will need to call `compile()` on your model after modifying the `trainable` property. Here's an example:
+Additionally, you can use the `set_trainable` method of a layer with`True` or `False` after instantiation. For this to take effect, you will need to call `compile()` on your model after modifying the `trainable` property. Here's an example:
 
 ```python
 x = Input(shape=(32,))
 layer = Dense(32)
-layer.trainable = False
+layer.set_trainable(False)
 y = layer(x)
 
 frozen_model = Model(x, y)
 # in the model below, the weights of `layer` will not be updated during training
 frozen_model.compile(optimizer='rmsprop', loss='mse')
 
-layer.trainable = True
+layer.set_trainable(True)
 trainable_model = Model(x, y)
 # with this model the weights of the layer will be updated during training
 # (which will also affect the above model since it uses the same layer instance)
@@ -305,6 +305,26 @@ trainable_model.compile(optimizer='rmsprop', loss='mse')
 frozen_model.fit(data, labels)  # this does NOT update the weights of `layer`
 trainable_model.fit(data, labels)  # this updates the weights of `layer`
 ```
+
+The same is valid for models nested inside models:
+
+```python
+from keras.models import load_model
+
+# Load an already trained model
+sub_model = load_model('my_pretrained_model.h5')
+sub_model.set_trainable(False)
+
+# And append a few layers on top:
+x = Input(shape=(32,))
+y = sub_model(input)
+y = Dense(64, activation='relu')(y)
+y = Dense(1, activation='sigmoid')(y)
+
+# Only the two last dense layers will be trained
+model = Model(inputs=x, outputs=y)
+```
+
 
 ---
 

--- a/docs/templates/models/about-keras-models.md
+++ b/docs/templates/models/about-keras-models.md
@@ -31,3 +31,5 @@ model = model_from_yaml(yaml_string)
 ```
 - `model.save_weights(filepath)`: saves the weights of the model as a HDF5 file.
 - `model.load_weights(filepath, by_name=False)`: loads the weights of the model from a HDF5 file (created by `save_weights`). By default, the architecture is expected to be unchanged. To load weights into a different architecture (with some layers in common), use `by_name=True` to load only those layers with the same name.
+- `model.set_trainable(trainable)`: sets recursively the trainable property of all the layers in the model to `True` or `False`.
+

--- a/examples/mnist_acgan.py
+++ b/examples/mnist_acgan.py
@@ -158,7 +158,7 @@ if __name__ == '__main__':
     fake = generator([latent, image_class])
 
     # we only want to be able to train generation for the combined model
-    discriminator.trainable = False
+    discriminator.set_trainable(False)
     fake, aux = discriminator(fake)
     combined = Model([latent, image_class], [fake, aux])
 

--- a/examples/mnist_transfer_cnn.py
+++ b/examples/mnist_transfer_cnn.py
@@ -118,7 +118,7 @@ train_model(model,
 
 # freeze feature layers and rebuild model
 for l in feature_layers:
-    l.trainable = False
+    l.set_trainable(False)
 
 # transfer: train dense layers for new classification task [5..9]
 train_model(model,

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -2646,6 +2646,7 @@ class Container(Layer):
         """Recursively set the trainable value of all the layers and sub-models"""
         for layer in self.layers:
             layer.set_trainable(trainable)
+        self.trainable = trainable  # Set the model itself
 
     def summary(self, line_length=None, positions=None, print_fn=print):
         """Prints a string summary of the network.

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -234,6 +234,7 @@ class Layer(object):
         get_output_shape_at(node_index)
         get_input_mask_at(node_index)
         get_output_mask_at(node_index)
+        set_trainable(trainable)
 
     # Class Methods
         from_config(config)
@@ -1261,6 +1262,9 @@ class Layer(object):
                                    self.name + '.build(batch_input_shape)`.')
         return sum([K.count_params(p) for p in self.weights])
 
+    def set_trainable(self, trainable):
+        self.trainable = trainable
+
 
 class InputLayer(Layer):
     """Layer to be used as an entry point into a graph.
@@ -1465,6 +1469,7 @@ class Container(Layer):
         set_weights
         get_config
         compute_output_shape
+        set_trainable
 
     # Class Methods
         from_config
@@ -2636,6 +2641,11 @@ class Container(Layer):
             A YAML string.
         """
         return yaml.dump(self._updated_config(), **kwargs)
+
+    def set_trainable(self, trainable):
+        """Recursively set the trainable value of all the layers and sub-models"""
+        for layer in self.layers:
+            layer.set_trainable(trainable)
 
     def summary(self, line_length=None, positions=None, print_fn=print):
         """Prints a string summary of the network.

--- a/tests/keras/engine/test_topology.py
+++ b/tests/keras/engine/test_topology.py
@@ -77,6 +77,49 @@ def test_trainable_weights():
 
 
 @keras_test
+def test_set_trainable_weights():
+    a = Input(shape=(2,))
+    b = Dense(1)(a)
+    model = Model(a, b)
+
+    weights = model.weights
+    assert model.trainable_weights == weights
+    assert model.non_trainable_weights == []
+
+    model.set_trainable(False)
+    assert model.trainable_weights == []
+    assert model.non_trainable_weights == weights
+
+    model.set_trainable(True)
+    assert model.trainable_weights == weights
+    assert model.non_trainable_weights == []
+
+    model.layers[1].set_trainable(False)
+    assert model.trainable_weights == []
+    assert model.non_trainable_weights == weights
+
+    # sequential model
+    model = Sequential()
+    model.add(Dense(1, input_dim=2))
+    weights = model.weights
+
+    assert model.trainable_weights == weights
+    assert model.non_trainable_weights == []
+
+    model.trainable = False
+    assert model.trainable_weights == []
+    assert model.non_trainable_weights == weights
+
+    model.set_trainable(True)
+    assert model.trainable_weights == weights
+    assert model.non_trainable_weights == []
+
+    model.layers[0].set_trainable(False)
+    assert model.trainable_weights == []
+    assert model.non_trainable_weights == weights
+
+
+@keras_test
 @pytest.mark.skipif((K.backend() == 'cntk'),
                     reason="cntk does not support add learning_phase() as input")
 def test_learning_phase():


### PR DESCRIPTION
Doing `model.trainable = False` doesn't do anything, since its layers seem to still be trainable. I propose the method `set_trainable` for both layers and models that will recursively set the parameter.

The main use case is when we have sub-models inside the model we want to freeze, since we won't have to manually loop through an unknown number of layer depths.

If you think this is a good addition, I'll change the examples, add some docs, and a test.