### PR TITLE
Throw exception in LSTM layer if timesteps=1 and unroll=True

### DIFF
--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -109,7 +109,8 @@ class Recurrent(Layer):
             else a symbolic loop will be used.
             Unrolling can speed-up a RNN,
             although it tends to be more memory-intensive.
-            Unrolling is only suitable for short sequences.
+            Unrolling is only suitable for short sequences
+            and for sequences with a length greater than 1.
         implementation: one of {0, 1, or 2}.
             If set to 0, the RNN will use
             an implementation that uses fewer, larger matrix products,
@@ -315,9 +316,10 @@ class Recurrent(Layer):
                              str(len(initial_state)) +
                              ' initial states.')
         input_shape = K.int_shape(inputs)
-        if self.unroll and input_shape[1] is None:
+        timesteps = input_shape[1]
+        if self.unroll and timesteps in [None, 1]:
             raise ValueError('Cannot unroll a RNN if the '
-                             'time dimension is undefined. \n'
+                             'time dimension is undefined or equal to 1. \n'
                              '- If using a Sequential model, '
                              'specify the time dimension by passing '
                              'an `input_shape` or `batch_input_shape` '
@@ -336,7 +338,7 @@ class Recurrent(Layer):
                                              mask=mask,
                                              constants=constants,
                                              unroll=self.unroll,
-                                             input_length=input_shape[1])
+                                             input_length=timesteps)
         if self.stateful:
             updates = []
             for i in range(len(states)):

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -109,8 +109,7 @@ class Recurrent(Layer):
             else a symbolic loop will be used.
             Unrolling can speed-up a RNN,
             although it tends to be more memory-intensive.
-            Unrolling is only suitable for short sequences
-            and for sequences with a length greater than 1.
+            Unrolling is only suitable for short sequences.
         implementation: one of {0, 1, or 2}.
             If set to 0, the RNN will use
             an implementation that uses fewer, larger matrix products,

--- a/tests/keras/layers/recurrent_test.py
+++ b/tests/keras/layers/recurrent_test.py
@@ -326,7 +326,7 @@ def test_state_reuse(layer_class):
 def test_unroll_true_throws_exception_with_one_timestep():
     model = Sequential()
     with pytest.raises(ValueError):
-      model.add(recurrent.LSTM(units=5, batch_input_shape=(1, 1, 5), unroll=True))
+        model.add(recurrent.LSTM(units=5, batch_input_shape=(1, 1, 5), unroll=True))
 
 
 if __name__ == '__main__':

--- a/tests/keras/layers/recurrent_test.py
+++ b/tests/keras/layers/recurrent_test.py
@@ -323,5 +323,11 @@ def test_state_reuse(layer_class):
     outputs = model.predict(inputs)
 
 
+def test_unroll_true_throws_exception_with_one_timestep():
+    model = Sequential()
+    with pytest.raises(ValueError):
+      model.add(recurrent.LSTM(units=5, batch_input_shape=(1, 1, 5), unroll=True))
+
+
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
I noticed that when working with LSTM layers and setting `unroll=True`, Keras allows the LSTM to be initialized with one timestep, which leads to mismatched dimensions:

```
In [1]: from keras.models import Sequential
   ...: from keras.layers import LSTM, Dense
   ...: from keras import backend as K
   ...: 
Using Theano backend.

In [2]: model = Sequential()
   ...: model.add(LSTM(50, batch_input_shape=(1, 1, 10), unroll=True))
   ...: 

In [3]: model.layers[-1].output_shape
Out[3]: (1, 50)

In [4]: K.ndim(model.outputs[0])
Out[4]: 1
```

This leads to pretty cryptic errors down the road:

```
In [5]: model.add(Dense(1))
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-5-b296f1d485b9> in <module>()
----> 1 model.add(Dense(1))

/Users/nicole/.virtualenvs/theano/lib/python3.5/site-packages/Keras-2.0.4-py3.5.egg/keras/models.py in add(self, layer)
    473                           output_shapes=[self.outputs[0]._keras_shape])
    474         else:
--> 475             output_tensor = layer(self.outputs[0])
    476             if isinstance(output_tensor, list):
    477                 raise TypeError('All layers in a Sequential model '

/Users/nicole/.virtualenvs/theano/lib/python3.5/site-packages/Keras-2.0.4-py3.5.egg/keras/engine/topology.py in __call__(self, inputs, **kwargs)
    539                 # Raise exceptions in case the input is not compatible
    540                 # with the input_spec specified in the layer constructor.
--> 541                 self.assert_input_compatibility(inputs)
    542 
    543                 # Collect input shapes to build layer.

/Users/nicole/.virtualenvs/theano/lib/python3.5/site-packages/Keras-2.0.4-py3.5.egg/keras/engine/topology.py in assert_input_compatibility(self, inputs)
    454                                      self.name + ': expected min_ndim=' +
    455                                      str(spec.min_ndim) + ', found ndim=' +
--> 456                                      str(K.ndim(x)))
    457             # Check dtype.
    458             if spec.dtype is not None:

ValueError: Input 0 is incompatible with layer dense_1: expected min_ndim=2, found ndim=1
```

Since it doesn't make sense to use `unroll=True` with one timestep (as my understanding is that there is nothing to unroll!), it would be nicer if we threw an exception earlier, like the one in this pull request!

```
In [1]: from keras.models import Sequential
Using Theano backend.

In [2]: from keras.layers import LSTM

In [3]: model = Sequential()

In [4]: model.add(LSTM(5, batch_input_shape=(1, 1, 5), unroll=True))
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-4-9fc973708cdf> in <module>()
----> 1 model.add(LSTM(5, batch_input_shape=(1, 1, 5), unroll=True))

/Users/nicole/GitHub/keras/keras/models.pyc in add(self, layer)
    434                 # and create the node connecting the current layer
    435                 # to the input layer we just created.
--> 436                 layer(x)
    437 
    438             if len(layer.inbound_nodes) != 1:

/Users/nicole/GitHub/keras/keras/layers/recurrent.pyc in __call__(self, inputs, initial_state, **kwargs)
    259         # modify the input spec to include the state.
    260         if initial_state is None:
--> 261             return super(Recurrent, self).__call__(inputs, **kwargs)
    262 
    263         if not isinstance(initial_state, (list, tuple)):

/Users/nicole/GitHub/keras/keras/engine/topology.pyc in __call__(self, inputs, **kwargs)
    594 
    595             # Actually call the layer, collecting output(s), mask(s), and shape(s).
--> 596             output = self.call(inputs, **kwargs)
    597             output_mask = self.compute_mask(inputs, previous_mask)
    598 

/Users/nicole/GitHub/keras/keras/layers/recurrent.pyc in call(self, inputs, mask, training, initial_state)
    319         timesteps = input_shape[1]
    320         if self.unroll and timesteps in [None, 1]:
--> 321             raise ValueError('Cannot unroll a RNN if the '
    322                              'time dimension is undefined or equal to 1. \n'
    323                              '- If using a Sequential model, '

ValueError: Cannot unroll a RNN if the time dimension is undefined or equal to 1. 
- If using a Sequential model, specify the time dimension by passing an `input_shape` or `batch_input_shape` argument to your first layer. If your first layer is an Embedding, you can also use the `input_length` argument.
- If using the functional API, specify the time dimension by passing a `shape` or `batch_shape` argument to your Input layer.
```