### PR TITLE
Add graph rewrite primitives

### DIFF
--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -1515,7 +1515,7 @@ class Container(Layer):
         self.input_layers = []
         self.input_layers_node_indices = []
         self.input_layers_tensor_indices = []
-        # list of layers (1 to 1 mapping with self.inputs,
+        # list of layers (1 to 1 mapping with self.outputs,
         # hence the same layer might appear twice)
         self.output_layers = []
         self.output_layers_node_indices = []
@@ -2611,7 +2611,7 @@ class Container(Layer):
             f.close()
 
     def _updated_config(self):
-        """Util hared between different serialization methods.
+        """Util shared between different serialization methods.
 
         # Returns
             Model config with Keras version information added.

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -2824,6 +2824,328 @@ def _collect_input_shape(input_tensors):
         return shapes[0]
     return shapes
 
+def _get_keras_layer(x):
+    """
+    Helper function to normalize layers/tensors to keras layers.
+    """
+    if hasattr(x, '_keras_history'):
+        return x._keras_history[0]
+    return x
+
+def rebase(model, onto, rebase_from=None, new_name=None):
+    """Rebase one model onto another.
+
+    # Arguments
+        model: The `Model` to rebase onto the argument `onto`
+
+        onto: A `Model` containing the architecture that `model` should be
+            rebased onto.  In particular, the layers within `onto.outputs`
+            should directly correspond to those within `rebase_from`; this will
+            define the connections between the base model and the model being
+            rebased on top of it.
+        
+        rebase_from: A list of layers the rebasing starts from, defaults to
+            `model.inputs`, but can be used to discard a beginning segment
+            of `model`.  These layers will not be a part of the rebased model.
+
+    # Returns
+        A new `Model` containing the desired architecture.  Note that the
+        weights from `model` are transferred to the new model's layers only
+        if the shapes of the layers are equivalent.
+    """
+    from collections import deque
+
+    def _collect_all_deps(x, deps={}):
+        """
+        Given a keras layer/tensor, collect all dependencies and add them into
+        a mapping from keras layer -> tensor, the same as maintained within the
+        `xfer` mapping.
+        """
+        x = _get_keras_layer(x)
+
+        for n in x.inbound_nodes:
+            for idx in range(len(n.inbound_layers)):
+                l = n.inbound_layers[idx]
+                deps[l] = n.input_tensors[idx]
+
+                # Recurse until we get all of the deps
+                deps = _collect_all_deps(l, deps)
+        
+        return deps
+
+
+    def _should_prune_layer(x, outputs):
+        """
+        Returns `True` if `x` does not eventually lead to one of the `outputs`.
+
+        Used to determine whether a layer should be pruned from consideration
+        when initializing `to_build`.
+        """
+        x = _get_keras_layer(x)
+
+        # If this layer is one of the given "good outputs", do not prune!
+        if x in outputs:
+            return False
+
+        # If this layer is a terminal point and is not in outputs, prune!
+        if len(x.outbound_nodes) == 0:
+            return True
+
+        # Otherwise, fully explore the downstream graph until we've exhausted
+        # every possibility that we should not prune.
+        return all(_should_prune_layer(n.outbound_layer, outputs) for n in x.outbound_nodes)
+
+    
+    # rebase_from denotes the beginning edge of the `model` we will rebase onto
+    # the `onto` model.
+    if rebase_from is None:
+        rebase_from = model.inputs
+    rebase_from = [_get_keras_layer(l) for l in _to_list(rebase_from)]
+
+    if len(onto.outputs) != len(rebase_from):
+        raise ValueError('Cannot rebase a Model with %d'%(len(rebase_from)) +
+            ' inputs onto a Model with %d outputs'%(len(onto.outputs)))
+
+    # Build a mapping from layers within `model`, to tensors in `onto`.  This
+    # mapping will grow as we build the model out, but we must seed it with
+    # these first few layers before bootstrapping onto the main rebase loop.
+    input_idxs = range(len(rebase_from))
+    xfer = {rebase_from[idx]:onto.outputs[idx] for idx in input_idxs}
+
+    # We also add everything upstream of `rebase_from` so that if some of the
+    # layers we must build depend on layers upstream of what has already been
+    # built, we don't redo extra work
+    for l in rebase_from:
+        xfer = _collect_all_deps(l, xfer)
+
+    # For all outputs from `rebase_from`, insert them into `to_build`, which
+    # will be our list of layers that we have yet to build, bundled together
+    # with their dependencies.  We only do this for nodes which eventually lead
+    # to `model.outputs` though.
+    to_build = deque()
+    layer_outputs = [_get_keras_layer(l) for l in model.outputs]
+    for idx in range(len(rebase_from)):
+        l = rebase_from[idx]
+        
+        # Get all the outputs from this layer
+        for n in l.outbound_nodes:
+            out_layer = n.outbound_layer
+
+            # If this layer doesn't actually reach `model.outputs`, skip it
+            if _should_prune_layer(out_layer, layer_outputs):
+                continue
+
+            # If this layer is actually already in xfer, skip it
+            if out_layer in xfer:
+                continue
+
+            # If this layer is already in to_build, skip it
+            if any(x[0] == out_layer for x in to_build):
+                continue
+
+            # Get all the dependencies (inputs) for this output            
+            deps = []
+            for n_in in out_layer.inbound_nodes:
+                deps += [_get_keras_layer(l) for l in n_in.inbound_layers]
+
+            # Add this output as one of the next layers to build
+            to_build.append((out_layer, deps))
+    
+    # Now walk forward through the old model until we've rebuilt everything on
+    # top of `onto`, which we do by running until `to_build` is empty.  We also
+    # track new outputs, which we will register with the model at the end.
+    new_outputs = []
+    while len(to_build) != 0:
+        # Grab the next layer to build
+        next_to_build, next_deps = to_build.popleft()
+
+        # Translate all the dependencies, if possible
+        dep_idxs = range(len(next_deps))
+        for idx in dep_idxs:
+            if next_deps[idx] in xfer:
+                next_deps[idx] = xfer[next_deps[idx]]
+
+        # If any of the deps are not already built, then don't build it
+        if any(next_deps[idx] not in xfer.values() for idx in dep_idxs):
+            to_build.append((next_to_build, next_deps))
+        else:
+            # Otherwise, build it!  Start by instantiating a new layer:
+            config = next_to_build.get_config()
+            next_layer = next_to_build.__class__.from_config(config)
+
+            # Hook that layer up to its inputs.  This seems a little ad-hoc,
+            # there must be a more reliable way to hook up layers.
+            if len(next_deps) == 1:
+                y = next_layer(next_deps[0])
+            else:
+                y = next_layer(next_deps)
+
+            # If weight shape has not changed, copy the weights over:
+            w_old = next_to_build.get_weights()
+            w_new = next_layer.get_weights()
+            if len(w_old) == len(w_new):
+                widxs = range(len(w_old))
+                if all([w_old[idx].shape == w_new[idx].shape for idx in widxs]):
+                    next_layer.set_weights(w_old)
+
+            # Register it in `xfer`, so that it can be used as a dependency in the future.
+            xfer[next_to_build] = y
+
+            # Queue this layer's outputs (along with its dependencies)
+            for n in next_to_build.outbound_nodes:
+                out = n.outbound_layer
+
+                # Don't add this layer onto `to_build` if it's already there
+                if any(x[0] == out for x in to_build):
+                    continue
+
+                # Don't add this layer onto `to_build` if it's already in `xfer`:
+                if out in xfer:
+                    continue
+
+                out_deps = []
+                for n_in in out.inbound_nodes:
+                    out_deps += n_in.inbound_layers
+
+                to_build.append((out, [_get_keras_layer(l) for l in out_deps]))
+
+            # If there were actually no outbound_nodes, then this is a new output!
+            if not next_to_build.outbound_nodes:
+                new_outputs += [y]
+
+    return model.__class__(inputs=onto.inputs, outputs=new_outputs, name=new_name)
+
+def switch_fork(model, old_prong, new_prong):
+    """
+    Given a fork within a graph, return a new `Model` with the fork switched.
+
+    # Arguments
+        model: The `Model` to edit
+        old_prong: A Layer within `Model` that is the old prong of the fork.
+        new_prong: A new Layer that has been built off of members of `model`
+                   that is the new prong of the fork.
+    
+    # Returns
+        A new Model with the requested topology.
+
+    #Example
+    
+        `model` contains the following topology:
+
+            [A (Input)] -> [B] -> [C] -> [D] -> [E] -> [F (Output)]
+
+        You then create a "fork", by creating two new layers off of `B`:
+
+                              /-> [C] -> [D] -> [E] -> [F (Output)]
+            [A (Input)] -> [B]
+                              \-> [G] -> [H]
+
+        By calling `switch_fork(model, D, H)`, the model will transform to:
+
+                              /-> [C] -> [D]
+            [A (Input)] -> [B]
+                              \-> [G] -> [H] -> [E] -> [F (Output)]
+
+        And the old prong can be safely ignored, resulting in a topology of:
+
+            [A (Input)] -> [B] -> [G] -> [H] -> [E] -> [F (Output)]
+    """
+    from keras.models import Model
+
+    def _collect_downstream_inputs(x, inputs, outputs = []):
+        """
+        Identify inputs to layers downstream of `x` that are not already within
+        the collection `inputs`, and add them in.  Despite that we are
+        collecting _inputs_ to downstream layers, these represent the _outputs_
+        of our `new_base` `Model`, hence the confusing function name.
+        """
+        x = _get_keras_layer(x)
+        
+        # For every layer going out of `x`:
+        for n in x.outbound_nodes:
+            l = n.outbound_layer
+
+            # Add this layer into `outputs`
+            if not l in outputs:
+                outputs.append(l)
+            
+            # For every _input_ to this output layer:
+            for n_in in l.inbound_nodes:
+                for idx in range(len(n_in.inbound_layers)):
+                    # If this input has not already been collected into inputs,
+                    # and it's not an output of a previous layer
+                    t_in = n_in.input_tensors[idx]
+                    l_in = n_in.inbound_layers[idx]
+                    if not t_in in inputs and not l_in in outputs:
+                        inputs.append(n_in.input_tensors[idx])
+            
+            # Recurse down into this output layer
+            _collect_downstream_inputs(l, inputs, outputs)
+        
+        # Return the collected inputs
+        return inputs
+
+
+    # The first thing we must do is to identify the outputs of `new_base`. One
+    # output will be `new_prong`, but the inputs to any other layer downstream
+    # of `old_prong` will be an output as well.  This denotes the "line" of
+    # layers that we will begin the rebasing from, working our way downstream.
+    rebase_from = _collect_downstream_inputs(old_prong, [old_prong])
+
+    # Remove `old_prong` from `rebase_from`, add in `new_prong` and call it the
+    # `new_base_outputs`.
+    base_outputs = [x if x != old_prong else new_prong for x in rebase_from]
+
+    # Construct new_base, then rebase `model` on top of this new fork!
+    new_base = Model(inputs=model.inputs, outputs=base_outputs)
+    return rebase(model, new_base, rebase_from=rebase_from)
+
+def insert_layer(model, after, to_insert):
+    """
+    Insert a layer within `model` after the layer `after`.
+
+    # Arguments
+        model: The `Model` to edit
+        after: A Layer within `Model` to insert a new layer after.
+        to_insert: The Layer to insert by calling `to_insert(after)`.
+    
+    # Returns
+        A new Model with the requested topology.
+    """
+    return switch_fork(model, after, to_insert(after))
+
+def remove_layer(model, to_remove):
+    """
+    Remove the layer `to_remove` within `model`
+
+    # Arguments
+        model: The `Model` to edit
+        to_remove: A Layer within `Model` that should be removed.
+    
+    # Returns
+        A new Model with the requested topology.
+    """
+    def _get_input_tensors(x):
+        x = _get_keras_layer(x)
+        
+        input_tensors = []
+        for n in x.inbound_nodes:
+            for idx in range(len(n.inbound_layers)):
+                input_tensors += [n.input_tensors[idx]]
+        return input_tensors
+
+
+    # Find `to_remove`'s precursor; if there is none, (e.g. it's an `Input`) or
+    # there are multiple (e.g. it's a Merge layer like an `Add`) error out:
+    precursor = _get_input_tensors(to_remove)
+    if len(precursor) == 0:
+        raise ValueError("Cannot remove the Input layer to a Model")
+    if len(precursor) > 1:
+        raise ValueError("Cannot remove a merge-style layer; use `rebase()`")
+    precursor = precursor[0]
+    
+    return switch_fork(model, to_remove, precursor)
+
 
 def save_weights_to_hdf5_group(f, layers):
     from .. import __version__ as keras_version


