### PR TITLE
Fix stop_gradient inconsistent API

### DIFF
--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -1886,7 +1886,10 @@ def batch_set_value(tuples):
 
 
 def stop_gradient(variables):
-    return C.stop_gradient(C.combine(variables))
+    if isinstance(variables, (list, tuple)):
+        return map(C.stop_gradient, variables)
+    else:
+        return C.stop_gradient(variables)
 
 
 def switch(condition, then_expression, else_expression):

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -2304,12 +2304,17 @@ def stop_gradient(variables):
     """Returns `variables` but with zero gradient w.r.t. every other variable.
 
     # Arguments
-        variables: List of variables.
+        variables: tensor or list of tensors to consider constant with respect
+            to any other variable.
 
     # Returns
-        The same list of variables.
+        A single tensor or a list of tensors (depending on the passed argument)
+            that has constant gradient with respect to any other variable.
     """
-    return tf.stop_gradient(variables)
+    if isinstance(variables, (list, tuple)):
+        return map(tf.stop_gradient, variables)
+    else:
+        return tf.stop_gradient(variables)
 
 
 # CONTROL FLOW

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1211,10 +1211,20 @@ def gradients(loss, variables):
 
 
 def stop_gradient(variables):
-    """Returns `variables` but with zero gradient with respect to every other
-    variables.
+    """Returns `variables` but with zero gradient w.r.t. every other variable.
+
+    # Arguments
+        variables: tensor or list of tensors to consider constant with respect
+            to any other variable.
+
+    # Returns
+        A single tensor or a list of tensors (depending on the passed argument)
+            that has constant gradient with respect to any other variable.
     """
-    return theano.gradient.disconnected_grad(variables)
+    if isinstance(variables, (list, tuple)):
+        return map(theano.gradient.disconnected_grad, variables)
+    else:
+        return theano.gradient.disconnected_grad(variables)
 
 
 # CONTROL FLOW

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -491,6 +491,17 @@ class TestBackend(object):
             assert_allclose(zero_list[i], z_list[i], atol=1e-05)
             assert_allclose(zero_list[i + 1], zero_list[i + 1], atol=1e-05)
 
+    def test_stop_gradient(self):
+        # This test checks the consistency of the stop_gradient backend API.
+        # It doesn't check the functionality (which is checked at the
+        # test_gradient test).
+        val = np.random.random((4, 2))
+        for k in BACKENDS:
+            a = k.variable(val)
+            b = k.square(a)
+            c, d = k.stop_gradient([a, b])
+            e = k.stop_gradient(b)
+
     # cntk currently not support function in this way, so can't test as this
     def test_function(self):
         test_backend = [KTH, KTF]


### PR DESCRIPTION
The `stop_gradient` documentation states that the argument should be a list of
variables. The Theano implementation crashes if the argument is a list of
variables and the CNTK implementation crashes regardless but expects a list anyway (since it passes it to combine). The TensorFlow implementation expects one variable but in case a list is passed it doesn't crash as long as the shapes are all the same.

This commit handles both cases as can be expected. The following code illustrates the current Keras behaviour.

```python
val = np.random.rand(10, 3)
backends = [KTH, KTF, KC]
as = [k.variable(val) for k in backends]
bs = [k.square(a) for k, a in zip(backends, as)]

a, b = as[1], bs[1]
KTF.stop_gradient(a)  # works
KTF.stop_gradient([a, b])  # works but returns a tensor?

a, b = as[0], bs[0]
KTH.stop_gradient(a)  # works
KTH.stop_gradient([a, b])  # crashes

a, b = as[2], bs[2]
KC.stop_gradient(a)  # crashes
KC.stop_gradient([a, b])  # crashes
```
This PR makes the behaviour consistent. When passed a single tensor a single tensor is returned. When passed a list or a tuple a list is returned.

Although returning a list and expecting a list would be more consistent with the previous documentation it wouldn't be consistent with the code's behaviour which could result in breaking others' code. This change now is backwards compatible but makes the behaviour consistent and documents it.