### PR TITLE
Minor tensorboard callback fixes

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -658,6 +658,7 @@ class TensorBoard(Callback):
                     if self.write_grads:
                         grads = model.optimizer.get_gradients(model.total_loss,
                                                               weight)
+
                         def is_indexed_slices(grad):
                             return type(grad).__name__ == 'IndexedSlices'
                         grads = [

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -658,6 +658,11 @@ class TensorBoard(Callback):
                     if self.write_grads:
                         grads = model.optimizer.get_gradients(model.total_loss,
                                                               weight)
+                        def is_indexed_slices(grad):
+                            return type(grad).__name__ == 'IndexedSlices'
+                        grads = [
+                            grad.values if is_indexed_slices(grad) else grad
+                            for grad in grads]
                         tf.summary.histogram('{}_grad'.format(mapped_weight_name), grads)
                     if self.write_images:
                         w_img = tf.squeeze(weight)
@@ -741,6 +746,9 @@ class TensorBoard(Callback):
     def on_epoch_end(self, epoch, logs=None):
         logs = logs or {}
 
+        if not self.validation_data and self.histogram_freq:
+            raise ValueError("If printing histograms, validation_data must be "
+                             "provided, and cannot be a generator.")
         if self.validation_data and self.histogram_freq:
             if epoch % self.histogram_freq == 0:
 

--- a/tests/keras/test_callbacks.py
+++ b/tests/keras/test_callbacks.py
@@ -414,34 +414,110 @@ def test_TensorBoard(tmpdir):
                   optimizer='sgd',
                   metrics=['accuracy'])
 
-    tsb = callbacks.TensorBoard(log_dir=filepath, histogram_freq=1,
-                                write_images=True, write_grads=True,
-                                embeddings_freq=1,
-                                embeddings_layer_names=['dense_1'],
-                                batch_size=5)
-    cbks = [tsb]
+    # we must generate new callbacks for each test, as they aren't stateless
+    def callbacks_factory(histogram_freq):
+      return [callbacks.TensorBoard(log_dir=filepath,
+                                    histogram_freq=histogram_freq,
+                                    write_images=True, write_grads=True,
+                                    embeddings_freq=1,
+                                    embeddings_layer_names=['dense_1'],
+                                    batch_size=5)]
 
     # fit without validation data
     model.fit(X_train, y_train, batch_size=batch_size,
-              callbacks=cbks, epochs=3)
+              callbacks=callbacks_factory(histogram_freq=0), epochs=3)
 
     # fit with validation data and accuracy
     model.fit(X_train, y_train, batch_size=batch_size,
               validation_data=(X_test, y_test),
-              callbacks=cbks, epochs=2)
+              callbacks=callbacks_factory(histogram_freq=0), epochs=2)
 
     # fit generator without validation data
     model.fit_generator(data_generator(True), len(X_train), epochs=2,
-                        callbacks=cbks)
+                        callbacks=callbacks_factory(histogram_freq=0))
 
     # fit generator with validation data and accuracy
     model.fit_generator(data_generator(True), len(X_train), epochs=2,
                         validation_data=(X_test, y_test),
-                        callbacks=cbks)
+                        callbacks=callbacks_factory(histogram_freq=1))
 
     assert os.path.isdir(filepath)
     shutil.rmtree(filepath)
     assert not tmpdir.listdir()
