### PR TITLE
Leverage native channels_first support when a GPU is available in TF.

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -3035,7 +3035,7 @@ def _postprocess_conv3d_output(x, data_format):
 
 
 def _is_gpu_available():
-    """Returns the name of a GPU device if available or the empty string."""
+    """Returns whether any GPU device is available."""
     for x in device_lib.list_local_devices():
         if x.device_type == 'GPU' or x.device_type == 'SYCL':
             return True

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -5,6 +5,7 @@ from tensorflow.python.ops import control_flow_ops
 from tensorflow.python.ops import functional_ops
 from tensorflow.python.ops import ctc_ops as ctc
 from tensorflow.python.ops import variables as tf_variables
+from tensorflow.python.client import device_lib
 
 from collections import defaultdict
 
@@ -2905,7 +2906,8 @@ def _preprocess_deconv3d_output_shape(x, shape, data_format):
         The output shape.
     """
     if data_format == 'channels_first':
-        shape = (shape[0], shape[2], shape[3], shape[4], shape[1])
+        if not _is_gpu_available():
+            shape = (shape[0], shape[2], shape[3], shape[4], shape[1])
 
     if shape[0] is None:
         shape = (tf.shape(x)[0], ) + tuple(shape[1:])
@@ -2913,7 +2915,7 @@ def _preprocess_deconv3d_output_shape(x, shape, data_format):
     return shape
 
 
-def _preprocess_deconv_output_shape(x, shape, data_format):
+def _preprocess_deconv2d_output_shape(x, shape, data_format):
     """Get the output_shape for the deconvolution.
 
     # Arguments
@@ -2925,7 +2927,8 @@ def _preprocess_deconv_output_shape(x, shape, data_format):
         The output shape.
     """
     if data_format == 'channels_first':
-        shape = (shape[0], shape[2], shape[3], shape[1])
+        if not _is_gpu_available():
+            shape = (shape[0], shape[2], shape[3], shape[1])
 
     if shape[0] is None:
         shape = (tf.shape(x)[0], ) + tuple(shape[1:])
@@ -2943,15 +2946,18 @@ def _preprocess_conv2d_input(x, data_format):
     # Returns
         A tensor.
     """
-    if dtype(x) == 'float64':
-        x = tf.cast(x, 'float32')
-    if data_format == 'channels_first':
-        # TF uses the last dimension as channel dimension,
-        # instead of the 2nd one.
-        # TH input shape: (samples, input_depth, rows, cols)
-        # TF input shape: (samples, rows, cols, input_depth)
-        x = tf.transpose(x, (0, 2, 3, 1))
-    return x
+    # With 4d inputs, tf.nn.convolution only supports
+    # data_format NHWC when on CPU, so we transpose the inputs
+    # in case we are in data_format channels_first.
+    if data_format == 'channels_last':
+        tf_data_format = 'NHWC'
+    else:
+        if _is_gpu_available():
+            tf_data_format = 'NCHW'
+        else:
+            tf_data_format = 'NHWC'
+            x = tf.transpose(x, (0, 2, 3, 1))
+    return x, tf_data_format
 
 
 def _preprocess_conv3d_input(x, data_format):
@@ -2964,45 +2970,15 @@ def _preprocess_conv3d_input(x, data_format):
     # Returns
         A tensor.
     """
-    if dtype(x) == 'float64':
-        x = tf.cast(x, 'float32')
-    if data_format == 'channels_first':
-        x = tf.transpose(x, (0, 2, 3, 4, 1))
-    return x
-
-
-def _preprocess_conv2d_kernel(kernel, data_format):
-    """Transpose and cast the kernel before the conv2d.
-
-    # Arguments
-        kernel: kernel tensor.
-        data_format: string, `"channels_last"` or `"channels_first"`.
-
-    # Returns
-        A tensor.
-    """
-    if dtype(kernel) == 'float64':
-        kernel = tf.cast(kernel, 'float32')
-    if data_format == 'channels_first':
-        kernel = tf.transpose(kernel, (2, 3, 1, 0))
-    return kernel
-
-
-def _preprocess_conv3d_kernel(kernel, data_format):
-    """Transpose and cast the kernel before the conv3d.
-
-    # Arguments
-        kernel: kernel tensor.
-        data_format: string, `"channels_last"` or `"channels_first"`.
-
-    # Returns
-        A tensor.
-    """
-    if dtype(kernel) == 'float64':
-        kernel = tf.cast(kernel, 'float32')
-    if data_format == 'channels_first':
-        kernel = tf.transpose(kernel, (2, 3, 4, 1, 0))
-    return kernel
+    if data_format == 'channels_last':
+        tf_data_format = 'NDHWC'
+    else:
+        if _is_gpu_available():
+            tf_data_format = 'NCDHW'
+        else:
+            tf_data_format = 'NDHWC'
+            x = tf.transpose(x, (0, 2, 3, 4, 1))
+    return x, tf_data_format
 
 
 def _preprocess_padding(padding):
@@ -3036,12 +3012,9 @@ def _postprocess_conv2d_output(x, data_format):
     # Returns
         A tensor.
     """
