### PR TITLE
Fix sparse_categorical_crossentropy argument and add value test for it  (#7513)

### DIFF
--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -1629,7 +1629,7 @@ def categorical_crossentropy(target, output, from_logits=False):
 def sparse_categorical_crossentropy(target, output, from_logits=False):
     target = C.one_hot(target, output.shape[-1])
     target = C.reshape(target, output.shape)
-    return categorical_crossentropy(output, target, from_logits)
+    return categorical_crossentropy(target, output, from_logits)
 
 
 class Function(object):

--- a/tests/keras/losses_test.py
+++ b/tests/keras/losses_test.py
@@ -57,5 +57,14 @@ def test_categorical_hinge():
     assert np.isclose(expected_loss, np.mean(loss))
 
 
+def test_sparse_categorical_crossentropy():
+    y_pred = K.variable(np.array([[0.3, 0.6, 0.1],
+                                  [0.1, 0.2, 0.7]]))
+    y_true = K.variable(np.array([1, 2]))
+    expected_loss = - (np.log(0.6) + np.log(0.7)) / 2
+    loss = K.eval(losses.sparse_categorical_crossentropy(y_true, y_pred))
+    assert np.isclose(expected_loss, np.mean(loss))
+
+
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
If Keras needs to add value checking test for other loss functions, I will update this PR for them.
What should I do?