### PR TITLE
Demonstrate need for imagenet preprocessing support for input tensors

### DIFF
--- a/tests/keras/applications/imagenet_utils_test.py
+++ b/tests/keras/applications/imagenet_utils_test.py
@@ -3,6 +3,8 @@ import numpy as np
 from numpy.testing import assert_allclose
 
 from keras.applications import imagenet_utils as utils
+from keras import backend as K
+from keras.utils.test_utils import keras_test
 
 
 def test_preprocess_input():
@@ -23,6 +25,17 @@ def test_preprocess_input():
     out2 = utils.preprocess_input(np.transpose(x, (2, 0, 1)),
                                   'channels_first')
     assert_allclose(out1, out2.transpose(1, 2, 0))
+
+
+@pytest.mark.skipif(K.backend() != 'tensorflow', reason='input tensors supported only by TF')
+@keras_test
+def test_preprocess_input_tensor():
+    # Test image batch
+    import tensorflow as tf
+
+    x = np.random.uniform(0, 255, (2, 10, 10, 3))
+    x = tf.Variable(x, dtype=tf.float32)
+    assert utils.preprocess_input(x).shape == x.shape
 
 
 def test_decode_predictions():


### PR DESCRIPTION
With the goal of making input tensors as easy to use as numpy arrays, I'm trying to create an imagenet model loaded from pretrained weights that uses input tensors. This means for `keras.applications.*` images must be preprocessed in the same way as they are with numpy array inputs, so preprocess_input should support input tensors.

The internal implementation of `utils.preprocess_input()` needs to be updated so the test result in this pull request no longer fails:

```
_________________________ test_preprocess_input_tensor _________________________

    @pytest.mark.skipif(K.backend() != 'tensorflow', reason='input tensors supported only by TF')
    @keras_test
    def test_preprocess_input_tensor():
        # Test image batch
        import tensorflow as tf
    
        x = np.random.uniform(0, 255, (2, 10, 10, 3))
        x = tf.Variable(x, dtype=tf.float32)
>       assert utils.preprocess_input(x).shape == x.shape

tests/keras/applications/imagenet_utils_test.py:38: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

x = <tf.Tensor 'strided_slice:0' shape=(2, 10, 10, 3) dtype=float32>
data_format = 'channels_last'

>   ???
E   TypeError: 'Tensor' object does not support item assignment

build/bdist.linux-x86_64/egg/keras/applications/imagenet_utils.py:42: TypeError
====================== 1 failed, 3 passed in 1.58 seconds ======================
```

Am I correct that in the case of keras mean subtraction is performed without normalization for the models in applications?