### PR TITLE
Utils to create generators for numpy memmap arrays

### DIFF
--- a/keras/utils/np_utils.py
+++ b/keras/utils/np_utils.py
@@ -40,3 +40,81 @@ def normalize(x, axis=-1, order=2):
     l2 = np.atleast_1d(np.linalg.norm(x, order, axis))
     l2[l2 == 0] = 1
     return x / np.expand_dims(l2, axis)
+
+
+def batchyield_shuffle(x, y, shufflearr=None, batchsize=256, stopiter=None):
+    """Creates a generator over numpy arrays with
+    shuffling that can iterate over memmaped arrays
+
+    # Arguments
+        x: Feature data (numpy array or memmap)
+            to iterate over.
+        y: Target data (numpy array or memmap)
+            to iterate over.
+        shufflearr: (optional) if only you want to
+            iterate over a subset of indices
+        batchsize: size of returned batchsize
+        stopiter: total number of batches
+
+    # Returns
+        generator that returns batches of data
+    """
+    if shufflearr is not None:
+        if isinstance(x, np.ndarray):
+            n_samp = x.shape[0]
+        else:
+            n_samp = x[0].shape[0]
+        shufflearr = np.arange(n_samp)
+    np.random.shuffle(shufflearr)
+    dataind = 0
+    iterations = 0
+    while True:
+        if stopiter:
+            if iterations >= stopiter:
+                break
+        endind = dataind + batchsize
+        if endind > (shufflearr.shape[0] - 1):
+            np.random.shuffle(shufflearr)
+            dataind = 0
+            endind = batchsize
+        batchinds = shufflearr[dataind:endind]
+        dataind += batchsize
+        if isinstance(x, np.ndarray) and isinstance(y, np.ndarray):
+            yield (x[batchinds], y[batchinds])
+        elif isinstance(x, list) and isinstance(y, list):
+            yield ([kk[batchinds] for kk in x], [ss[batchinds] for ss in y])
+        iterations += 1
+
+
+def batchyield_choice(x, y, batchsize=256, stopiter=None):
+    """Creates a generator over numpy arrays a
+    random subset of indices that can iterate
+    over memmaped arrays
+
+    # Arguments
+        x: Feature data (numpy array or memmap)
+            to iterate over.
+        y: Target data (numpy array or memmap)
+            to iterate over.
+        batchsize: size of returned batchsize
+        stopiter: total number of batches
+
+    # Returns
+        generator that returns batches of data
+    """
+    dataind = 0
+    iterations = 0
+    if isinstance(x, np.ndarray):
+        n_samp = x.shape[0]
+    else:
+        n_samp = x[0].shape[0]
+    while True:
+        if stopiter:
+            if iterations >= stopiter:
+                break
+        batchinds = np.random.choice(n_samp, batchsize, replace=False)
+        if isinstance(x, np.ndarray) and isinstance(y, np.ndarray):
+            yield (x[batchinds], y[batchinds])
+        elif isinstance(x, list) and isinstance(y, list):
+            yield ([kk[batchinds] for kk in x], [ss[batchinds] for ss in y])
+        iterations += 1

--- a/tests/keras/utils/np_utils_test.py
+++ b/tests/keras/utils/np_utils_test.py
@@ -1,0 +1,111 @@
+'''Tests for functions in np_utils.py.
+'''
+import os
+import pytest
+from keras.models import Sequential
+from keras.layers import Dense
+from keras.utils.np_utils import batchyield_choice, batchyield_shuffle
+import numpy as np
+import warnings
+import h5py
+
+
+@pytest.fixture
+def in_tmpdir(tmpdir):
+    """Runs a function in a temporary directory.
+
+    Checks that the directory is empty afterwards.
+    """
+    with tmpdir.as_cwd():
+        yield None
+    assert not tmpdir.listdir()
+
+
+def create_dataset(npy_path='test'):
+    X = np.random.randn(200, 10).astype('float32')
+    y = np.random.randint(0, 2, size=(200, 1))
+    np.save(npy_path + '_X.npy', X)
+    np.save(npy_path + '_y.npy', y)
+
+
+def test_np_utils_batchyield_shuffle(in_tmpdir):
+    '''Test for memmap generators in utils/np_utils.py
+    '''
+    npy_path = 'test'
+    create_dataset(npy_path)
+
+    # Memmap numpy file
+    X = np.load(npy_path + '_X.npy', mmap_mode='r')
+    y = np.load(npy_path + '_y.npy', mmap_mode='r')
+
+    # Shuffle only first 150 indices
+    shuffle_train = np.arange(150)
+
+    fitgen = batchyield_shuffle(X, y, shuffle_train, batchsize=32)
+
+    X_test = X[150:]
+    y_test = y[150:]
+
+    # HDF5Matrix behave more or less like Numpy matrices with regards to
+    # indexing
+
+    model = Sequential()
+    model.add(Dense(64, input_shape=(10,), activation='relu'))
+    model.add(Dense(1, activation='sigmoid'))
+
+    model.compile(loss='binary_crossentropy', optimizer='sgd')
+
+    model.fit_generator(fitgen, 10, verbose=False)
+    # test that evalutation and prediction don't crash and return reasonable
+    # results
+    out_pred = model.predict(X_test, batch_size=32, verbose=False)
+    out_eval = model.evaluate(X_test, y_test, batch_size=32, verbose=False)
+
+    assert out_pred.shape == (50, 1), 'Prediction shape does not match'
+    assert out_eval.shape == (), 'Shape of evaluation does not match'
+    assert out_eval > 0, 'Evaluation value does not meet criteria: {}'.format(
+        out_eval)
+
+    os.remove(npy_path + '_X.npy')
+    os.remove(npy_path + '_y.npy')
+
+
+def test_np_utils_batchyield_choice(in_tmpdir):
+    '''Test for memmap generators in utils/np_utils.py
+    '''
+    npy_path = 'test'
+    create_dataset(npy_path)
+
+    # Memmap numpy file
+    X = np.load(npy_path + '_X.npy', mmap_mode='r')
+    y = np.load(npy_path + '_y.npy', mmap_mode='r')
+
+    # Creates generator to use in fit_generator
+    fitgen = batchyield_choice(X, y, batchsize=32)
+
+    X_test = X[150:]
+    y_test = y[150:]
+
+    model = Sequential()
+    model.add(Dense(64, input_shape=(10,), activation='relu'))
+    model.add(Dense(1, activation='sigmoid'))
+
+    model.compile(loss='binary_crossentropy', optimizer='sgd')
+
+    model.fit_generator(fitgen, 10, verbose=False)
+    # test that evalutation and prediction don't crash and return reasonable
+    # results
+    out_pred = model.predict(X_test, batch_size=32, verbose=False)
+    out_eval = model.evaluate(X_test, y_test, batch_size=32, verbose=False)
+
+    assert out_pred.shape == (50, 1), 'Prediction shape does not match'
+    assert out_eval.shape == (), 'Shape of evaluation does not match'
+    assert out_eval > 0, 'Evaluation value does not meet criteria: {}'.format(
+        out_eval)
+
+    os.remove(npy_path + '_X.npy')
+    os.remove(npy_path + '_y.npy')
+
+
+if __name__ == '__main__':
+    pytest.main([__file__])


### PR DESCRIPTION
Added utils to iterate over memmapped numpy arrays, so that one can use numpy arrays that don't fit in memory.

Tests are adapted from the HDF5-tests.