### PR TITLE
Passed the scheduling argument through the `*_generator` function.

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1631,7 +1631,7 @@ class Model(Container):
                       max_queue_size=10,
                       workers=1,
                       use_multiprocessing=False,
-                      ordered=True,
+                      shuffle=True,
                       initial_epoch=0):
         """Fits the model on data yielded batch-by-batch by a Python generator.
 
@@ -1681,8 +1681,8 @@ class Model(Container):
                 non picklable arguments to the generator
                 as they can't be passed
                 easily to children processes.
-            ordered: Sequential querying of data if `True`,
-                random otherwise. Only used with instances of Sequence (
+            shuffle: whether to shuffle the data at the beginning of each
+                epoch. Only used with instances of Sequence (
                 keras.utils.Sequence).
             initial_epoch: epoch at which to start training
                 (useful for resuming a previous training run)
@@ -1786,7 +1786,7 @@ class Model(Container):
             if is_sequence:
                 enqueuer = OrderedEnqueuer(generator,
                                            use_multiprocessing=use_multiprocessing,
-                                           ordered=ordered)
+                                           shuffle=shuffle)
             else:
                 enqueuer = GeneratorEnqueuer(generator,
                                              use_multiprocessing=use_multiprocessing,

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1682,7 +1682,7 @@ class Model(Container):
                 as they can't be passed
                 easily to children processes.
             shuffle: whether to shuffle the data at the beginning of each
-                epoch. Only used with instances of Sequence (
+                epoch. Only used with instances of `Sequence` (
                 keras.utils.Sequence).
             initial_epoch: epoch at which to start training
                 (useful for resuming a previous training run)

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1631,6 +1631,7 @@ class Model(Container):
                       max_queue_size=10,
                       workers=1,
                       use_multiprocessing=False,
+                      ordered=True,
                       initial_epoch=0):
         """Fits the model on data yielded batch-by-batch by a Python generator.
 
@@ -1680,6 +1681,8 @@ class Model(Container):
                 non picklable arguments to the generator
                 as they can't be passed
                 easily to children processes.
+            ordered: Sequential querying of data if 'True',
+                random otherwise.
             initial_epoch: epoch at which to start training
                 (useful for resuming a previous training run)
 
@@ -1781,7 +1784,8 @@ class Model(Container):
         try:
             if is_sequence:
                 enqueuer = OrderedEnqueuer(generator,
-                                           use_multiprocessing=use_multiprocessing)
+                                           use_multiprocessing=use_multiprocessing,
+                                           ordered=ordered)
             else:
                 enqueuer = GeneratorEnqueuer(generator,
                                              use_multiprocessing=use_multiprocessing,
@@ -1848,7 +1852,8 @@ class Model(Container):
                                 validation_steps,
                                 max_queue_size=max_queue_size,
                                 workers=workers,
-                                use_multiprocessing=use_multiprocessing)
+                                use_multiprocessing=use_multiprocessing,
+                                ordered=ordered)
                         else:
                             # No need for try/except because
                             # data has already been validated.
@@ -1879,7 +1884,8 @@ class Model(Container):
     def evaluate_generator(self, generator, steps,
                            max_queue_size=10,
                            workers=1,
-                           use_multiprocessing=False):
+                           use_multiprocessing=False,
+                           ordered=True):
         """Evaluates the model on a data generator.
 
         The generator should return the same kind of data
@@ -1903,6 +1909,8 @@ class Model(Container):
                 non picklable arguments to the generator
                 as they can't be passed
                 easily to children processes.
+            ordered: Sequential querying of data if 'True',
+                random otherwise.
 
         # Returns
             Scalar test loss (if the model has a single output and no metrics)
@@ -1932,7 +1940,8 @@ class Model(Container):
         try:
             if is_sequence:
                 enqueuer = OrderedEnqueuer(generator,
-                                           use_multiprocessing=use_multiprocessing)
+                                           use_multiprocessing=use_multiprocessing,
+                                           ordered=ordered)
             else:
                 enqueuer = GeneratorEnqueuer(generator,
                                              use_multiprocessing=use_multiprocessing,
@@ -1992,6 +2001,7 @@ class Model(Container):
                           max_queue_size=10,
                           workers=1,
                           use_multiprocessing=False,
+                          ordered=True,
                           verbose=0):
         """Generates predictions for the input samples from a data generator.
 
@@ -2015,6 +2025,8 @@ class Model(Container):
                 non picklable arguments to the generator
                 as they can't be passed
                 easily to children processes.
+            ordered: Sequential querying of data if `True`,
+                random otherwise.
             verbose: verbosity mode, 0 or 1.
 
         # Returns
