### PR TITLE
Suppress warnings of CNTK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,9 @@ matrix:
         - python: 3.5
           env: KERAS_BACKEND=theano THEANO_FLAGS=optimizer=fast_compile
         - python: 2.7
-          env: KERAS_BACKEND=cntk
+          env: KERAS_BACKEND=cntk PYTHONWARNINGS=ignore
         - python: 3.5
-          env: KERAS_BACKEND=cntk
+          env: KERAS_BACKEND=cntk PYTHONWARNINGS=ignore
 install:
   # code below is taken from http://conda.pydata.org/docs/travis.html
   # We do this conditionally because it saves us some downloading if the


### PR DESCRIPTION
It is important to reduce sizes of log files for using CI tools. This PR suppresses warnings in order to prevent the sizes from growing larger than necessary. After CNTK is added, log files include too many warnings about type conversion of float64<->32 (less meaningful). In case of [the latest log](https://travis-ci.org/fchollet/keras/jobs/264198585), there are 997 warnings which results in a heavy log file (2.6MB). Before CNTK is added, the sizes were usually 700-800KB.