### PR TITLE
Fix/load_img

### DIFF
--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -328,9 +328,8 @@ def load_img(path, grayscale=False, target_size=None):
         if img.mode != 'RGB':
             img = img.convert('RGB')
     if target_size:
-        hw_tuple = (target_size[1], target_size[0])
-        if img.size != hw_tuple:
-            img = img.resize(hw_tuple)
+        if img.size != target_size:
+            img = img.resize(target_size)
     return img
 
 


### PR DESCRIPTION
For some reason there was swapped height and width from the input `target_shape` tuple in the `load_img` function.
This PR fixes it in a way that code corresponds with the desired format (docstring).

I assume that nobody has reported this, because usage of the rectangular image shape is the most common usage.