@@ -2041,7 +2053,8 @@ class Model(Container):
         try:
             if is_sequence:
                 enqueuer = OrderedEnqueuer(generator,
-                                           use_multiprocessing=use_multiprocessing)
+                                           use_multiprocessing=use_multiprocessing,
+                                           ordered=ordered)
             else:
                 enqueuer = GeneratorEnqueuer(generator,
                                              use_multiprocessing=use_multiprocessing,

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1682,7 +1682,8 @@ class Model(Container):
                 as they can't be passed
                 easily to children processes.
             ordered: Sequential querying of data if `True`,
-                random otherwise.
+                random otherwise. Only used with instances of Sequence (
+                keras.utils.Sequence).
             initial_epoch: epoch at which to start training
                 (useful for resuming a previous training run)
 
@@ -1852,8 +1853,7 @@ class Model(Container):
                                 validation_steps,
                                 max_queue_size=max_queue_size,
                                 workers=workers,
-                                use_multiprocessing=use_multiprocessing,
-                                ordered=ordered)
+                                use_multiprocessing=use_multiprocessing)
                         else:
                             # No need for try/except because
                             # data has already been validated.
@@ -1884,8 +1884,7 @@ class Model(Container):
     def evaluate_generator(self, generator, steps,
                            max_queue_size=10,
                            workers=1,
-                           use_multiprocessing=False,
-                           ordered=True):
+                           use_multiprocessing=False):
         """Evaluates the model on a data generator.
 
         The generator should return the same kind of data
@@ -1909,8 +1908,6 @@ class Model(Container):
                 non picklable arguments to the generator
                 as they can't be passed
                 easily to children processes.
-            ordered: Sequential querying of data if `True`,
-                random otherwise.
 
         # Returns
             Scalar test loss (if the model has a single output and no metrics)
@@ -1940,8 +1937,7 @@ class Model(Container):
         try:
             if is_sequence:
                 enqueuer = OrderedEnqueuer(generator,
-                                           use_multiprocessing=use_multiprocessing,
-                                           ordered=ordered)
+                                           use_multiprocessing=use_multiprocessing)
             else:
                 enqueuer = GeneratorEnqueuer(generator,
                                              use_multiprocessing=use_multiprocessing,
@@ -2001,7 +1997,6 @@ class Model(Container):
                           max_queue_size=10,
                           workers=1,
                           use_multiprocessing=False,
-                          ordered=True,
                           verbose=0):
         """Generates predictions for the input samples from a data generator.
 
@@ -2025,8 +2020,6 @@ class Model(Container):
                 non picklable arguments to the generator
                 as they can't be passed
                 easily to children processes.
-            ordered: Sequential querying of data if `True`,
-                random otherwise.
             verbose: verbosity mode, 0 or 1.
 
         # Returns
@@ -2053,8 +2046,7 @@ class Model(Container):
         try:
             if is_sequence:
                 enqueuer = OrderedEnqueuer(generator,
-                                           use_multiprocessing=use_multiprocessing,
-                                           ordered=ordered)
+                                           use_multiprocessing=use_multiprocessing)
             else:
                 enqueuer = GeneratorEnqueuer(generator,
                                              use_multiprocessing=use_multiprocessing,

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1681,7 +1681,7 @@ class Model(Container):
                 non picklable arguments to the generator
                 as they can't be passed
                 easily to children processes.
-            ordered: Sequential querying of data if 'True',
+            ordered: Sequential querying of data if `True`,
                 random otherwise.
             initial_epoch: epoch at which to start training
                 (useful for resuming a previous training run)
@@ -1909,7 +1909,7 @@ class Model(Container):
                 non picklable arguments to the generator
                 as they can't be passed
                 easily to children processes.
-            ordered: Sequential querying of data if 'True',
+            ordered: Sequential querying of data if `True`,
                 random otherwise.
 
         # Returns

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -342,7 +342,6 @@ class Sequence(object):
         """
         raise NotImplementedError
 
-
     @abstractmethod
     def __len__(self):
         """Number of batch in the Sequence.
@@ -352,12 +351,12 @@ class Sequence(object):
         """
         raise NotImplementedError
 
-
     @abstractmethod
     def on_epoch_end(self):
         """A function which is called at the end of the epoch.
         """
         raise NotImplementedError
+
 
 def get_index(ds, i):
     """Quick fix for Python2, otherwise, it cannot be pickled.

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -445,7 +445,7 @@ class OrderedEnqueuer(SequenceEnqueuer):
 
     def __init__(self, sequence,
                  use_multiprocessing=False,
-                 shuffle=True):
+                 shuffle=False):
         self.sequence = sequence
         self.use_multiprocessing = use_multiprocessing
         self.shuffle = shuffle
