### PR TITLE
Add seed parameter for image augmentation method.

### DIFF
--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -526,11 +526,12 @@ class ImageDataGenerator(object):
                               'first by calling `.fit(numpy_data)`.')
         return x
 
-    def random_transform(self, x):
+    def random_transform(self, x, seed=None):
         """Randomly augment a single image tensor.
 
         # Arguments
             x: 3D tensor, single image.
+            seed: random seed.
 
         # Returns
             A randomly transformed version of the input (same shape).
@@ -539,6 +540,9 @@ class ImageDataGenerator(object):
         img_row_axis = self.row_axis - 1
         img_col_axis = self.col_axis - 1
         img_channel_axis = self.channel_axis - 1
+
+        if seed is not None:
+            np.random.seed(seed)
 
         # use composition of homographies
         # to generate final transform that needs to be applied


### PR DESCRIPTION
This PR adds a seed parameters to keras.preprocessing.image.random_transform.

The case I had required both image and corresponding segmentation to be augmented. I'm not using the flow methods or `NumpyIterator`/`DirectoryIterator`. Instead I wrote my own generator which uses `random_transform` to transform images.

Using this PR I can use a seed like the current timestamp to feed to `random_transform` to get identical transforms for my image/segmentation pair. This is analogous to the example at the bottom of [this page](https://keras.io/preprocessing/image/). However, in that case one seed suffices. In my case I have to use a different seed every time I plan to use `random_transform` on an image/segmentation pair (otherwise if I used a constant seed I'd get the same transformation applied to every pair). Not important for this PR necessarily, but it gives some additional information to people reading this.