### PR TITLE
Improve TF backend's Switch function

### DIFF
--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -674,7 +674,9 @@ def squeeze(x, axis):
 
 
 def tile(x, n):
-    if isinstance(n, list):
+    if isinstance(n, int):
+        n = (n,)
+    elif isinstance(n, list):
         n = tuple(n)
 
     shape = int_shape(x)

--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -2074,7 +2074,7 @@ def switch(condition, then_expression, else_expression):
     elif ndim_cond < ndim_expr:
         ndim_diff = ndim_expr - ndim_cond
         for _ in range(ndim_diff):
-            cond = expand_dims(cond)
+            condition = expand_dims(condition)
         tile_shape = shape(then_expression)[-ndim_diff:]
         condition = tile(condition, tile_shape)
     return C.element_select(condition,

--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -2063,6 +2063,20 @@ def stop_gradient(variables):
 
 
 def switch(condition, then_expression, else_expression):
+    ndim_cond = ndim(condition)
+    ndim_expr = ndom(then_expression)
+    if ndim_cond > ndim_expr:
+            raise ValueError('Rank of condition should be less'
+                             ' than or equal to rank of then and'
+                             ' else expressions. ndim(condition)=' +
+                             str(cond_ndim) + ', ndim(then_expression)'
+                             '=' + str(expr_ndim))
+    elif ndim_cond < ndim_expr:
+        ndim_diff = expr_ndim - cond_ndim
+        for _ in range(ndim_diff):
+            cond = expand_dims(cond)
+        tile_shape = shape(then_expression)[-ndim_diff:]
+        cond = tile(cond, tile_shape)
     return C.element_select(condition,
                             then_expression,
                             else_expression)

--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -683,7 +683,7 @@ def tile(x, n):
     num_dynamic_axis = _get_dynamic_axis_num(x)
     # Padding the axis
     if len(n) < len(shape):
-        n = tuple([None for _ in range(len(shape) - len(n))]) + n
+        n = tuple([1 for _ in range(len(shape) - len(n))]) + n
 
     if len(n) != len(shape):
         raise NotImplementedError

--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -2064,7 +2064,7 @@ def stop_gradient(variables):
 
 def switch(condition, then_expression, else_expression):
     ndim_cond = ndim(condition)
-    ndim_expr = ndom(then_expression)
+    ndim_expr = ndim(then_expression)
     if ndim_cond > ndim_expr:
             raise ValueError('Rank of condition should be less'
                              ' than or equal to rank of then and'

--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -2068,11 +2068,11 @@ def switch(condition, then_expression, else_expression):
     ndim_cond = ndim(condition)
     ndim_expr = ndim(then_expression)
     if ndim_cond > ndim_expr:
-            raise ValueError('Rank of condition should be less'
-                             ' than or equal to rank of then and'
-                             ' else expressions. ndim(condition)=' +
-                             str(cond_ndim) + ', ndim(then_expression)'
-                             '=' + str(expr_ndim))
+        raise ValueError('Rank of condition should be less'
+                         ' than or equal to rank of then and'
+                         ' else expressions. ndim(condition)=' +
+                         str(cond_ndim) + ', ndim(then_expression)'
+                         '=' + str(expr_ndim))
     elif ndim_cond < ndim_expr:
         shape_expr = int_shape(then_expression)
         ndim_diff = ndim_expr - ndim_cond

--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -2072,7 +2072,7 @@ def switch(condition, then_expression, else_expression):
                              str(cond_ndim) + ', ndim(then_expression)'
                              '=' + str(expr_ndim))
     elif ndim_cond < ndim_expr:
-        ndim_diff = expr_ndim - cond_ndim
+        ndim_diff = ndim_expr - ndim_cond
         for _ in range(ndim_diff):
             cond = expand_dims(cond)
         tile_shape = shape(then_expression)[-ndim_diff:]

--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -2076,7 +2076,7 @@ def switch(condition, then_expression, else_expression):
         for _ in range(ndim_diff):
             cond = expand_dims(cond)
         tile_shape = shape(then_expression)[-ndim_diff:]
-        cond = tile(cond, tile_shape)
+        condition = tile(condition, tile_shape)
     return C.element_select(condition,
                             then_expression,
                             else_expression)

--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -2072,11 +2072,11 @@ def switch(condition, then_expression, else_expression):
                              str(cond_ndim) + ', ndim(then_expression)'
                              '=' + str(expr_ndim))
     elif ndim_cond < ndim_expr:
+        shape_expr = int_shape(then_expression)
         ndim_diff = ndim_expr - ndim_cond
-        for _ in range(ndim_diff):
+        for i in range(ndim_diff):
             condition = expand_dims(condition)
