### PR TITLE
Increase test coverage

### DIFF
--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -1845,12 +1845,12 @@ class Container(Layer):
         else:
             if not name:
                 raise ValueError('Provide either a layer name or layer index.')
-        layer = None
+
         for layer in self.layers:
             if layer.name == name:
                 return layer
-        if not layer:
-            raise ValueError('No such layer: ' + name)
+
+        raise ValueError('No such layer: ' + name)
 
     @property
     def updates(self):

--- a/tests/keras/legacy/interface_test.py
+++ b/tests/keras/legacy/interface_test.py
@@ -1,7 +1,6 @@
 import pytest
 import json
 from keras.utils.test_utils import keras_test
-from keras.engine.topology import preprocess_weights_for_loading
 import keras
 import numpy as np
 
@@ -110,10 +109,6 @@ def test_lstm_legacy_interface():
     new_layer = keras.layers.LSTM(2, input_shape=[3, 5], name='d')
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
-    preprocess_weights_for_loading(new_layer,
-                                   [np.random.random(x) for x in [(5, 2), (2, 2), (2,)] * 4],
-                                   original_keras_version='1')
-
     old_layer = keras.layers.LSTM(input_shape=[3, 5], output_dim=2, name='d', consume_less='mem')
     new_layer = keras.layers.LSTM(2, input_shape=[3, 5], name='d', implementation=1)
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
@@ -211,10 +206,6 @@ def test_gru_legacy_interface():
     old_layer = keras.layers.GRU(input_shape=[3, 5], output_dim=2, name='d')
     new_layer = keras.layers.GRU(2, input_shape=[3, 5], name='d')
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
-
-    preprocess_weights_for_loading(new_layer,
-                                   [np.random.random(x) for x in [(5, 2), (2, 2), (2,)] * 3],
-                                   original_keras_version='1')
 
     old_layer = keras.layers.GRU(2, init='normal',
                                  inner_init='glorot_uniform',


### PR DESCRIPTION
This PR adds topology tests for the [current](https://travis-ci.org/fchollet/keras/builds/263264803) following missing lines:
```
keras/engine/topology.py                   1281    159    88%   25-26, 167-173, 279, 294, 339, 351, 411-412, 426, 438, 444-446, 454, 462, 471-472, 476, 486-487, 492, 550-553, 567, 608-611, 711-713, 731-736, 781, 784, 792, 915, 935, 1012, 1020-1022, 1046, 1054-1056, 1087, 1119, 1168, 1182, 1253, 1293, 1299-1303, 1310-1314, 1319-1322, 1334-1335, 1428, 1536-1537, 1664, 1790, 1840, 1846-1853, 2004-2010, 2037, 2041, 2057-2058, 2063, 2071, 2153, 2204, 2253, 2407, 2411, 2413-2414, 2547-2557, 2583, 2586, 2590, 2627-2634, 2695, 2700, 2786, 2803-2804, 2826, 2834, 2875-2882, 2891-2898, 2901-2904, 2954-2955, 2960-2982, 2991-2993, 2997, 3015, 3019, 3036, 3055, 3087, 3091, 3118
```