### PR TITLE
Unbroadcast batch size dimension in Theano backend

### DIFF
--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1412,7 +1412,7 @@ def rnn(step_function, inputs, initial_states,
             # Theano likes to make shape==1 dimensions
             # in the initial states (outputs_info) broadcastable
             if len(initial_states) > 0:
-                initial_states[0] = T.unbroadcast(initial_states[0], 1)
+                initial_states[0] = T.unbroadcast(initial_states[0], 0, 1)
 
             results, _ = theano.scan(
                 _step,

--- a/tests/keras/layers/recurrent_test.py
+++ b/tests/keras/layers/recurrent_test.py
@@ -552,5 +552,17 @@ def test_stacked_rnn_attributes():
     assert layer.get_losses_for(x) == [y]
 
 
+@rnn_test
+def test_batch_size_equal_one(layer_class):
+    inputs = Input(batch_shape=(1, timesteps, embedding_dim))
+    layer = layer_class(units)
+    outputs = layer(inputs)
+    model = Model(inputs, outputs)
+    model.compile('sgd', 'mse')
+    x = np.random.random((1, timesteps, embedding_dim))
+    y = np.random.random((1, units))
+    model.train_on_batch(x, y)
+
+
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
Unbroadcasting batch size dimension is important when batch size is 1. In this case initial state of recurrent layer (LSTM, GRU) is broadcasting to row vector which leads to error: 

> Inconsistency in the inner graph of scan 'scan_fn' : an input and an output are associated with the same recurrent state and should have the same type but have type 'GpuArrayType<None>(float32, row)' and 'GpuArrayType<None>(float32, matrix)' respectively.

keras v2.0.8
theano v0.10.0b3+9.g4552f38 (dev)