### PR TITLE
Fixes to example/stateful_lstm.py

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -48,6 +48,9 @@ Compares different LSTM implementations on the IMDB sentiment classification tas
 [lstm_text_generation.py](lstm_text_generation.py)
 Generates text from Nietzsche's writings.
 
+[lstm_stateful.py](lstm_stateful.py)
+Demonstrates how to use stateful RNNs to model long sequences efficiently.
+
 [mnist_acgan.py](mnist_acgan.py)
 Implementation of AC-GAN ( Auxiliary Classifier GAN ) on the MNIST dataset
 
@@ -95,9 +98,6 @@ Trains and evaluate a simple MLP on the Reuters newswire topic classification ta
 
 [reuters_mlp_relu_vs_selu.py](reuters_mlp_relu_vs_selu.py)
 Compares self-normalizing MLPs with regular MLPs.
-
-[stateful_lstm.py](stateful_lstm.py)
-Demonstrates how to use stateful RNNs to model long sequences efficiently.
 
 [variational_autoencoder.py](variational_autoencoder.py)
 Demonstrates how to build a variational autoencoder.

--- a/examples/lstm_stateful.py
+++ b/examples/lstm_stateful.py
@@ -8,9 +8,9 @@ import numpy as np
 import matplotlib.pyplot as plt
 import pandas as pd
 
-# --------------------
+# -------------------
 # EDITABLE PARAMETERS
-# --------------------
+# -------------------
 
 # timesteps to use in the output averaging of the input
 # e.g. use 2 for 2-point average
@@ -28,9 +28,9 @@ input_len = 1000
 batch_size = 1
 epochs = 10
 
-# ----------------------------
-# DO NOT EDIT UNDER THIS LINE
-# ----------------------------
+# ------------
+# MAIN PROGRAM
+# ------------
 
 print("*" * 33)
 if lahead >= tsteps:
@@ -107,9 +107,7 @@ def create_model(stateful: bool):
     model.add(LSTM(20,
               input_shape=(lahead, 1),
               batch_size=batch_size,
-              return_sequences=False,
-              stateful=stateful,
-              activation='tanh'))
+              stateful=stateful))
     model.add(Dense(1))
     model.compile(loss='mse', optimizer='adam')
     return model
@@ -119,38 +117,38 @@ model_stateful = create_model(stateful=True)
 
 
 # split train/test data
-def split_data(X, y, ratio: int = 0.8):
+def split_data(x, y, ratio: int = 0.8):
     to_train = int(input_len * ratio)
     # tweak to match with batch_size
     to_train -= to_train % batch_size
 
-    X_train = X[:to_train]
+    x_train = x[:to_train]
     y_train = y[:to_train]
-    X_test = X[to_train:]
+    x_test = x[to_train:]
     y_test = y[to_train:]
 
     # tweak to match with batch_size
-    to_drop = X.shape[0] % batch_size
+    to_drop = x.shape[0] % batch_size
     if to_drop > 0:
-        X_test = X_test[:-1 * to_drop]
+        x_test = x_test[:-1 * to_drop]
         y_test = y_test[:-1 * to_drop]
 
     # some reshaping
     reshape_3 = lambda x: x.values.reshape((x.shape[0], x.shape[1], 1))
-    X_train = reshape_3(X_train)
-    X_test = reshape_3(X_test)
+    x_train = reshape_3(x_train)
+    x_test = reshape_3(x_test)
 
     reshape_2 = lambda x: x.values.reshape((x.shape[0], 1))
     y_train = reshape_2(y_train)
     y_test = reshape_2(y_test)
 
-    return (X_train, y_train), (X_test, y_test)
+    return (x_train, y_train), (x_test, y_test)
 
 
-(X_train, y_train), (X_test, y_test) = split_data(data_input, expected_output)
-print('X_train.shape: ', X_train.shape)
+(x_train, y_train), (x_test, y_test) = split_data(data_input, expected_output)
+print('x_train.shape: ', x_train.shape)
 print('y_train.shape: ', y_train.shape)
-print('X_test.shape: ', X_test.shape)
+print('x_test.shape: ', x_test.shape)
 print('y_test.shape: ', y_test.shape)
 
 print('Training')
