### PR TITLE
Correct casting on newer versions of Numpy

### DIFF
--- a/keras/applications/inception_v3.py
+++ b/keras/applications/inception_v3.py
@@ -388,7 +388,7 @@ def InceptionV3(include_top=True,
 
 
 def preprocess_input(x):
-    x /= 255.
+    np.divide(x , 255.,out=norm, casting="unsafe")
     x -= 0.5
     x *= 2.
     return x


### PR DESCRIPTION
This PR corrects the casting of float to int for newer Numpy versions, it was marked as a warning in previous versions.
