### PR TITLE
fix KerasRegressor score function

### DIFF
--- a/keras/wrappers/scikit_learn.py
+++ b/keras/wrappers/scikit_learn.py
@@ -330,5 +330,5 @@ class KerasRegressor(BaseWrapper):
         kwargs = self.filter_sk_params(Sequential.evaluate, kwargs)
         loss = self.model.evaluate(x, y, **kwargs)
         if isinstance(loss, list):
-            return loss[0]
-        return loss
+            return -loss[0]
+        return -loss


### PR DESCRIPTION
KerasRegressor score function returns the loss (that one would like aim to minimise) and not a score (that one would like to maximise).

For instance, if you use it with gridsearchCV it would select the worst model instead of the best.