### PR TITLE
Convert tuple to list, instead of list of tuple.

### DIFF
--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -2751,6 +2751,8 @@ def _to_list(x):
     """
     if isinstance(x, list):
         return x
+    elif isinstance(x, tuple):
+        return list(x)
     return [x]
 
 


### PR DESCRIPTION
This PR modifies `_to_list` to convert a tuple to a list, instead of a list of tuple.

Previous case:
```
>>> _to_list((1,))
[(1,)]
```

New case:
```
>>> _to_list((1,))
[1]
```

Due to this change, custom layers can return multiple outputs.

```
class SpecialLayer(Layer):
	def call(self, inputs):
		a = tf.zeros((5, 5))
		b = tf.ones((5, 5))
		return a, b # this is not possible without this PR, only through returning [a, b], but semantically this makes more sense

	def compute_mask(self, inputs, mask=None):
		return [None, None]
```

The above layer would give an error without this PR:

```
Traceback (most recent call last):
  File "/tmp/special_layer.py", line 16, in <module>
    a, b = SpecialLayer()([x])
  File "/usr/lib/python3.6/site-packages/tensorflow/contrib/keras/python/keras/engine/topology.py", line 448, in __call__
    arguments=user_kwargs)
  File "/usr/lib/python3.6/site-packages/tensorflow/contrib/keras/python/keras/engine/topology.py", line 502, in _add_inbound_node
    arguments=arguments)
  File "/usr/lib/python3.6/site-packages/tensorflow/contrib/keras/python/keras/engine/topology.py", line 181, in __init__
    self.output_shapes = [K.int_shape(x) for x in output_tensors]
  File "/usr/lib/python3.6/site-packages/tensorflow/contrib/keras/python/keras/engine/topology.py", line 181, in <listcomp>
    self.output_shapes = [K.int_shape(x) for x in output_tensors]
  File "/usr/lib/python3.6/site-packages/tensorflow/contrib/keras/python/keras/backend.py", line 618, in int_shape
    shape = x.get_shape()
AttributeError: 'tuple' object has no attribute 'get_shape'
```

EDIT: It appears to have broken some tests. I'll check this out.