### PR TITLE
Setup.py missing classifiers fixed. Now announce Py2 and Py3 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,21 +20,16 @@ setup(name='Keras',
                     'pytest-cov'],
       },
       classifiers=[
-          'Development Status :: 4 - Beta',
+          'Development Status :: 5 - Production/Stable',
           'Intended Audience :: Developers',
           'Intended Audience :: Education',
           'Intended Audience :: Science/Research',
-          'License :: OSI Approved :: Apache Software License',
+          'License :: OSI Approved :: MIT License',
           'Programming Language :: Python :: 2',
           'Programming Language :: Python :: 2.7',
           'Programming Language :: Python :: 3',
-          'Programming Language :: Python :: 3.5',
-          'Topic :: Scientific/Engineering',
-          'Topic :: Scientific/Engineering :: Mathematics',
-          'Topic :: Scientific/Engineering :: Artificial Intelligence',
-          'Topic :: Software Development',
-          'Topic :: Software Development :: Libraries',  
-          'Topic :: Software Development :: Libraries :: Python Modules',  
+          'Programming Language :: Python :: 3.6',
+          'Topic :: Software Development :: Libraries',
+          'Topic :: Software Development :: Libraries :: Python Modules'
       ],
-      packages=find_packages()
-)
+      packages=find_packages())

--- a/setup.py
+++ b/setup.py
@@ -19,4 +19,22 @@ setup(name='Keras',
                     'pytest-xdist',
                     'pytest-cov'],
       },
-      packages=find_packages())
+      classifiers=[
+          'Development Status :: 4 - Beta',
+          'Intended Audience :: Developers',
+          'Intended Audience :: Education',
+          'Intended Audience :: Science/Research',
+          'License :: OSI Approved :: Apache Software License',
+          'Programming Language :: Python :: 2',
+          'Programming Language :: Python :: 2.7',
+          'Programming Language :: Python :: 3',
+          'Programming Language :: Python :: 3.5',
+          'Topic :: Scientific/Engineering',
+          'Topic :: Scientific/Engineering :: Mathematics',
+          'Topic :: Scientific/Engineering :: Artificial Intelligence',
+          'Topic :: Software Development',
+          'Topic :: Software Development :: Libraries',  
+          'Topic :: Software Development :: Libraries :: Python Modules',  
+      ],
+      packages=find_packages()
+)


### PR DESCRIPTION
Hello everyone,

As you may find on PyPI: <https://pypi.python.org/pypi/keras/json>, keras is reported with an empty list of classifiers which can cause a lot of problems to anyone using the PyPI API to retrieve information about Keras (e.g. most CI tools).

This PR was made to declare the missing classifiers.

```python
######################## Old Version ########################
"classifiers": [
  ]

######################## New Version ########################
classifiers=[
       "Development Status :: 4 - Beta",
        
        'Intended Audience :: Developers',
        'Intended Audience :: Education',
        'Intended Audience :: Science/Research',
        
        'License :: OSI Approved :: Apache Software License',
        
        'Programming Language :: Python :: 2',
        'Programming Language :: Python :: 2.7',
        'Programming Language :: Python :: 3',
        'Programming Language :: Python :: 3.6',
        
        'Topic :: Scientific/Engineering',
        'Topic :: Scientific/Engineering :: Mathematics',
        'Topic :: Scientific/Engineering :: Artificial Intelligence',
        'Topic :: Software Development',
        'Topic :: Software Development :: Libraries',  
        'Topic :: Software Development :: Libraries :: Python Modules',
    ],
```

I basically had only one doubt, should I have declared Keras as Beta release or Stable release ? I can update my PR if needed.

Thanks a lot and have a great day,

Best Regards,

Jonathan DEKHTIAR