### PR TITLE
Allow switching out keras.json using KERAS_JSON environment variable

### DIFF
--- a/docs/templates/backend.md
+++ b/docs/templates/backend.md
@@ -47,6 +47,17 @@ Using TensorFlow backend.
 
 ----
 
+## Switching from one config file to another
+
+You can switch the config file using the environment variable ``KERAS_JSON``:
+
+```bash
+KERAS_JSON=./custom_keras.json python -c "from keras import backend"
+Using TensorFlow backend.
+```
+
+----
+
 ## keras.json details
 
 

--- a/docs/templates/backend.md
+++ b/docs/templates/backend.md
@@ -49,10 +49,10 @@ Using TensorFlow backend.
 
 ## Switching from one config file to another
 
-You can switch the config file using the environment variable ``KERAS_JSON``:
+You can switch the config file using the environment variable ``KERAS_CONFIG``:
 
 ```bash
-KERAS_JSON=./custom_keras.json python -c "from keras import backend"
+KERAS_CONFIG=./custom_keras.json python -c "from keras import backend"
 Using TensorFlow backend.
 ```
 

--- a/keras/backend/__init__.py
+++ b/keras/backend/__init__.py
@@ -21,8 +21,8 @@ _keras_dir = os.path.join(_keras_base_dir, '.keras')
 _BACKEND = 'tensorflow'
 
 # Attempt to read Keras config file.
-if 'KERAS_JSON' in os.environ:
-    _config_path = os.path.expanduser(os.environ['KERAS_JSON'])
+if 'KERAS_CONFIG' in os.environ:
+    _config_path = os.path.expanduser(os.environ['KERAS_CONFIG'])
 else:
     _config_path = os.path.expanduser(os.path.join(_keras_dir, 'keras.json'))
 

--- a/keras/backend/__init__.py
+++ b/keras/backend/__init__.py
@@ -21,7 +21,11 @@ _keras_dir = os.path.join(_keras_base_dir, '.keras')
 _BACKEND = 'tensorflow'
 
 # Attempt to read Keras config file.
-_config_path = os.path.expanduser(os.path.join(_keras_dir, 'keras.json'))
+if 'KERAS_JSON' in os.environ:
+    _config_path = os.path.expanduser(os.environ['KERAS_JSON'])
+else:
+    _config_path = os.path.expanduser(os.path.join(_keras_dir, 'keras.json'))
+
 if os.path.exists(_config_path):
     try:
         _config = json.load(open(_config_path))


### PR DESCRIPTION
When switching between backends and Keras versions, different `keras.json` files may be required for different installations. Right now only the backend can be switched using `KERAS_BACKEND`, 

Between Keras 1 and 2, the setting `image_dim_ordering` was renamed  to `image_data_format`, and between Theano and TensorFlow, its setting changed from `channels_last` to `channels_first`.

To make all these different settings (and future changes) possible, the user should be able to create several config files and select the ones to use.

This pull request allows that using a simple environment variable `KERAS_JSON`. To use it you'd run

    KERAS_JSON=./custom_keras.json python -c "import keras"