### PR TITLE
Import statements now try to add the various backends one by one, so …

### DIFF
--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -4,12 +4,28 @@ import numpy as np
 import scipy.sparse as sparse
 
 from keras import backend as K
-from keras.backend import theano_backend as KTH, floatx, set_floatx, variable
-from keras.backend import tensorflow_backend as KTF
+from keras.backend import floatx, set_floatx, variable
 from keras.utils.conv_utils import convert_kernel
-from keras.backend import cntk_backend as KC
 
-BACKENDS = [KTH, KTF, KC]
+BACKENDS = []  # Holds a list of all available back-ends
+
+try:
+    from keras.backend import cntk_backend as KC
+    BACKENDS.append(KC)
+except:
+    print("Could not import the CNTK back-end")
+
+try:
+    from keras.backend import tensorflow_backend as KTF
+    BACKENDS.append(KTF)
+except:
+    print("Could not import the Tensorflow back-end.")
+
+try:
+    from keras.backend import theano_backend as KTH
+    BACKENDS.append(KTH)
+except:
+    print("Could not import the Theano back-end")
 
 
 def check_dtype(var, dtype):

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -14,19 +14,19 @@ try:
     from keras.backend import cntk_backend as KC
     BACKENDS.append(KC)
 except ImportError:
-    warnings.warn("Could not import the CNTK backend")
+    warnings.warn('Could not import the CNTK backend')
 
 try:
     from keras.backend import tensorflow_backend as KTF
     BACKENDS.append(KTF)
 except ImportError:
-    warnings.warn("Could not import the Tensorflow backend.")
+    warnings.warn('Could not import the Tensorflow backend.')
 
 try:
     from keras.backend import theano_backend as KTH
     BACKENDS.append(KTH)
 except ImportError:
-    warnings.warn("Could not import the Theano backend")
+    warnings.warn('Could not import the Theano backend')
 
 
 def check_dtype(var, dtype):

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -2,6 +2,7 @@ import pytest
 from numpy.testing import assert_allclose
 import numpy as np
 import scipy.sparse as sparse
+import warnings
 
 from keras import backend as K
 from keras.backend import floatx, set_floatx, variable
@@ -12,20 +13,20 @@ BACKENDS = []  # Holds a list of all available back-ends
 try:
     from keras.backend import cntk_backend as KC
     BACKENDS.append(KC)
-except:
-    print("Could not import the CNTK back-end")
+except ImportError:
+    warnings.warn("Could not import the CNTK backend")
 
 try:
     from keras.backend import tensorflow_backend as KTF
     BACKENDS.append(KTF)
-except:
-    print("Could not import the Tensorflow back-end.")
+except ImportError:
+    warnings.warn("Could not import the Tensorflow backend.")
 
 try:
     from keras.backend import theano_backend as KTH
     BACKENDS.append(KTH)
-except:
-    print("Could not import the Theano back-end")
+except ImportError:
+    warnings.warn("Could not import the Theano backend")
 
 
 def check_dtype(var, dtype):


### PR DESCRIPTION
…that most tests will run even if only one backend is installed

This will allow people on their own machines to run the tests more easily even if they have only one or two of the backends installed. Not all backends are necessarily available on all platforms, so this should improve the portability of the tests.