### PR TITLE
Allow dynamic shape for repeat_elements

### DIFF
--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -286,19 +286,12 @@ class TestBackend(object):
                     if hasattr(z, '_keras_shape'):
                         assert z._keras_shape == z.shape
 
-                # test theano shape inference when
-                # input shape has None entries
-                if K.backend() == 'theano':
+                if K.backend() != 'cntk':
                     shape = list(shape)
                     shape[rep_axis] = None
                     x = K.placeholder(shape=shape)
                     y = K.repeat_elements(x, reps, axis=rep_axis)
                     assert y._keras_shape == tuple(shape)
-
-        # Test invalid use cases
-        with pytest.raises(ValueError):
-            ztf = KTF.placeholder(shape=(None, 2, 3))
-            KTF.repeat_elements(ztf, 5, axis=0)
 
     def test_tile(self):
         shape = (3, 4)

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -292,6 +292,7 @@ class TestBackend(object):
                     x = K.placeholder(shape=shape)
                     y = K.repeat_elements(x, reps, axis=rep_axis)
                     assert y._keras_shape == tuple(shape)
+                if K.backend() == 'tensorflow':
                     assert y._keras_shape == tuple(y.get_shape().as_list())
 
     def test_tile(self):

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -292,6 +292,7 @@ class TestBackend(object):
                     x = K.placeholder(shape=shape)
                     y = K.repeat_elements(x, reps, axis=rep_axis)
                     assert y._keras_shape == tuple(shape)
+                    assert y._keras_shape == tuple(y.get_shape().as_list())
 
     def test_tile(self):
         shape = (3, 4)


### PR DESCRIPTION
Fixes #7410 
Correctly handle dynamic shape to be passed to `repeat_elements` in tensorflow backend. Before this commit, it raised error if the axis to be repeated was None.