### PR TITLE
Use izip instead of zip

### DIFF
--- a/docs/templates/preprocessing/image.md
+++ b/docs/templates/preprocessing/image.md
@@ -174,6 +174,8 @@ model.fit_generator(
 Example of transforming images and masks together.
 
 ```python
+import itertools
+
 # we create two instances with the same arguments
 data_gen_args = dict(featurewise_center=True,
                      featurewise_std_normalization=True,
@@ -200,7 +202,7 @@ mask_generator = mask_datagen.flow_from_directory(
     seed=seed)
 
 # combine generators into one which yields image and masks
-train_generator = zip(image_generator, mask_generator)
+train_generator = itertools.izip(image_generator, mask_generator)
 
 model.fit_generator(
     train_generator,


### PR DESCRIPTION
Isnt it better to recommend the generator version of zip (itertools.izip). That avoids looping through all the items for no reason and could take a long time if you are not careful with steps.