### PR DESCRIPTION
Greetings, Keras devs.

I asked some questions about graph rewriting on the slack channel a while back, and the feedback I got from there has led me to this pull request, implementing what I have come to believe is the most fundamental operation required to perform "net surgery" within Keras.  My use case stems from wanting to build a library of network optimizations (things like factorizing a square-ish `Dense` layer into two smaller `Dense` layers using SVD and restricting the rank of the SVD representation) and needing the machinery available to replace subgraphs within a model with a new architecture and new weights.  I started by looking at how I might insert nodes, but quickly discovered that although Keras provides easy methods to grow a model "downstream", it is difficult to remove nodes from the "upstream" of a Model, or to, more ambitiously, "rebase" or "graft" a portion of a Model onto another one.  This pull request provides a prototype implementation of this "rebasing", allowing a section of a predefined `Model` to be rebased on top of another `Model`.  This allows for simple and flexible model manipulations; inserting layers and removing layers can all be phrased within the framework of adding layers onto the end of a model, and rebasing a model onto a new base model.

This PR adds four methods: the fundamental `rebase()` operation, a slightly higher level `switch_fork()` operation, and the very high-level `insert_layer()` and `remove_layer()` operations.  I have provided tests for all four methods.

- `rebase(model, onto, rebase_from)` rebases argument `model` onto argument `onto`, both of which are of type `Model`/`Container`.  The "rebase" operation allows one to completely rewrite a graph on top of another graph, and the implementation of `rebase()` performs the following steps:
    -  It first identifies the "upstream edge" of the model it will be reconstructing.  By default, this is `model.inputs`, but if we are, for instance, replacing the first half of `model` with a new graph, then this upstream edge (passed in as `rebase_from`) must be realized, and correspondences between these layers must be drawn from the old model to the new model.
    - It next steps through the old model, recreating nodes from the old model on top of the new model, with the same configuration (and weights, if possible) as specified within the old model.
    - Finally, a new `Model`/`Container` is returned with the desired topology

