### PR TITLE
Subtract merge layer

### DIFF
--- a/keras/layers/merge.py
+++ b/keras/layers/merge.py
@@ -238,6 +238,9 @@ class Subtract(_Merge):
         if len(inputs) != 2:
             raise ValueError('`Subtract` layer should be called '
                              'on exactly 2 inputs')
+        if inputs[0]._keras_shape != inputs[1]._keras_shape:
+            raise ValueError('`Subtract` layer should be called '
+                             'on inputs of the same shape')
         return inputs[0] - inputs[1]
 
 

--- a/keras/layers/merge.py
+++ b/keras/layers/merge.py
@@ -227,7 +227,8 @@ class Subtract(_Merge):
         x1 = keras.layers.Dense(8, activation='relu')(input1)
         input2 = keras.layers.Input(shape=(32,))
         x2 = keras.layers.Dense(8, activation='relu')(input2)
-        subtracted = keras.layers.Subtract()([x1, x2]) # equivalent to subtracted = keras.layers.subtract([x1, x2])
+        # Equivalent to subtracted = keras.layers.subtract([x1, x2])
+        subtracted = keras.layers.Subtract()([x1, x2])
 
         out = keras.layers.Dense(4)(subtracted)
         model = keras.models.Model(inputs=[input1, input2], outputs=out)

--- a/keras/layers/merge.py
+++ b/keras/layers/merge.py
@@ -215,8 +215,8 @@ class Subtract(_Merge):
     """Layer that subtracts two inputs.
 
     It takes as input a list of tensors of size 2,
-    both of the same shape, and returns
-    a single tensor (also of the same shape).
+    both of the same shape, and returns a single tensor, inputs[0] - inputs[1],
+    also of the same shape.
 
     # Examples
 

--- a/keras/layers/merge.py
+++ b/keras/layers/merge.py
@@ -211,6 +211,36 @@ class Add(_Merge):
         return output
 
 
+class Subtract(_Merge):
+    """Layer that subtracts two inputs.
+
+    It takes as input a list of tensors of size 2,
+    both of the same shape, and returns
+    a single tensor (also of the same shape).
+
+    # Examples
+
+    ```python
+        import keras
+
+        input1 = keras.layers.Input(shape=(16,))
+        x1 = keras.layers.Dense(8, activation='relu')(input1)
+        input2 = keras.layers.Input(shape=(32,))
+        x2 = keras.layers.Dense(8, activation='relu')(input2)
+        subtracted = keras.layers.Subtract()([x1, x2]) # equivalent to subtracted = keras.layers.subtract([x1, x2])
+
+        out = keras.layers.Dense(4)(subtracted)
+        model = keras.models.Model(inputs=[input1, input2], outputs=out)
+    ```
+    """
+
+    def _merge_function(self, inputs):
+        if len(inputs) != 2:
+            raise ValueError('`Subtract` layer should be called '
+                             'on exactly 2 inputs')
+        return inputs[0] - inputs[1]
+
+
 class Multiply(_Merge):
     """Layer that multiplies (element-wise) a list of inputs.
 
@@ -483,6 +513,34 @@ def add(inputs, **kwargs):
     ```
     """
     return Add(**kwargs)(inputs)
+
+
+def subtract(inputs, **kwargs):
+    """Functional interface to the `Subtract` layer.
+
+    # Arguments
+        inputs: A list of input tensors (exactly 2).
+        **kwargs: Standard layer keyword arguments.
+
+    # Returns
+        A tensor, the difference of the inputs.
+
+    # Examples
+
+    ```python
+        import keras
+
+        input1 = keras.layers.Input(shape=(16,))
+        x1 = keras.layers.Dense(8, activation='relu')(input1)
+        input2 = keras.layers.Input(shape=(32,))
+        x2 = keras.layers.Dense(8, activation='relu')(input2)
+        subtracted = keras.layers.subtract([x1, x2])
+
+        out = keras.layers.Dense(4)(subtracted)
+        model = keras.models.Model(inputs=[input1, input2], outputs=out)
+    ```
+    """
+    return Subtract(**kwargs)(inputs)
 
 
 def multiply(inputs, **kwargs):

--- a/keras/layers/merge.py
+++ b/keras/layers/merge.py
@@ -215,7 +215,7 @@ class Subtract(_Merge):
     """Layer that subtracts two inputs.
 
     It takes as input a list of tensors of size 2,
-    both of the same shape, and returns a single tensor, inputs[0] - inputs[1],
+    both of the same shape, and returns a single tensor, (inputs[0] - inputs[1]),
     also of the same shape.
 
     # Examples

--- a/tests/keras/layers/merge_test.py
+++ b/tests/keras/layers/merge_test.py
@@ -47,6 +47,7 @@ def test_merge_subtract():
     i1 = layers.Input(shape=(4, 5))
     i2 = layers.Input(shape=(4, 5))
     i3 = layers.Input(shape=(4, 5))
+    i4 = layers.Input(shape=(3, 5))
     o = layers.subtract([i1, i2])
     assert o._keras_shape == (None, 4, 5)
     model = models.Model([i1, i2], o)
@@ -74,6 +75,8 @@ def test_merge_subtract():
         subtract_layer([i1, i2, i3])
     with pytest.raises(ValueError):
         subtract_layer([i1])
+    with pytest.raises(ValueError):
+        subtract_layer([i1, i4])
 
 
 @keras_test


### PR DESCRIPTION
With the merge method being deprecated by end of 8/2017, there needs to be a way to define a subtraction of two layers. This Subtract layer takes exactly two tensors and returns the difference.