### PR TITLE
Fixes set_learning_phase in CNTK

### DIFF
--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -57,7 +57,7 @@ def set_learning_phase(value):
         raise ValueError('CNTK Backend: Set learning phase '
                          'with value %s is not supported, '
                          'expected 0 or 1.' % value)
-    v = np.float32([value])
+    v = np.asarray(value)
     _LEARNING_PHASE.value = v
 
 


### PR DESCRIPTION
CNTK scalar constants need `shape=(1)` => https://docs.microsoft.com/en-us/cognitive-toolkit/Parameters-And-Constants

Was getting an error when calling

```
K.set_learning_phase(0)
```