+
+
+@keras_test
+@pytest.mark.skipif((K.backend() != 'tensorflow'),
+                    reason='Requires tensorflow backend')
+def test_TensorBoard_histogram_freq_must_have_validation_data(tmpdir):
+    np.random.seed(np.random.randint(1, 1e7))
+    filepath = str(tmpdir / 'logs')
+
+    (X_train, y_train), (X_test, y_test) = get_test_data(
+        num_train=train_samples,
+        num_test=test_samples,
+        input_shape=(input_dim,),
+        classification=True,
+        num_classes=num_class)
+    y_test = np_utils.to_categorical(y_test)
+    y_train = np_utils.to_categorical(y_train)
+
+    def data_generator(train):
+        if train:
+            max_batch_index = len(X_train) // batch_size
+        else:
+            max_batch_index = len(X_test) // batch_size
+        i = 0
+        while 1:
+            if train:
+                # simulate multi-input/output models
+                yield (X_train[i * batch_size: (i + 1) * batch_size],
+                       y_train[i * batch_size: (i + 1) * batch_size])
+            else:
+                yield (X_test[i * batch_size: (i + 1) * batch_size],
+                       y_test[i * batch_size: (i + 1) * batch_size])
+            i += 1
+            i = i % max_batch_index
+
+    inp = Input((input_dim,))
+    hidden = Dense(num_hidden, activation='relu')(inp)
+    hidden = Dropout(0.1)(hidden)
+    output = Dense(num_class, activation='softmax')(hidden)
+    model = Model(inputs=inp, outputs=output)
+    model.compile(loss='categorical_crossentropy',
+                  optimizer='sgd',
+                  metrics=['accuracy'])
+
+    # we must generate new callbacks for each test, as they aren't stateless
+    def callbacks_factory(histogram_freq):
+      return [callbacks.TensorBoard(log_dir=filepath,
+                                    histogram_freq=histogram_freq,
+                                    write_images=True, write_grads=True,
+                                    embeddings_freq=1,
+                                    embeddings_layer_names=['dense_1'],
+                                    batch_size=5)]
+
+    # fit without validation data should raise ValueError if histogram_freq > 0
+    with pytest.raises(ValueError) as raised_exception:
+      model.fit(X_train, y_train, batch_size=batch_size,
+                callbacks=callbacks_factory(histogram_freq=1), epochs=3)
+    assert 'validation_data must be provided' in str(raised_exception.value)
+
+    # fit generator without validation data should raise ValueError if
+    # histogram_freq > 0
+    with pytest.raises(ValueError) as raised_exception:
+      model.fit_generator(data_generator(True), len(X_train), epochs=2,
+                          callbacks=callbacks_factory(histogram_freq=1))
+    assert 'validation_data must be provided' in str(raised_exception.value)
+
+    # fit generator with validation data generator should raise ValueError if
+    # histogram_freq > 0
+    with pytest.raises(ValueError) as raised_exception:
+      model.fit_generator(data_generator(True), len(X_train), epochs=2,
+                          validation_data=data_generator(False),
+                          validation_steps=1,
+                          callbacks=callbacks_factory(histogram_freq=1))
+    assert 'validation_data must be provided' in str(raised_exception.value)
 
 
 @keras_test
@@ -489,30 +565,32 @@ def test_TensorBoard_multi_input_output(tmpdir):
                   optimizer='sgd',
                   metrics=['accuracy'])
 
-    tsb = callbacks.TensorBoard(log_dir=filepath, histogram_freq=1,
-                                write_images=True, write_grads=True,
-                                embeddings_freq=1,
-                                embeddings_layer_names=['dense_1'],
-                                batch_size=5)
-    cbks = [tsb]
+    # we must generate new callbacks for each test, as they aren't stateless
+    def callbacks_factory(histogram_freq):
+      return [callbacks.TensorBoard(log_dir=filepath,
+                                    histogram_freq=histogram_freq,
+                                    write_images=True, write_grads=True,
+                                    embeddings_freq=1,
+                                    embeddings_layer_names=['dense_1'],
+                                    batch_size=5)]
 
     # fit without validation data
     model.fit([X_train] * 2, [y_train] * 2, batch_size=batch_size,
-              callbacks=cbks, epochs=3)
+              callbacks=callbacks_factory(histogram_freq=0), epochs=3)
 
     # fit with validation data and accuracy
     model.fit([X_train] * 2, [y_train] * 2, batch_size=batch_size,
               validation_data=([X_test] * 2, [y_test] * 2),
-              callbacks=cbks, epochs=2)
+              callbacks=callbacks_factory(histogram_freq=1), epochs=2)
 
     # fit generator without validation data
     model.fit_generator(data_generator(True), len(X_train), epochs=2,
-                        callbacks=cbks)
+                        callbacks=callbacks_factory(histogram_freq=0))
 
     # fit generator with validation data and accuracy
     model.fit_generator(data_generator(True), len(X_train), epochs=2,
                         validation_data=([X_test] * 2, [y_test] * 2),
-                        callbacks=cbks)
+                        callbacks=callbacks_factory(histogram_freq=1))
 
     assert os.path.isdir(filepath)
     shutil.rmtree(filepath)

--- a/tests/keras/test_callbacks.py
+++ b/tests/keras/test_callbacks.py
@@ -416,12 +416,12 @@ def test_TensorBoard(tmpdir):
 
     # we must generate new callbacks for each test, as they aren't stateless
     def callbacks_factory(histogram_freq):