- `switch_fork(model, old_prong, new_prong)` uses `rebase()` to effect a common mid-level operation; as a user, I wish to replace a particular linear subgraph within a `Model`, so I construct the new subgraph I wish to use as a branch extending off the side of the original model.  `switch_fork()` can then take everything downstream from the linear subgraph of interest and place it onto the fork that I just created. Example, taken from the `switch_fork()` docstring:
```
`model` contains the following topology:

            [A (Input)] -> [B] -> [C] -> [D] -> [E] -> [F (Output)]

        You then create a "fork", by creating two new layers off of `B`:

                              /-> [C] -> [D] -> [E] -> [F (Output)]
            [A (Input)] -> [B]
                              \-> [G] -> [H]

        By calling `switch_fork(model, D, H)`, the model will transform to:

                              /-> [C] -> [D]
            [A (Input)] -> [B]
                              \-> [G] -> [H] -> [E] -> [F (Output)]

        And the old prong can be safely ignored, resulting in a topology of:

            [A (Input)] -> [B] -> [G] -> [H] -> [E] -> [F (Output)]
```
- `insert_layer(model, after, to_insert)` uses `switch_fork()` to insert layers directly after another layer within a model.
- `remove_layer(model, to_remove)` uses `switch_fork()` to remove layers from a `Model`, throwing `ValueError`s when attempting to remove nonsensical Layers such as `Input` or `Merge` layers.


I am very open to feedback on everything from the technical details of how the `rebase()` function explores the Keras node graph, to the naming/placement of the functions.  Strictly speaking, none of this touches the internals of Keras itself, so it could be that this belongs in [keras-contrib](https://github.com/farizrahman4u/keras-contrib), but I was not explicitly told to open this PR there versus here, so I figured I'd start with here and see which way the wind blew.  The actual use cases of this work I hope to demo later, so for now it's just abstract capabilities rather than concrete applications.

Questions I have about the current implementation:
 - [ ] At the moment, I am very cavalier about things like "layers with multiple input nodes"; I pretty much assume that everything will have a single input node that can contain one or more inbound layers.  Where can I find a Layer that has multiple input nodes so I can see how horribly this breaks?
 - [ ] My layer recreation code is also rather cavalier about [creation of nodes with multiple inputs](https://github.com/staticfloat/keras/blob/4d57365b40875b4d167507a1346fecd21c9f3814/keras/engine/topology.py#L2940-L2945), is there a more principled way to feed inputs into Layer creation than `LayerName(*layer_deps)`?