### PR TITLE
Fix input shape of OCR model

### DIFF
--- a/examples/image_ocr.py
+++ b/examples/image_ocr.py
@@ -76,7 +76,7 @@ def speckle(img):
 # and a random amount of speckle noise
 
 def paint_text(text, w, h, rotate=False, ud=False, multi_fonts=False):
-    surface = cairo.ImageSurface(cairo.FORMAT_RGB24, w, h)
+    surface = cairo.ImageSurface(cairo.FORMAT_RGB24, width=w, height=h)
     with cairo.Context(surface) as context:
         context.set_source_rgb(1, 1, 1)  # White
         context.paint()
@@ -237,9 +237,9 @@ class TextImageGenerator(keras.callbacks.Callback):
         # width and height are backwards from typical Keras convention
         # because width is the time dimension when it gets fed into the RNN
         if K.image_data_format() == 'channels_first':
-            X_data = np.ones([size, 1, self.img_w, self.img_h])
+            X_data = np.ones([size, 1, self.img_h, self.img_w])
         else:
-            X_data = np.ones([size, self.img_w, self.img_h, 1])
+            X_data = np.ones([size, self.img_h, self.img_w, 1])
 
         labels = np.ones([size, self.absolute_max_string_len])
         input_length = np.zeros([size, 1])
@@ -250,18 +250,18 @@ class TextImageGenerator(keras.callbacks.Callback):
             # achieving translational invariance
             if train and i > size - 4:
                 if K.image_data_format() == 'channels_first':
-                    X_data[i, 0, 0:self.img_w, :] = self.paint_func('')[0, :, :].T
+                    X_data[i, 0, 0:self.img_h, :] = self.paint_func('')[0, :, :]
                 else:
-                    X_data[i, 0:self.img_w, :, 0] = self.paint_func('',)[0, :, :].T
+                    X_data[i, 0:self.img_h, :, 0] = self.paint_func('',)[0, :, :]
                 labels[i, 0] = self.blank_label
                 input_length[i] = self.img_w // self.downsample_factor - 2
                 label_length[i] = 1
                 source_str.append('')
             else:
                 if K.image_data_format() == 'channels_first':
-                    X_data[i, 0, 0:self.img_w, :] = self.paint_func(self.X_text[index + i])[0, :, :].T
+                    X_data[i, 0, 0:self.img_h, :] = self.paint_func(self.X_text[index + i])[0, :, :]
                 else:
-                    X_data[i, 0:self.img_w, :, 0] = self.paint_func(self.X_text[index + i])[0, :, :].T
+                    X_data[i, 0:self.img_h, :, 0] = self.paint_func(self.X_text[index + i])[0, :, :]
                 labels[i, :] = self.Y_data[index + i]
                 input_length[i] = self.img_w // self.downsample_factor - 2
                 label_length[i] = self.Y_len[index + i]
@@ -388,7 +388,7 @@ class VizCallback(keras.callbacks.Callback):
                 the_input = word_batch['the_input'][i, 0, :, :]
             else:
                 the_input = word_batch['the_input'][i, :, :, 0]
-            pylab.imshow(the_input.T, cmap='Greys_r')
+            pylab.imshow(the_input, cmap='Greys_r')
             pylab.xlabel('Truth = \'%s\'\nDecoded = \'%s\'' % (word_batch['source_str'][i], res[i]))
         fig = pylab.gcf()
         fig.set_size_inches(10, 13)
@@ -412,9 +412,9 @@ def train(run_name, start_epoch, stop_epoch, img_w):
     minibatch_size = 32
 
     if K.image_data_format() == 'channels_first':
-        input_shape = (1, img_w, img_h)
+        input_shape = (1, img_h, img_w)
     else:
-        input_shape = (img_w, img_h, 1)
+        input_shape = (img_h, img_w, 1)
 
     fdir = os.path.dirname(get_file('wordlists.tgz',
                                     origin='http://www.mythic-ai.com/datasets/wordlists.tgz', untar=True))
@@ -438,7 +438,7 @@ def train(run_name, start_epoch, stop_epoch, img_w):
                    name='conv2')(inner)
     inner = MaxPooling2D(pool_size=(pool_size, pool_size), name='max2')(inner)
 
-    conv_to_rnn_dims = (img_w // (pool_size ** 2), (img_h // (pool_size ** 2)) * conv_filters)
+    conv_to_rnn_dims = ((img_h // (pool_size ** 2)) * conv_filters, img_w // (pool_size ** 2))
     inner = Reshape(target_shape=conv_to_rnn_dims, name='reshape')(inner)
 
     # cuts down input size going into RNN:


### PR DESCRIPTION
The model used the input-shape (c,w,h) or (w,h,c) (w=width, h=height, c=channel). However, keras defines the shape as (c,h,w) or (h,w,c).

So basically rows and cols were flipped. 
This is not a problem, if the model is used by itself. But if you want to use it elsewhere, like convert it into the CoreML model format, then the input parameters are flipped. This commit fixes the „orientation“ of the input.