### PR TITLE
Fixing example code in Pretrained Word Embeddings

### DIFF
--- a/examples/pretrained_word_embeddings.py
+++ b/examples/pretrained_word_embeddings.py
@@ -119,7 +119,7 @@ for word, i in word_index.items():
 # note that we set trainable = False so as to keep the embeddings fixed
 embedding_layer = Embedding(num_words,
                             EMBEDDING_DIM,
-                            weights=[embedding_matrix],
+                            weights=[embedding_matrix[1:]],
                             input_length=MAX_SEQUENCE_LENGTH,
                             trainable=False)
 


### PR DESCRIPTION
Fixing `ValueError: Layer weight shape (20000, 100) not compatible with provided weight shape (20001, 100).`

The **word_index** starts from 1, so the first row of **embedding_matrix** shouldn't be used when creating the embedding layer.