### PR TITLE
Check if stop_training is true after on_batch_end in fit_generator

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1847,7 +1847,7 @@ class Model(Container):
                     callbacks.on_batch_end(batch_index, batch_logs)
                     if callback_model.stop_training:
                         break
-                        
+
                     # Construct epoch logs.
                     epoch_logs = {}
                     batch_index += 1

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1845,8 +1845,6 @@ class Model(Container):
                         batch_logs[l] = o
 
                     callbacks.on_batch_end(batch_index, batch_logs)
-                    if callback_model.stop_training:
-                        break
 
                     # Construct epoch logs.
                     epoch_logs = {}
@@ -1875,6 +1873,9 @@ class Model(Container):
                         # Same labels assumed.
                         for l, o in zip(out_labels, val_outs):
                             epoch_logs['val_' + l] = o
+
+                    if callback_model.stop_training:
+                        break
 
                 callbacks.on_epoch_end(epoch, epoch_logs)
                 epoch += 1

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1845,7 +1845,9 @@ class Model(Container):
                         batch_logs[l] = o
 
                     callbacks.on_batch_end(batch_index, batch_logs)
-
+                    if callback_model.stop_training:
+                        break
+                        
                     # Construct epoch logs.
                     epoch_logs = {}
                     batch_index += 1

--- a/tests/keras/test_callbacks.py
+++ b/tests/keras/test_callbacks.py
@@ -59,14 +59,18 @@ def test_TerminateOnNaN():
         i = 0
         while 1:
             yield (X_train[i * batch_size: (i + 1) * batch_size],
-                y_train[i * batch_size: (i + 1) * batch_size])
+                   y_train[i * batch_size: (i + 1) * batch_size])
             i += 1
             i = i % max_batch_index
-    history = model.fit_generator(data_generator(), len(X_train),
-                        validation_data=(X_test, y_test), callbacks=cbks, epochs=20)
+    history = model.fit_generator(data_generator(), 
+                                  len(X_train),
+                                  validation_data=(X_test, y_test), 
+                                  callbacks=cbks, 
+                                  epochs=20)
     loss = history.history['loss']
     assert len(loss) == 1
     assert loss[0] == np.inf or np.isnan(loss[0])
+
 
 @keras_test
 def test_ModelCheckpoint(tmpdir):

--- a/tests/keras/test_callbacks.py
+++ b/tests/keras/test_callbacks.py
@@ -62,10 +62,10 @@ def test_TerminateOnNaN():
                    y_train[i * batch_size: (i + 1) * batch_size])
             i += 1
             i = i % max_batch_index
-    history = model.fit_generator(data_generator(), 
+    history = model.fit_generator(data_generator(),
                                   len(X_train),
-                                  validation_data=(X_test, y_test), 
-                                  callbacks=cbks, 
+                                  validation_data=(X_test, y_test),
+                                  callbacks=cbks,
                                   epochs=20)
     loss = history.history['loss']
     assert len(loss) == 1


### PR DESCRIPTION
Without this change, setting model.stop_training = True in on_batch_end of a callback has no effect when using the fit_generator. This behaviour is different when using fit. This change makes fit and fit_generator respond alike to a training stop at the end of a batch in a callback.