### PR TITLE
Fixes a bug when num_words < MAX_NB_WORDS

### DIFF
--- a/examples/pretrained_word_embeddings.py
+++ b/examples/pretrained_word_embeddings.py
@@ -105,7 +105,7 @@ y_val = labels[-num_validation_samples:]
 print('Preparing embedding matrix.')
 
 # prepare embedding matrix
-num_words = min(MAX_NB_WORDS, len(word_index))
+num_words = min(MAX_NB_WORDS, len(word_index) - 1)
 embedding_matrix = np.zeros((num_words, EMBEDDING_DIM))
 for word, i in word_index.items():
     if i >= MAX_NB_WORDS:


### PR DESCRIPTION
When a corpus has less than MAX_NB_WORDS it will default to len(word_index) . However, since the index is zero based it causes an IndexError. eg. When there are 57 total words in the corpus you get the error 'IndexError: index 57 is out of bounds for axis 0 with size 57' since the index should stop at 56 (zero based).