@@ -480,7 +480,7 @@ class OrderedEnqueuer(SequenceEnqueuer):
         """Function to submit request to the executor and queue the `Future` objects."""
         sequence = list(range(len(self.sequence)))
         while True:
-            if not self.shuffle:
+            if self.shuffle:
                 random.shuffle(sequence)
             for i in sequence:
                 if self.stop_signal.is_set():

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -440,15 +440,15 @@ class OrderedEnqueuer(SequenceEnqueuer):
     # Arguments
         sequence: A `keras.utils.data_utils.Sequence` object.
         use_multiprocessing: use multiprocessing if True, otherwise threading
-        ordered: Sequential querying of datas if `True`, random otherwise.
+        shuffle: whether to shuffle the data at the beginning of each epoch
     """
 
     def __init__(self, sequence,
                  use_multiprocessing=False,
-                 ordered=True):
+                 shuffle=True):
         self.sequence = sequence
         self.use_multiprocessing = use_multiprocessing
-        self.ordered = ordered
+        self.shuffle = shuffle
         self.workers = 0
         self.executor = None
         self.queue = None
@@ -480,7 +480,7 @@ class OrderedEnqueuer(SequenceEnqueuer):
         """Function to submit request to the executor and queue the `Future` objects."""
         sequence = list(range(len(self.sequence)))
         while True:
-            if not self.ordered:
+            if not self.shuffle:
                 random.shuffle(sequence)
             for i in sequence:
                 if self.stop_signal.is_set():

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -354,8 +354,8 @@ class Sequence(object):
 
 
     @abstractmethod
-    def shuffle(self):
-        """Shuffle the Sequence.
+    def on_epoch_end(self):
+        """A function which is called at the end of the epoch.
         """
         raise NotImplementedError
 
@@ -482,20 +482,15 @@ class OrderedEnqueuer(SequenceEnqueuer):
         sequence = list(range(len(self.sequence)))
         while True:
             if not self.ordered:
-                # This needs altering, add a function into sequences to
-                # permutate the inner list also.
                 random.shuffle(sequence)
-                # Shuffle the sequence also - Ensures different items make up
-                #  a batch.
-                self.sequence.shuffle()
             for i in sequence:
                 if self.stop_signal.is_set():
                     return
-                # Do we need to pass in different numpy seeds for different
-                # pools? - Can do via a counter and self.random_seed
                 self.queue.put(
                     self.executor.apply_async(get_index,
                                               (self.sequence, i)), block=True)
+            # Call the internal on epoch end.
+            self.sequence.on_epoch_end()
 
     def get(self):
         """Creates a generator to extract data from the queue.

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -434,7 +434,7 @@ class OrderedEnqueuer(SequenceEnqueuer):
     # Arguments
         sequence: A `keras.utils.data_utils.Sequence` object.
         use_multiprocessing: use multiprocessing if True, otherwise threading
-        ordered: Sequential querying of datas if True, random otherwise.
+        ordered: Sequential querying of datas if `True`, random otherwise.
     """
 
     def __init__(self, sequence,

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -434,15 +434,15 @@ class OrderedEnqueuer(SequenceEnqueuer):
     # Arguments
         sequence: A `keras.utils.data_utils.Sequence` object.
         use_multiprocessing: use multiprocessing if True, otherwise threading
-        scheduling: Sequential querying of datas if 'sequential', random otherwise.
+        ordered: Sequential querying of datas if True, random otherwise.
     """
 
     def __init__(self, sequence,
                  use_multiprocessing=False,
-                 scheduling='sequential'):
+                 ordered=True):
         self.sequence = sequence
         self.use_multiprocessing = use_multiprocessing
-        self.scheduling = scheduling
+        self.ordered = ordered
         self.workers = 0
         self.executor = None
         self.queue = None
@@ -474,7 +474,7 @@ class OrderedEnqueuer(SequenceEnqueuer):
         """Function to submit request to the executor and queue the `Future` objects."""
         sequence = list(range(len(self.sequence)))
         while True:
-            if self.scheduling is not 'sequential':
+            if not self.ordered:
                 random.shuffle(sequence)
             for i in sequence:
                 if self.stop_signal.is_set():

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -342,6 +342,7 @@ class Sequence(object):
         """
         raise NotImplementedError
 
+
     @abstractmethod
     def __len__(self):
         """Number of batch in the Sequence.
@@ -351,6 +352,12 @@ class Sequence(object):
         """
         raise NotImplementedError
 
+
+    @abstractmethod
+    def shuffle(self):
+        """Shuffle the Sequence.
+        """
+        raise NotImplementedError
 
 def get_index(ds, i):
     """Quick fix for Python2, otherwise, it cannot be pickled.
@@ -475,10 +482,17 @@ class OrderedEnqueuer(SequenceEnqueuer):
         sequence = list(range(len(self.sequence)))
         while True:
             if not self.ordered:
+                # This needs altering, add a function into sequences to
+                # permutate the inner list also.
                 random.shuffle(sequence)
+                # Shuffle the sequence also - Ensures different items make up
+                #  a batch.
+                self.sequence.shuffle()
             for i in sequence:
                 if self.stop_signal.is_set():
                     return
+                # Do we need to pass in different numpy seeds for different
+                # pools? - Can do via a counter and self.random_seed
                 self.queue.put(
                     self.executor.apply_async(get_index,
                                               (self.sequence, i)), block=True)

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -353,7 +353,7 @@ class Sequence(object):
 
     @abstractmethod
     def on_epoch_end(self):
-        """A function which is called at the end of the epoch.
+        """Method called at the end of every epoch.
         """
         raise NotImplementedError
 

--- a/tests/keras/engine/test_training.py
+++ b/tests/keras/engine/test_training.py
@@ -31,6 +31,9 @@ class RandomSequence(Sequence):
             np.random.random((self.batch_size, 4)),
             np.random.random((self.batch_size, 3))]
 
