### PR TITLE
Fix test in training

### DIFF
--- a/tests/keras/engine/test_training.py
+++ b/tests/keras/engine/test_training.py
@@ -281,9 +281,10 @@ def test_model_methods():
     out = model.predict([input_a_np, input_b_np], batch_size=4)
 
     # empty batch
-    with pytest.raises(StopIteration):
+    with pytest.raises(ValueError):
         def gen_data():
-            yield (np.asarray([]), np.asarray([]))
+            while True:
+                yield (np.asarray([]), np.asarray([]))
         out = model.evaluate_generator(gen_data(), steps=1)
 
     # x is not a list of numpy arrays.


### PR DESCRIPTION
This test could fail if the worker iterates over the generator before Keras could throw the ValueError.

The StopIteration was caught because exceptions were weirdly handled before and would always throw StopIteration over the real exception : ValueError.