### PR TITLE
Improve content of PyPI tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+include LICENSE
+include README.md
+graft docs
+graft examples
+graft tests


### PR DESCRIPTION
The current release on PyPI contains the package files and setup script only. Although nominal for running a `pip install`, its content falls a bit short for packaging on Linux distributions such as Debian. This commit provides a manifest template to produce a more comprehensive tarball for PyPI:

- The README file is the single entry-point for maintainers to get information about the package. It is worth shipping regardless (`sdist` does it by default with `README.rst`, but not with `README.md`).
- The LICENSE file is the single entry-point for copyright related information. Should be shipped by default too, but is not present in the tarball for some reason. Adding it explicitly does not hurt.
- The `docs` and `examples` are worth having to enable builds of a corresponding documentation package for `keras`.
- The `tests` are also worth distributing to allow for build-time and continuous testing of the package downstream.