### PR TITLE
Remove requirement that batch_size divides len(x_train) in Variational Autoencoder examples.

### DIFF
--- a/examples/variational_autoencoder.py
+++ b/examples/variational_autoencoder.py
@@ -20,7 +20,7 @@ epochs = 50
 epsilon_std = 1.0
 
 
-x = Input(batch_shape=(batch_size, original_dim))
+x = Input(shape=(original_dim,))
 h = Dense(intermediate_dim, activation='relu')(x)
 z_mean = Dense(latent_dim)(h)
 z_log_var = Dense(latent_dim)(h)
@@ -28,7 +28,7 @@ z_log_var = Dense(latent_dim)(h)
 
 def sampling(args):
     z_mean, z_log_var = args
-    epsilon = K.random_normal(shape=(batch_size, latent_dim), mean=0.,
+    epsilon = K.random_normal(shape=(K.shape(z_mean)[0], latent_dim), mean=0.,
                               stddev=epsilon_std)
     return z_mean + K.exp(z_log_var / 2) * epsilon
 

--- a/examples/variational_autoencoder_deconv.py
+++ b/examples/variational_autoencoder_deconv.py
@@ -31,7 +31,7 @@ intermediate_dim = 128
 epsilon_std = 1.0
 epochs = 5
 
-x = Input(batch_shape=(batch_size,) + original_img_size)
+x = Input(shape=original_img_size)
 conv_1 = Conv2D(img_chns,
                 kernel_size=(2, 2),
                 padding='same', activation='relu')(x)
@@ -56,7 +56,7 @@ z_log_var = Dense(latent_dim)(hidden)
 
 def sampling(args):
     z_mean, z_log_var = args
-    epsilon = K.random_normal(shape=(batch_size, latent_dim),
+    epsilon = K.random_normal(shape=(K.shape(z_mean)[0], latent_dim),
                               mean=0., stddev=epsilon_std)
     return z_mean + K.exp(z_log_var) * epsilon
 


### PR DESCRIPTION
Copying almost verbatim from PR https://github.com/fchollet/keras/pull/7036 which addressed the issue without solving it.

Currently the Variational Autoencoder examples at `examples/variational_autoencoder.py` and `examples/variational_autoencoder_deconv.py` fail when the training set size is not a multiple of the batch size (related to #5255, and in a way to #3332).

This PR allows to use any batch size by computing the batch size in the `sampling` function at runtime.

Bug reproducibility steps:

- change the batch size (`examples/variational_autoencoder.py` at line 15 and `examples/variational_autoencoder_deconv.py` at line 24) to something that doesn't divide mnist train set size, for instance 51
- run `examples/variational_autoencoder.py` or `examples/variational_autoencoder_deconv.py`
