### PR TITLE
Zoneout implementation for RNN units + new implementation for GRU and LSTM

### DIFF
--- a/tests/keras/layers/recurrent_test.py
+++ b/tests/keras/layers/recurrent_test.py
@@ -85,8 +85,35 @@ def test_dropout(layer_class):
 
 
 @rnn_test
+def test_zoneout(layer_class):
+    if layer_class is not recurrent.LSTM:
+        layer_test(layer_class,
+                   kwargs={'units': units,
+                           'zoneout_probability': 0.2},
+                   input_shape=(num_samples, timesteps, embedding_dim))
+        # Test that zoneout is not applied during testing
+        x = np.random.random((num_samples, timesteps, embedding_dim))
+        layer = layer_class(units, zoneout_probability=0.5,
+                            input_shape=(timesteps, embedding_dim))
+    else:
+        layer_test(layer_class,
+                   kwargs={'units': units,
+                           'state_zoneout': 0.2,
+                           'cell_zoneout': 0.2},
+                   input_shape=(num_samples, timesteps, embedding_dim))
+        # Test that zoneout is not applied during testing
+        x = np.random.random((num_samples, timesteps, embedding_dim))
+        layer = layer_class(units, state_zoneout=0.5, cell_zoneout=0.5,
+                            input_shape=(timesteps, embedding_dim))
+    model = Sequential([layer])
+    y1 = model.predict(x)
+    y2 = model.predict(x)
+    assert_allclose(y1, y2)
+
+
+@rnn_test
 def test_implementation_mode(layer_class):
-    for mode in [0, 1, 2]:
+    for mode in [0, 1, 2, 3]:
         layer_test(layer_class,
                    kwargs={'units': units,
                            'implementation': mode},


### PR DESCRIPTION
+Zoneout implementation for all the RNN units without breaking the API
+Another implementation for GRU and LSTM which is like implementation 0 and 2 together (it uses fused matrices for forget gate and input gates and it also computes input times recurrent kernel in a big matrix)
+using implementation=some random number is not informative so I wrote an Enum for it without breaking the old codes
+deleted some duplicate codes for generating dropout masks by defining a function