### PR TITLE
Allow sample_weight / class_weight to be applied to metrics

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -564,7 +564,7 @@ class Model(Container):
     """
 
     def compile(self, optimizer, loss, metrics=None, loss_weights=None,
-                sample_weight_mode=None, weight_metrics=False, **kwargs):
+                sample_weight_mode=None, weigh_metrics=False, **kwargs):
         """Configures the model for training.
 
         # Arguments
@@ -597,7 +597,7 @@ class Model(Container):
                 If the model has multiple outputs, you can use a different
                 `sample_weight_mode` on each output by passing a
                 dictionary or a list of modes.
-            weight_metrics: bool whether or not to apply `sample_weight` or
+            weigh_metrics: bool whether or not to apply `sample_weight` or
                 `class_weight` to the supplied metrics during training and testing
             **kwargs: when using the Theano/CNTK backends, these arguments
                 are passed into K.function. When using the TensorFlow backend,
@@ -835,7 +835,7 @@ class Model(Container):
                 continue
             y_true = self.targets[i]
             y_pred = self.outputs[i]
-            weights = sample_weights[i] if weight_metrics else None
+            weights = sample_weights[i] if weigh_metrics else None
             output_metrics = nested_metrics[i]
             for metric in output_metrics:
                 if metric == 'accuracy' or metric == 'acc':

--- a/tests/test_loss_weighting.py
+++ b/tests/test_loss_weighting.py
@@ -170,15 +170,15 @@ def test_sample_weights_with_weighted_metrics():
     (x_train, y_train), (x_test, y_test), (sample_weight, class_weight, test_ids) = _get_test_data()
 
     history = model.fit(x_train, y_train, batch_size=batch_size,
-              epochs=epochs // 3, verbose=0,
-              sample_weight=sample_weight)
+                        epochs=epochs // 3, verbose=0,
+                        sample_weight=sample_weight)
 
     assert history.history['loss'] == history.history[loss_full_name]
 
     history = model.fit(x_train, y_train, batch_size=batch_size,
-              epochs=epochs // 3, verbose=0,
-              sample_weight=sample_weight,
-              validation_split=0.1)
+                        epochs=epochs // 3, verbose=0,
+                        sample_weight=sample_weight,
+                        validation_split=0.1)
 
     assert history.history['val_loss'] == history.history['val_' + loss_full_name]
 

--- a/tests/test_loss_weighting.py
+++ b/tests/test_loss_weighting.py
@@ -165,7 +165,7 @@ def test_class_weight_wrong_classes():
 @keras_test
 def test_sample_weights_with_weighted_metrics():
     model = create_sequential_model()
-    model.compile(loss=loss, optimizer='rmsprop', metrics=[loss], weight_metrics=True)
+    model.compile(loss=loss, optimizer='rmsprop', metrics=[loss], weigh_metrics=True)
 
     (x_train, y_train), (x_test, y_test), (sample_weight, class_weight, test_ids) = _get_test_data()
 


### PR DESCRIPTION
I noticed a lot of issues related to the sample weights not being applied to metrics. 

* https://github.com/fchollet/keras/issues/1642
* https://github.com/fchollet/keras/issues/3855
* https://github.com/fchollet/keras/issues/4137
* https://github.com/fchollet/keras/issues/4313

There is currently not an easy way to build a custom metric to achieve this, as a custom metric can only accept `y_true` and `y_pred`. It is probably possible with a callback metric but that seems like a lot of work for something that is in popular demand and should be supported as a first-class option. I noticed this was attempted in https://github.com/fchollet/keras/pull/4335, but was abandoned. I also noticed that the setting was per-metric in that PR, whereas I am proposing the setting at the `compile()` level such that its application is consistent between `fit()` and `evaluate()`. Example usage:

```python
from keras.models import Sequential
from keras.layers import Dense

import numpy as np

X = np.random.normal(size=(100, 10))
y = np.random.randint(2, size=100)
sample_weight = np.random.normal(size=100)
loss = 'binary_crossentropy'

model = Sequential()
model.add(Dense(10, input_shape=(10, )))
model.add(Dense(1, activation='sigmoid'))

model.compile(loss=loss, optimizer='rmsprop', metrics=[loss], weight_metrics=False)

model.fit(X, y, epochs=5, verbose=2, sample_weight=sample_weight)
```

```
Epoch 1/5
0s - loss: -2.1792e-02 - binary_crossentropy: 0.9223
Epoch 2/5
0s - loss: -3.2389e-02 - binary_crossentropy: 0.9294
Epoch 3/5
0s - loss: -3.5780e-02 - binary_crossentropy: 0.9285
Epoch 4/5
0s - loss: -3.6447e-02 - binary_crossentropy: 0.9311
Epoch 5/5
0s - loss: -3.8856e-02 - binary_crossentropy: 0.9264
```

Now with `weight_metrics=True`:

```python
model.compile(loss=loss, optimizer='rmsprop', metrics=[loss], weight_metrics=True)

model.fit(X, y, epochs=5, verbose=2, sample_weight=sample_weight)
```

```
Epoch 1/5
0s - loss: -3.7481e-02 - binary_crossentropy: -3.7481e-02
Epoch 2/5
0s - loss: -4.5657e-02 - binary_crossentropy: -4.5657e-02
Epoch 3/5
0s - loss: -5.1353e-02 - binary_crossentropy: -5.1353e-02
Epoch 4/5
0s - loss: -5.3839e-02 - binary_crossentropy: -5.3839e-02
Epoch 5/5
0s - loss: -5.6900e-02 - binary_crossentropy: -5.6900e-02
```

I think the consistency here is nice. Additionally, if `sample_weight` is passed to `evaluate()` and `weight_metrics=True` in `compile()`, any metrics will also be weighted.

```python
model.evaluate(X, y, verbose=2, sample_weight=sample_weight)
```

```
[-0.084627518355846407, -0.084627518355846407]
```