### PR TITLE
Unlock InceptionResNetV2 for CNTK

### DIFF
--- a/docs/templates/applications.md
+++ b/docs/templates/applications.md
@@ -475,7 +475,7 @@ keras.applications.inception_resnet_v2.InceptionResNetV2(include_top=True, weigh
 
 Inception-ResNet V2 model, with weights pre-trained on ImageNet.
 
-This model is available for both the Theano and TensorFlow backend (but not CNTK), and can be built both
+This model is available for Theano, TensorFlow and CNTK backends, and can be built both
 with `'channels_first'` data format (channels, height, width) or `'channels_last'` data format (height, width, channels).
 
 The default input size for this model is 299x299.

--- a/keras/applications/inception_resnet_v2.py
+++ b/keras/applications/inception_resnet_v2.py
@@ -184,8 +184,8 @@ def InceptionResNetV2(include_top=True,
     set `"image_data_format": "channels_last"` in your Keras config
     at `~/.keras/keras.json`.
 
-    The model and the weights are compatible with both TensorFlow and Theano
-    backends (but not CNTK). The data format convention used by the model is
+    The model and the weights are compatible with TensorFlow, Theano and
+    CNTK backends. The data format convention used by the model is
     the one specified in your Keras config file.
 
     Note that the default input image size for this model is 299x299, instead
@@ -226,11 +226,7 @@ def InceptionResNetV2(include_top=True,
     # Raises
         ValueError: in case of invalid argument for `weights`,
             or invalid input shape.
-        RuntimeError: If attempting to run this model with an unsupported backend.
     """
-    if K.backend() in {'cntk'}:
-        raise RuntimeError(K.backend() + ' backend is currently unsupported for this model.')
-
     if weights not in {'imagenet', None}:
         raise ValueError('The `weights` argument should be either '
                          '`None` (random initialization) or `imagenet` '

--- a/tests/keras/applications/applications_test.py
+++ b/tests/keras/applications/applications_test.py
@@ -173,16 +173,12 @@ def test_inceptionv3_variable_input_channels():
 
 
 @keras_test
-@pytest.mark.skipif((K.backend() == 'cntk'),
-                    reason='InceptionResNetV2 is not supported on CNTK')
 def test_inceptionresnetv2():
     model = applications.InceptionResNetV2(weights=None)
     assert model.output_shape == (None, 1000)
 
 
 @keras_test
-@pytest.mark.skipif((K.backend() == 'cntk'),
-                    reason='InceptionResNetV2 is not supported on CNTK')
 def test_inceptionresnetv2_notop():
     global_image_data_format = K.image_data_format()
 
@@ -198,16 +194,12 @@ def test_inceptionresnetv2_notop():
 
 
 @keras_test
-@pytest.mark.skipif((K.backend() == 'cntk'),
-                    reason='InceptionResNetV2 is not supported on CNTK')
 def test_inceptionresnetv2_pooling():
     model = applications.InceptionResNetV2(weights=None, include_top=False, pooling='avg')
     assert model.output_shape == (None, 1536)
 
 
 @keras_test
-@pytest.mark.skipif((K.backend() == 'cntk'),
-                    reason='InceptionResNetV2 is not supported on CNTK')
 def test_inceptionresnetv2_variable_input_channels():
     global_image_data_format = K.image_data_format()
 

--- a/tests/keras/applications/applications_test.py
+++ b/tests/keras/applications/applications_test.py
@@ -182,7 +182,8 @@ def test_inceptionresnetv2():
     p = Process(target=target, args=(queue,))
     p.start()
     p.join()
-    model_output_shape = queue.get()
+    assert not queue.empty(), 'Model creation failed.'
+    model_output_shape = queue.get_nowait()
     assert model_output_shape == (None, 1000)
 
 
@@ -199,17 +200,19 @@ def test_inceptionresnetv2_notop():
     p = Process(target=target, args=(queue,))
     p.start()
     p.join()
-    model_output_shape_first = queue.get()
+    K.set_image_data_format(global_image_data_format)
+    assert not queue.empty(), 'Model creation failed.'
+    model_output_shape = queue.get_nowait()
+    assert model_output_shape == (None, 1536, None, None)
 
     K.set_image_data_format('channels_last')
     p = Process(target=target, args=(queue,))
     p.start()
     p.join()
-    model_output_shape_last = queue.get()
-
     K.set_image_data_format(global_image_data_format)
-    assert model_output_shape_first == (None, 1536, None, None)
-    assert model_output_shape_last == (None, None, None, 1536)
+    assert not queue.empty(), 'Model creation failed.'
+    model_output_shape = queue.get_nowait()
+    assert model_output_shape == (None, None, None, 1536)
 
 
 @keras_test
@@ -221,7 +224,8 @@ def test_inceptionresnetv2_pooling():
     p = Process(target=target, args=(queue,))
     p.start()
     p.join()
-    model_output_shape = queue.get()
+    assert not queue.empty(), 'Model creation failed.'
+    model_output_shape = queue.get_nowait()
     assert model_output_shape == (None, 1536)
 
 
@@ -235,13 +239,15 @@ def test_inceptionresnetv2_variable_input_channels():
     p = Process(target=target, args=(queue, (None, None, 1)))
     p.start()
     p.join()
-    model_output_shape = queue.get()
+    assert not queue.empty(), 'Model creation failed.'
+    model_output_shape = queue.get_nowait()
     assert model_output_shape == (None, None, None, 1536)
 
     p = Process(target=target, args=(queue, (None, None, 4)))
     p.start()
     p.join()
-    model_output_shape = queue.get()
+    assert not queue.empty(), 'Model creation failed.'
+    model_output_shape = queue.get_nowait()
     assert model_output_shape == (None, None, None, 1536)
 
 

--- a/tests/keras/applications/applications_test.py
+++ b/tests/keras/applications/applications_test.py
@@ -201,25 +201,13 @@ def test_inceptionresnetv2_pooling():
 
 @keras_test
 def test_inceptionresnetv2_variable_input_channels():
-    global_image_data_format = K.image_data_format()
-
-    K.set_image_data_format('channels_first')
-    input_shape = (1, None, None)
-    model = applications.InceptionResNetV2(weights=None, include_top=False, input_shape=input_shape)
-    assert model.output_shape == (None, 1536, None, None)
-    input_shape = (4, None, None)
-    model = applications.InceptionResNetV2(weights=None, include_top=False, input_shape=input_shape)
-    assert model.output_shape == (None, 1536, None, None)
-
-    K.set_image_data_format('channels_last')
     input_shape = (None, None, 1)
     model = applications.InceptionResNetV2(weights=None, include_top=False, input_shape=input_shape)
     assert model.output_shape == (None, None, None, 1536)
+
     input_shape = (None, None, 4)
     model = applications.InceptionResNetV2(weights=None, include_top=False, input_shape=input_shape)
     assert model.output_shape == (None, None, None, 1536)
-
-    K.set_image_data_format(global_image_data_format)
 
 
 @keras_test


### PR DESCRIPTION
With #7910 and #7907 applied, `InceptionResNetV2` now gives correct results for CNTK backend (the errors in #7753 and #7910 do not occur anymore after #7907 is applied). This PR unlocks the model and the related tests for CNTK backend.