### PR TITLE
Use sum instead of mean in cosine_proximity

### DIFF
--- a/keras/losses.py
+++ b/keras/losses.py
@@ -71,7 +71,7 @@ def poisson(y_true, y_pred):
 def cosine_proximity(y_true, y_pred):
     y_true = K.l2_normalize(y_true, axis=-1)
     y_pred = K.l2_normalize(y_pred, axis=-1)
-    return -K.mean(y_true * y_pred, axis=-1)
+    return -K.sum(y_true * y_pred, axis=-1)
 
 
 # Aliases.


### PR DESCRIPTION
This PR resolves #7954.

Currently cosine proximity is scaled down by `y_pred.shape[-1]` because it uses `K.mean(..., axis=-1)`. That is, if the final layer is `Dense(100)`, the cosine proximity will be divided by 100, and the range is restricted to `[-0.01, 0.01]` instead of `[-1, 1]`. Changing from `K.mean()` to `K.sum()` solves the problem.