### PR TITLE
ResNet use GlobalAveragePooling2D

### DIFF
--- a/keras/applications/resnet50.py
+++ b/keras/applications/resnet50.py
@@ -19,7 +19,6 @@ from ..layers import Activation
 from ..layers import Flatten
 from ..layers import Conv2D
 from ..layers import MaxPooling2D
-from ..layers import AveragePooling2D
 from ..layers import GlobalAveragePooling2D
 from ..layers import GlobalMaxPooling2D
 from ..layers import BatchNormalization
@@ -228,10 +227,8 @@ def ResNet50(include_top=True, weights='imagenet',
     x = identity_block(x, 3, [512, 512, 2048], stage=5, block='b')
     x = identity_block(x, 3, [512, 512, 2048], stage=5, block='c')
 
-    x = AveragePooling2D((7, 7), name='avg_pool')(x)
-
     if include_top:
-        x = Flatten()(x)
+        x = GlobalAveragePooling2D()(x)
         x = Dense(classes, activation='softmax', name='fc1000')(x)
     else:
         if pooling == 'avg':

--- a/tests/keras/applications/applications_test.py
+++ b/tests/keras/applications/applications_test.py
@@ -25,7 +25,7 @@ def test_resnet50_notop():
 def test_resnet50_notop_specified_input_shape():
     input_shape = (3, 300, 300) if K.image_data_format() == 'channels_first' else (300, 300, 3)
     model = applications.ResNet50(weights=None, include_top=False, input_shape=input_shape)
-    output_shape = (None, 2048, 1, 1) if K.image_data_format() == 'channels_first' else (None, 1, 1, 2048)
+    output_shape = (None, 2048, 10, 10) if K.image_data_format() == 'channels_first' else (None, 10, 10, 2048)
     assert model.output_shape == output_shape
 
 


### PR DESCRIPTION
This PR is in response to https://github.com/fchollet/keras/pull/7425#issuecomment-317859425 , where the conclusion was to use `GlobalAveragePooling2D` instead of `AveragePooling2D` with a `(7, 7)` kernel (which would only make sense for images of shape `(224, 224, 3)`).

In addition the average pooling layer is moved inside the `if include_top:`, as per the documentation:
```
        pooling: Optional pooling mode for feature extraction
            when `include_top` is `False`.
            - `None` means that the output of the model will be
                the 4D tensor output *of the
                last convolutional layer*.
```

Note that the old behaviour can be used by setting `include_top=False` and `pooling='avg'`. If this change is not correct, then I am curious about the use of the `pooling` parameter. Without this PR and with `include_top=False`, `pool='avg'` and `input_shape=(224, 224, 3)` there would basically be two `GlobalAveragePooling2D` layers after eachother (one through the `AveragePooling2D` with a `(7, 7)` kernel, which is effectively a `GlobalAveragePooling2D` layer given this input).

@fchollet there is a big chance you don't want to change this either, but I at least wanted to try.