### PR TITLE
Update TensorFlow and CNTK backend strings

### DIFF
--- a/docs/templates/activations.md
+++ b/docs/templates/activations.md
@@ -16,7 +16,7 @@ This is equivalent to:
 model.add(Dense(64, activation='tanh'))
 ```
 
-You can also pass an element-wise Tensorflow/Theano function as an activation:
+You can also pass an element-wise TensorFlow/Theano/CNTK function as an activation:
 
 ```python
 from keras import backend as K
@@ -31,4 +31,4 @@ model.add(Activation(K.tanh))
 
 ## On "Advanced Activations"
 
-Activations that are more complex than a simple Tensorflow/Theano function (eg. learnable activations, which maintain a state) are available as [Advanced Activation layers](layers/advanced-activations.md), and can be found in the module `keras.layers.advanced_activations`. These include `PReLU` and `LeakyReLU`.
+Activations that are more complex than a simple TensorFlow/Theano/CNTK function (eg. learnable activations, which maintain a state) are available as [Advanced Activation layers](layers/advanced-activations.md), and can be found in the module `keras.layers.advanced_activations`. These include `PReLU` and `LeakyReLU`.

--- a/keras/applications/mobilenet.py
+++ b/keras/applications/mobilenet.py
@@ -42,7 +42,7 @@ the 100 % MobileNet on various input sizes:
 ------------------------------------------------------------------------
 
 The weights for all 16 models are obtained and translated
-from Tensorflow checkpoints found at
+from TensorFlow checkpoints found at
 https://github.com/tensorflow/models/blob/master/slim/nets/mobilenet_v1.md
 
 # Reference
