### PR TITLE
keras.preprocessing.sequence: Fix skipgram() results.

### DIFF
--- a/keras/preprocessing/sequence.py
+++ b/keras/preprocessing/sequence.py
@@ -158,9 +158,8 @@ def skipgrams(sequence, vocabulary_size,
             if sampling_table[wi] < random.random():
                 continue
 
-        window_start = max(0, i - window_size)
-        window_end = min(len(sequence), i + window_size + 1)
-        for j in range(window_start, window_end):
+        window_end = min(len(sequence), i + window_size)
+        for j in range(i, window_end):
             if j != i:
                 wj = sequence[j]
                 if not wj:


### PR DESCRIPTION
  * Don't return out of order grams

  * Adhere to the window size

  * Return far fewer results which could help keep training sizes down

Fixes #7327.