### PR TITLE
Improve examples

### DIFF
--- a/docs/templates/getting-started/functional-api-guide.md
+++ b/docs/templates/getting-started/functional-api-guide.md
@@ -242,7 +242,7 @@ encoded_b = lstm(b)
 lstm.output
 ```
 ```
->> AssertionError: Layer lstm_1 has multiple inbound nodes,
+>> AttributeError: Layer lstm_1 has multiple inbound nodes,
 hence the notion of "layer output" is ill-defined.
 Use `get_output_at(node_index)` instead.
 ```

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -445,7 +445,7 @@ def shape(x):
         A symbolic shape (which is itself a tensor).
 
     # Examples
-    ```
+    ```python
         # TensorFlow example
         >>> from keras import backend as K
         >>> tf_session = K.get_session()

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -53,11 +53,11 @@ def get_uid(prefix=''):
         An integer.
 
     # Example
-    ```
+    ```python
         >>> keras.backend.get_uid('dense')
-        >>> 1
+        1
         >>> keras.backend.get_uid('dense')
-        >>> 2
+        2
     ```
 
     """

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -591,7 +591,7 @@ class TensorBoard(Callback):
 
     If you have installed TensorFlow with pip, you should be able
     to launch TensorBoard from the command line:
-    ```
+    ```sh
     tensorboard --logdir=/full_path_to_your_logs
     ```
 


### PR DESCRIPTION
This PR increases consistency for docstring examples. Additionally, `layer.output` raises `AttributeError` in case of multiple inbound nodes.