### PR TITLE
make ImageDataGenerator generator repeatable

### DIFF
--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -834,7 +834,7 @@ class NumpyArrayIterator(Iterator):
         for i, j in enumerate(index_array):
             x = self.x[j]
             if self.seed is not None:
-                seed = self.seed + self.total_batches_seen + i if self.seed
+                seed = self.seed + self.total_batches_seen + i
             else:
                 seed = None
             x = self.image_data_generator.random_transform(x.astype(K.floatx()), seed=seed)
@@ -1062,7 +1062,7 @@ class DirectoryIterator(Iterator):
                            target_size=self.target_size)
             x = img_to_array(img, data_format=self.data_format)
             if self.seed is not None:
-                seed = self.seed + self.total_batches_seen + i if self.seed
+                seed = self.seed + self.total_batches_seen + i
             else:
                 seed = None
             x = self.image_data_generator.random_transform(x, seed=seed)

--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -680,8 +680,11 @@ class ImageDataGenerator(object):
             ax = np.zeros(tuple([rounds * x.shape[0]] + list(x.shape)[1:]), dtype=K.floatx())
             for r in range(rounds):
                 for i in range(x.shape[0]):
-                    seed = self.seed + r if self.seed is not None else None
-                    ax[i + r * x.shape[0]] = self.random_transform(x[i], seed=seed)
+                    if seed is not None:
+                        seed_r = seed + r
+                     else:
+                        seed_r = None
+                    ax[i + r * x.shape[0]] = self.random_transform(x[i], seed=seed_r)
             x = ax
 
         if self.featurewise_center:

--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -682,7 +682,7 @@ class ImageDataGenerator(object):
                 for i in range(x.shape[0]):
                     if seed is not None:
                         seed_r = seed + r
-                     else:
+                    else:
                         seed_r = None
                     ax[i + r * x.shape[0]] = self.random_transform(x[i], seed=seed_r)
             x = ax

--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -160,9 +160,9 @@ def random_channel_shift(x, intensity, channel_axis=0, seed=None):
     x = np.rollaxis(x, channel_axis, 0)
     min_x, max_x = np.min(x), np.max(x)
     channel_images = []
+    if seed is not None:
+        np.random.seed(seed)
     for x_channel in x:
-        if seed is not None:
-            np.random.seed(seed)
         channel_image = np.clip(x_channel + np.random.uniform(-intensity, intensity), min_x, max_x)
         channel_images.append(channel_image)
     x = np.stack(channel_images, axis=0)
@@ -545,9 +545,6 @@ class ImageDataGenerator(object):
         img_row_axis = self.row_axis - 1
         img_col_axis = self.col_axis - 1
         img_channel_axis = self.channel_axis - 1
-
-        if seed is not None:
-            np.random.seed(seed)
 
         # use composition of homographies
         # to generate final transform that needs to be applied

--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -161,7 +161,7 @@ def random_channel_shift(x, intensity, channel_axis=0, seed=None):
     min_x, max_x = np.min(x), np.max(x)
     channel_images = []
     for x_channel in x:
-        if seed:
+        if seed is not None:
             np.random.seed(seed)
         channel_image = np.clip(x_channel + np.random.uniform(-intensity, intensity), min_x, max_x)
         channel_images.append(channel_image)
@@ -618,8 +618,6 @@ class ImageDataGenerator(object):
                                 fill_mode=self.fill_mode, cval=self.cval)
 
         if self.channel_shift_range != 0:
-            # if seed is not None:
-            #     np.random.seed(seed)
             x = random_channel_shift(x,
                                      self.channel_shift_range,
                                      img_channel_axis, seed)


### PR DESCRIPTION
We want ImageDataGenerator to be repeatable so we can 1) have repeatable research 2) so we can transform a mask and image in parallel (like in the keras docs).

In PR #3751 I made it mostly repeatable but I recently ran more tests and found problems. It's not repeatable when using flow_from_directory, and it's not repeatable if the mask and image have different number of channels. 

This PR fixes that by adding `np.random.seed(seed)` where needed. 

I have two unit tests I can add if desired?