### PR TITLE
HDF5Matrix can handle np.int64 indexing

### DIFF
--- a/keras/utils/io_utils.py
+++ b/keras/utils/io_utils.py
@@ -72,7 +72,7 @@ class HDF5Matrix(object):
                 idx = slice(start + self.start, stop + self.start)
             else:
                 raise IndexError
-        elif isinstance(key, int):
+        elif isinstance(key, (int, np.integer)):
             if key + self.start < self.end:
                 idx = key + self.start
             else:


### PR DESCRIPTION
Right now HDF5Matrix's raise an index error when a np.int64 number is used to index them (such as from np.arange). In contrast normal numpy array can handle this situation. This PR fixes that by also checking for numpy integer types.