### PR TITLE
Change in variational autoencoder example to resolve issue #6373 

### DIFF
--- a/examples/variational_autoencoder.py
+++ b/examples/variational_autoencoder.py
@@ -78,7 +78,7 @@ vae.fit(x_train,
         shuffle=True,
         epochs=epochs,
         batch_size=batch_size,
-        validation_data=(x_test, x_test))
+        validation_data=(x_test, None))
 
 # build a model to project inputs on the latent space
 encoder = Model(x, z_mean)

--- a/examples/variational_autoencoder_deconv.py
+++ b/examples/variational_autoencoder_deconv.py
@@ -148,7 +148,7 @@ vae.fit(x_train,
         shuffle=True,
         epochs=epochs,
         batch_size=batch_size,
-        validation_data=(x_test, x_test))
+        validation_data=(x_test, None))
 
 # build a model to project inputs on the latent space
 encoder = Model(x, z_mean)


### PR DESCRIPTION
We are getting error "ValueError: The model expects 0 input arrays, but only received one array." by passing x and y data as validation_data. As we haven't used y in computing loss. So, changing value of y to None in validation_data.