### PR TITLE
[Performance] Add a manager to share the sequence

### DIFF
--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -359,7 +359,8 @@ class HolderManager(multiprocessing.managers.BaseManager):
 
 
 class Holder(object):
-    """ Object to encapsulate a Sequence.
+    """Object to encapsulate a Sequence.
+
     This allows the Sequence to be shared across multiple workers.
 
     # Arguments

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -354,10 +354,17 @@ class Sequence(object):
 
 
 class HolderManager(multiprocessing.managers.BaseManager):
+    """Custom manager to share a Holder object."""
     pass
 
 
-class Holder:
+class Holder(object):
+    """ Object to encapsulate a Sequence.
+    This allows the Sequence to be shared across multiple workers.
+
+    # Arguments
+        seq: Sequence object to be shared.
+    """
     def __init__(self, seq):
         self.seq = seq
 
@@ -367,6 +374,7 @@ class Holder:
     def __len__(self):
         return len(self.seq)
 
+# Register the Holder class using the ListProxy (allows __len__ and __getitem__)
 HolderManager.register('Holder', Holder, multiprocessing.managers.ListProxy)
 
 

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 
 import hashlib
 import multiprocessing
+import multiprocessing.managers
 import os
 import random
 import shutil
@@ -352,11 +353,28 @@ class Sequence(object):
         raise NotImplementedError
 
 
+class HolderManager(multiprocessing.managers.BaseManager):
+    pass
+
+
+class Holder:
+    def __init__(self, seq):
+        self.seq = seq
+
+    def __getitem__(self, idx):
+        return self.seq[idx]
+
+    def __len__(self):
+        return len(self.seq)
+
+HolderManager.register('Holder', Holder, multiprocessing.managers.ListProxy)
+
+
 def get_index(ds, i):
     """Quick fix for Python2, otherwise, it cannot be pickled.
 
     # Arguments
-        ds: a Sequence object
+        ds: a Holder or Sequence object
         i: index
 
     # Returns
@@ -440,7 +458,9 @@ class OrderedEnqueuer(SequenceEnqueuer):
     def __init__(self, sequence,
                  use_multiprocessing=False,
                  scheduling='sequential'):
-        self.sequence = sequence
+        self.manager = HolderManager()
+        self.manager.start()
+        self.sequence = self.manager.Holder(sequence)
         self.use_multiprocessing = use_multiprocessing
         self.scheduling = scheduling
         self.workers = 0
@@ -517,6 +537,7 @@ class OrderedEnqueuer(SequenceEnqueuer):
         self.executor.close()
         self.executor.join()
         self.run_thread.join(timeout)
+        self.manager.shutdown()
 
 
 class GeneratorEnqueuer(SequenceEnqueuer):


### PR DESCRIPTION
This PR aims at making the Sequence faster when using "LARGE" object. 
I do not fully understand the "C Magic" behind the slowdown, but there seems to be a lot of time wasted copying the Sequence to each worker.

Sharing the Sequence is really fast.
```
('Took Holder Manager list', 0.12332582473754883)
('Took list', 30.01058602333069)
```
You can reproduce with : https://gist.github.com/Dref360/95c0d6df9372b29c103066daeb3ce3b2

This fix is supported by both Python 2 and 3.
I don't think adding a test to validate the speedup is useful since this may create a flaky test.