### PR TITLE
Switch to pydot 1.2.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(name='Keras',
       install_requires=['theano', 'pyyaml', 'six'],
       extras_require={
           'h5py': ['h5py'],
-          'visualize': ['pydot-ng'],
+          'visualize': ['pydot>=1.2.0'],
           'tests': ['pytest',
                     'pytest-pep8',
                     'pytest-xdist',


### PR DESCRIPTION
Development of `pydot` has now converged [here](https://github.com/erocarrera/pydot), with version 1.2.0 providing the missing Python 3 support. The old `pydot` and `pydot-ng` are no longer maintained.