### PR TITLE
Fix graph compilation when using half floats.

### DIFF
--- a/keras/optimizers.py
+++ b/keras/optimizers.py
@@ -552,8 +552,8 @@ class Nadam(Optimizer):
         t = self.iterations + 1
 
         # Due to the recommendations in [2], i.e. warming momentum schedule
-        momentum_cache_t = self.beta_1 * (1. - 0.5 * (K.pow(0.96, t * self.schedule_decay)))
-        momentum_cache_t_1 = self.beta_1 * (1. - 0.5 * (K.pow(0.96, (t + 1) * self.schedule_decay)))
+        momentum_cache_t = self.beta_1 * (1. - 0.5 * (K.pow(K.cast_to_floatx(0.96), t * self.schedule_decay)))
+        momentum_cache_t_1 = self.beta_1 * (1. - 0.5 * (K.pow(K.cast_to_floatx(0.96), (t + 1) * self.schedule_decay)))
         m_schedule_new = self.m_schedule * momentum_cache_t
         m_schedule_next = self.m_schedule * momentum_cache_t * momentum_cache_t_1
         self.updates.append((self.m_schedule, m_schedule_new))


### PR DESCRIPTION
The constants here are stored as float32 by default and break graph compilation for float16. The fix is to simply "cast_to_floatx()" on the constants.  Tensorflow automatically does this so I'm not sure why keras has this issue.