### PR TITLE
Fix computation of receptive field size for 'channels_last'

### DIFF
--- a/keras/initializers.py
+++ b/keras/initializers.py
@@ -458,7 +458,7 @@ def _compute_fans(shape, data_format='channels_last'):
             fan_in = shape[1] * receptive_field_size
             fan_out = shape[0] * receptive_field_size
         elif data_format == 'channels_last':
-            receptive_field_size = np.prod(shape[:2])
+            receptive_field_size = np.prod(shape[:-2])
             fan_in = shape[-2] * receptive_field_size
             fan_out = shape[-1] * receptive_field_size
         else:


### PR DESCRIPTION
For the 'channels_last' case the receptive_field_size needs to be computed as the product of all dimensions except the last two (input_depth, depth). The old version computes it incorrectly for Conv1D and Conv3D. 