### PR TITLE
Add weighted_metrics arg to compile

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -598,7 +598,7 @@ class Model(Container):
                 `sample_weight_mode` on each output by passing a
                 dictionary or a list of modes.
             weighted_metrics: list of metrics to be evaluated and weighted
-            by sample_weight or class_weight during training and testing
+                by sample_weight or class_weight during training and testing
             **kwargs: when using the Theano/CNTK backends, these arguments
                 are passed into K.function. When using the TensorFlow backend,
                 these arguments are passed into `tf.Session.run`.

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -843,7 +843,7 @@ class Model(Container):
             output_weighted_metrics = nested_weighted_metrics[i]
 
             def handle_metrics(metrics, weights=None):
-                metric_name_prefix = 'weighted_' if weights else ''
+                metric_name_prefix = 'weighted_' if weights is not None else ''
 
                 for metric in metrics:
                     if metric == 'accuracy' or metric == 'acc':

--- a/keras/models.py
+++ b/keras/models.py
@@ -745,6 +745,7 @@ class Sequential(Model):
     def compile(self, optimizer, loss,
                 metrics=None,
                 sample_weight_mode=None,
+                weighted_metrics=None,
                 **kwargs):
         """Configures the learning process.
 
@@ -760,6 +761,8 @@ class Sequential(Model):
             sample_weight_mode: if you need to do timestep-wise
                 sample weighting (2D weights), set this to "temporal".
                 "None" defaults to sample-wise weights (1D).
+            weighted_metrics: list of metrics to be evaluated and weighted
+                by sample_weight or class_weight during training and testing
             **kwargs: for Theano/CNTK backends, these are passed into
                 K.function. When using the TensorFlow backend, these are
                 passed into `tf.Session.run`.
@@ -780,12 +783,14 @@ class Sequential(Model):
         self.model.compile(optimizer, loss,
                            metrics=metrics,
                            sample_weight_mode=sample_weight_mode,
+                           weighted_metrics=weighted_metrics,
                            **kwargs)
         self.optimizer = self.model.optimizer
         self.loss = self.model.loss
         self.total_loss = self.model.total_loss
         self.loss_weights = self.model.loss_weights
         self.metrics = self.model.metrics
+        self.weighted_metrics = self.model.weighted_metrics
         self.metrics_tensors = self.model.metrics_tensors
         self.metrics_names = self.model.metrics_names
         self.sample_weight_mode = self.model.sample_weight_mode

--- a/tests/test_loss_weighting.py
+++ b/tests/test_loss_weighting.py
@@ -9,6 +9,7 @@ from keras.models import Sequential, Model
 from keras.layers import Dense, Activation, GRU, TimeDistributed, Input
 from keras.utils import np_utils
 from keras.utils.test_utils import keras_test
+from numpy.testing import assert_almost_equal, assert_array_almost_equal
 
 num_classes = 10
 batch_size = 128
@@ -170,7 +171,7 @@ def test_weighted_metrics_with_sample_weight():
                         sample_weight=sample_weight)
 
     h = history.history
-    np.testing.assert_array_almost_equal(h['loss'], h['weighted_' + loss_full_name], decimal=decimal)
+    assert_array_almost_equal(h['loss'], h['weighted_' + loss_full_name], decimal=decimal)
 
     history = model.fit(x_train, y_train, batch_size=batch_size,
                         epochs=epochs // 3, verbose=0,
@@ -178,7 +179,7 @@ def test_weighted_metrics_with_sample_weight():
                         validation_split=0.1)
 
     h = history.history
-    np.testing.assert_almost_equal(h['val_loss'], h['val_weighted_' + loss_full_name], decimal=decimal)
+    assert_almost_equal(h['val_loss'], h['val_weighted_' + loss_full_name], decimal=decimal)
 
     model.train_on_batch(x_train[:32], y_train[:32],
                          sample_weight=sample_weight[:32])
@@ -193,7 +194,7 @@ def test_weighted_metrics_with_sample_weight():
 
     assert loss_score < standard_score_sequential
     assert loss_score != metric_score
-    np.testing.assert_almost_equal(loss_score, weighted_metric_score, decimal=decimal)
+    assert_almost_equal(loss_score, weighted_metric_score, decimal=decimal)
 
 
 @keras_test
@@ -205,17 +206,19 @@ def test_weighted_metrics_with_no_sample_weight():
 
     (x_train, y_train), (x_test, y_test), _ = _get_test_data()
 
-    history = model.fit(x_train, y_train, batch_size=batch_size, epochs=epochs // 3, verbose=0)
+    history = model.fit(x_train, y_train, batch_size=batch_size,
+                        epochs=epochs // 3, verbose=0)
 
     h = history.history
-    np.testing.assert_array_almost_equal(h['loss'], h[loss_full_name], decimal=decimal)
-    np.testing.assert_array_almost_equal(h['loss'], h['weighted_' + loss_full_name], decimal=decimal)
+    assert_array_almost_equal(h['loss'], h[loss_full_name], decimal=decimal)
+    assert_array_almost_equal(h['loss'], h['weighted_' + loss_full_name], decimal=decimal)
 
-    history = model.fit(x_train, y_train, batch_size=batch_size, epochs=epochs // 3, verbose=0, validation_split=0.1)
+    history = model.fit(x_train, y_train, batch_size=batch_size,
+                        epochs=epochs // 3, verbose=0, validation_split=0.1)
 
     h = history.history
-    np.testing.assert_array_almost_equal(h['val_loss'], h['val_' + loss_full_name], decimal=decimal)
-    np.testing.assert_array_almost_equal(h['val_loss'], h['val_weighted_' + loss_full_name], decimal=decimal)
+    assert_array_almost_equal(h['val_loss'], h['val_' + loss_full_name], decimal=decimal)
+    assert_array_almost_equal(h['val_loss'], h['val_weighted_' + loss_full_name], decimal=decimal)
 
     model.train_on_batch(x_train[:32], y_train[:32])
     model.test_on_batch(x_train[:32], y_train[:32])
@@ -223,8 +226,8 @@ def test_weighted_metrics_with_no_sample_weight():
     scores = model.evaluate(x_test, y_test, verbose=0)
     loss_score, metric_score, weighted_metric_score = scores
 
-    np.testing.assert_almost_equal(loss_score, metric_score, decimal=decimal)
-    np.testing.assert_almost_equal(loss_score, weighted_metric_score, decimal=decimal)
+    assert_almost_equal(loss_score, metric_score, decimal=decimal)
+    assert_almost_equal(loss_score, weighted_metric_score, decimal=decimal)
 
 
 @keras_test
@@ -267,7 +270,7 @@ def test_weighted_metrics_with_multiple_outputs():
     unweighted_metric = history.history['output2_' + loss_full_name][0]
     weighted_metric = history.history['output2_weighted_' + loss_full_name][0]
 
-    np.testing.assert_almost_equal(unweighted_metric * weight, weighted_metric, decimal=decimal)
+    assert_almost_equal(unweighted_metric * weight, weighted_metric, decimal=decimal)
 
 
 @keras_test

--- a/tests/test_loss_weighting.py
+++ b/tests/test_loss_weighting.py
@@ -25,9 +25,9 @@ standard_weight = 1
 standard_score_sequential = 0.5
 
 decimal_precision = {
-  'cntk': 2,
-  'theano': 6,
-  'tensorflow': 6
+    'cntk': 2,
+    'theano': 6,
+    'tensorflow': 6
 }
 
 


### PR DESCRIPTION
Alternative to https://github.com/fchollet/keras/pull/7482.

This implementation is growing on me. I think the flexibility here is nice.

```python
from keras.models import Sequential
from keras.layers import Dense

import numpy as np

X = np.random.normal(size=(100, 10))
y = np.random.randint(2, size=100)
sample_weight = np.random.normal(size=100)
loss = 'binary_crossentropy'

model = Sequential()
model.add(Dense(10, input_shape=(10, )))
model.add(Dense(1, activation='sigmoid'))

model.compile(loss=loss, optimizer='rmsprop', metrics=[loss], weighted_metrics=[loss])

model.fit(X, y, epochs=5, verbose=2, sample_weight=sample_weight)
```

```
Epoch 1/5
0s - loss: -1.1340e-01 - binary_crossentropy: 0.7633 - weighted_binary_crossentropy: -1.1340e-01
Epoch 2/5
0s - loss: -1.2764e-01 - binary_crossentropy: 0.7729 - weighted_binary_crossentropy: -1.2764e-01
Epoch 3/5
0s - loss: -1.3798e-01 - binary_crossentropy: 0.7782 - weighted_binary_crossentropy: -1.3798e-01
Epoch 4/5
0s - loss: -1.4393e-01 - binary_crossentropy: 0.7837 - weighted_binary_crossentropy: -1.4393e-01
Epoch 5/5
0s - loss: -1.5062e-01 - binary_crossentropy: 0.7877 - weighted_binary_crossentropy: -1.5062e-01
```