@@ -162,32 +160,32 @@ for i in range(epochs):
     # lower resolution than the original series contained in data_input.
     # Each of these series are offset by one step and can be
     # extracted with data_input[i::batch_size].
-    model_stateful.fit(X_train,
+    model_stateful.fit(x_train,
                        y_train,
                        batch_size=batch_size,
                        epochs=1,
                        verbose=1,
-                       validation_data=(X_test, y_test),
+                       validation_data=(x_test, y_test),
                        shuffle=False)
     model_stateful.reset_states()
 
 print('Predicting')
-predicted_stateful = model_stateful.predict(X_test, batch_size=batch_size)
+predicted_stateful = model_stateful.predict(x_test, batch_size=batch_size)
 
 print('Creating Stateless Model...')
 model_stateless = create_model(stateful=False)
 
 print('Training')
-model_stateless.fit(X_train,
+model_stateless.fit(x_train,
                     y_train,
                     batch_size=batch_size,
                     epochs=epochs,
                     verbose=1,
-                    validation_data=(X_test, y_test),
+                    validation_data=(x_test, y_test),
                     shuffle=False)
 
 print('Predicting')
-predicted_stateless = model_stateless.predict(X_test, batch_size=batch_size)
+predicted_stateless = model_stateless.predict(x_test, batch_size=batch_size)
 
 # ----------------------------
 

--- a/examples/lstm_stateful.py
+++ b/examples/lstm_stateful.py
@@ -40,9 +40,10 @@ print('Generating Data...')
 cos = gen_cosine_amp()
 print('Input shape:', cos.shape)
 
+# set the target to be a two-point average of the cosine input
 expected_output = np.zeros((len(cos), 1))
 for i in range(len(cos) - lahead):
-    expected_output[i, 0] = np.mean(cos[i + 1:i + lahead + 1])
+    expected_output[i, 0] = np.mean(cos[i + 0:i + lahead + 1])
 
 print('Output shape:', expected_output.shape)
 
@@ -61,7 +62,7 @@ model.compile(loss='mse', optimizer='rmsprop')
 
 print('Training')
 for i in range(epochs):
-    print('Epoch', i, '/', epochs)
+    print('Epoch', i+1, '/', epochs)
 
     # Note that the last state for sample i in a batch will
     # be used as initial state for sample i in the next batch.

--- a/examples/lstm_stateful.py
+++ b/examples/lstm_stateful.py
@@ -62,7 +62,7 @@ model.compile(loss='mse', optimizer='rmsprop')
 
 print('Training')
 for i in range(epochs):
-    print('Epoch', i+1, '/', epochs)
+    print('Epoch', i + 1, '/', epochs)
 
     # Note that the last state for sample i in a batch will
     # be used as initial state for sample i in the next batch.

--- a/examples/lstm_stateful.py
+++ b/examples/lstm_stateful.py
@@ -1,91 +1,206 @@
 '''Example script showing how to use stateful RNNs
 to model long sequences efficiently.
+Depending on the parameters, either only the stateful LSTM converges,
+or both the stateful and stateless LSTM converge.
 '''
 from __future__ import print_function
 import numpy as np
 import matplotlib.pyplot as plt
+import pandas as pd
+
+# --------------------
+# EDITABLE PARAMETERS
+# --------------------
+
+# timesteps to use in the output averaging of the input
+# e.g. use 2 for 2-point average
+tsteps = 2
+
+# number of elements ahead that are used to make the LSTM prediction
+# when lahead >= tsteps, the stateless LSTM can converge
+# similar to the stateful LSTM
+lahead = 1
+
+# length of input
+input_len = 1000
+
+# training parameters
+batch_size = 1
+epochs = 10
+
+# ----------------------------
+# DO NOT EDIT UNDER THIS LINE
+# ----------------------------
+
+print("*" * 33)
+if lahead >= tsteps:
+    print("STATELESS LSTM WILL ALSO CONVERGE")
+else:
+    print("STATELESS LSTM WILL NOT  CONVERGE")
+print("*" * 33)
+
+# add a few points to account for the
+# nan-values that will be dropped in preprocessing
+to_drop = max(tsteps - 1, lahead - 1)
+input_len += to_drop
+
+
+def gen_uniform_amp(amp=1, xn=10000):
+    """Generates uniform random data between
+    -amp and +amp
+    and of length xn
+
+    Arguments:
+        amp: maximum/minimum range of uniform data
+        xn: length of series
+    """
+    data_input = np.random.uniform(-1 * amp, +1 * amp, xn)
+    data_input = pd.DataFrame(data_input)
+    return data_input
+
+
+np.random.seed(1986)
+
+print('Generating Data...')
+data_input = gen_uniform_amp(amp=0.1, xn=input_len)
+
+# set the target to be a N-point average of the input
+expected_output = data_input.rolling(window=tsteps, center=False).mean()
+
+# when lahead > 1, need to stride the input
+# https://docs.scipy.org/doc/numpy/reference/generated/numpy.repeat.html
+if lahead > 1:
+    data_input = np.repeat(data_input.values, repeats=lahead, axis=1)
+    data_input = pd.DataFrame(data_input)
+    for i, c in enumerate(data_input.columns):
+        data_input[c] = data_input[c].shift(i)
+
+# drop the nan
+expected_output = expected_output[to_drop:]
+data_input = data_input[to_drop:]
+
+print('Input shape:', data_input.shape)
+print('Output shape:', expected_output.shape)
+print('Input head: ')
+print(data_input.head())
+print('Output head: ')
+print(expected_output.head())
+print('Input tail: ')
+print(data_input.tail())
+print('Output tail: ')
+print(expected_output.tail())
+
+print('Plotting input and expected output')
+plt.plot(data_input[0][:10], '.')
+plt.plot(expected_output[0][:10], '-')
+plt.legend(['Input', 'Expected output'])
+plt.title('Input')
+plt.show()
+
+
 from keras.models import Sequential
 from keras.layers import Dense, LSTM
 
 
-# since we are using stateful rnn tsteps can be set to 1
-tsteps = 1
-batch_size = 25
-epochs = 25
-# number of elements ahead that are used to make the prediction
-lahead = 1
+def create_model(stateful: bool):
+    model = Sequential()
+    model.add(LSTM(20,
+              input_shape=(lahead, 1),
+              batch_size=batch_size,
+              return_sequences=False,
+              stateful=stateful,
+              activation='tanh'))
+    model.add(Dense(1))
+    model.compile(loss='mse', optimizer='adam')
+    return model
+
+print('Creating Stateful Model...')
+model_stateful = create_model(stateful=True)
 
 
-def gen_cosine_amp(amp=100, period=1000, x0=0, xn=50000, step=1, k=0.0001):
-    """Generates an absolute cosine time series with the amplitude
-    exponentially decreasing
+# split train/test data
+def split_data(X, y, ratio: int = 0.8):
+    to_train = int(input_len * ratio)
+    # tweak to match with batch_size
+    to_train -= to_train % batch_size
 
-    Arguments:
-        amp: amplitude of the cosine function
-        period: period of the cosine function
-        x0: initial x of the time series
-        xn: final x of the time series
-        step: step of the time series discretization
-        k: exponential rate
-    """
-    cos = np.zeros(((xn - x0) * step, 1, 1))
-    for i in range(len(cos)):
-        idx = x0 + i * step
-        cos[i, 0, 0] = amp * np.cos(2 * np.pi * idx / period)
-        cos[i, 0, 0] = cos[i, 0, 0] * np.exp(-k * idx)
-    return cos
+    X_train = X[:to_train]
+    y_train = y[:to_train]
+    X_test = X[to_train:]
+    y_test = y[to_train:]
+
+    # tweak to match with batch_size
+    to_drop = X.shape[0] % batch_size
+    if to_drop > 0:
+        X_test = X_test[:-1 * to_drop]
+        y_test = y_test[:-1 * to_drop]
+
+    # some reshaping
+    reshape_3 = lambda x: x.values.reshape((x.shape[0], x.shape[1], 1))
+    X_train = reshape_3(X_train)
+    X_test = reshape_3(X_test)
+
+    reshape_2 = lambda x: x.values.reshape((x.shape[0], 1))
+    y_train = reshape_2(y_train)
+    y_test = reshape_2(y_test)
+
+    return (X_train, y_train), (X_test, y_test)
 
 
-print('Generating Data...')
-cos = gen_cosine_amp()
-print('Input shape:', cos.shape)
-
-# set the target to be a two-point average of the cosine input
-expected_output = np.zeros((len(cos), 1))
-for i in range(len(cos) - lahead):
-    expected_output[i, 0] = np.mean(cos[i + 0:i + lahead + 1])
-
-print('Output shape:', expected_output.shape)
-
-print('Creating Model...')
-model = Sequential()
-model.add(LSTM(50,
-               input_shape=(tsteps, 1),
-               batch_size=batch_size,
-               return_sequences=True,
-               stateful=True))
-model.add(LSTM(50,
-               return_sequences=False,
-               stateful=True))
-model.add(Dense(1))
-model.compile(loss='mse', optimizer='rmsprop')
+(X_train, y_train), (X_test, y_test) = split_data(data_input, expected_output)
+print('X_train.shape: ', X_train.shape)
+print('y_train.shape: ', y_train.shape)
+print('X_test.shape: ', X_test.shape)
+print('y_test.shape: ', y_test.shape)
 
 print('Training')
 for i in range(epochs):
     print('Epoch', i + 1, '/', epochs)
-
     # Note that the last state for sample i in a batch will
     # be used as initial state for sample i in the next batch.
     # Thus we are simultaneously training on batch_size series with
-    # lower resolution than the original series contained in cos.
+    # lower resolution than the original series contained in data_input.
     # Each of these series are offset by one step and can be
-    # extracted with cos[i::batch_size].
-
-    model.fit(cos, expected_output,
-              batch_size=batch_size,
-              epochs=1,
-              verbose=1,
-              shuffle=False)
-    model.reset_states()
+    # extracted with data_input[i::batch_size].
+    model_stateful.fit(X_train,
+                       y_train,
+                       batch_size=batch_size,
+                       epochs=1,
+                       verbose=1,
+                       validation_data=(X_test, y_test),
+                       shuffle=False)
+    model_stateful.reset_states()
 
 print('Predicting')
-predicted_output = model.predict(cos, batch_size=batch_size)
+predicted_stateful = model_stateful.predict(X_test, batch_size=batch_size)
+
+print('Creating Stateless Model...')
+model_stateless = create_model(stateful=False)
+
+print('Training')
+model_stateless.fit(X_train,
+                    y_train,
+                    batch_size=batch_size,
+                    epochs=epochs,
+                    verbose=1,
+                    validation_data=(X_test, y_test),
+                    shuffle=False)
+
+print('Predicting')
+predicted_stateless = model_stateless.predict(X_test, batch_size=batch_size)
+
+# ----------------------------
 
 print('Plotting Results')
-plt.subplot(2, 1, 1)
-plt.plot(expected_output)
+plt.subplot(3, 1, 1)
+plt.plot(y_test)
 plt.title('Expected')
-plt.subplot(2, 1, 2)
-plt.plot(predicted_output)
-plt.title('Predicted')
+plt.subplot(3, 1, 2)
+# drop the first "tsteps-1" because it is not possible to predict them
+# since the "previous" timesteps to use do not exist
+plt.plot((y_test - predicted_stateful).flatten()[tsteps - 1:])
+plt.title('Stateful: Expected - Predicted')
+plt.subplot(3, 1, 3)
+plt.plot((y_test - predicted_stateless).flatten())
+plt.title('Stateless: Expected - Predicted')
 plt.show()


### PR DESCRIPTION
- rename file to `lstm_stateful.py` so it shows up together with the other `lstm_*.py` example files
- fix input average: the existing code is not doing any averaging because `cos[i + 1:i + lahead + 1]` is just one point. I think the purpose was for it to be a 2-point average.
- aesthetic progress fix: the progress message was 0-based, i.e. first message was `Epoch 0 / 25`. 