+    def on_epoch_end(self):
+        pass
+
 
 @keras_test
 def test_check_array_lengths():

--- a/tests/keras/utils/data_utils_test.py
+++ b/tests/keras/utils/data_utils_test.py
@@ -208,8 +208,7 @@ def test_ordered_enqueuer_threads_not_ordered():
     acc = []
     for i in range(100):
         acc.append(next(gen_output)[0, 0, 0, 0])
-    assert acc != list(range(100)), "Order was not keep in " \
-                                     "GeneratorEnqueuer with threads"
+    assert acc != list(range(100)), "Order was not keep in GeneratorEnqueuer with threads"
     enqueuer.stop()
 
 

--- a/tests/keras/utils/data_utils_test.py
+++ b/tests/keras/utils/data_utils_test.py
@@ -199,6 +199,20 @@ def test_ordered_enqueuer_threads():
     enqueuer.stop()
 
 
+def test_ordered_enqueuer_threads_not_ordered():
+    enqueuer = OrderedEnqueuer(TestSequence([3, 200, 200, 3]),
+                               use_multiprocessing=False,
+                               ordered=False)
+    enqueuer.start(3, 10)
+    gen_output = enqueuer.get()
+    acc = []
+    for i in range(100):
+        acc.append(next(gen_output)[0, 0, 0, 0])
+    assert acc != list(range(100)), "Order was not keep in " \
+                                     "GeneratorEnqueuer with threads"
+    enqueuer.stop()
+
+
 def test_ordered_enqueuer_processes():
     enqueuer = OrderedEnqueuer(TestSequence([3, 200, 200, 3]), use_multiprocessing=True)
     enqueuer.start(3, 10)

--- a/tests/keras/utils/data_utils_test.py
+++ b/tests/keras/utils/data_utils_test.py
@@ -121,6 +121,9 @@ class TestSequence(Sequence):
     def __len__(self):
         return 100
 
+    def on_epoch_end(self):
+        pass
+
 
 class FaultSequence(Sequence):
     def __getitem__(self, item):
@@ -128,6 +131,9 @@ class FaultSequence(Sequence):
 
     def __len__(self):
         return 100
+
+    def on_epoch_end(self):
+        pass
 
 
 @threadsafe_generator
@@ -202,7 +208,7 @@ def test_ordered_enqueuer_threads():
 def test_ordered_enqueuer_threads_not_ordered():
     enqueuer = OrderedEnqueuer(TestSequence([3, 200, 200, 3]),
                                use_multiprocessing=False,
-                               ordered=False)
+                               shuffle=True)
     enqueuer.start(3, 10)
     gen_output = enqueuer.get()
     acc = []


### PR DESCRIPTION
Previously, the scheduling parameter was not passed to the OrderedEnqueuer, which was needed in training.
Since the scheduling parameter is currently a binary decision, I've also altered the value to a boolean and changed the kwarg to be more descriptive.

It also, seems we may need a shuffle function inside the Sequence call. Currently, only the input is shuffled, whilst this ensures some randomness this could be improved on via a function call.

Also, @fchollet do you remember why in the generators you passed different seeds? - This is also missing from the current code, however, it is trivial to implement.