### PR TITLE
Fix doc example of models.py's method fit_generator()

### DIFF
--- a/keras/models.py
+++ b/keras/models.py
@@ -1096,7 +1096,7 @@ class Sequential(Model):
                         # and labels, from each line in the file
                         x, y = process_line(line)
                         yield (x, y)
-                        f.close()
+                    f.close()
 
             model.fit_generator(generate_arrays_from_file('/my_file.txt'),
                                 steps_per_epoch=1000, epochs=10)


### PR DESCRIPTION
This fix a minor bug in docstring. The file pointer closed in the iteration.