### PR TITLE
Fixed warning showing up when channel axis is 1

### DIFF
--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -643,7 +643,7 @@ class ImageDataGenerator(object):
         if x.ndim != 4:
             raise ValueError('Input to `.fit()` should have rank 4. '
                              'Got array with shape: ' + str(x.shape))
-        if x.shape[self.channel_axis] not in {3, 4}:
+        if x.shape[self.channel_axis] not in {1, 3, 4}:
             warnings.warn(
                 'Expected input to be images (as Numpy array) '
                 'following the data format convention "' + self.data_format + '" '


### PR DESCRIPTION
In the case of greyscale images, channel axis should be of length 1, however a warning was still displayed due to incorrect checks. Added 1 as a valid length.