### PR TITLE
Fix HDF5Matrix.__getitem__ for validation_split

### DIFF
--- a/keras/utils/io_utils.py
+++ b/keras/utils/io_utils.py
@@ -67,7 +67,7 @@ class HDF5Matrix(object):
             if start is None:
                 start = 0
             if stop is None:
-                stop = self.data.shape[0]
+                stop = self.shape[0]
             if stop + self.start <= self.end:
                 idx = slice(start + self.start, stop + self.start)
             else:

--- a/tests/keras/utils/io_utils_test.py
+++ b/tests/keras/utils/io_utils_test.py
@@ -73,6 +73,9 @@ def test_io_utils(in_tmpdir):
     assert out_eval.shape == (), 'Shape of evaluation does not match'
     assert out_eval > 0, 'Evaluation value does not meet criteria: {}'.format(out_eval)
 
+    # test slicing for shortened array
+    assert len(X_train[0:]) == len(X_train), 'Incorrect shape for sliced data'
+
     os.remove(h5_path)
 
 


### PR DESCRIPTION
There was a bug in the `__getitem__` method of `HDF5Matrix` class in keras/utils/io_utils.py (currently line 70) in which `stop` was set to `self.data.shape[0]`. This means that `stop` was be set to the total number of elements in the file rather than the artificial stopping point specified by `end`. This results in an IndexError when fitting a model with a validation_split. 

See https://github.com/fchollet/keras/issues/7862

The problem was solved by setting `stop` to `self.shape[0]` rather than `self.data.shape[0]`.

I could add a unit test for this, but it wasn't clear whether they should go in `test_model_methds` found in keras/tests/keras/engine/test_training.py or `test_io_utils` found in tests/keras/utils/io_utils_test.py.

Maybe it's worth merging the tests found in `test_io_utils` into test_training.py for maintence?