### PR TITLE
Allow to reshape unknown tensors.

### DIFF
--- a/tests/keras/layers/core_test.py
+++ b/tests/keras/layers/core_test.py
@@ -79,6 +79,10 @@ def test_reshape():
                kwargs={'target_shape': (1, -1)},
                input_shape=(3, 2, 4))
 
+    layer_test(layers.Reshape,
+               kwargs={'target_shape': (-1, 1)},
+               input_shape=(None, None, 4))
+
 
 @keras_test
 def test_permute():


### PR DESCRIPTION
The current implementation of `keras.layers.Reshape` does not allow the reshaping of tensors of unknown shape (ie. `(None, None, 3)` for any arbitrary image). Strangely enough, the underlying code of `tensorflow.reshape` does allow this kind of reshape (and already handles `-1` in the target shape), I'm not sure about other backends.

**Motivation**
The following code shows what this PR fixes:

```
import keras

inputs = keras.layers.Input((None, None, 3))
outputs = keras.layers.Reshape((-1, 1))(inputs)

model = keras.models.Model(inputs=inputs, outputs=outputs)

print("Success!")
```

Without this PR the result is:

```
Using TensorFlow backend.
Traceback (most recent call last):
  File "test.py", line 4, in <module>
    outputs = keras.layers.Reshape((-1, 1))(inputs)
  File "/home/hgaiser/.local/lib/python3.6/site-packages/Keras-2.0.8-py3.6.egg/keras/engine/topology.py", line 602, in __call__
  File "/home/hgaiser/.local/lib/python3.6/site-packages/Keras-2.0.8-py3.6.egg/keras/layers/core.py", line 391, in call
  File "/home/hgaiser/.local/lib/python3.6/site-packages/Keras-2.0.8-py3.6.egg/keras/layers/core.py", line 376, in compute_output_shape
  File "/home/hgaiser/.local/lib/python3.6/site-packages/Keras-2.0.8-py3.6.egg/keras/layers/core.py", line 364, in _fix_unknown_dimension
  File "/home/hgaiser/.local/lib/python3.6/site-packages/numpy/core/fromnumeric.py", line 2518, in prod
    out=out, **kwargs)
  File "/home/hgaiser/.local/lib/python3.6/site-packages/numpy/core/_methods.py", line 35, in _prod
    return umr_prod(a, axis, dtype, out, keepdims)
TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'
```

With this PR the result is:
```
Using TensorFlow backend.
Success!
```

ps. my current workaround is:
```
outputs = keras.layers.Lambda(lambda x: keras.backend.reshape(x,
 (keras.backend.shape(x)[0],) + (-1, 1)))(inputs)
```