### PR TITLE
Update cntk backend with CNTK 2.1 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,9 +56,9 @@ install:
   
   # install cntk
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      pip install https://cntk.ai/PythonWheel/CPU-Only/cntk-2.0-cp27-cp27mu-linux_x86_64.whl;
+      pip install https://cntk.ai/PythonWheel/CPU-Only/cntk-2.1-cp27-cp27mu-linux_x86_64.whl;
     elif [[ "$TRAVIS_PYTHON_VERSION" == "3.5" ]]; then
-      pip install https://cntk.ai/PythonWheel/CPU-Only/cntk-2.0-cp35-cp35m-linux_x86_64.whl;
+      pip install https://cntk.ai/PythonWheel/CPU-Only/cntk-2.1-cp35-cp35m-linux_x86_64.whl;
     fi
 
   # install pydot for visualization tests

--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -539,7 +539,7 @@ def gather(reference, indices):
     # Will udpate with gather op in next release
     num_class = reference.shape[0]
     one_hot_matrix = C.ops.one_hot(indices, num_class)
-    return C.times(one_hot_matrix, reference)
+    return C.times(one_hot_matrix, reference, output_rank=len(reference.shape) - 1)
 
 
 def _remove_dims(x, axis, keepdims=False):

--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -1714,7 +1714,15 @@ class Function(object):
 
             if tensor == _LEARNING_PHASE:
                 _LEARNING_PHASE.value = np.asarray(value)
-
+            else:
+                # in current version cntk can't support input with variable
+                # length. Will support it in next release.
+                if not self._is_input_shape_compatible(value, tensor):
+                    raise ValueError('CNTK backend: The placeholder has been resolved '
+                                     'to shape `%s`, but input shape is `%s`. Currently '
+                                     'CNTK can not take variable length inputs. Please '
+                                     'pass inputs that have a static shape.'
+                                     % (str(tensor.shape), str(value.shape)))
             feed_dict[tensor] = value
 
         updated = []

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -186,8 +186,7 @@ class TestBackend(object):
                                    BACKENDS, cntk_two_dynamicity=True, axes=(1, 1))
 
         check_single_tensor_operation('transpose', (4, 2), BACKENDS)
-        # cntk doesn't support reverse yet
-        check_single_tensor_operation('reverse', (4, 3, 2), [KTH, KTF], axes=1)
+        check_single_tensor_operation('reverse', (4, 3, 2), BACKENDS, axes=1)
         check_single_tensor_operation('reverse', (4, 3, 2), [KTH, KTF], axes=(1, 2))
 
     def test_random_variables(self):

--- a/tests/keras/layers/recurrent_test.py
+++ b/tests/keras/layers/recurrent_test.py
@@ -99,8 +99,6 @@ def test_implementation_mode(layer_class):
 
 
 @rnn_test
-@pytest.mark.skipif((K.backend() == 'cntk'),
-                    reason="cntk does not support mask on RNN yet")
 def test_statefulness(layer_class):
     model = Sequential()
     model.add(embeddings.Embedding(embedding_num, embedding_dim,
@@ -171,8 +169,6 @@ def test_regularizer(layer_class):
 
 
 @keras_test
-@pytest.mark.skipif((K.backend() == 'cntk'),
-                    reason="cntk does not support mask on RNN yet")
 def test_masking_layer():
     ''' This test based on a previously failing issue here:
     https://github.com/fchollet/keras/issues/1567

--- a/tests/keras/layers/wrappers_test.py
+++ b/tests/keras/layers/wrappers_test.py
@@ -122,8 +122,6 @@ def test_regularizers():
 
 
 @keras_test
-@pytest.mark.skipif((K.backend() == 'cntk'),
-                    reason='cntk does not support reverse yet')
 def test_Bidirectional():
     rnn = recurrent.SimpleRNN
     samples = 2

--- a/tests/keras/legacy/layers_test.py
+++ b/tests/keras/legacy/layers_test.py
@@ -184,8 +184,6 @@ def test_merge():
 
 
 @keras_test
-@pytest.mark.skipif((K.backend() == 'cntk'),
-                    reason="cntk does not support stateful RNN yet")
 def test_merge_mask_2d():
     rand = lambda *shape: np.asarray(np.random.random(shape) > 0.5, dtype='int32')
 
@@ -219,8 +217,6 @@ def test_merge_mask_2d():
 
 
 @keras_test
-@pytest.mark.skipif((K.backend() == 'cntk'),
-                    reason="cntk does not support stateful RNN yet")
 def test_merge_mask_3d():
     rand = lambda *shape: np.asarray(np.random.random(shape) > 0.5, dtype='int32')
 


### PR DESCRIPTION
This pull request is to update with CNTK 2.1 release features:
1. support mask in recurrent layer.
2. support reverse op and bidirection wrapper
3. cntk native op to support stateful recurrent layer.
4. update the ci test to use cntk 2.1 release binary.