### PR TITLE
Use try / except to select raw_input() vs. input()

### DIFF
--- a/docs/autogen.py
+++ b/docs/autogen.py
@@ -67,9 +67,11 @@ import inspect
 import os
 import shutil
 import sys
-if sys.version[0] == '2':
-    reload(sys)
+try:
+    reload(sys)  # Python 2
     sys.setdefaultencoding('utf8')
+except NameError:
+    pass         # Python 3
 
 import keras
 from keras import utils

--- a/keras/utils/io_utils.py
+++ b/keras/utils/io_utils.py
@@ -140,9 +140,10 @@ def ask_to_proceed_with_overwrite(filepath):
     # Returns
         True if we can proceed with overwrite, False otherwise.
     """
-    get_input = input
-    if sys.version_info[:2] <= (2, 7):
-        get_input = raw_input
+    try:
+        get_input = raw_input  # Python 2
+    except NameError:
+        get_input = input      # Python 3
     overwrite = get_input('[WARNING] %s already exists - overwrite? '
                           '[y/n]' % (filepath))
     while overwrite not in ['y', 'n']:


### PR DESCRIPTION
This approach will placate [flake8](http://flake8.readthedocs.io) and other similar linters.  Without this change flake8 on Python 3 responds like:

```
# stop the build if there are Python syntax errors or undefined names
$ flake8 . --count --select=E901,E999,F821,F822,F823 --statistics
./keras/utils/io_utils.py:145:21: F821 undefined name 'raw_input'
```