-
     if data_format == 'channels_first':
-        x = tf.transpose(x, (0, 3, 1, 2))
-
-    if floatx() == 'float64':
-        x = tf.cast(x, 'float64')
+        if not _is_gpu_available():
+            x = tf.transpose(x, (0, 3, 1, 2))
     return x
 
 
@@ -3056,11 +3029,17 @@ def _postprocess_conv3d_output(x, data_format):
         A tensor.
     """
     if data_format == 'channels_first':
-        x = tf.transpose(x, (0, 4, 1, 2, 3))
-
-    if floatx() == 'float64':
-        x = tf.cast(x, 'float64')
+        if not _is_gpu_available():
+            x = tf.transpose(x, (0, 4, 1, 2, 3))
     return x
+
+
+def _is_gpu_available():
+    """Returns the name of a GPU device if available or the empty string."""
+    for x in device_lib.list_local_devices():
+        if x.device_type == 'GPU' or x.device_type == 'SYCL':
+            return True
+    return False
 
 
 def conv1d(x, kernel, strides=1, padding='valid',
@@ -3124,10 +3103,8 @@ def conv2d(x, kernel, strides=(1, 1), padding='valid',
     if data_format not in {'channels_first', 'channels_last'}:
         raise ValueError('Unknown data_format ' + str(data_format))
 
-    # With 4d inputs, tf.nn.convolution only supports
-    # data_format NHWC, so we transpose the inputs
-    # in case we are in data_format channels_first.
-    x = _preprocess_conv2d_input(x, data_format)
+    x, tf_data_format = _preprocess_conv2d_input(x, data_format)
+
     padding = _preprocess_padding(padding)
     x = tf.nn.convolution(
         input=x,
@@ -3135,7 +3112,7 @@ def conv2d(x, kernel, strides=(1, 1), padding='valid',
         dilation_rate=dilation_rate,
         strides=strides,
         padding=padding,
-        data_format='NHWC')
+        data_format=tf_data_format)
     return _postprocess_conv2d_output(x, data_format)
 
 
@@ -3166,12 +3143,16 @@ def conv2d_transpose(x, kernel, output_shape, strides=(1, 1),
     if isinstance(output_shape, (tuple, list)):
         output_shape = tf.stack(output_shape)
 
-    x = _preprocess_conv2d_input(x, data_format)
-    output_shape = _preprocess_deconv_output_shape(x, output_shape, data_format)
+    x, tf_data_format = _preprocess_conv2d_input(x, data_format)
+    output_shape = _preprocess_deconv2d_output_shape(x, output_shape, data_format)
     padding = _preprocess_padding(padding)
-    strides = (1,) + strides + (1,)
+    if tf_data_format == 'NCHW':
+        strides = (1, 1) + strides
+    else:
+        strides = (1,) + strides + (1,)
 
     x = tf.nn.conv2d_transpose(x, kernel, output_shape, strides,
+                               data_format=tf_data_format,
                                padding=padding)
     x = _postprocess_conv2d_output(x, data_format)
     return x
@@ -3202,14 +3183,18 @@ def separable_conv2d(x, depthwise_kernel, pointwise_kernel, strides=(1, 1),
     if data_format not in {'channels_first', 'channels_last'}:
         raise ValueError('Unknown data_format ' + str(data_format))
 
-    x = _preprocess_conv2d_input(x, data_format)
+    x, tf_data_format = _preprocess_conv2d_input(x, data_format)
     padding = _preprocess_padding(padding)
-    strides = (1,) + strides + (1,)
+    if tf_data_format == 'NCHW':
+        strides = (1, 1) + strides
+    else:
+        strides = (1,) + strides + (1,)
 
     x = tf.nn.separable_conv2d(x, depthwise_kernel, pointwise_kernel,
                                strides=strides,
                                padding=padding,
-                               rate=dilation_rate)
+                               rate=dilation_rate,
+                               data_format=tf_data_format)
     return _postprocess_conv2d_output(x, data_format)
 
 
@@ -3237,14 +3222,18 @@ def depthwise_conv2d(x, depthwise_kernel, strides=(1, 1), padding='valid',
     if data_format not in {'channels_first', 'channels_last'}:
         raise ValueError('Unknown data_format ' + str(data_format))
 
-    x = _preprocess_conv2d_input(x, data_format)
+    x, tf_data_format = _preprocess_conv2d_input(x, data_format)
     padding = _preprocess_padding(padding)
-    strides = (1,) + strides + (1,)
+    if tf_data_format == 'NCHW':
+        strides = (1, 1) + strides
+    else:
+        strides = (1,) + strides + (1,)
 
     x = tf.nn.depthwise_conv2d(x, depthwise_kernel,
                                strides=strides,
                                padding=padding,
-                               rate=dilation_rate)
+                               rate=dilation_rate,
+                               data_format=tf_data_format)
     return _postprocess_conv2d_output(x, data_format)
 
 
@@ -3276,7 +3265,7 @@ def conv3d(x, kernel, strides=(1, 1, 1), padding='valid',
     # With 5d inputs, tf.nn.convolution only supports
     # data_format NDHWC, so we transpose the inputs
     # in case we are in data_format channels_first.
-    x = _preprocess_conv3d_input(x, data_format)
+    x, tf_data_format = _preprocess_conv3d_input(x, data_format)
     padding = _preprocess_padding(padding)
     x = tf.nn.convolution(
         input=x,
@@ -3284,7 +3273,7 @@ def conv3d(x, kernel, strides=(1, 1, 1), padding='valid',
         dilation_rate=dilation_rate,
         strides=strides,
         padding=padding,
-        data_format='NDHWC')
+        data_format=tf_data_format)
     return _postprocess_conv3d_output(x, data_format)
 
 
@@ -3315,13 +3304,17 @@ def conv3d_transpose(x, kernel, output_shape, strides=(1, 1, 1),
     if isinstance(output_shape, (tuple, list)):
         output_shape = tf.stack(output_shape)
 
-    x = _preprocess_conv3d_input(x, data_format)
+    x, tf_data_format = _preprocess_conv3d_input(x, data_format)
     output_shape = _preprocess_deconv3d_output_shape(x, output_shape, data_format)
     padding = _preprocess_padding(padding)
-    strides = (1,) + strides + (1,)
+    if tf_data_format == 'NCHW':
+        strides = (1, 1) + strides
+    else:
+        strides = (1,) + strides + (1,)
 
     x = tf.nn.conv3d_transpose(x, kernel, output_shape, strides,
-                               padding=padding)
+                               padding=padding,
+                               data_format=tf_data_format)
     return _postprocess_conv3d_output(x, data_format)
 
 
@@ -3351,15 +3344,22 @@ def pool2d(x, pool_size, strides=(1, 1),
         raise ValueError('Unknown data_format ' + str(data_format))
 
     padding = _preprocess_padding(padding)
-    strides = (1,) + strides + (1,)
-    pool_size = (1,) + pool_size + (1,)
-
-    x = _preprocess_conv2d_input(x, data_format)
+    x, tf_data_format = _preprocess_conv2d_input(x, data_format)
+    if tf_data_format == 'NCHW':
+        strides = (1, 1) + strides
+        pool_size = (1, 1) + pool_size
+    else:
+        strides = (1,) + strides + (1,)
+        pool_size = (1,) + pool_size + (1,)
 
     if pool_mode == 'max':
-        x = tf.nn.max_pool(x, pool_size, strides, padding=padding)
+        x = tf.nn.max_pool(x, pool_size, strides,
+                           padding=padding,
+                           data_format=tf_data_format)
     elif pool_mode == 'avg':
-        x = tf.nn.avg_pool(x, pool_size, strides, padding=padding)
+        x = tf.nn.avg_pool(x, pool_size, strides,
+                           padding=padding,
+                           data_format=tf_data_format)
     else:
         raise ValueError('Invalid pooling mode:', pool_mode)
 
@@ -3391,15 +3391,22 @@ def pool3d(x, pool_size, strides=(1, 1, 1), padding='valid',
         raise ValueError('Unknown data_format ' + str(data_format))
 
     padding = _preprocess_padding(padding)
-    strides = (1,) + strides + (1,)
-    pool_size = (1,) + pool_size + (1,)
-
-    x = _preprocess_conv3d_input(x, data_format)
+    x, tf_data_format = _preprocess_conv3d_input(x, data_format)
+    if tf_data_format == 'NCDHW':
+        strides = (1, 1) + strides
+        pool_size = (1, 1) + pool_size
+    else:
+        strides = (1,) + strides + (1,)
+        pool_size = (1,) + pool_size + (1,)
 
     if pool_mode == 'max':
-        x = tf.nn.max_pool3d(x, pool_size, strides, padding=padding)
+        x = tf.nn.max_pool3d(x, pool_size, strides,
+                             padding=padding,
+                             data_format=tf_data_format)
     elif pool_mode == 'avg':
-        x = tf.nn.avg_pool3d(x, pool_size, strides, padding=padding)
+        x = tf.nn.avg_pool3d(x, pool_size, strides,
+                             padding=padding,
+                             data_format=tf_data_format)
     else:
         raise ValueError('Invalid pooling mode:', pool_mode)
 
@@ -3446,7 +3453,11 @@ def bias_add(x, bias, data_format=None):
     elif ndim(x) == 4:
         if data_format == 'channels_first':
             if len(bias_shape) == 1:
-                x += reshape(bias, (1, bias_shape[0], 1, 1))
+                if _is_gpu_available():
+                    x = tf.nn.bias_add(x, bias,
+                                       data_format='NCHW')
+                else:
+                    x += reshape(bias, (1, bias_shape[0], 1, 1))
             else:
                 x += reshape(bias, (1, bias_shape[2]) + bias_shape[:2])
         elif data_format == 'channels_last':

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -840,7 +840,7 @@ class Dense(Layer):
     def call(self, inputs):
         output = K.dot(inputs, self.kernel)
         if self.use_bias:
-            output = K.bias_add(output, self.bias)
+            output = K.bias_add(output, self.bias, data_format='channels_last')
         if self.activation is not None:
             output = self.activation(output)
         return output

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -869,29 +869,19 @@ class TestBackend(object):
         xshape = (5, 4, 3, 2)
         xval = np.random.random(xshape)
         xtf = KTF.variable(xval)
-        ztf = KTF._preprocess_deconv_output_shape(xtf, xshape, 'channels_first')
+        ztf = KTF._preprocess_deconv2d_output_shape(xtf, xshape, 'channels_first')
         assert ztf == (5, 3, 2, 4)
 
-        for dtype in [None, 'float64']:
+        for dtype in ['float32']:
             xval = np.random.random((5, 4, 3, 2))
             xtf = KTF.variable(xval, dtype=dtype)
-            ztf = KTF.eval(KTF._preprocess_conv2d_input(xtf, 'channels_first'))
+            ztf = KTF.eval(KTF._preprocess_conv2d_input(xtf, 'channels_first')[0])
             assert ztf.shape == (5, 3, 2, 4)
 
             xval = np.random.random((6, 5, 4, 3, 2))
             xtf = KTF.variable(xval, dtype=dtype)
-            ztf = KTF.eval(KTF._preprocess_conv3d_input(xtf, 'channels_first'))
+            ztf = KTF.eval(KTF._preprocess_conv3d_input(xtf, 'channels_first')[0])
             assert ztf.shape == (6, 4, 3, 2, 5)
-
-            xval = np.random.random((5, 4, 3, 2))
-            xtf = KTF.variable(xval, dtype=dtype)
-            ztf = KTF.eval(KTF._preprocess_conv2d_kernel(xtf, 'channels_first'))
-            assert ztf.shape == (3, 2, 4, 5)
-
-            xval = np.random.random((6, 5, 4, 3, 2))
-            xtf = KTF.variable(xval, dtype=dtype)
-            ztf = KTF.eval(KTF._preprocess_conv3d_kernel(xtf, 'channels_first'))
-            assert ztf.shape == (4, 3, 2, 5, 6)
 
         xval = np.random.random((5, 4, 3, 2))
         xtf = KTF.variable(xval)


### PR DESCRIPTION
This PR tries to check if a GPU device is available, and if so, works under the assumption that conv and pooling ops will be executed on GPU, thus allowing the native use of NCHW layout when using the channels_first data format, in TensorFlow.

This is not a fully reliable way to check for GPU execution, but I believe this is the best we have now.

@TimZaman maybe you have thoughts about how to improve it?