### PR TITLE
Allow Reshape to reduced it's dimensions: changed Reshape ValueError to UserWarning

### DIFF
--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -367,7 +367,9 @@ class Reshape(Layer):
                 raise ValueError(msg)
             output_shape[unknown] = original // known
         elif original != known:
-            raise ValueError(msg)
+            warnings.warn(
+                UserWarning('Total size of new array may have been changed when using Reshape layer.'
+                            ' Ensure this is desired behavior'))
 
         return tuple(output_shape)
 

--- a/tests/keras/layers/core_test.py
+++ b/tests/keras/layers/core_test.py
@@ -78,6 +78,10 @@ def test_reshape():
                kwargs={'target_shape': (1, -1)},
                input_shape=(3, 2, 4))
 
+    layer_test(layers.Reshape,
+               kwargs={'target_shape': (2, 4)},
+               input_shape=(3, 2, 4))
+
 
 @keras_test
 def test_permute():


### PR DESCRIPTION
Reshape Layer does not allow for the reduction of dimensions. 
Example:
Reshape Input: `(None, first_dims, other_dims)`
Reshape Output: `(None * first_dims, other_dims)`
This example will lead to raised error the size of the total array does take into account the None dimension size and thinks it's and error. However, sometimes you do want this behavior.

It's a minor change to allow Reshape to behave closer to tf.reshape(). This behavior is already used inside of TimeDistributed, and will allow me and others to use Reshape directly without having to create a custom layer or TimeDistributed wrapper which leads to many bugs.

@fchollet let me know if the warning message is acceptable or should change it's jargon to something more specific.