### PR TITLE
Recurrent layer to treat 2nd and the rest of inputs as initial_states

### DIFF
--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -252,6 +252,14 @@ class Recurrent(Layer):
         return inputs
 
     def __call__(self, inputs, initial_state=None, **kwargs):
+
+        # If there are multiple inputs, then
+        # they should be the main input and `initial_state`
+        # e.g. when loading model from file
+        if isinstance(inputs, (list, tuple)) and len(inputs) > 1 and initial_state is None:
+            initial_state = inputs[1:]
+            inputs = inputs[0]
+
         # If `initial_state` is specified,
         # and if it a Keras tensor,
         # then add it to the inputs and temporarily

--- a/tests/keras/layers/recurrent_test.py
+++ b/tests/keras/layers/recurrent_test.py
@@ -290,6 +290,7 @@ def test_initial_states_as_other_inputs(layer_class):
     targets = np.random.random((num_samples, units))
     model.fit([main_inputs] + initial_state, targets)
 
+
 @rnn_test
 def test_specify_state_with_masking(layer_class):
     ''' This test based on a previously failing issue here:

--- a/tests/keras/layers/recurrent_test.py
+++ b/tests/keras/layers/recurrent_test.py
@@ -288,7 +288,7 @@ def test_initial_states_as_other_inputs(layer_class):
     initial_state = [np.random.random((num_samples, units))
                      for _ in range(num_states)]
     targets = np.random.random((num_samples, units))
-    model.fit([main_inputs] + initial_state, targets)
+    model.train_on_batch([main_inputs] + initial_state, targets)
 
 
 @rnn_test

--- a/tests/keras/layers/recurrent_test.py
+++ b/tests/keras/layers/recurrent_test.py
@@ -269,6 +269,28 @@ def test_reset_states_with_values(layer_class):
 
 
 @rnn_test
+def test_initial_states_as_other_inputs(layer_class):
+    num_states = 2 if layer_class is recurrent.LSTM else 1
+
+    # Test with Keras tensor
+    main_inputs = Input((timesteps, embedding_dim))
+    initial_state = [Input((units,)) for _ in range(num_states)]
+    inputs = [main_inputs] + initial_state
+
+    layer = layer_class(units)
+    output = layer(inputs)
+    assert initial_state[0] in layer.inbound_nodes[0].input_tensors
+
+    model = Model(inputs, output)
+    model.compile(loss='categorical_crossentropy', optimizer='adam')
+
+    main_inputs = np.random.random((num_samples, timesteps, embedding_dim))
+    initial_state = [np.random.random((num_samples, units))
+                     for _ in range(num_states)]
+    targets = np.random.random((num_samples, units))
+    model.fit([main_inputs] + initial_state, targets)
+
+@rnn_test
 def test_specify_state_with_masking(layer_class):
     ''' This test based on a previously failing issue here:
     https://github.com/fchollet/keras/issues/1567

--- a/tests/test_model_saving.py
+++ b/tests/test_model_saving.py
@@ -350,6 +350,7 @@ def test_saving_custom_activation_function():
     out2 = model.predict(x)
     assert_allclose(out, out2, atol=1e-05)
 
+
 @keras_test
 def test_saving_recurrent_layer_with_init_state():
     VECTOR_SIZE = 8

--- a/tests/test_model_saving.py
+++ b/tests/test_model_saving.py
@@ -6,7 +6,7 @@ from numpy.testing import assert_allclose
 
 from keras import backend as K
 from keras.models import Model, Sequential
-from keras.layers import Dense, Lambda, RepeatVector, TimeDistributed
+from keras.layers import Dense, Lambda, RepeatVector, TimeDistributed, LSTM
 from keras.layers import Input
 from keras import optimizers
 from keras import losses
@@ -350,6 +350,24 @@ def test_saving_custom_activation_function():
     out2 = model.predict(x)
     assert_allclose(out, out2, atol=1e-05)
 
+@keras_test
+def test_saving_recurrent_layer_with_init_state():
+    VECTOR_SIZE = 8
+    INPUT_LENGTH = 20
+
+    input_initial_state = Input(shape=(VECTOR_SIZE,))
+    input_x = Input(shape=(INPUT_LENGTH, VECTOR_SIZE))
+
+    lstm = LSTM(VECTOR_SIZE, return_sequences=True)(
+        input_x, initial_state=[input_initial_state, input_initial_state])
+
+    model = Model(inputs=[input_x, input_initial_state], outputs=[lstm])
+
+    _, fname = tempfile.mkstemp('.h5')
+    model.save(fname)
+
+    loaded_model = load_model(fname)
+    os.remove(fname)
 
 if __name__ == '__main__':
     pytest.main([__file__])

--- a/tests/test_model_saving.py
+++ b/tests/test_model_saving.py
@@ -353,13 +353,13 @@ def test_saving_custom_activation_function():
 
 @keras_test
 def test_saving_recurrent_layer_with_init_state():
-    VECTOR_SIZE = 8
-    INPUT_LENGTH = 20
+    vector_size = 8
+    input_length = 20
 
-    input_initial_state = Input(shape=(VECTOR_SIZE,))
-    input_x = Input(shape=(INPUT_LENGTH, VECTOR_SIZE))
+    input_initial_state = Input(shape=(vector_size,))
+    input_x = Input(shape=(input_length, vector_size))
 
-    lstm = LSTM(VECTOR_SIZE, return_sequences=True)(
+    lstm = LSTM(vector_size, return_sequences=True)(
         input_x, initial_state=[input_initial_state, input_initial_state])
 
     model = Model(inputs=[input_x, input_initial_state], outputs=[lstm])


### PR DESCRIPTION
Hi. I'm submitting a PR for a bug reported in #7612. 

I think the Recurrent layer should treat a part of the inputs as `initial_states`. I think this is also what you want to do according to the API doc. If you have a different design, please suggest.