@@ -364,7 +364,7 @@ def MobileNet(input_shape=None,
     """
 
     if K.backend() != 'tensorflow':
-        raise RuntimeError('Only Tensorflow backend is currently supported, '
+        raise RuntimeError('Only TensorFlow backend is currently supported, '
                            'as other backends do not support '
                            'depthwise convolution.')
 

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -374,10 +374,10 @@ def is_keras_tensor(x):
     ```python
         >>> from keras import backend as K
         >>> np_var = numpy.array([1, 2])
-        >>> K.is_keras_tensor(np_var) # A numpy array is not a symbolic yensor.
+        >>> K.is_keras_tensor(np_var) # A numpy array is not a symbolic tensor.
         ValueError
         >>> k_var = tf.placeholder('float32', shape=(1,1))
-        >>> K.is_keras_tensor(k_var) # A variable created directly from tensorflow/theano is not a Keras tensor.
+        >>> K.is_keras_tensor(k_var) # A variable indirectly created outside of keras is not a Keras tensor.
         False
         >>> keras_var = K.variable(np_var)
         >>> K.is_keras_tensor(keras_var)  # A variable created with the keras backend is a Keras tensor.
@@ -2287,7 +2287,7 @@ def function(inputs, outputs, updates=None, **kwargs):
     if kwargs:
         for key in kwargs:
             if not (has_arg(tf.Session.run, key, True) or has_arg(Function.__init__, key, True)):
-                msg = 'Invalid argument "%s" passed to K.function with Tensorflow backend' % key
+                msg = 'Invalid argument "%s" passed to K.function with TensorFlow backend' % key
                 raise ValueError(msg)
     return Function(inputs, outputs, updates=updates, **kwargs)
 
@@ -3127,7 +3127,7 @@ def conv2d(x, kernel, strides=(1, 1), padding='valid',
         strides: strides tuple.
         padding: string, `"same"` or `"valid"`.
         data_format: string, `"channels_last"` or `"channels_first"`.
-            Whether to use Theano or TensorFlow data format
+            Whether to use Theano or TensorFlow/CNTK data format
             for inputs/kernels/outputs.
         dilation_rate: tuple of 2 integers.
 
@@ -3168,7 +3168,7 @@ def conv2d_transpose(x, kernel, output_shape, strides=(1, 1),
         strides: strides tuple.
         padding: string, `"same"` or `"valid"`.
         data_format: string, `"channels_last"` or `"channels_first"`.
-            Whether to use Theano or TensorFlow data format
+            Whether to use Theano or TensorFlow/CNTK data format
             for inputs/kernels/outputs.
 
     # Returns
@@ -3276,7 +3276,7 @@ def conv3d(x, kernel, strides=(1, 1, 1), padding='valid',
         strides: strides tuple.
         padding: string, `"same"` or `"valid"`.
         data_format: string, `"channels_last"` or `"channels_first"`.
-            Whether to use Theano or TensorFlow data format
+            Whether to use Theano or TensorFlow/CNTK data format
             for inputs/kernels/outputs.
         dilation_rate: tuple of 3 integers.
 
@@ -3317,7 +3317,7 @@ def conv3d_transpose(x, kernel, output_shape, strides=(1, 1, 1),
         strides: strides tuple.
         padding: string, "same" or "valid".
         data_format: string, `"channels_last"` or `"channels_first"`.
-            Whether to use Theano or TensorFlow data format
+            Whether to use Theano or TensorFlow/CNTK data format
             for inputs/kernels/outputs.
 
     # Returns

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1894,8 +1894,8 @@ def conv2d_transpose(x, kernel, output_shape, strides=(1, 1),
 
     if padding == 'same' and kernel_shape[0] % 2 == 0:
         raise ValueError('In `Conv2DTranspose`, with padding mode `same`, '
-                         'even kernel sizes are only supported with Tensorflow. '
-                         'With Theano, set `kernel_size` to an odd number.')
+                         'even kernel sizes are not supported with Theano. '
+                         'You can set `kernel_size` to an odd number.')
 
     kernel_shape = _preprocess_conv2d_filter_shape(kernel_shape, data_format)
 
@@ -2005,8 +2005,8 @@ def conv3d_transpose(x, kernel, output_shape, strides=(1, 1, 1),
 
     if padding == 'same' and kernel_shape[0] % 2 == 0:
         raise ValueError('In `Conv3DTranspose`, with padding mode `same`, '
-                         'even kernel sizes are only supported with Tensorflow. '
-                         'With Theano, set `kernel_size` to an odd number.')
+                         'even kernel sizes are not supported with Theano. '
+                         'You can set `kernel_size` to an odd number.')
 
     kernel_shape = _preprocess_conv3d_filter_shape(kernel_shape, data_format)
 

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -626,8 +626,8 @@ class Model(Container):
                 If the model has multiple outputs, you can use a different
                 `sample_weight_mode` on each output by passing a
                 dictionary or a list of modes.
-            **kwargs: when using the Theano backend, these arguments
-                are passed into K.function. When using the Tensorflow backend,
+            **kwargs: when using the Theano/CNTK backends, these arguments
+                are passed into K.function. When using the TensorFlow backend,
                 these arguments are passed into `tf.Session.run`.
 
         # Raises

--- a/keras/models.py
+++ b/keras/models.py
@@ -758,9 +758,9 @@ class Sequential(Model):
             sample_weight_mode: if you need to do timestep-wise
                 sample weighting (2D weights), set this to "temporal".
                 "None" defaults to sample-wise weights (1D).
-            **kwargs: for Theano backend, these are passed into K.function.
-                When using the Tensorflow backend, these are passed into
-                `tf.Session.run`.
+            **kwargs: for Theano/CNTK backends, these are passed into
+                K.function. When using the TensorFlow backend, these are
+                passed into `tf.Session.run`.
 
         # Example
             ```python

--- a/tests/keras/applications/applications_test.py
+++ b/tests/keras/applications/applications_test.py
@@ -171,7 +171,7 @@ def test_inceptionv3_pooling():
 
 @keras_test
 @pytest.mark.skipif((K.backend() != 'tensorflow'),
-                    reason="MobileNets are supported only on Tensorflow")
+                    reason="MobileNets are supported only on TensorFlow")
 def test_mobilenet():
     model = applications.MobileNet(weights=None)
     assert model.output_shape == (None, 1000)
@@ -179,7 +179,7 @@ def test_mobilenet():
 
 @keras_test
 @pytest.mark.skipif((K.backend() != 'tensorflow'),
-                    reason="MobileNets are supported only on Tensorflow")
+                    reason="MobileNets are supported only on TensorFlow")
 def test_mobilenet_no_top():
     model = applications.MobileNet(weights=None, include_top=False)
     assert model.output_shape == (None, None, None, 1024)
@@ -187,7 +187,7 @@ def test_mobilenet_no_top():
 
 @keras_test
 @pytest.mark.skipif((K.backend() != 'tensorflow'),
-                    reason="MobileNets are supported only on Tensorflow")
+                    reason="MobileNets are supported only on TensorFlow")
 def test_mobilenet_pooling():
     model = applications.MobileNet(weights=None, include_top=False, pooling='avg')
     assert model.output_shape == (None, 1024)

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -1396,7 +1396,7 @@ class TestBackend(object):
         label_lens = np.expand_dims(np.asarray([5, 4]), 1)
         input_lens = np.expand_dims(np.asarray([5, 5]), 1)  # number of timesteps
 
-        # the Theano and Tensorflow CTC code use different methods to ensure
+        # the Theano and TensorFlow CTC code use different methods to ensure
         # numerical stability.  The Theano code subtracts out the max
         # before the final log, so the results are different but scale
         # identically and still train properly


### PR DESCRIPTION
This PR updates backend strings mainly involving CNTK. Additionally, `Tensorflow` are replaced by `TensorFlow` for consistency over docstrings.