### PR TITLE
Remove "Using TensorFlow backend." message

### DIFF
--- a/docs/templates/backend.md
+++ b/docs/templates/backend.md
@@ -45,6 +45,9 @@ KERAS_BACKEND=tensorflow python -c "from keras import backend"
 Using TensorFlow backend.
 ```
 
+At startup, prints the selected backend to stderr.
+To suppress this, set `KERAS_ANNOUNCE_BACKEND=no` in the environment.
+
 ----
 
 ## keras.json details

--- a/keras/backend/__init__.py
+++ b/keras/backend/__init__.py
@@ -72,14 +72,20 @@ if 'KERAS_BACKEND' in os.environ:
     _BACKEND = _backend
 
 # Import backend functions.
+_announce_backend = True
+if 'KERAS_ANNOUNCE_BACKEND' in os.environ:
+    _announce_backend = os.environ['KERAS_ANNOUNCE_BACKEND'] != 'no'
 if _BACKEND == 'cntk':
-    sys.stderr.write('Using CNTK backend\n')
+    if _announce_backend:
+        sys.stderr.write('Using CNTK backend\n')
     from .cntk_backend import *
 elif _BACKEND == 'theano':
-    sys.stderr.write('Using Theano backend.\n')
+    if _announce_backend:
+        sys.stderr.write('Using Theano backend.\n')
     from .theano_backend import *
 elif _BACKEND == 'tensorflow':
-    sys.stderr.write('Using TensorFlow backend.\n')
+    if _announce_backend:
+        sys.stderr.write('Using TensorFlow backend.\n')
     from .tensorflow_backend import *
 else:
     raise ValueError('Unknown backend: ' + str(_BACKEND))


### PR DESCRIPTION
I've encountered an inconvenience with the automatic printout of the backend, and I find the suggestions on how to work around it (e.g. redirect stderr) to be unsatisfactory.

This PR (somewhat boldly) proposes something that can be done. Please treat it as a starting point.

Argument for the outright removal of these lines: this information seems not very useful and easily accessible through other means.