### PR TITLE
IndexError fix

### DIFF
--- a/examples/pretrained_word_embeddings.py
+++ b/examples/pretrained_word_embeddings.py
@@ -105,8 +105,8 @@ y_val = labels[-num_validation_samples:]
 print('Preparing embedding matrix.')
 
 # prepare embedding matrix
-num_words = min(MAX_NB_WORDS, len(word_index) + 1)
-embedding_matrix = np.zeros((num_words, EMBEDDING_DIM))
+num_words = min(MAX_NB_WORDS, len(word_index))
+embedding_matrix = np.zeros((num_words + 1, EMBEDDING_DIM))
 for word, i in word_index.items():
     if i >= MAX_NB_WORDS:
         continue

--- a/examples/pretrained_word_embeddings.py
+++ b/examples/pretrained_word_embeddings.py
@@ -113,7 +113,7 @@ for word, i in word_index.items():
     embedding_vector = embeddings_index.get(word)
     if embedding_vector is not None:
         # words not found in embedding index will be all-zeros.
-        embedding_matrix[i - 1] = embedding_vector
+        embedding_matrix[i] = embedding_vector
 
 # load pre-trained word embeddings into an Embedding layer
 # note that we set trainable = False so as to keep the embeddings fixed

--- a/examples/pretrained_word_embeddings.py
+++ b/examples/pretrained_word_embeddings.py
@@ -113,7 +113,7 @@ for word, i in word_index.items():
     embedding_vector = embeddings_index.get(word)
     if embedding_vector is not None:
         # words not found in embedding index will be all-zeros.
-        embedding_matrix[i] = embedding_vector
+        embedding_matrix[i - 1] = embedding_vector
 
 # load pre-trained word embeddings into an Embedding layer
 # note that we set trainable = False so as to keep the embeddings fixed

--- a/examples/pretrained_word_embeddings.py
+++ b/examples/pretrained_word_embeddings.py
@@ -105,7 +105,7 @@ y_val = labels[-num_validation_samples:]
 print('Preparing embedding matrix.')
 
 # prepare embedding matrix
-num_words = min(MAX_NB_WORDS, len(word_index))
+num_words = min(MAX_NB_WORDS, len(word_index) + 1)
 embedding_matrix = np.zeros((num_words, EMBEDDING_DIM))
 for word, i in word_index.items():
     if i >= MAX_NB_WORDS:


### PR DESCRIPTION
When a corpus has less than MAX_NB_WORDS, num_words will be set to len(word_index) . However, since the index is zero based it causes an IndexError. eg. When there are 57 total words in the corpus you get the error 'IndexError: index 57 is out of bounds for axis 0 with size 57' since the index should stop at 56 (zero based).