### PR TITLE
Sort files in DirectoryIterator because os.walk orders them arbitrarily

### DIFF
--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -910,7 +910,7 @@ def _list_valid_filenames_in_directory(directory, white_list_formats,
     subdir = os.path.basename(directory)
     basedir = os.path.dirname(directory)
     for root, _, files in _recursive_list(directory):
-        for fname in files:
+        for fname in sorted(files):
             is_valid = False
             for extension in white_list_formats:
                 if fname.lower().endswith('.' + extension):

--- a/tests/keras/preprocessing/image_test.py
+++ b/tests/keras/preprocessing/image_test.py
@@ -175,7 +175,7 @@ class TestImage(object):
         # check number of classes and images
         assert len(dir_iterator.class_indices) == num_classes
         assert len(dir_iterator.classes) == count
-        assert sorted(dir_iterator.filenames) == sorted(filenames)
+        assert dir_iterator.filenames == sorted(filenames)
 
         # Test invalid use cases
         with pytest.raises(ValueError):


### PR DESCRIPTION
The filenames yielded by the `DirectoryIterator` are in arbitrary order because it uses `os.walk` (which uses `os.listdir` under the hood. The docs for `os.listdir` mention that the filenames are ordered arbitrarily: https://docs.python.org/3/library/os.html#os.listdir .  On Mac OSX, the filenames seem to be sorted lexicographically, but on Ubuntu 17.04 with ext4 filesystem, they seem to be given in an arbitary, non-lexicographic order.

The Keras docs give an example of combining images with masks using `flow_from_directory`, which requires that the files be sorted: https://keras.io/preprocessing/image/ . This fix is important for that to work on all systems.

Fixes #6418 