-        tile_shape = shape(then_expression)[-ndim_diff:]
-        condition = tile(condition, tile_shape)
+            condition = tile(condition, expr_shape[ndim_cond + i])
     return C.element_select(condition,
                             then_expression,
                             else_expression)

--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -2076,7 +2076,7 @@ def switch(condition, then_expression, else_expression):
         ndim_diff = ndim_expr - ndim_cond
         for i in range(ndim_diff):
             condition = expand_dims(condition)
-            condition = tile(condition, expr_shape[ndim_cond + i])
+            condition = tile(condition, shape_expr[ndim_cond + i])
     return C.element_select(condition,
                             then_expression,
                             else_expression)

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -2561,7 +2561,7 @@ def switch(condition, then_expression, else_expression):
     should be symbolic tensors of the *same shape*.
 
     # Arguments
-        condition: scalar tensor (`int` or `bool`).
+        condition: tensor (`int` or `bool`).
         then_expression: either a tensor, or a callable that returns a tensor.
         else_expression: either a tensor, or a callable that returns a tensor.
 

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -2594,8 +2594,12 @@ def switch(condition, then_expression, else_expression):
         if callable(else_expression):
             else_expression = else_expression()
         expr_ndim = ndim(then_expression)
-        assert cond_ndim <= expr_ndim, 'Rank of condition should be less'
-        ' than or equal to rank of then and else expressions.'
+        if cond_ndim > expr_ndim:
+            raise ValueError('Rank of condition should be less'
+                             ' than or equal to rank of then and'
+                             ' else expressions. ndim(condition)=' +
+                             str(cond_ndim) + ', ndim(then_expression)'
+                             '=' + str(expr_ndim))
         if cond_ndim > 1:
             ndim_diff = expr_ndim - cond_ndim
             cond_shape = tf.concat([tf.shape(condition), [1] * ndim_diff], axis=0)

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -2598,9 +2598,9 @@ def switch(condition, then_expression, else_expression):
             else_expression = else_expression()
         expr_ndim = ndim(then_expression)
         if cond_ndim > expr_ndim:
