### PR TITLE
Change default size to allow different MobileNet sizes

### DIFF
--- a/keras/applications/mobilenet.py
+++ b/keras/applications/mobilenet.py
@@ -377,9 +377,24 @@ def MobileNet(input_shape=None,
         raise ValueError('If using `weights` as ImageNet with `include_top` '
                          'as true, `classes` should be 1000')
 
-    # Determine proper input shape.
+    # Determine proper input shape and default size.
+    if input_shape is None:
+        default_size = 224
+    else:
+        if K.image_data_format() == 'channels_first':
+            rows = input_shape[1]
+            cols = input_shape[2]
+        else:
+            rows = input_shape[0]
+            cols = input_shape[1]
+
+        if rows == cols and rows in [128, 160, 192, 224]:
+            default_size = rows
+        else:
+            default_size = 224
+
     input_shape = _obtain_input_shape(input_shape,
-                                      default_size=224,
+                                      default_size=default_size,
                                       min_size=32,
                                       data_format=K.image_data_format(),
                                       include_top=include_top or weights)

--- a/tests/keras/applications/applications_test.py
+++ b/tests/keras/applications/applications_test.py
@@ -193,6 +193,21 @@ def test_mobilenet_pooling():
     assert model.output_shape == (None, 1024)
 
 
+@keras_test
+@pytest.mark.skipif((K.backend() != 'tensorflow'),
+                    reason="MobileNets are supported only on TensorFlow")
+def test_mobilenet_image_size():
+    valid_image_sizes = [128, 160, 192, 224]
+    for size in valid_image_sizes:
+        input_shape = (size, size, 3) if K.image_data_format() == 'channels_last' else (3, size, size)
+        model = applications.MobileNet(input_shape=input_shape, weights='imagenet', include_top=True)
+        assert model.input_shape == (None,) + input_shape
+
+    invalid_image_shape = (112, 112, 3) if K.image_data_format() == 'channels_last' else (3, 112, 112)
+    with pytest.raises(ValueError):
+        model = applications.MobileNet(input_shape=invalid_image_shape, weights='imagenet', include_top=True)
+
+
 @pytest.mark.skipif(K.backend() != 'tensorflow', reason='Requires TF backend')
 @keras_test
 def test_depthwise_conv_2d():


### PR DESCRIPTION
@fchollet There is a MobileNet image size selection problem in the current implementation. 

Due to the use of `_obtain_input_shape(...)`, the default_size provided is a static 224. While this generally works well for models with only 1 input size, for the MobileNet family of models, it is not suitable.

The issue is that when one passes `input_shape` as anything other than the default of 224 (128, 160 and 192 are supported as well), an error stating that the default size required with `include_top=True` is (224, 224, 3) is raised. This is a problem, since there exist weights for smaller input size models. They just can't be accessed with the standard working of `_obtain_input_shape`.

There are two possible ways to fix this : 

1) Make `_obtain_input_shape` support a list of default sizes. Usage of this method would be simpler then, though a very clean implementation would be a tad bit more difficult (but can be managed).

2) Do a pre-check for `input_shape` (if provided), check it is one of the possible sizes supported by MobileNet, and then change the `default_size` to match this input size. There is a fallback to the `default_size` = 224 if the provided input shape is not in the list of supported sizes (and then `_obtain_input_shape` can check and raise errors if needed).
This means there is no need to change the `_obtain_input_shape` code, and the task falls to the method caller to make sure the correct `default_size` is provided. 

In my opinion, since it is relatively rare for a single model to be trained on different image sizes, I prefer option 2. Therefore, that has been implemented in this PR.