### PR TITLE
Update dockerfile to be able to change versions of dependencies.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,6 @@
-FROM nvidia/cuda:8.0-cudnn5-devel
+ARG cuda_version=8.0
+ARG cudnn_version=6
+FROM nvidia/cuda:${cuda_version}-cudnn${cudnn_version}-devel
 
 ENV CONDA_DIR /opt/conda
 ENV PATH $CONDA_DIR/bin:$PATH

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -6,11 +6,14 @@ GPU?=0
 DOCKER_FILE=Dockerfile
 DOCKER=GPU=$(GPU) nvidia-docker
 BACKEND=tensorflow
+PYTHON_VERSION?=3.5
+CUDA_VERSION?=8.0
+CUDNN_VERSION?=6
 TEST=tests/
 SRC=$(shell dirname `pwd`)
 
 build:
-	docker build -t keras --build-arg python_version=3.5 -f $(DOCKER_FILE) .
+	docker build -t keras --build-arg python_version=$(PYTHON_VERSION) --build-arg cuda_version=$(CUDA_VERSION) --build-arg cudnn_version=$(CUDNN_VERSION) -f $(DOCKER_FILE) .
 
 bash: build
 	$(DOCKER) run -it -v $(SRC):/src -v $(DATA):/data --env KERAS_BACKEND=$(BACKEND) keras bash


### PR DESCRIPTION
**Background**
[Current version of Tensorflow](https://github.com/tensorflow/tensorflow/blob/r1.3/RELEASE.md) prebuilt binaries have been built with cuDNN 6. So it does not work with a docker container image based on nvidia/cuda:8.0-cudnn5-devel and it causes the following error.
```
ImportError: libcudnn.so.6: cannot open shared object file: No such file or directory
```

[Current version of CNTK](https://docs.microsoft.com/en-us/cognitive-toolkit/ReleaseNotes/CNTK_2_1_Release_Notes) supports cuDNN 6. However [Current version of Theano](http://deeplearning.net/software/theano/library/sandbox/cuda/dnn.html#libdoc-cuda-dnn) does not support cuDNN 6 officially.

Different backends require a different version of cuDNN.

**Changes**
For flexibility, make CUDA, cuDNN and Python version of a docker image changeable.
```
make build CUDNN_VERSION=6 CUDA_VERSION=8.0 PYTHON_VERSION=3.5
```

[NVIDIA provides  various docker images](https://hub.docker.com/r/nvidia/cuda/). Switching the docker base image of Keras container can solve the problem.