-            raise ValueError('Rank of condition should be less'
-                             ' than or equal to rank of then and'
-                             ' else expressions. ndim(condition)=' +
+            raise ValueError('Rank of `condition` should be less than or'
+                             ' equal to rank of `then_expression` and '
+                             '`else_expression`. ndim(condition)=' +
                              str(cond_ndim) + ', ndim(then_expression)'
                              '=' + str(expr_ndim))
         if cond_ndim > 1:

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -2571,7 +2571,7 @@ def switch(condition, then_expression, else_expression):
     if condition.dtype != tf.bool:
         condition = tf.cast(condition, 'bool')
     cond_ndim = ndim(condition)
-    if cond_ndim == 0:
+    if not cond_ndim:
         if not callable(then_expression):
             def then_expression_fn():
                 return then_expression
@@ -2589,6 +2589,10 @@ def switch(condition, then_expression, else_expression):
         # tf.where needs its condition tensor
         # to be the same shape as its two
         # result tensors
+        if callable(then_expression):
+            then_expression = then_expression()
+        if callable(else_expression):
+            else_expression = else_expression()
         expr_ndim = ndim(then_expression)
         assert cond_ndim <= expr_ndim, 'Rank of condition should be less than or equal to rank of then and else expressions.'
         if cond_ndim > 1:

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -2567,6 +2567,9 @@ def switch(condition, then_expression, else_expression):
 
     # Returns
         The selected tensor.
+
+    # Raises
+        ValueError: If rank of `condition` is greater than rank of expressions.
     """
     if condition.dtype != tf.bool:
         condition = tf.cast(condition, 'bool')

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -2598,10 +2598,9 @@ def switch(condition, then_expression, else_expression):
         ' than or equal to rank of then and else expressions.'
         if cond_ndim > 1:
             ndim_diff = expr_ndim - cond_ndim
-            for _ in range(ndim_diff):
-                condition = tf.expand_dims(condition, -1)
-            cond_shape = shape(condition)
-            expr_shape = shape(then_expression)
+            cond_shape = tf.concat([tf.shape(condition), [1] * ndim_diff], axis=0)
+            condition = tf.reshape(condition, cond_shape)
+            expr_shape = tf.shape(then_expression)
             shape_diff = expr_shape - cond_shape
             tile_shape = tf.where(shape_diff > 0, expr_shape, tf.ones_like(expr_shape))
             condition = tf.tile(condition, tile_shape)

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -2583,8 +2583,8 @@ def switch(condition, then_expression, else_expression):
         else:
             else_expression_fn = else_expression
         x = tf.cond(condition,
-            then_expression_fn,
-            else_expression_fn)
+                    then_expression_fn,
+                    else_expression_fn)
     else:
         # tf.where needs its condition tensor
         # to be the same shape as its two
@@ -2594,7 +2594,8 @@ def switch(condition, then_expression, else_expression):
         if callable(else_expression):
             else_expression = else_expression()
         expr_ndim = ndim(then_expression)
-        assert cond_ndim <= expr_ndim, 'Rank of condition should be less than or equal to rank of then and else expressions.'
+        assert cond_ndim <= expr_ndim, 'Rank of condition should be less'
+        ' than or equal to rank of then and else expressions.'
         if cond_ndim > 1:
             ndim_diff = expr_ndim - cond_ndim
             for _ in range(ndim_diff):

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1457,6 +1457,12 @@ def switch(condition, then_expression, else_expression):
         then_expression = then_expression()
     if callable(else_expression):
         else_expression = else_expression()
+    cond_ndim = ndim(condition)
+    expr_ndim = ndim(then_expression)
+    if cond_ndim < expr_ndim:
+        ndim_diff = expr_ndim - cond_ndim
+        for _ in range(ndim_diff):
+            condition = expand_dims(condition)
     return T.switch(condition, then_expression, else_expression)
 
 

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -656,7 +656,7 @@ class TestBackend(object):
         shapes = []
         shapes.append([(4, 3, 2), (4, 3, 2), (4, 3, 2)])
         shapes.append([(4, 3,), (4, 3, 2), (4, 3, 2)])
-        shapes.append([(4), (4, 3, 2), (4, 3, 2)])
+        shapes.append([(4,), (4, 3, 2), (4, 3, 2)])
         for s in shapes:
             z_list = []
             arrays = list(map(np.random.random, s))

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -655,11 +655,8 @@ class TestBackend(object):
         # non scalar
         shapes = []
         shapes.append([(4, 3, 2), (4, 3, 2), (4, 3, 2)])
-        shapes.append([(4, 3, 1), (4, 3, 2), (4, 3, 2)])
-        shapes.append([(4, 1, 1), (4, 3, 2), (4, 3, 2)])
-        shapes.append([(4, 3), (4, 3, 2), (4, 3, 2)])
-        shapes.append([(4, 1), (4, 3, 2), (4, 3, 2)])
-        shapes.append([(4,), (4, 3, 2), (4, 3, 2)])
+        shapes.append([(4, 3,), (4, 3, 2), (4, 3, 2)])
+        shapes.append([(4), (4, 3, 2), (4, 3, 2)])
         for s in shapes:
             z_list = []
             arrays = list(map(np.random.random, s))

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -644,14 +644,30 @@ class TestBackend(object):
                             rtol=1e-5)
 
     def test_switch(self):
+        # scalar
         val = np.random.random()
         z_list = []
         for k in BACKENDS:
             x = k.variable(val)
             x = k.switch(k.greater_equal(x, 0.5), x * 0.1, x * 0.2)
             z_list.append(k.eval(x))
-
         assert_list_pairwise(z_list)
+        # non scalar
+        shapes = []
+        shapes.append([(4, 3, 2), (4, 3, 2), (4, 3, 2)])
+        shapes.append([(4, 3, 1), (4, 3, 2), (4, 3, 2)])
+        shapes.append([(4, 1, 1), (4, 3, 2), (4, 3, 2)])
+        shapes.append([(4, 3), (4, 3, 2), (4, 3, 2)])
+        shapes.append([(4, 1), (4, 3, 2), (4, 3, 2)])
+        shapes.append([(4,), (4, 3, 2), (4, 3, 2)])
+        for s in shapes:
+            z_list = []
+            arrays = list(map(np.random.random, s))
+            for k in BACKENDS:
+                x, then_expr, else_expr = map(k.variable, arrays)
+                cond = k.greater_equal(x, 0.5)
+                z_list.append(k.eval(k.switch(cond, then_expr, else_expr)))
+            assert_list_pairwise(z_list)
 
     def test_dropout(self):
         val = np.random.random((100, 100))


### PR DESCRIPTION
As of now, K.switch supports only scalar condition on TF backend. This PR makes TF backend's switch function behave more like Theano's switch; with element-wise selection and broadcasting when required.

* If rank of `condition` == 0 (scalar), call `tf.cond` like before
* If rank of `condition` == 1, call `tf.where`
* If rank of `condition` > 1, make sure shape of `condition` is same as that of the expressions by applying `expand_dims` and `tile` ops; then call `tf.where`
