### PR TITLE
Set AveragePooling2D stride for ResNet50 to 1.

### DIFF
--- a/keras/applications/resnet50.py
+++ b/keras/applications/resnet50.py
@@ -229,7 +229,7 @@ def ResNet50(include_top=True, weights='imagenet',
     x = identity_block(x, 3, [512, 512, 2048], stage=5, block='b')
     x = identity_block(x, 3, [512, 512, 2048], stage=5, block='c')
 
-    x = AveragePooling2D((7, 7), name='avg_pool')(x)
+    x = AveragePooling2D((7, 7), strides=(1, 1), name='avg_pool')(x)
 
     if include_top:
         x = Flatten()(x)

--- a/tests/keras/applications/applications_test.py
+++ b/tests/keras/applications/applications_test.py
@@ -25,7 +25,7 @@ def test_resnet50_notop():
 def test_resnet50_notop_specified_input_shape():
     input_shape = (3, 300, 300) if K.image_data_format() == 'channels_first' else (300, 300, 3)
     model = applications.ResNet50(weights=None, include_top=False, input_shape=input_shape)
-    output_shape = (None, 2048, 1, 1) if K.image_data_format() == 'channels_first' else (None, 1, 1, 2048)
+    output_shape = (None, 2048, 4, 4) if K.image_data_format() == 'channels_first' else (None, 4, 4, 2048)
     assert model.output_shape == output_shape
 
 


### PR DESCRIPTION
As shown in https://github.com/KaimingHe/deep-residual-networks/blob/master/prototxt/ResNet-50-deploy.prototxt#L2299 , the stride for ResNet50 average pooling should be 1. Currently it is not set, which according to [the documentation](https://keras.io/layers/pooling/#averagepooling2d) means it will take the pooling size, which is (7, 7).

This PR sets the stride for the AveragePooling2D to (1, 1) and adjusts a unit test accordingly.