### PR TITLE
Changed exception to warning for NumpyIterator

### DIFF
--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -780,11 +780,11 @@ class NumpyArrayIterator(Iterator):
         channels_axis = 3 if data_format == 'channels_last' else 1
         if self.x.shape[channels_axis] not in {1, 3, 4}:
             warnings.warn('NumpyArrayIterator is set to use the '
-                             'data format convention "' + data_format + '" '
-                             '(channels on axis ' + str(channels_axis) + '), i.e. expected '
-                             'either 1, 3 or 4 channels on axis ' + str(channels_axis) + '. '
-                             'However, it was passed an array with shape ' + str(self.x.shape) +
-                             ' (' + str(self.x.shape[channels_axis]) + ' channels).')
+                          'data format convention "' + data_format + '" '
+                          '(channels on axis ' + str(channels_axis) + '), i.e. expected '
+                          'either 1, 3 or 4 channels on axis ' + str(channels_axis) + '. '
+                          'However, it was passed an array with shape ' + str(self.x.shape) +
+                          ' (' + str(self.x.shape[channels_axis]) + ' channels).')
         if y is not None:
             self.y = np.asarray(y)
         else:

--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -779,7 +779,7 @@ class NumpyArrayIterator(Iterator):
                              'with shape', self.x.shape)
         channels_axis = 3 if data_format == 'channels_last' else 1
         if self.x.shape[channels_axis] not in {1, 3, 4}:
-            raise warnings.warn('NumpyArrayIterator is set to use the '
+            warnings.warn('NumpyArrayIterator is set to use the '
                              'data format convention "' + data_format + '" '
                              '(channels on axis ' + str(channels_axis) + '), i.e. expected '
                              'either 1, 3 or 4 channels on axis ' + str(channels_axis) + '. '

--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -779,7 +779,7 @@ class NumpyArrayIterator(Iterator):
                              'with shape', self.x.shape)
         channels_axis = 3 if data_format == 'channels_last' else 1
         if self.x.shape[channels_axis] not in {1, 3, 4}:
-            raise ValueError('NumpyArrayIterator is set to use the '
+            raise warnings.warn('NumpyArrayIterator is set to use the '
                              'data format convention "' + data_format + '" '
                              '(channels on axis ' + str(channels_axis) + '), i.e. expected '
                              'either 1, 3 or 4 channels on axis ' + str(channels_axis) + '. '


### PR DESCRIPTION
Right now NumpyIterator wont let us use multichannel data but it's common in satellite datasets such as [Kaggle's Dstl Satellite Imagery Feature Detection](https://www.kaggle.com/c/dstl-satellite-imagery-feature-detection) or [spacenet](https://spacenetchallenge.github.io/). This changes the exception to a warning.