### PR TITLE
model_to_dot (vis_utils.py) includes activation fn

### DIFF
--- a/keras/utils/vis_utils.py
+++ b/keras/utils/vis_utils.py
@@ -85,6 +85,8 @@ def model_to_dot(model,
                 outputlabels = str(layer.output_shape)
             except AttributeError:
                 outputlabels = 'multiple'
+            if hasattr(layer, 'activation'):
+                outputlabels = outputlabels + ' (' + layer.activation.__name__ + ')'
             if hasattr(layer, 'input_shape'):
                 inputlabels = str(layer.input_shape)
             elif hasattr(layer, 'input_shapes'):


### PR DESCRIPTION
The name of the activation function applied to a layer's output is now included in the output label for that layer for images created by the model_to_dot() function in vis_utils.py.