-      return [callbacks.TensorBoard(log_dir=filepath,
-                                    histogram_freq=histogram_freq,
-                                    write_images=True, write_grads=True,
-                                    embeddings_freq=1,
-                                    embeddings_layer_names=['dense_1'],
-                                    batch_size=5)]
+        return [callbacks.TensorBoard(log_dir=filepath,
+                                      histogram_freq=histogram_freq,
+                                      write_images=True, write_grads=True,
+                                      embeddings_freq=1,
+                                      embeddings_layer_names=['dense_1'],
+                                      batch_size=5)]
 
     # fit without validation data
     model.fit(X_train, y_train, batch_size=batch_size,
@@ -490,33 +490,33 @@ def test_TensorBoard_histogram_freq_must_have_validation_data(tmpdir):
 
     # we must generate new callbacks for each test, as they aren't stateless
     def callbacks_factory(histogram_freq):
-      return [callbacks.TensorBoard(log_dir=filepath,
-                                    histogram_freq=histogram_freq,
-                                    write_images=True, write_grads=True,
-                                    embeddings_freq=1,
-                                    embeddings_layer_names=['dense_1'],
-                                    batch_size=5)]
+        return [callbacks.TensorBoard(log_dir=filepath,
+                                      histogram_freq=histogram_freq,
+                                      write_images=True, write_grads=True,
+                                      embeddings_freq=1,
+                                      embeddings_layer_names=['dense_1'],
+                                      batch_size=5)]
 
     # fit without validation data should raise ValueError if histogram_freq > 0
     with pytest.raises(ValueError) as raised_exception:
-      model.fit(X_train, y_train, batch_size=batch_size,
-                callbacks=callbacks_factory(histogram_freq=1), epochs=3)
+        model.fit(X_train, y_train, batch_size=batch_size,
+                  callbacks=callbacks_factory(histogram_freq=1), epochs=3)
     assert 'validation_data must be provided' in str(raised_exception.value)
 
     # fit generator without validation data should raise ValueError if
     # histogram_freq > 0
     with pytest.raises(ValueError) as raised_exception:
-      model.fit_generator(data_generator(True), len(X_train), epochs=2,
-                          callbacks=callbacks_factory(histogram_freq=1))
+        model.fit_generator(data_generator(True), len(X_train), epochs=2,
+                            callbacks=callbacks_factory(histogram_freq=1))
     assert 'validation_data must be provided' in str(raised_exception.value)
 
     # fit generator with validation data generator should raise ValueError if
     # histogram_freq > 0
     with pytest.raises(ValueError) as raised_exception:
-      model.fit_generator(data_generator(True), len(X_train), epochs=2,
-                          validation_data=data_generator(False),
-                          validation_steps=1,
-                          callbacks=callbacks_factory(histogram_freq=1))
+        model.fit_generator(data_generator(True), len(X_train), epochs=2,
+                            validation_data=data_generator(False),
+                            validation_steps=1,
+                            callbacks=callbacks_factory(histogram_freq=1))
     assert 'validation_data must be provided' in str(raised_exception.value)
 
 
@@ -567,12 +567,12 @@ def test_TensorBoard_multi_input_output(tmpdir):
 
     # we must generate new callbacks for each test, as they aren't stateless
     def callbacks_factory(histogram_freq):
-      return [callbacks.TensorBoard(log_dir=filepath,
-                                    histogram_freq=histogram_freq,
-                                    write_images=True, write_grads=True,
-                                    embeddings_freq=1,
-                                    embeddings_layer_names=['dense_1'],
-                                    batch_size=5)]
+        return [callbacks.TensorBoard(log_dir=filepath,
+                                      histogram_freq=histogram_freq,
+                                      write_images=True, write_grads=True,
+                                      embeddings_freq=1,
+                                      embeddings_layer_names=['dense_1'],
+                                      batch_size=5)]
 
     # fit without validation data
     model.fit([X_train] * 2, [y_train] * 2, batch_size=batch_size,


### PR DESCRIPTION
1. The issue described in https://github.com/fchollet/keras/issues/7397
I.e. the embedding layer has gradients represented by an IndexedSlice as opposed to a tensor. The dense gradient tensor expected by tensorflow should be extracted with the .values function.
2. Fail loudly if validation_data is None and histogram_freq is non-zero.