### PR TITLE
add example for passing in custom objects in load_model

### DIFF
--- a/docs/templates/getting-started/faq.md
+++ b/docs/templates/getting-started/faq.md
@@ -102,6 +102,9 @@ del model  # deletes the existing model
 # returns a compiled model
 # identical to the previous one
 model = load_model('my_model.h5')
+
+# if you have custom layers or functions, pass it in with the custom_objects argument
+model = load_model('my_model.h5', custom_objects={'AttentionLayer': AttentionLayer})
 ```
 
 If you only need to save the **architecture of a model**, and not its weights or its training configuration, you can do:


### PR DESCRIPTION
There isn't any documentation on how to load custom layers when using `load_model` apart from [this issue](https://github.com/fchollet/keras/issues/4871). Putting an example in official documentation will help people who are trying to load their model with custom layers/functions.