### PR TITLE
Improve line length to better accommodate sharing notebooks

### DIFF
--- a/keras/utils/layer_utils.py
+++ b/keras/utils/layer_utils.py
@@ -39,7 +39,7 @@ def print_summary(model, line_length=None, positions=None, print_fn=print):
         # header names for the different log elements
         to_display = ['Layer (type)', 'Output Shape', 'Param #']
     else:
-        line_length = line_length or 100
+        line_length = line_length or 98
         positions = positions or [.33, .55, .67, 1.]
         if positions[-1] <= 1:
             positions = [int(line_length * p) for p in positions]


### PR DESCRIPTION
<img width="1028" alt="screenshot 2017-09-16 05 48 34" src="https://user-images.githubusercontent.com/817438/30512429-369ae120-9aa4-11e7-84e4-124e0b3f457f.png">

When sharing iPython notebooks on GitHub (the primary way folks share their work) either as a [gist](https://gist.github.com/rjpower/eacf87bafbf8a21b09a42bdab5ca2e23) or as part of a regular [repository](https://github.com/adammenges/ml-muse/blob/master/yolo/yolov2.ipynb), `model.summary()` looks slightly off. It's consistently two characters too long (see screenshot above), with the default page size, giving ourselves as much room as possible and going full screen. We tested it on a 12" Macbook, 15" linux machine, and a 27" iMac.

Down to improve this anyway folks see fit, looking forward to the feedback.