### PR TITLE
Performance improvement for channels_first 2D data with TensorFlow

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -2950,9 +2950,6 @@ def _preprocess_deconv_output_shape(x, shape, data_format):
     # Returns
         The output shape.
     """
-    if data_format == 'channels_first' or data_format=='NCHW':
-        shape = (shape[0], shape[2], shape[3], shape[1])
-
     if shape[0] is None:
         shape = (tf.shape(x)[0], ) + tuple(shape[1:])
         shape = tf.stack(list(shape))
@@ -3130,10 +3127,6 @@ def conv2d_transpose(x, kernel, output_shape, strides=(1, 1),
         ValueError: if `data_format` is neither `channels_last` or `channels_first`.
     """
     data_format = _preprocess_data_format(data_format)
-    if data_format is None:
-        data_format = image_data_format()
-    if data_format not in {'channels_first', 'channels_last'}:
-        raise ValueError('Unknown data_format ' + str(data_format))
     if isinstance(output_shape, (tuple, list)):
         output_shape = tf.stack(output_shape)
 

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -2956,7 +2956,6 @@ def _preprocess_deconv_output_shape(x, shape, data_format):
     return shape
 
 
-
 def _preprocess_conv3d_input(x, data_format):
     """Transpose and cast the input before the conv3d.
 
@@ -2990,7 +2989,19 @@ def _preprocess_conv3d_kernel(kernel, data_format):
         kernel = tf.transpose(kernel, (2, 3, 4, 1, 0))
     return kernel
 
+
 def _preprocess_data_format(data_format=None):
+    """Convert Keras image_data_format() strings into TensorFlow NCHW/NHWC.
+
+    # Arguments
+        data_format: string, `"channels_last"` or `"channels_first"`.
+
+    # Returns
+        A string, `"NHWC"` or `"NCHW"`
+
+    # Raises
+        A ValueError, if input string is not a valid Keras image_data_format() string.
+    """
     if data_format is None:
         data_format = K.image_data_format()
     if data_format == 'channels_first':
@@ -2999,6 +3010,7 @@ def _preprocess_data_format(data_format=None):
         return 'NHWC'
     else:
         raise ValueError('Unknown data_format ' + str(data_format))
+
 
 def _preprocess_padding(padding):
     """Convert keras' padding to tensorflow's padding.
@@ -3019,6 +3031,7 @@ def _preprocess_padding(padding):
     else:
         raise ValueError('Invalid padding:', padding)
     return padding
+
 
 def _postprocess_conv3d_output(x, data_format):
     """Transpose and cast the output from conv3d if needed.
@@ -3135,10 +3148,10 @@ def conv2d_transpose(x, kernel, output_shape, strides=(1, 1),
     if data_format == 'NHWC':
         strides = (1,) + strides + (1,)
     else:
-        strides = (1,1) + strides
+        strides = (1, 1) + strides
 
     x = tf.nn.conv2d_transpose(x, kernel, output_shape, strides,
-                               padding=padding,data_format=data_format)
+                               padding=padding, data_format=data_format)
 
     return x
 
@@ -3168,7 +3181,7 @@ def separable_conv2d(x, depthwise_kernel, pointwise_kernel, strides=(1, 1),
     if data_format == 'NHWC':
         strides = (1,) + strides + (1,)
     else:
-        strides = (1,1) + strides
+        strides = (1, 1) + strides
 
     x = tf.nn.separable_conv2d(x, depthwise_kernel, pointwise_kernel,
                                strides=strides,
@@ -3203,7 +3216,7 @@ def depthwise_conv2d(x, depthwise_kernel, strides=(1, 1), padding='valid',
     if data_format == 'NHWC':
         strides = (1,) + strides + (1,)
     else:
-        strides = (1,1) + strides
+        strides = (1, 1) + strides
     x = tf.nn.depthwise_conv2d(x, depthwise_kernel,
                                strides=strides,
                                data_format=data_format,
@@ -3315,13 +3328,13 @@ def pool2d(x, pool_size, strides=(1, 1),
         strides = (1,) + strides + (1,)
         pool_size = (1,) + pool_size + (1,)
     else:
-        strides = (1,1) + strides
-        pool_size = (1,1) + pool_size
+        strides = (1, 1) + strides
+        pool_size = (1, 1) + pool_size
 
     if pool_mode == 'max':
-        x = tf.nn.max_pool(x, pool_size, strides, padding=padding,data_format=data_format)
+        x = tf.nn.max_pool(x, pool_size, strides, padding=padding, data_format=data_format)
     elif pool_mode == 'avg':
-        x = tf.nn.avg_pool(x, pool_size, strides, padding=padding,data_format=data_format)
+        x = tf.nn.avg_pool(x, pool_size, strides, padding=padding, data_format=data_format)
     else:
         raise ValueError('Invalid pooling mode:', pool_mode)
 
@@ -3406,7 +3419,7 @@ def bias_add(x, bias, data_format=None):
             else:
                 x += reshape(bias, (1,) + bias_shape)
     elif ndim(x) == 4:
-        x = tf.nn.bias_add(x,bias,data_format=_preprocess_data_format(data_format))
+        x = tf.nn.bias_add(x, bias, data_format=_preprocess_data_format(data_format))
     elif ndim(x) == 3:
         if data_format == 'channels_first':
             if len(bias_shape) == 1:


### PR DESCRIPTION
**Background**
Current TensorFlow performance guidance recommends using the channels_first (NCHW in TF parlance) data format (https://www.tensorflow.org/performance/performance_guide).  Currently, Keras implements  channels_first data in conv2d and pool2d by transposing the data to channels_last, convolving it, and transposing back.  This is very inefficient, especially since TensorFlow currently converts to channels_first internally (at least for CUDA).

**Changes**
I changed the 2D convolution-related functions in the TF backend module (conv2d, pool2d) to pass the tensors as-is to TensorFlow and set the TF data_format field.  Additionally, I changed the 2D branch in bias_add to call tf.bias_add for both code paths.

I am less familiar with the 1D and 3D operations, so I left them alone.

**Testing**
On top of validating that the keras/layers tests passed, I benchmarked the various data formats against the mnist_cnn.py example (Running tensorflow-master on an nVidia 1080GTX; proportional results were observed on a K80 as well):

> MNIST training time (channels_last, baseline): 61s
MNIST training time (channels_first, baseline): 122s
MNISTtraining  time (channels_first, modified): 51s

Not only do we recover the lost performance when using channels_first data, we gain some additional performance
