### PR TITLE
Update Docker to cudnn6 and fix src mapping

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:8.0-cudnn5-devel
+FROM nvidia/cuda:8.0-cudnn6-devel
 
 ENV CONDA_DIR /opt/conda
 ENV PATH $CONDA_DIR/bin:$PATH
@@ -31,7 +31,8 @@ RUN conda install -y python=${python_version} && \
     pip install tensorflow-gpu && \
     pip install https://cntk.ai/PythonWheel/GPU/cntk-2.1-cp35-cp35m-linux_x86_64.whl && \
     conda install Pillow scikit-learn notebook pandas matplotlib mkl nose pyyaml six h5py && \
-    conda install theano pygpu && \
+    conda install theano pygpu bcolz && \
+    pip install sklearn_pandas && \
     git clone git://github.com/fchollet/keras.git /src && pip install -e /src[tests] && \
     pip install git+git://github.com/fchollet/keras.git && \
     conda clean -yt

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -7,20 +7,20 @@ DOCKER_FILE=Dockerfile
 DOCKER=GPU=$(GPU) nvidia-docker
 BACKEND=tensorflow
 TEST=tests/
-SRC=$(shell dirname `pwd`)
+SRC?=$(shell dirname `pwd`)
 
 build:
 	docker build -t keras --build-arg python_version=3.5 -f $(DOCKER_FILE) .
 
 bash: build
-	$(DOCKER) run -it -v $(SRC):/src -v $(DATA):/data --env KERAS_BACKEND=$(BACKEND) keras bash
+	$(DOCKER) run -it -v $(SRC):/src/workspace -v $(DATA):/data --env KERAS_BACKEND=$(BACKEND) keras bash
 
 ipython: build
-	$(DOCKER) run -it -v $(SRC):/src -v $(DATA):/data --env KERAS_BACKEND=$(BACKEND) keras ipython
+	$(DOCKER) run -it -v $(SRC):/src/workspace -v $(DATA):/data --env KERAS_BACKEND=$(BACKEND) keras ipython
 
 notebook: build
-	$(DOCKER) run -it -v $(SRC):/src -v $(DATA):/data --net=host --env KERAS_BACKEND=$(BACKEND) keras
+	$(DOCKER) run -it -v $(SRC):/src/workspace -v $(DATA):/data --net=host --env KERAS_BACKEND=$(BACKEND) keras
 
 test: build
-	$(DOCKER) run -it -v $(SRC):/src -v $(DATA):/data --env KERAS_BACKEND=$(BACKEND) keras py.test $(TEST)
+	$(DOCKER) run -it -v $(SRC):/src/workspace -v $(DATA):/data --env KERAS_BACKEND=$(BACKEND) keras py.test $(TEST)
 


### PR DESCRIPTION
I had to make a few tweaks to the Keras Docker image to get it up and running. 

* Upgraded cuDNN5 to cuDNN6 following [Tensorflow's example](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/tools/docker/Dockerfile.gpu#L1). 
* Changed the workspace directory to be able to `import keras`. This fixes #6750.
* Added `SRC` as a configurable parameter in the Makefile to be able to use something like `make notebook GPU=0 BACKEND=tensorflow DATA=~/project/foo/data SRC=~/project/foo`

Before these tweaks I got `libcudnn.so.6: cannot open shared object file: No such file or directory`

After the edits, I was able to run `make test` with the following results:

```
E ValueError: Unexpectedly found an instance of type `<class 'theano.gpuarray.type.GpuArraySharedVariable'>`. Expected a symbolic tensor instance.

keras/backend/theano_backend.py:211: ValueError

1 failed, 505 passed, 1 skipped, 212 warnings
```

I believe Theano works with cuDNN6 and that it is officially supported: https://github.com/Theano/Theano/blob/master/theano/gpuarray/cudnn_defs.py#L13

In other words: I don't know whether the test failure is caused by cuDNN version change or not, but I think not.