### PR TITLE
Add Inception-ResNet v2 to application

### DIFF
--- a/docs/templates/applications.md
+++ b/docs/templates/applications.md
@@ -14,6 +14,7 @@ Weights are downloaded automatically when instantiating a model. They are stored
 - [VGG19](#vgg19)
 - [ResNet50](#resnet50)
 - [InceptionV3](#inceptionv3)
+- [InceptionResNetV2](#inceptionresnetv2)
 - [MobileNet](#mobilenet)
 
 All of these architectures (except Xception and MobileNet) are compatible with both TensorFlow and Theano, and upon instantiation the models will be built according to the image data format set in your Keras configuration file at `~/.keras/keras.json`. For instance, if you have set `image_data_format=channels_last`, then any model loaded from this repository will get built according to the TensorFlow data format convention, "Width-Height-Depth".
@@ -170,6 +171,7 @@ model = InceptionV3(input_tensor=input_tensor, weights='imagenet', include_top=T
 - [VGG19](#vgg19)
 - [ResNet50](#resnet50)
 - [InceptionV3](#inceptionv3)
+- [InceptionResNetV2](#inceptionresnetv2)
 - [MobileNet](#mobilenet)
 
 -----
@@ -189,17 +191,17 @@ and a top-5 validation accuracy of 0.945.
 
 Note that this model is only available for the TensorFlow backend,
 due to its reliance on `SeparableConvolution` layers. Additionally it only supports
-the data format "channels_last" (height, width, channels).
+the data format `channels_last` (height, width, channels).
 
 The default input size for this model is 299x299.
 
 ### Arguments
 
 - include_top: whether to include the fully-connected layer at the top of the network.
-- weights: one of `None` (random initialization) or "imagenet" (pre-training on ImageNet).
+- weights: one of `None` (random initialization) or `'imagenet'` (pre-training on ImageNet).
 - input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as image input for the model.
 - input_shape: optional shape tuple, only to be specified
-    if `include_top` is False (otherwise the input shape
+    if `include_top` is `False` (otherwise the input shape
     has to be `(299, 299, 3)`.
     It should have exactly 3 inputs channels,
     and width and height should be no smaller than 71.
@@ -209,19 +211,19 @@ The default input size for this model is 299x299.
     - `None` means that the output of the model will be
         the 4D tensor output of the
         last convolutional layer.
-    - `avg` means that global average pooling
+    - `'avg'` means that global average pooling
         will be applied to the output of the
         last convolutional layer, and thus
         the output of the model will be a 2D tensor.
-    - `max` means that global max pooling will
+    - `'max'` means that global max pooling will
         be applied.
 - classes: optional number of classes to classify images 
-    into, only to be specified if `include_top` is True, and 
+    into, only to be specified if `include_top` is `True`, and 
     if no `weights` argument is specified.
 
 ### Returns
 
-A Keras model instance.
+A Keras `Model` instance.
 
 ### References
 
@@ -244,17 +246,17 @@ keras.applications.vgg16.VGG16(include_top=True, weights='imagenet', input_tenso
 VGG16 model, with weights pre-trained on ImageNet.
 
 This model is available for both the Theano and TensorFlow backend, and can be built both
-with "channels_first" data format (channels, height, width) or "channels_last" data format (height, width, channels).
+with `channels_first` data format (channels, height, width) or `channels_last` data format (height, width, channels).
 
 The default input size for this model is 224x224.
 
 ### Arguments
 
 - include_top: whether to include the 3 fully-connected layers at the top of the network.
-- weights: one of `None` (random initialization) or "imagenet" (pre-training on ImageNet).
+- weights: one of `None` (random initialization) or `'imagenet'` (pre-training on ImageNet).
 - input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as image input for the model.
 - input_shape: optional shape tuple, only to be specified
-    if `include_top` is False (otherwise the input shape
+    if `include_top` is `False` (otherwise the input shape
     has to be `(224, 224, 3)` (with `channels_last` data format)
     or `(3, 224, 224)` (with `channels_first` data format).
     It should have exactly 3 inputs channels,
@@ -265,19 +267,19 @@ The default input size for this model is 224x224.
     - `None` means that the output of the model will be
         the 4D tensor output of the
         last convolutional layer.
-    - `avg` means that global average pooling
+    - `'avg'` means that global average pooling
         will be applied to the output of the
         last convolutional layer, and thus
         the output of the model will be a 2D tensor.
-    - `max` means that global max pooling will
+    - `'max'` means that global max pooling will
         be applied.
 - classes: optional number of classes to classify images 
-    into, only to be specified if `include_top` is True, and 
+    into, only to be specified if `include_top` is `True`, and 
     if no `weights` argument is specified.
-    
+
 ### Returns
 
-A Keras model instance.
+A Keras `Model` instance.
 
 ### References
 
@@ -300,17 +302,17 @@ keras.applications.vgg19.VGG19(include_top=True, weights='imagenet', input_tenso
 VGG19 model, with weights pre-trained on ImageNet.
 
 This model is available for both the Theano and TensorFlow backend, and can be built both
-with "channels_first" data format (channels, height, width) or "channels_last" data format (height, width, channels).
+with `channels_first` data format (channels, height, width) or `channels_last` data format (height, width, channels).
 
 The default input size for this model is 224x224.
 
 ### Arguments
 
 - include_top: whether to include the 3 fully-connected layers at the top of the network.
-- weights: one of `None` (random initialization) or "imagenet" (pre-training on ImageNet).
+- weights: one of `None` (random initialization) or `'imagenet'` (pre-training on ImageNet).
 - input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as image input for the model.
 - input_shape: optional shape tuple, only to be specified
-    if `include_top` is False (otherwise the input shape
+    if `include_top` is `False` (otherwise the input shape
     has to be `(224, 224, 3)` (with `channels_last` data format)
     or `(3, 224, 224)` (with `channels_first` data format).
     It should have exactly 3 inputs channels,
@@ -321,19 +323,19 @@ The default input size for this model is 224x224.
     - `None` means that the output of the model will be
         the 4D tensor output of the
         last convolutional layer.
-    - `avg` means that global average pooling
+    - `'avg'` means that global average pooling
         will be applied to the output of the
         last convolutional layer, and thus
         the output of the model will be a 2D tensor.
-    - `max` means that global max pooling will
+    - `'max'` means that global max pooling will
         be applied.
 - classes: optional number of classes to classify images 
-    into, only to be specified if `include_top` is True, and 
+    into, only to be specified if `include_top` is `True`, and 
     if no `weights` argument is specified.
-    
+
 ### Returns
 
-A Keras model instance.
+A Keras `Model` instance.
 
 
 ### References
@@ -357,7 +359,7 @@ keras.applications.resnet50.ResNet50(include_top=True, weights='imagenet', input
 ResNet50 model, with weights pre-trained on ImageNet.
 
 This model is available for both the Theano and TensorFlow backend, and can be built both
-with "channels_first" data format (channels, height, width) or "channels_last" data format (height, width, channels).
+with `channels_first` data format (channels, height, width) or `channels_last` data format (height, width, channels).
 
 The default input size for this model is 224x224.
 
@@ -365,10 +367,10 @@ The default input size for this model is 224x224.
 ### Arguments
 
 - include_top: whether to include the fully-connected layer at the top of the network.
-- weights: one of `None` (random initialization) or "imagenet" (pre-training on ImageNet).
+- weights: one of `None` (random initialization) or `'imagenet'` (pre-training on ImageNet).
 - input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as image input for the model.
 - input_shape: optional shape tuple, only to be specified
-    if `include_top` is False (otherwise the input shape
+    if `include_top` is `False` (otherwise the input shape
     has to be `(224, 224, 3)` (with `channels_last` data format)
     or `(3, 224, 224)` (with `channels_first` data format).
     It should have exactly 3 inputs channels,
@@ -379,19 +381,19 @@ The default input size for this model is 224x224.
     - `None` means that the output of the model will be
         the 4D tensor output of the
         last convolutional layer.
-    - `avg` means that global average pooling
+    - `'avg'` means that global average pooling
         will be applied to the output of the
         last convolutional layer, and thus
         the output of the model will be a 2D tensor.
-    - `max` means that global max pooling will
+    - `'max'` means that global max pooling will
         be applied.
 - classes: optional number of classes to classify images 
-    into, only to be specified if `include_top` is True, and 
+    into, only to be specified if `include_top` is `True`, and 
     if no `weights` argument is specified.
-    
+
 ### Returns
 
-A Keras model instance.
+A Keras `Model` instance.
 
 ### References
 
@@ -413,7 +415,7 @@ keras.applications.inception_v3.InceptionV3(include_top=True, weights='imagenet'
 Inception V3 model, with weights pre-trained on ImageNet.
 
 This model is available for both the Theano and TensorFlow backend, and can be built both
-with "channels_first" data format (channels, height, width) or "channels_last" data format (height, width, channels).
+with `channels_first` data format (channels, height, width) or `channels_last` data format (height, width, channels).
 
 The default input size for this model is 299x299.
 
@@ -421,10 +423,10 @@ The default input size for this model is 299x299.
 ### Arguments
 
 - include_top: whether to include the fully-connected layer at the top of the network.
-- weights: one of `None` (random initialization) or "imagenet" (pre-training on ImageNet).
+- weights: one of `None` (random initialization) or `'imagenet'` (pre-training on ImageNet).
 - input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as image input for the model.
 - input_shape: optional shape tuple, only to be specified
-    if `include_top` is False (otherwise the input shape
+    if `include_top` is `False` (otherwise the input shape
     has to be `(299, 299, 3)` (with `channels_last` data format)
     or `(3, 299, 299)` (with `channels_first` data format).
     It should have exactly 3 inputs channels,
@@ -435,23 +437,81 @@ The default input size for this model is 299x299.
     - `None` means that the output of the model will be
         the 4D tensor output of the
         last convolutional layer.
-    - `avg` means that global average pooling
+    - `'avg'` means that global average pooling
         will be applied to the output of the
         last convolutional layer, and thus
         the output of the model will be a 2D tensor.
-    - `max` means that global max pooling will
+    - `'max'` means that global max pooling will
         be applied.
 - classes: optional number of classes to classify images 
-    into, only to be specified if `include_top` is True, and 
+    into, only to be specified if `include_top` is `True`, and 
     if no `weights` argument is specified.
-    
+
 ### Returns
 
-A Keras model instance.
+A Keras `Model` instance.
 
 ### References
 
 - [Rethinking the Inception Architecture for Computer Vision](http://arxiv.org/abs/1512.00567)
+
+### License
+
+These weights are released under [the Apache License](https://github.com/tensorflow/models/blob/master/LICENSE).
+
+-----
+
+## InceptionResNetV2
+
+
+```python
+keras.applications.inception_resnet_v2.InceptionResNetV2(include_top=True, weights='imagenet', input_tensor=None, input_shape=None, pooling=None, classes=1000, dropout_keep_prob=0.8)
+```
+
+Inception-ResNet V2 model, with weights pre-trained on ImageNet.
+
+This model is available for both the Theano and TensorFlow backend, and can be built both
+with `channels_first` data format (channels, height, width) or `channels_last` data format (height, width, channels).
+
+The default input size for this model is 299x299.
+
+
+### Arguments
+
+- include_top: whether to include the fully-connected layer at the top of the network.
+- weights: one of `None` (random initialization) or `'imagenet'` (pre-training on ImageNet).
+- input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as image input for the model.
+- input_shape: optional shape tuple, only to be specified
+    if `include_top` is `False` (otherwise the input shape
+    has to be `(299, 299, 3)` (with `channels_last` data format)
+    or `(3, 299, 299)` (with `channels_first` data format).
+    It should have exactly 3 inputs channels,
+    and width and height should be no smaller than 139.
+    E.g. `(150, 150, 3)` would be one valid value.
+- pooling: Optional pooling mode for feature extraction
+    when `include_top` is `False`.
+    - `None` means that the output of the model will be
+        the 4D tensor output of the
+        last convolutional layer.
+    - `'avg'` means that global average pooling
+        will be applied to the output of the
+        last convolutional layer, and thus
+        the output of the model will be a 2D tensor.
+    - `'max'` means that global max pooling will
+        be applied.
+- classes: optional number of classes to classify images 
+    into, only to be specified if `include_top` is `True`, and 
+    if no `weights` argument is specified.
+- dropout_keep_prob: dropout keep rate after pooling and before the
+    classification layer, only to be specified if `include_top` is `True`.
+
+### Returns
+
+A Keras `Model` instance.
+
+### References
+
+- [Inception-v4, Inception-ResNet and the Impact of Residual Connections on Learning](https://arxiv.org/abs/1602.07261)
 
 ### License
 
@@ -487,7 +547,7 @@ The default input size for this model is 224x224.
 ### Arguments
 
 - input_shape: optional shape tuple, only to be specified
-    if `include_top` is False (otherwise the input shape
+    if `include_top` is `False` (otherwise the input shape
     has to be `(224, 224, 3)` (with `channels_last` data format)
     or (3, 224, 224) (with `channels_first` data format).
     It should have exactly 3 inputs channels,
@@ -506,7 +566,7 @@ The default input size for this model is 224x224.
 - include_top: whether to include the fully-connected
     layer at the top of the network.
 - weights: `None` (random initialization) or
-    `imagenet` (ImageNet weights)
+    `'imagenet'` (ImageNet weights)
 - input_tensor: optional Keras tensor (i.e. output of
     `layers.Input()`)
     to use as image input for the model.
@@ -515,20 +575,20 @@ The default input size for this model is 224x224.
     - `None` means that the output of the model
     will be the 4D tensor output of the
         last convolutional layer.
-    - `avg` means that global average pooling
+    - `'avg'` means that global average pooling
         will be applied to the output of the
         last convolutional layer, and thus
         the output of the model will be a
         2D tensor.
-    - `max` means that global max pooling will
+    - `'max'` means that global max pooling will
         be applied.
 - classes: optional number of classes to classify images
-    into, only to be specified if `include_top` is True, and
+    into, only to be specified if `include_top` is `True`, and
     if no `weights` argument is specified.
-    
+
 ### Returns
 
-A Keras model instance.
+A Keras `Model` instance.
 
 ### References
 

--- a/docs/templates/applications.md
+++ b/docs/templates/applications.md
@@ -470,7 +470,7 @@ keras.applications.inception_resnet_v2.InceptionResNetV2(include_top=True, weigh
 
 Inception-ResNet V2 model, with weights pre-trained on ImageNet.
 
-This model is available for both the Theano and TensorFlow backend, and can be built both
+This model is available for both the Theano and TensorFlow backend (but not CNTK), and can be built both
 with `channels_first` data format (channels, height, width) or `channels_last` data format (height, width, channels).
 
 The default input size for this model is 299x299.

--- a/docs/templates/applications.md
+++ b/docs/templates/applications.md
@@ -465,7 +465,7 @@ These weights are released under [the Apache License](https://github.com/tensorf
 
 
 ```python
-keras.applications.inception_resnet_v2.InceptionResNetV2(include_top=True, weights='imagenet', input_tensor=None, input_shape=None, pooling=None, classes=1000, dropout_keep_prob=0.8)
+keras.applications.inception_resnet_v2.InceptionResNetV2(include_top=True, weights='imagenet', input_tensor=None, input_shape=None, pooling=None, classes=1000)
 ```
 
 Inception-ResNet V2 model, with weights pre-trained on ImageNet.
@@ -502,8 +502,6 @@ The default input size for this model is 299x299.
 - classes: optional number of classes to classify images 
     into, only to be specified if `include_top` is `True`, and 
     if no `weights` argument is specified.
-- dropout_keep_prob: dropout keep rate after pooling and before the
-    classification layer, only to be specified if `include_top` is `True`.
 
 ### Returns
 

--- a/docs/templates/applications.md
+++ b/docs/templates/applications.md
@@ -191,7 +191,7 @@ and a top-5 validation accuracy of 0.945.
 
 Note that this model is only available for the TensorFlow backend,
 due to its reliance on `SeparableConvolution` layers. Additionally it only supports
-the data format `channels_last` (height, width, channels).
+the data format `'channels_last'` (height, width, channels).
 
 The default input size for this model is 299x299.
 
@@ -246,7 +246,7 @@ keras.applications.vgg16.VGG16(include_top=True, weights='imagenet', input_tenso
 VGG16 model, with weights pre-trained on ImageNet.
 
 This model is available for both the Theano and TensorFlow backend, and can be built both
-with `channels_first` data format (channels, height, width) or `channels_last` data format (height, width, channels).
+with `'channels_first'` data format (channels, height, width) or `'channels_last'` data format (height, width, channels).
 
 The default input size for this model is 224x224.
 
@@ -257,8 +257,8 @@ The default input size for this model is 224x224.
 - input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as image input for the model.
 - input_shape: optional shape tuple, only to be specified
     if `include_top` is `False` (otherwise the input shape
-    has to be `(224, 224, 3)` (with `channels_last` data format)
-    or `(3, 224, 224)` (with `channels_first` data format).
+    has to be `(224, 224, 3)` (with `'channels_last'` data format)
+    or `(3, 224, 224)` (with `'channels_first'` data format).
     It should have exactly 3 inputs channels,
     and width and height should be no smaller than 48.
     E.g. `(200, 200, 3)` would be one valid value.
@@ -302,7 +302,7 @@ keras.applications.vgg19.VGG19(include_top=True, weights='imagenet', input_tenso
 VGG19 model, with weights pre-trained on ImageNet.
 
 This model is available for both the Theano and TensorFlow backend, and can be built both
-with `channels_first` data format (channels, height, width) or `channels_last` data format (height, width, channels).
+with `'channels_first'` data format (channels, height, width) or `'channels_last'` data format (height, width, channels).
 
 The default input size for this model is 224x224.
 
@@ -313,8 +313,8 @@ The default input size for this model is 224x224.
 - input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as image input for the model.
 - input_shape: optional shape tuple, only to be specified
     if `include_top` is `False` (otherwise the input shape
-    has to be `(224, 224, 3)` (with `channels_last` data format)
-    or `(3, 224, 224)` (with `channels_first` data format).
+    has to be `(224, 224, 3)` (with `'channels_last'` data format)
+    or `(3, 224, 224)` (with `'channels_first'` data format).
     It should have exactly 3 inputs channels,
     and width and height should be no smaller than 48.
     E.g. `(200, 200, 3)` would be one valid value.
@@ -359,7 +359,7 @@ keras.applications.resnet50.ResNet50(include_top=True, weights='imagenet', input
 ResNet50 model, with weights pre-trained on ImageNet.
 
 This model is available for both the Theano and TensorFlow backend, and can be built both
-with `channels_first` data format (channels, height, width) or `channels_last` data format (height, width, channels).
+with `'channels_first'` data format (channels, height, width) or `'channels_last'` data format (height, width, channels).
 
 The default input size for this model is 224x224.
 
@@ -371,8 +371,8 @@ The default input size for this model is 224x224.
 - input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as image input for the model.
 - input_shape: optional shape tuple, only to be specified
     if `include_top` is `False` (otherwise the input shape
-    has to be `(224, 224, 3)` (with `channels_last` data format)
-    or `(3, 224, 224)` (with `channels_first` data format).
+    has to be `(224, 224, 3)` (with `'channels_last'` data format)
+    or `(3, 224, 224)` (with `'channels_first'` data format).
     It should have exactly 3 inputs channels,
     and width and height should be no smaller than 197.
     E.g. `(200, 200, 3)` would be one valid value.
@@ -415,7 +415,7 @@ keras.applications.inception_v3.InceptionV3(include_top=True, weights='imagenet'
 Inception V3 model, with weights pre-trained on ImageNet.
 
 This model is available for both the Theano and TensorFlow backend, and can be built both
-with `channels_first` data format (channels, height, width) or `channels_last` data format (height, width, channels).
+with `'channels_first'` data format (channels, height, width) or `'channels_last'` data format (height, width, channels).
 
 The default input size for this model is 299x299.
 
@@ -427,8 +427,8 @@ The default input size for this model is 299x299.
 - input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as image input for the model.
 - input_shape: optional shape tuple, only to be specified
     if `include_top` is `False` (otherwise the input shape
-    has to be `(299, 299, 3)` (with `channels_last` data format)
-    or `(3, 299, 299)` (with `channels_first` data format).
+    has to be `(299, 299, 3)` (with `'channels_last'` data format)
+    or `(3, 299, 299)` (with `'channels_first'` data format).
     It should have exactly 3 inputs channels,
     and width and height should be no smaller than 139.
     E.g. `(150, 150, 3)` would be one valid value.
@@ -471,7 +471,7 @@ keras.applications.inception_resnet_v2.InceptionResNetV2(include_top=True, weigh
 Inception-ResNet V2 model, with weights pre-trained on ImageNet.
 
 This model is available for both the Theano and TensorFlow backend (but not CNTK), and can be built both
-with `channels_first` data format (channels, height, width) or `channels_last` data format (height, width, channels).
+with `'channels_first'` data format (channels, height, width) or `'channels_last'` data format (height, width, channels).
 
 The default input size for this model is 299x299.
 
@@ -483,8 +483,8 @@ The default input size for this model is 299x299.
 - input_tensor: optional Keras tensor (i.e. output of `layers.Input()`) to use as image input for the model.
 - input_shape: optional shape tuple, only to be specified
     if `include_top` is `False` (otherwise the input shape
-    has to be `(299, 299, 3)` (with `channels_last` data format)
-    or `(3, 299, 299)` (with `channels_first` data format).
+    has to be `(299, 299, 3)` (with `'channels_last'` data format)
+    or `(3, 299, 299)` (with `'channels_first'` data format).
     It should have exactly 3 inputs channels,
     and width and height should be no smaller than 139.
     E.g. `(150, 150, 3)` would be one valid value.
@@ -546,8 +546,8 @@ The default input size for this model is 224x224.
 
 - input_shape: optional shape tuple, only to be specified
     if `include_top` is `False` (otherwise the input shape
-    has to be `(224, 224, 3)` (with `channels_last` data format)
-    or (3, 224, 224) (with `channels_first` data format).
+    has to be `(224, 224, 3)` (with `'channels_last'` data format)
+    or (3, 224, 224) (with `'channels_first'` data format).
     It should have exactly 3 inputs channels,
     and width and height should be no smaller than 32.
     E.g. `(200, 200, 3)` would be one valid value.

--- a/docs/templates/getting-started/faq.md
+++ b/docs/templates/getting-started/faq.md
@@ -418,6 +418,8 @@ Code and pre-trained weights are available for the following image classificatio
 - VGG19
 - ResNet50
 - Inception v3
+- Inception-ResNet v2
+- MobileNet v1
 
 They can be imported from the module `keras.applications`:
 
@@ -427,6 +429,8 @@ from keras.applications.vgg16 import VGG16
 from keras.applications.vgg19 import VGG19
 from keras.applications.resnet50 import ResNet50
 from keras.applications.inception_v3 import InceptionV3
+from keras.applications.inception_resnet_v2 import InceptionResNetV2
+from keras.applications.mobilenet import MobileNet
 
 model = VGG16(weights='imagenet', include_top=True)
 ```

--- a/keras/applications/__init__.py
+++ b/keras/applications/__init__.py
@@ -2,5 +2,6 @@ from .vgg16 import VGG16
 from .vgg19 import VGG19
 from .resnet50 import ResNet50
 from .inception_v3 import InceptionV3
+from .inception_resnet_v2 import InceptionResNetV2
 from .xception import Xception
 from .mobilenet import MobileNet

--- a/keras/applications/inception_resnet_v2.py
+++ b/keras/applications/inception_resnet_v2.py
@@ -1,0 +1,448 @@
+# -*- coding: utf-8 -*-
+"""Inception-ResNet V2 model for Keras.
+
+Model naming and structure follows TF-slim implementation (which has some additional
+layers and different number of filters from the original arXiv paper):
+https://github.com/tensorflow/models/blob/master/slim/nets/inception_resnet_v2.py
+
+Pre-trained ImageNet weights are also converted from TF-slim, which can be found in:
+https://github.com/tensorflow/models/tree/master/slim#pre-trained-models
+
+# Reference
+- [Inception-v4, Inception-ResNet and the Impact of
+   Residual Connections on Learning](https://arxiv.org/abs/1602.07261)
+
+"""
+from __future__ import print_function
+from __future__ import absolute_import
+
+import warnings
+from functools import partial
+
+from ..models import Model
+from ..layers import Activation
+from ..layers import AveragePooling2D
+from ..layers import BatchNormalization
+from ..layers import Concatenate
+from ..layers import Conv2D
+from ..layers import Dense
+from ..layers import Dropout
+from ..layers import GlobalAveragePooling2D
+from ..layers import GlobalMaxPooling2D
+from ..layers import Input
+from ..layers import Lambda
+from ..layers import MaxPooling2D
+from ..utils.data_utils import get_file
+from ..engine.topology import get_source_inputs
+from ..applications.imagenet_utils import _obtain_input_shape
+from .. import backend as K
+
+
+BASE_WEIGHT_URL = 'https://github.com/myutwo150/keras-inception-resnet-v2/releases/download/v0.1/'
+
+
+def preprocess_input(x):
+    """Preprocesses a numpy array encoding a batch of images.
+
+    This function applies the "Inception" preprocessing which converts
+    the RGB values from [0, 255] to [-1, 1]. Note that this preprocessing
+    function is different from `imagenet_utils.preprocess_input()`.
+
+    # Arguments
+        x: a 4D numpy array consists of RGB values within [0, 255].
+
+    # Returns
+        Preprocessed array.
+    """
+    x /= 255.
+    x -= 0.5
+    x *= 2.
+    return x
+
+
+def conv2d_bn(x,
+              filters,
+              kernel_size,
+              strides=1,
+              padding='same',
+              activation='relu',
+              use_bias=False,
+              name=None):
+    """Utility function to apply conv + BN.
+
+    # Arguments
+        x: input tensor.
+        filters: filters in `Conv2D`.
+        kernel_size: kernel size as in `Conv2D`.
+        padding: padding mode in `Conv2D`.
+        activation: activation in `Conv2D`.
+        strides: strides in `Conv2D`.
+        name: name of the ops; will become `name + '_Activation'`
+            for the activation and `name + '_BatchNorm'` for the
+            batch norm layer.
+
+    # Returns
+        Output tensor after applying `Conv2D` and `BatchNormalization`.
+    """
+    x = Conv2D(filters,
+               kernel_size,
+               strides=strides,
+               padding=padding,
+               use_bias=use_bias,
+               name=name)(x)
+    if not use_bias:
+        bn_axis = 1 if K.image_data_format() == 'channels_first' else 3
+        bn_name = _generate_layer_name('BatchNorm', prefix=name)
+        x = BatchNormalization(axis=bn_axis, scale=False, name=bn_name)(x)
+    if activation is not None:
+        ac_name = _generate_layer_name('Activation', prefix=name)
+        x = Activation(activation, name=ac_name)(x)
+    return x
+
+
+def _generate_layer_name(name, branch_idx=None, prefix=None):
+    """Utility function for generating layer names.
+
+    If `prefix` is `None`, returns `None` to use default automatic layer names.
+    Otherwise, the returned layer name is:
+        - PREFIX_NAME if `branch_idx` is not given.
+        - PREFIX_Branch_0_NAME if e.g. `branch_idx=0` is given.
+
+    # Arguments
+        name: base layer name string, e.g. `'Concatenate'` or `'Conv2d_1x1'`.
+        branch_idx: an `int`. If given, will add e.g. `'Branch_0'`
+            after `prefix` and in front of `name` in order to identify
+            layers in the same block but in different branches.
+        prefix: string prefix that will be added in front of `name` to make
+            all layer names unique (e.g. which block this layer belongs to).
+
+    # Returns
+        The layer name.
+    """
+    if prefix is None:
+        return None
+    if branch_idx is None:
+        return '_'.join((prefix, name))
+    return '_'.join((prefix, 'Branch', str(branch_idx), name))
+
+
+def _inception_resnet_block(x, scale, block_type, block_idx, activation='relu'):
+    """Adds a Inception-ResNet block.
+
+    This function builds 3 types of Inception-ResNet blocks mentioned
+    in the paper, controlled by the `block_type` argument (which is the
+    block name used in the official TF-slim implementation):
+        - Inception-ResNet-A: `block_type='Block35'`
+        - Inception-ResNet-B: `block_type='Block17'`
+        - Inception-ResNet-C: `block_type='Block8'`
+
+    # Arguments
+        x: input tensor.
+        scale: scaling factor to scale the residuals before adding
+            them to the shortcut branch.
+        block_type: `'Block35'`, `'Block17'` or `'Block8'`, determines
+            the network structure in the residual branch.
+        block_idx: used for generating layer names.
+        activation: name of the activation function to use at the end
+            of the block (see [activations](../activations.md)).
+            When `activation=None`, no activation is applied
+            (i.e., "linear" activation: `a(x) = x`).
+
+    # Returns
+        Output tensor for the block.
+
+    # Raises
+        ValueError: if `block_type` is not one of `'Block35'`,
+            `'Block17'` or `'Block8'`.
+    """
+    channel_axis = 1 if K.image_data_format() == 'channels_first' else 3
+    if block_idx is None:
+        prefix = None
+    else:
+        prefix = '_'.join((block_type, str(block_idx)))
+    name_fmt = partial(_generate_layer_name, prefix=prefix)
+
+    if block_type == 'Block35':
+        branch_0 = conv2d_bn(x, 32, 1, name=name_fmt('Conv2d_1x1', 0))
+        branch_1 = conv2d_bn(x, 32, 1, name=name_fmt('Conv2d_0a_1x1', 1))
+        branch_1 = conv2d_bn(branch_1, 32, 3, name=name_fmt('Conv2d_0b_3x3', 1))
+        branch_2 = conv2d_bn(x, 32, 1, name=name_fmt('Conv2d_0a_1x1', 2))
+        branch_2 = conv2d_bn(branch_2, 48, 3, name=name_fmt('Conv2d_0b_3x3', 2))
+        branch_2 = conv2d_bn(branch_2, 64, 3, name=name_fmt('Conv2d_0c_3x3', 2))
+        branches = [branch_0, branch_1, branch_2]
+    elif block_type == 'Block17':
+        branch_0 = conv2d_bn(x, 192, 1, name=name_fmt('Conv2d_1x1', 0))
+        branch_1 = conv2d_bn(x, 128, 1, name=name_fmt('Conv2d_0a_1x1', 1))
+        branch_1 = conv2d_bn(branch_1, 160, [1, 7], name=name_fmt('Conv2d_0b_1x7', 1))
+        branch_1 = conv2d_bn(branch_1, 192, [7, 1], name=name_fmt('Conv2d_0c_7x1', 1))
+        branches = [branch_0, branch_1]
+    elif block_type == 'Block8':
+        branch_0 = conv2d_bn(x, 192, 1, name=name_fmt('Conv2d_1x1', 0))
+        branch_1 = conv2d_bn(x, 192, 1, name=name_fmt('Conv2d_0a_1x1', 1))
+        branch_1 = conv2d_bn(branch_1, 224, [1, 3], name=name_fmt('Conv2d_0b_1x3', 1))
+        branch_1 = conv2d_bn(branch_1, 256, [3, 1], name=name_fmt('Conv2d_0c_3x1', 1))
+        branches = [branch_0, branch_1]
+    else:
+        raise ValueError('Unknown Inception-ResNet block type. '
+                         'Expects "Block35", "Block17" or "Block8", '
+                         'but got: ' + str(block_type))
+
+    mixed = Concatenate(axis=channel_axis, name=name_fmt('Concatenate'))(branches)
+    up = conv2d_bn(mixed,
+                   K.int_shape(x)[channel_axis],
+                   1,
+                   activation=None,
+                   use_bias=True,
+                   name=name_fmt('Conv2d_1x1'))
+    x = Lambda(lambda inputs, scale: inputs[0] + inputs[1] * scale,
+               output_shape=K.int_shape(x)[1:],
+               arguments={'scale': scale},
+               name=name_fmt('ScaleSum'))([x, up])
+    if activation is not None:
+        x = Activation(activation, name=name_fmt('Activation'))(x)
+    return x
+
+
+def InceptionResNetV2(include_top=True,
+                      weights='imagenet',
+                      input_tensor=None,
+                      input_shape=None,
+                      pooling=None,
+                      classes=1000,
+                      dropout_keep_prob=0.8):
+    """Instantiates the Inception-ResNet v2 architecture.
+
+    Optionally loads weights pre-trained on ImageNet.
+    Note that when using TensorFlow, for best performance you should
+    set `"image_data_format": "channels_last"` in your Keras config
+    at `~/.keras/keras.json`.
+
+    The model and the weights are compatible with both TensorFlow and Theano.
+    The data format convention used by the model is the one specified in your
+    Keras config file.
+
+    Note that the default input image size for this model is 299x299, instead
+    of 224x224 as in the VGG16 and ResNet models. Also, the input preprocessing
+    function is different (i.e., do not use `imagenet_utils.preprocess_input()`
+    with this model. Use `preprocess_input()` defined in this module instead).
+
+    # Arguments
+        include_top: whether to include the fully-connected
+            layer at the top of the network.
+        weights: one of `None` (random initialization)
+            or `'imagenet'` (pre-training on ImageNet).
+        input_tensor: optional Keras tensor (i.e. output of `layers.Input()`)
+            to use as image input for the model.
+        input_shape: optional shape tuple, only to be specified
+            if `include_top` is `False` (otherwise the input shape
+            has to be `(299, 299, 3)` (with `channels_last` data format)
+            or `(3, 299, 299)` (with `channels_first` data format).
+            It should have exactly 3 inputs channels,
+            and width and height should be no smaller than 139.
+            E.g. `(150, 150, 3)` would be one valid value.
+        pooling: Optional pooling mode for feature extraction
+            when `include_top` is `False`.
+            - `None` means that the output of the model will be
+                the 4D tensor output of the last convolutional layer.
+            - `'avg'` means that global average pooling
+                will be applied to the output of the
+                last convolutional layer, and thus
+                the output of the model will be a 2D tensor.
+            - `'max'` means that global max pooling will be applied.
+        classes: optional number of classes to classify images
+            into, only to be specified if `include_top` is `True`, and
+            if no `weights` argument is specified.
+        dropout_keep_prob: dropout keep rate after pooling and before the
+            classification layer, only to be specified if `include_top` is `True`.
+
+    # Returns
+        A Keras `Model` instance.
+
+    # Raises
+        ValueError: in case of invalid argument for `weights`,
+            or invalid input shape.
+    """
+    if weights not in {'imagenet', None}:
+        raise ValueError('The `weights` argument should be either '
+                         '`None` (random initialization) or `imagenet` '
+                         '(pre-training on ImageNet).')
+
+    if weights == 'imagenet' and include_top and classes != 1000:
+        raise ValueError('If using `weights` as imagenet with `include_top`'
+                         ' as true, `classes` should be 1000')
+
+    # Determine proper input shape
+    input_shape = _obtain_input_shape(
+        input_shape,
+        default_size=299,
+        min_size=139,
+        data_format=K.image_data_format(),
+        require_flatten=False,
+        weights=weights)
+
+    if input_tensor is None:
+        img_input = Input(shape=input_shape)
+    else:
+        if not K.is_keras_tensor(input_tensor):
+            img_input = Input(tensor=input_tensor, shape=input_shape)
+        else:
+            img_input = input_tensor
+
+    # Stem block: 35 x 35 x 192
+    x = conv2d_bn(img_input, 32, 3, strides=2, padding='valid', name='Conv2d_1a_3x3')
+    x = conv2d_bn(x, 32, 3, padding='valid', name='Conv2d_2a_3x3')
+    x = conv2d_bn(x, 64, 3, name='Conv2d_2b_3x3')
+    x = MaxPooling2D(3, strides=2, name='MaxPool_3a_3x3')(x)
+    x = conv2d_bn(x, 80, 1, padding='valid', name='Conv2d_3b_1x1')
+    x = conv2d_bn(x, 192, 3, padding='valid', name='Conv2d_4a_3x3')
+    x = MaxPooling2D(3, strides=2, name='MaxPool_5a_3x3')(x)
+
+    # Mixed 5b (Inception-A block): 35 x 35 x 320
+    channel_axis = 1 if K.image_data_format() == 'channels_first' else 3
+    name_fmt = partial(_generate_layer_name, prefix='Mixed_5b')
+    branch_0 = conv2d_bn(x, 96, 1, name=name_fmt('Conv2d_1x1', 0))
+    branch_1 = conv2d_bn(x, 48, 1, name=name_fmt('Conv2d_0a_1x1', 1))
+    branch_1 = conv2d_bn(branch_1, 64, 5, name=name_fmt('Conv2d_0b_5x5', 1))
+    branch_2 = conv2d_bn(x, 64, 1, name=name_fmt('Conv2d_0a_1x1', 2))
+    branch_2 = conv2d_bn(branch_2, 96, 3, name=name_fmt('Conv2d_0b_3x3', 2))
+    branch_2 = conv2d_bn(branch_2, 96, 3, name=name_fmt('Conv2d_0c_3x3', 2))
+    branch_pool = AveragePooling2D(3,
+                                   strides=1,
+                                   padding='same',
+                                   name=name_fmt('AvgPool_0a_3x3', 3))(x)
+    branch_pool = conv2d_bn(branch_pool, 64, 1, name=name_fmt('Conv2d_0b_1x1', 3))
+    branches = [branch_0, branch_1, branch_2, branch_pool]
+    x = Concatenate(axis=channel_axis, name='Mixed_5b')(branches)
+
+    # 10x Block35 (Inception-ResNet-A block): 35 x 35 x 320
+    for block_idx in range(1, 11):
+        x = _inception_resnet_block(x,
+                                    scale=0.17,
+                                    block_type='Block35',
+                                    block_idx=block_idx)
+
+    # Mixed 6a (Reduction-A block): 17 x 17 x 1088
+    name_fmt = partial(_generate_layer_name, prefix='Mixed_6a')
+    branch_0 = conv2d_bn(x,
+                         384,
+                         3,
+                         strides=2,
+                         padding='valid',
+                         name=name_fmt('Conv2d_1a_3x3', 0))
+    branch_1 = conv2d_bn(x, 256, 1, name=name_fmt('Conv2d_0a_1x1', 1))
+    branch_1 = conv2d_bn(branch_1, 256, 3, name=name_fmt('Conv2d_0b_3x3', 1))
+    branch_1 = conv2d_bn(branch_1,
+                         384,
+                         3,
+                         strides=2,
+                         padding='valid',
+                         name=name_fmt('Conv2d_1a_3x3', 1))
+    branch_pool = MaxPooling2D(3,
+                               strides=2,
+                               padding='valid',
+                               name=name_fmt('MaxPool_1a_3x3', 2))(x)
+    branches = [branch_0, branch_1, branch_pool]
+    x = Concatenate(axis=channel_axis, name='Mixed_6a')(branches)
+
+    # 20x Block17 (Inception-ResNet-B block): 17 x 17 x 1088
+    for block_idx in range(1, 21):
+        x = _inception_resnet_block(x,
+                                    scale=0.1,
+                                    block_type='Block17',
+                                    block_idx=block_idx)
+
+    # Mixed 7a (Reduction-B block): 8 x 8 x 2080
+    name_fmt = partial(_generate_layer_name, prefix='Mixed_7a')
+    branch_0 = conv2d_bn(x, 256, 1, name=name_fmt('Conv2d_0a_1x1', 0))
+    branch_0 = conv2d_bn(branch_0,
+                         384,
+                         3,
+                         strides=2,
+                         padding='valid',
+                         name=name_fmt('Conv2d_1a_3x3', 0))
+    branch_1 = conv2d_bn(x, 256, 1, name=name_fmt('Conv2d_0a_1x1', 1))
+    branch_1 = conv2d_bn(branch_1,
+                         288,
+                         3,
+                         strides=2,
+                         padding='valid',
+                         name=name_fmt('Conv2d_1a_3x3', 1))
+    branch_2 = conv2d_bn(x, 256, 1, name=name_fmt('Conv2d_0a_1x1', 2))
+    branch_2 = conv2d_bn(branch_2, 288, 3, name=name_fmt('Conv2d_0b_3x3', 2))
+    branch_2 = conv2d_bn(branch_2,
+                         320,
+                         3,
+                         strides=2,
+                         padding='valid',
+                         name=name_fmt('Conv2d_1a_3x3', 2))
+    branch_pool = MaxPooling2D(3,
+                               strides=2,
+                               padding='valid',
+                               name=name_fmt('MaxPool_1a_3x3', 3))(x)
+    branches = [branch_0, branch_1, branch_2, branch_pool]
+    x = Concatenate(axis=channel_axis, name='Mixed_7a')(branches)
+
+    # 10x Block8 (Inception-ResNet-C block): 8 x 8 x 2080
+    for block_idx in range(1, 10):
+        x = _inception_resnet_block(x,
+                                    scale=0.2,
+                                    block_type='Block8',
+                                    block_idx=block_idx)
+    x = _inception_resnet_block(x,
+                                scale=1.,
+                                activation=None,
+                                block_type='Block8',
+                                block_idx=10)
+
+    # Final convolution block
+    x = conv2d_bn(x, 1536, 1, name='Conv2d_7b_1x1')
+
+    if include_top:
+        # Classification block
+        x = GlobalAveragePooling2D(name='AvgPool')(x)
+        x = Dropout(1.0 - dropout_keep_prob, name='Dropout')(x)
+        x = Dense(classes, name='Logits')(x)
+        x = Activation('softmax', name='Predictions')(x)
+    else:
+        if pooling == 'avg':
+            x = GlobalAveragePooling2D(name='AvgPool')(x)
+        elif pooling == 'max':
+            x = GlobalMaxPooling2D(name='MaxPool')(x)
+
+    # Ensure that the model takes into account
+    # any potential predecessors of `input_tensor`
+    if input_tensor is not None:
+        inputs = get_source_inputs(input_tensor)
+    else:
+        inputs = img_input
+
+    # Create model
+    model = Model(inputs, x, name='inception_resnet_v2')
+
+    # Load weights
+    if weights == 'imagenet':
+        if K.image_data_format() == 'channels_first':
+            if K.backend() == 'tensorflow':
+                warnings.warn('You are using the TensorFlow backend, yet you '
+                              'are using the Theano '
+                              'image data format convention '
+                              '(`image_data_format="channels_first"`). '
+                              'For best performance, set '
+                              '`image_data_format="channels_last"` in '
+                              'your Keras config '
+                              'at ~/.keras/keras.json.')
+        if include_top:
+            weights_filename = 'inception_resnet_v2_weights_tf_dim_ordering_tf_kernels.h5'
+            weights_path = get_file(weights_filename,
+                                    BASE_WEIGHT_URL + weights_filename,
+                                    cache_subdir='models',
+                                    md5_hash='e693bd0210a403b3192acc6073ad2e96')
+        else:
+            weights_filename = 'inception_resnet_v2_weights_tf_dim_ordering_tf_kernels_notop.h5'
+            weights_path = get_file(weights_filename,
+                                    BASE_WEIGHT_URL + weights_filename,
+                                    cache_subdir='models',
+                                    md5_hash='d19885ff4a710c122648d3b5c3b684e4')
+        model.load_weights(weights_path)
+
+    return model

--- a/keras/applications/inception_resnet_v2.py
+++ b/keras/applications/inception_resnet_v2.py
@@ -217,9 +217,9 @@ def InceptionResNetV2(include_top=True,
     set `"image_data_format": "channels_last"` in your Keras config
     at `~/.keras/keras.json`.
 
-    The model and the weights are compatible with both TensorFlow and Theano.
-    The data format convention used by the model is the one specified in your
-    Keras config file.
+    The model and the weights are compatible with both TensorFlow and Theano
+    backends (but not CNTK). The data format convention used by the model is
+    the one specified in your Keras config file.
 
     Note that the default input image size for this model is 299x299, instead
     of 224x224 as in the VGG16 and ResNet models. Also, the input preprocessing
@@ -261,7 +261,11 @@ def InceptionResNetV2(include_top=True,
     # Raises
         ValueError: in case of invalid argument for `weights`,
             or invalid input shape.
+        RuntimeError: If attempting to run this model with an unsupported backend.
     """
+    if K.backend() in {'cntk'}:
+        raise RuntimeError(K.backend() + ' backend is currently unsupported for this model.')
+
     if weights not in {'imagenet', None}:
         raise ValueError('The `weights` argument should be either '
                          '`None` (random initialization) or `imagenet` '

--- a/keras/applications/inception_resnet_v2.py
+++ b/keras/applications/inception_resnet_v2.py
@@ -207,8 +207,8 @@ def InceptionResNetV2(include_top=True,
             to use as image input for the model.
         input_shape: optional shape tuple, only to be specified
             if `include_top` is `False` (otherwise the input shape
-            has to be `(299, 299, 3)` (with `channels_last` data format)
-            or `(3, 299, 299)` (with `channels_first` data format).
+            has to be `(299, 299, 3)` (with `'channels_last'` data format)
+            or `(3, 299, 299)` (with `'channels_first'` data format).
             It should have exactly 3 inputs channels,
             and width and height should be no smaller than 139.
             E.g. `(150, 150, 3)` would be one valid value.

--- a/keras/applications/inception_resnet_v2.py
+++ b/keras/applications/inception_resnet_v2.py
@@ -17,7 +17,6 @@ from __future__ import print_function
 from __future__ import absolute_import
 
 import warnings
-from functools import partial
 
 from ..models import Model
 from ..layers import Activation
@@ -26,7 +25,6 @@ from ..layers import BatchNormalization
 from ..layers import Concatenate
 from ..layers import Conv2D
 from ..layers import Dense
-from ..layers import Dropout
 from ..layers import GlobalAveragePooling2D
 from ..layers import GlobalMaxPooling2D
 from ..layers import Input
@@ -77,9 +75,8 @@ def conv2d_bn(x,
         padding: padding mode in `Conv2D`.
         activation: activation in `Conv2D`.
         strides: strides in `Conv2D`.
-        name: name of the ops; will become `name + '_Activation'`
-            for the activation and `name + '_BatchNorm'` for the
-            batch norm layer.
+        name: name of the ops; will become `name + '_ac'` for the activation
+            and `name + '_bn'` for the batch norm layer.
 
     # Returns
         Output tensor after applying `Conv2D` and `BatchNormalization`.
@@ -92,38 +89,12 @@ def conv2d_bn(x,
                name=name)(x)
     if not use_bias:
         bn_axis = 1 if K.image_data_format() == 'channels_first' else 3
-        bn_name = _generate_layer_name('BatchNorm', prefix=name)
+        bn_name = None if name is None else name + '_bn'
         x = BatchNormalization(axis=bn_axis, scale=False, name=bn_name)(x)
     if activation is not None:
-        ac_name = _generate_layer_name('Activation', prefix=name)
+        ac_name = None if name is None else name + '_ac'
         x = Activation(activation, name=ac_name)(x)
     return x
-
-
-def _generate_layer_name(name, branch_idx=None, prefix=None):
-    """Utility function for generating layer names.
-
-    If `prefix` is `None`, returns `None` to use default automatic layer names.
-    Otherwise, the returned layer name is:
-        - PREFIX_NAME if `branch_idx` is not given.
-        - PREFIX_Branch_0_NAME if e.g. `branch_idx=0` is given.
-
-    # Arguments
-        name: base layer name string, e.g. `'Concatenate'` or `'Conv2d_1x1'`.
-        branch_idx: an `int`. If given, will add e.g. `'Branch_0'`
-            after `prefix` and in front of `name` in order to identify
-            layers in the same block but in different branches.
-        prefix: string prefix that will be added in front of `name` to make
-            all layer names unique (e.g. which block this layer belongs to).
-
-    # Returns
-        The layer name.
-    """
-    if prefix is None:
-        return None
-    if branch_idx is None:
-        return '_'.join((prefix, name))
-    return '_'.join((prefix, 'Branch', str(branch_idx), name))
 
 
 def _inception_resnet_block(x, scale, block_type, block_idx, activation='relu'):
@@ -132,15 +103,15 @@ def _inception_resnet_block(x, scale, block_type, block_idx, activation='relu'):
     This function builds 3 types of Inception-ResNet blocks mentioned
     in the paper, controlled by the `block_type` argument (which is the
     block name used in the official TF-slim implementation):
-        - Inception-ResNet-A: `block_type='Block35'`
-        - Inception-ResNet-B: `block_type='Block17'`
-        - Inception-ResNet-C: `block_type='Block8'`
+        - Inception-ResNet-A: `block_type='block35'`
+        - Inception-ResNet-B: `block_type='block17'`
+        - Inception-ResNet-C: `block_type='block8'`
 
     # Arguments
         x: input tensor.
         scale: scaling factor to scale the residuals before adding
             them to the shortcut branch.
-        block_type: `'Block35'`, `'Block17'` or `'Block8'`, determines
+        block_type: `'block35'`, `'block17'` or `'block8'`, determines
             the network structure in the residual branch.
         block_idx: used for generating layer names.
         activation: name of the activation function to use at the end
@@ -152,54 +123,50 @@ def _inception_resnet_block(x, scale, block_type, block_idx, activation='relu'):
         Output tensor for the block.
 
     # Raises
-        ValueError: if `block_type` is not one of `'Block35'`,
-            `'Block17'` or `'Block8'`.
+        ValueError: if `block_type` is not one of `'block35'`,
+            `'block17'` or `'block8'`.
     """
-    channel_axis = 1 if K.image_data_format() == 'channels_first' else 3
-    if block_idx is None:
-        prefix = None
-    else:
-        prefix = '_'.join((block_type, str(block_idx)))
-    name_fmt = partial(_generate_layer_name, prefix=prefix)
-
-    if block_type == 'Block35':
-        branch_0 = conv2d_bn(x, 32, 1, name=name_fmt('Conv2d_1x1', 0))
-        branch_1 = conv2d_bn(x, 32, 1, name=name_fmt('Conv2d_0a_1x1', 1))
-        branch_1 = conv2d_bn(branch_1, 32, 3, name=name_fmt('Conv2d_0b_3x3', 1))
-        branch_2 = conv2d_bn(x, 32, 1, name=name_fmt('Conv2d_0a_1x1', 2))
-        branch_2 = conv2d_bn(branch_2, 48, 3, name=name_fmt('Conv2d_0b_3x3', 2))
-        branch_2 = conv2d_bn(branch_2, 64, 3, name=name_fmt('Conv2d_0c_3x3', 2))
+    if block_type == 'block35':
+        branch_0 = conv2d_bn(x, 32, 1)
+        branch_1 = conv2d_bn(x, 32, 1)
+        branch_1 = conv2d_bn(branch_1, 32, 3)
+        branch_2 = conv2d_bn(x, 32, 1)
+        branch_2 = conv2d_bn(branch_2, 48, 3)
+        branch_2 = conv2d_bn(branch_2, 64, 3)
         branches = [branch_0, branch_1, branch_2]
-    elif block_type == 'Block17':
-        branch_0 = conv2d_bn(x, 192, 1, name=name_fmt('Conv2d_1x1', 0))
-        branch_1 = conv2d_bn(x, 128, 1, name=name_fmt('Conv2d_0a_1x1', 1))
-        branch_1 = conv2d_bn(branch_1, 160, [1, 7], name=name_fmt('Conv2d_0b_1x7', 1))
-        branch_1 = conv2d_bn(branch_1, 192, [7, 1], name=name_fmt('Conv2d_0c_7x1', 1))
+    elif block_type == 'block17':
+        branch_0 = conv2d_bn(x, 192, 1)
+        branch_1 = conv2d_bn(x, 128, 1)
+        branch_1 = conv2d_bn(branch_1, 160, [1, 7])
+        branch_1 = conv2d_bn(branch_1, 192, [7, 1])
         branches = [branch_0, branch_1]
-    elif block_type == 'Block8':
-        branch_0 = conv2d_bn(x, 192, 1, name=name_fmt('Conv2d_1x1', 0))
-        branch_1 = conv2d_bn(x, 192, 1, name=name_fmt('Conv2d_0a_1x1', 1))
-        branch_1 = conv2d_bn(branch_1, 224, [1, 3], name=name_fmt('Conv2d_0b_1x3', 1))
-        branch_1 = conv2d_bn(branch_1, 256, [3, 1], name=name_fmt('Conv2d_0c_3x1', 1))
+    elif block_type == 'block8':
+        branch_0 = conv2d_bn(x, 192, 1)
+        branch_1 = conv2d_bn(x, 192, 1)
+        branch_1 = conv2d_bn(branch_1, 224, [1, 3])
+        branch_1 = conv2d_bn(branch_1, 256, [3, 1])
         branches = [branch_0, branch_1]
     else:
         raise ValueError('Unknown Inception-ResNet block type. '
-                         'Expects "Block35", "Block17" or "Block8", '
+                         'Expects "block35", "block17" or "block8", '
                          'but got: ' + str(block_type))
 
-    mixed = Concatenate(axis=channel_axis, name=name_fmt('Concatenate'))(branches)
+    block_name = block_type + '_' + str(block_idx)
+    channel_axis = 1 if K.image_data_format() == 'channels_first' else 3
+    mixed = Concatenate(axis=channel_axis, name=block_name + '_mixed')(branches)
     up = conv2d_bn(mixed,
                    K.int_shape(x)[channel_axis],
                    1,
                    activation=None,
                    use_bias=True,
-                   name=name_fmt('Conv2d_1x1'))
+                   name=block_name + '_conv')
+
     x = Lambda(lambda inputs, scale: inputs[0] + inputs[1] * scale,
                output_shape=K.int_shape(x)[1:],
                arguments={'scale': scale},
-               name=name_fmt('ScaleSum'))([x, up])
+               name=block_name)([x, up])
     if activation is not None:
-        x = Activation(activation, name=name_fmt('Activation'))(x)
+        x = Activation(activation, name=block_name + '_ac')(x)
     return x
 
 
@@ -208,8 +175,7 @@ def InceptionResNetV2(include_top=True,
                       input_tensor=None,
                       input_shape=None,
                       pooling=None,
-                      classes=1000,
-                      dropout_keep_prob=0.8):
+                      classes=1000):
     """Instantiates the Inception-ResNet v2 architecture.
 
     Optionally loads weights pre-trained on ImageNet.
@@ -252,8 +218,6 @@ def InceptionResNetV2(include_top=True,
         classes: optional number of classes to classify images
             into, only to be specified if `include_top` is `True`, and
             if no `weights` argument is specified.
-        dropout_keep_prob: dropout keep rate after pooling and before the
-            classification layer, only to be specified if `include_top` is `True`.
 
     # Returns
         A Keras `Model` instance.
@@ -293,125 +257,86 @@ def InceptionResNetV2(include_top=True,
             img_input = input_tensor
 
     # Stem block: 35 x 35 x 192
-    x = conv2d_bn(img_input, 32, 3, strides=2, padding='valid', name='Conv2d_1a_3x3')
-    x = conv2d_bn(x, 32, 3, padding='valid', name='Conv2d_2a_3x3')
-    x = conv2d_bn(x, 64, 3, name='Conv2d_2b_3x3')
-    x = MaxPooling2D(3, strides=2, name='MaxPool_3a_3x3')(x)
-    x = conv2d_bn(x, 80, 1, padding='valid', name='Conv2d_3b_1x1')
-    x = conv2d_bn(x, 192, 3, padding='valid', name='Conv2d_4a_3x3')
-    x = MaxPooling2D(3, strides=2, name='MaxPool_5a_3x3')(x)
+    x = conv2d_bn(img_input, 32, 3, strides=2, padding='valid')
+    x = conv2d_bn(x, 32, 3, padding='valid')
+    x = conv2d_bn(x, 64, 3)
+    x = MaxPooling2D(3, strides=2)(x)
+    x = conv2d_bn(x, 80, 1, padding='valid')
+    x = conv2d_bn(x, 192, 3, padding='valid')
+    x = MaxPooling2D(3, strides=2)(x)
 
     # Mixed 5b (Inception-A block): 35 x 35 x 320
-    channel_axis = 1 if K.image_data_format() == 'channels_first' else 3
-    name_fmt = partial(_generate_layer_name, prefix='Mixed_5b')
-    branch_0 = conv2d_bn(x, 96, 1, name=name_fmt('Conv2d_1x1', 0))
-    branch_1 = conv2d_bn(x, 48, 1, name=name_fmt('Conv2d_0a_1x1', 1))
-    branch_1 = conv2d_bn(branch_1, 64, 5, name=name_fmt('Conv2d_0b_5x5', 1))
-    branch_2 = conv2d_bn(x, 64, 1, name=name_fmt('Conv2d_0a_1x1', 2))
-    branch_2 = conv2d_bn(branch_2, 96, 3, name=name_fmt('Conv2d_0b_3x3', 2))
-    branch_2 = conv2d_bn(branch_2, 96, 3, name=name_fmt('Conv2d_0c_3x3', 2))
-    branch_pool = AveragePooling2D(3,
-                                   strides=1,
-                                   padding='same',
-                                   name=name_fmt('AvgPool_0a_3x3', 3))(x)
-    branch_pool = conv2d_bn(branch_pool, 64, 1, name=name_fmt('Conv2d_0b_1x1', 3))
+    branch_0 = conv2d_bn(x, 96, 1)
+    branch_1 = conv2d_bn(x, 48, 1)
+    branch_1 = conv2d_bn(branch_1, 64, 5)
+    branch_2 = conv2d_bn(x, 64, 1)
+    branch_2 = conv2d_bn(branch_2, 96, 3)
+    branch_2 = conv2d_bn(branch_2, 96, 3)
+    branch_pool = AveragePooling2D(3, strides=1, padding='same')(x)
+    branch_pool = conv2d_bn(branch_pool, 64, 1)
     branches = [branch_0, branch_1, branch_2, branch_pool]
-    x = Concatenate(axis=channel_axis, name='Mixed_5b')(branches)
+    channel_axis = 1 if K.image_data_format() == 'channels_first' else 3
+    x = Concatenate(axis=channel_axis, name='mixed_5b')(branches)
 
-    # 10x Block35 (Inception-ResNet-A block): 35 x 35 x 320
+    # 10x block35 (Inception-ResNet-A block): 35 x 35 x 320
     for block_idx in range(1, 11):
         x = _inception_resnet_block(x,
                                     scale=0.17,
-                                    block_type='Block35',
+                                    block_type='block35',
                                     block_idx=block_idx)
 
     # Mixed 6a (Reduction-A block): 17 x 17 x 1088
-    name_fmt = partial(_generate_layer_name, prefix='Mixed_6a')
-    branch_0 = conv2d_bn(x,
-                         384,
-                         3,
-                         strides=2,
-                         padding='valid',
-                         name=name_fmt('Conv2d_1a_3x3', 0))
-    branch_1 = conv2d_bn(x, 256, 1, name=name_fmt('Conv2d_0a_1x1', 1))
-    branch_1 = conv2d_bn(branch_1, 256, 3, name=name_fmt('Conv2d_0b_3x3', 1))
-    branch_1 = conv2d_bn(branch_1,
-                         384,
-                         3,
-                         strides=2,
-                         padding='valid',
-                         name=name_fmt('Conv2d_1a_3x3', 1))
-    branch_pool = MaxPooling2D(3,
-                               strides=2,
-                               padding='valid',
-                               name=name_fmt('MaxPool_1a_3x3', 2))(x)
+    branch_0 = conv2d_bn(x, 384, 3, strides=2, padding='valid')
+    branch_1 = conv2d_bn(x, 256, 1)
+    branch_1 = conv2d_bn(branch_1, 256, 3)
+    branch_1 = conv2d_bn(branch_1, 384, 3, strides=2, padding='valid')
+    branch_pool = MaxPooling2D(3, strides=2, padding='valid')(x)
     branches = [branch_0, branch_1, branch_pool]
-    x = Concatenate(axis=channel_axis, name='Mixed_6a')(branches)
+    x = Concatenate(axis=channel_axis, name='mixed_6a')(branches)
 
-    # 20x Block17 (Inception-ResNet-B block): 17 x 17 x 1088
+    # 20x block17 (Inception-ResNet-B block): 17 x 17 x 1088
     for block_idx in range(1, 21):
         x = _inception_resnet_block(x,
                                     scale=0.1,
-                                    block_type='Block17',
+                                    block_type='block17',
                                     block_idx=block_idx)
 
     # Mixed 7a (Reduction-B block): 8 x 8 x 2080
-    name_fmt = partial(_generate_layer_name, prefix='Mixed_7a')
-    branch_0 = conv2d_bn(x, 256, 1, name=name_fmt('Conv2d_0a_1x1', 0))
-    branch_0 = conv2d_bn(branch_0,
-                         384,
-                         3,
-                         strides=2,
-                         padding='valid',
-                         name=name_fmt('Conv2d_1a_3x3', 0))
-    branch_1 = conv2d_bn(x, 256, 1, name=name_fmt('Conv2d_0a_1x1', 1))
-    branch_1 = conv2d_bn(branch_1,
-                         288,
-                         3,
-                         strides=2,
-                         padding='valid',
-                         name=name_fmt('Conv2d_1a_3x3', 1))
-    branch_2 = conv2d_bn(x, 256, 1, name=name_fmt('Conv2d_0a_1x1', 2))
-    branch_2 = conv2d_bn(branch_2, 288, 3, name=name_fmt('Conv2d_0b_3x3', 2))
-    branch_2 = conv2d_bn(branch_2,
-                         320,
-                         3,
-                         strides=2,
-                         padding='valid',
-                         name=name_fmt('Conv2d_1a_3x3', 2))
-    branch_pool = MaxPooling2D(3,
-                               strides=2,
-                               padding='valid',
-                               name=name_fmt('MaxPool_1a_3x3', 3))(x)
+    branch_0 = conv2d_bn(x, 256, 1)
+    branch_0 = conv2d_bn(branch_0, 384, 3, strides=2, padding='valid')
+    branch_1 = conv2d_bn(x, 256, 1)
+    branch_1 = conv2d_bn(branch_1, 288, 3, strides=2, padding='valid')
+    branch_2 = conv2d_bn(x, 256, 1)
+    branch_2 = conv2d_bn(branch_2, 288, 3)
+    branch_2 = conv2d_bn(branch_2, 320, 3, strides=2, padding='valid')
+    branch_pool = MaxPooling2D(3, strides=2, padding='valid')(x)
     branches = [branch_0, branch_1, branch_2, branch_pool]
-    x = Concatenate(axis=channel_axis, name='Mixed_7a')(branches)
+    x = Concatenate(axis=channel_axis, name='mixed_7a')(branches)
 
-    # 10x Block8 (Inception-ResNet-C block): 8 x 8 x 2080
+    # 10x block8 (Inception-ResNet-C block): 8 x 8 x 2080
     for block_idx in range(1, 10):
         x = _inception_resnet_block(x,
                                     scale=0.2,
-                                    block_type='Block8',
+                                    block_type='block8',
                                     block_idx=block_idx)
     x = _inception_resnet_block(x,
                                 scale=1.,
                                 activation=None,
-                                block_type='Block8',
+                                block_type='block8',
                                 block_idx=10)
 
     # Final convolution block
-    x = conv2d_bn(x, 1536, 1, name='Conv2d_7b_1x1')
+    x = conv2d_bn(x, 1536, 1, name='conv_7b')
 
     if include_top:
         # Classification block
-        x = GlobalAveragePooling2D(name='AvgPool')(x)
-        x = Dropout(1.0 - dropout_keep_prob, name='Dropout')(x)
-        x = Dense(classes, name='Logits')(x)
-        x = Activation('softmax', name='Predictions')(x)
+        x = GlobalAveragePooling2D(name='avg_pool')(x)
+        x = Dense(classes, activation='softmax', name='predictions')(x)
     else:
         if pooling == 'avg':
-            x = GlobalAveragePooling2D(name='AvgPool')(x)
+            x = GlobalAveragePooling2D()(x)
         elif pooling == 'max':
-            x = GlobalMaxPooling2D(name='MaxPool')(x)
+            x = GlobalMaxPooling2D()(x)
 
     # Ensure that the model takes into account
     # any potential predecessors of `input_tensor`

--- a/tests/keras/applications/applications_test.py
+++ b/tests/keras/applications/applications_test.py
@@ -235,6 +235,8 @@ def test_inceptionv3_variable_input_channels():
 
 
 @keras_test
+@pytest.mark.skipif((K.backend() == 'cntk'),
+                    reason='InceptionResNetV2 is not supported on CNTK')
 def test_inceptionresnetv2():
     model = applications.InceptionResNetV2(weights=None)
     assert model.output_shape == (None, 1000)
@@ -242,7 +244,7 @@ def test_inceptionresnetv2():
 
 @keras_test
 @pytest.mark.skipif((K.backend() == 'cntk'),
-                    reason='cntk does not support padding with non-concrete dimension')
+                    reason='InceptionResNetV2 is not supported on CNTK')
 def test_inceptionresnetv2_notop():
     model = applications.InceptionResNetV2(weights=None, include_top=False)
     assert model.output_shape == (None, None, None, 1536)
@@ -250,7 +252,7 @@ def test_inceptionresnetv2_notop():
 
 @keras_test
 @pytest.mark.skipif((K.backend() == 'cntk'),
-                    reason='cntk does not support padding with non-concrete dimension')
+                    reason='InceptionResNetV2 is not supported on CNTK')
 def test_inceptionresnetv2_pooling():
     model = applications.InceptionResNetV2(weights=None, include_top=False, pooling='avg')
     assert model.output_shape == (None, 1536)
@@ -258,7 +260,7 @@ def test_inceptionresnetv2_pooling():
 
 @keras_test
 @pytest.mark.skipif((K.backend() == 'cntk'),
-                    reason='cntk does not support padding with non-concrete dimension')
+                    reason='InceptionResNetV2 is not supported on CNTK')
 def test_inceptionresnetv2_variable_input_channels():
     input_shape = (1, None, None) if K.image_data_format() == 'channels_first' else (None, None, 1)
     model = applications.InceptionResNetV2(weights=None, include_top=False, input_shape=input_shape)

--- a/tests/keras/applications/applications_test.py
+++ b/tests/keras/applications/applications_test.py
@@ -235,6 +235,41 @@ def test_inceptionv3_variable_input_channels():
 
 
 @keras_test
+def test_inceptionresnetv2():
+    model = applications.InceptionResNetV2(weights=None)
+    assert model.output_shape == (None, 1000)
+
+
+@keras_test
+@pytest.mark.skipif((K.backend() == 'cntk'),
+                    reason='cntk does not support padding with non-concrete dimension')
+def test_inceptionresnetv2_notop():
+    model = applications.InceptionResNetV2(weights=None, include_top=False)
+    assert model.output_shape == (None, None, None, 1536)
+
+
+@keras_test
+@pytest.mark.skipif((K.backend() == 'cntk'),
+                    reason='cntk does not support padding with non-concrete dimension')
+def test_inceptionresnetv2_pooling():
+    model = applications.InceptionResNetV2(weights=None, include_top=False, pooling='avg')
+    assert model.output_shape == (None, 1536)
+
+
+@keras_test
+@pytest.mark.skipif((K.backend() == 'cntk'),
+                    reason='cntk does not support padding with non-concrete dimension')
+def test_inceptionresnetv2_variable_input_channels():
+    input_shape = (1, None, None) if K.image_data_format() == 'channels_first' else (None, None, 1)
+    model = applications.InceptionResNetV2(weights=None, include_top=False, input_shape=input_shape)
+    assert model.output_shape == (None, None, None, 1536)
+
+    input_shape = (4, None, None) if K.image_data_format() == 'channels_first' else (None, None, 4)
+    model = applications.InceptionResNetV2(weights=None, include_top=False, input_shape=input_shape)
+    assert model.output_shape == (None, None, None, 1536)
+
+
+@keras_test
 @pytest.mark.skipif((K.backend() != 'tensorflow'),
                     reason='MobileNets are supported only on TensorFlow')
 def test_mobilenet():

--- a/tests/keras/applications/applications_test.py
+++ b/tests/keras/applications/applications_test.py
@@ -246,8 +246,17 @@ def test_inceptionresnetv2():
 @pytest.mark.skipif((K.backend() == 'cntk'),
                     reason='InceptionResNetV2 is not supported on CNTK')
 def test_inceptionresnetv2_notop():
+    global_image_data_format = K.image_data_format()
+
+    K.set_image_data_format('channels_first')
+    model = applications.InceptionResNetV2(weights=None, include_top=False)
+    assert model.output_shape == (None, 1536, None, None)
+
+    K.set_image_data_format('channels_last')
     model = applications.InceptionResNetV2(weights=None, include_top=False)
     assert model.output_shape == (None, None, None, 1536)
+
+    K.set_image_data_format(global_image_data_format)
 
 
 @keras_test
@@ -262,13 +271,25 @@ def test_inceptionresnetv2_pooling():
 @pytest.mark.skipif((K.backend() == 'cntk'),
                     reason='InceptionResNetV2 is not supported on CNTK')
 def test_inceptionresnetv2_variable_input_channels():
-    input_shape = (1, None, None) if K.image_data_format() == 'channels_first' else (None, None, 1)
+    global_image_data_format = K.image_data_format()
+
+    K.set_image_data_format('channels_first')
+    input_shape = (1, None, None)
+    model = applications.InceptionResNetV2(weights=None, include_top=False, input_shape=input_shape)
+    assert model.output_shape == (None, 1536, None, None)
+    input_shape = (4, None, None)
+    model = applications.InceptionResNetV2(weights=None, include_top=False, input_shape=input_shape)
+    assert model.output_shape == (None, 1536, None, None)
+
+    K.set_image_data_format('channels_last')
+    input_shape = (None, None, 1)
+    model = applications.InceptionResNetV2(weights=None, include_top=False, input_shape=input_shape)
+    assert model.output_shape == (None, None, None, 1536)
+    input_shape = (None, None, 4)
     model = applications.InceptionResNetV2(weights=None, include_top=False, input_shape=input_shape)
     assert model.output_shape == (None, None, None, 1536)
 
-    input_shape = (4, None, None) if K.image_data_format() == 'channels_first' else (None, None, 4)
-    model = applications.InceptionResNetV2(weights=None, include_top=False, input_shape=input_shape)
-    assert model.output_shape == (None, None, None, 1536)
+    K.set_image_data_format(global_image_data_format)
 
 
 @keras_test


### PR DESCRIPTION
Adds the Inception-ResNet v2 architecture to the application module, with weights extracted and converted from the [TF-slim implementation](https://github.com/tensorflow/models/tree/master/slim#pre-trained-models).

Brief summary:
- Add `keras.applications.inception_resnet_v2.InceptionResNetV2()`
- Update test for applications
- Update docs for applications

Possible issues:

1. Model weights: right now the .h5 weight files are in my own public repo.
Once the model is included into Keras, I think it's better to move the weight files here.
Is there any suggested way to do it?

2. Layer naming:
    Layer naming follows TF-slim because it's easier to debug when converting the weights.
    But it's not that critical once the code and weight files are included into Keras.
    Right now the solution is not so elegant, and makes the code look a bit cluttered.
    Is there a better way to do it, or should I remove the layer names?

3. The `dropout_keep_rate` argument:
    The original paper and TF-slim use keep rate, but Keras uses drop rate (`= 1 - dropout_keep_rate`) in the `Dropout` layer. Should I change the API to use drop rate?