### PR TITLE
Fix ImageDataGenerator.standardize to support batches

### DIFF
--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -517,9 +517,9 @@ class ImageDataGenerator(object):
                               'first by calling `.fit(numpy_data)`.')
         if self.zca_whitening:
             if self.principal_components is not None:
-                flatx = np.reshape(x, (x.size))
+                flatx = np.reshape(x, (-1, np.prod(x.shape[-3:])))
                 whitex = np.dot(flatx, self.principal_components)
-                x = np.reshape(whitex, (x.shape[0], x.shape[1], x.shape[2]))
+                x = np.reshape(whitex, x.shape)
             else:
                 warnings.warn('This ImageDataGenerator specifies '
                               '`zca_whitening`, but it hasn\'t'

--- a/tests/keras/preprocessing/image_test.py
+++ b/tests/keras/preprocessing/image_test.py
@@ -228,6 +228,37 @@ class TestImage:
         assert image.random_zoom(x, (5, 5)).shape == (2, 28, 28)
         assert image.random_channel_shift(x, 20).shape == (2, 28, 28)
 
+    def test_batch_standardize(self):
+        # ImageDataGenerator.standardize should work on batches
+        for test_images in self.all_test_images:
+            img_list = []
+            for im in test_images:
+                img_list.append(image.img_to_array(im)[None, ...])
+
+            images = np.vstack(img_list)
+            generator = image.ImageDataGenerator(
+                featurewise_center=True,
+                samplewise_center=True,
+                featurewise_std_normalization=True,
+                samplewise_std_normalization=True,
+                zca_whitening=True,
+                rotation_range=90.,
+                width_shift_range=0.1,
+                height_shift_range=0.1,
+                shear_range=0.5,
+                zoom_range=0.2,
+                channel_shift_range=0.,
+                fill_mode='nearest',
+                cval=0.5,
+                horizontal_flip=True,
+                vertical_flip=True)
+            generator.fit(images, augment=True)
+
+            transformed = np.copy(images)
+            for i, im in enumerate(transformed):
+                transformed[i] = generator.random_transform(im)
+            transformed = generator.standardize(transformed)
+
 
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
This PR fixes standardize in ImageDataGenerator so that it doesn't crash when given a batch and zca whitening is selected. The following code showcases the crash that this PR fixes.

```python
from keras.datasets import cifar10
from keras.preprocessing.image import ImageDataGenerator

(x_tr, y_tr), (x_te, y_te) = cifar10.load_data()
g = ImageDataGenerator(zca_whitening=True)
g.fit(x_tr)
g.standardize(x_tr[:10])  # This shouldn't crash, but it does!
```