### PR TITLE
Add option to specify resampling method in load_img

### DIFF
--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -25,6 +25,18 @@ except ImportError:
     pil_image = None
 
 
+if pil_image is not None:
+    _PIL_INTERPOLATION_METHODS = {
+        'nearest': pil_image.NEAREST,
+        'box': pil_image.BOX,
+        'bilinear': pil_image.BILINEAR,
+        'hamming': pil_image.HAMMING,
+        'bicubic': pil_image.BICUBIC,
+        'lanczos': pil_image.LANCZOS,
+    }
+
+
+
 def random_rotation(x, rg, row_axis=1, col_axis=2, channel_axis=0,
                     fill_mode='nearest', cval=0.):
     """Performs a random rotation of a Numpy image tensor.
@@ -303,7 +315,7 @@ def img_to_array(img, data_format=None):
 
 
 def load_img(path, grayscale=False, target_size=None,
-             resample=pil_image.BILINEAR):
+             interpolation="bilinear"):
     """Loads an image into PIL format.
 
     # Arguments
@@ -311,9 +323,9 @@ def load_img(path, grayscale=False, target_size=None,
         grayscale: Boolean, whether to load the image as grayscale.
         target_size: Either `None` (default to original size)
             or tuple of ints `(img_height, img_width)`.
-        resample: An optional resampling filter when resizing. This can be one
-            of `PIL.Image.NEAREST`, `PIL.Image.BOX`, `PIL.Image.BILINEAR`,
-            `PIL.Image.HAMMING`, `PIL.Image.BICUBIC` or `PIL.Image.LANCZOS`.
+        interpolation: Interpolation method used to resample the image if the
+            target size does not equal the loaded image. Supported methods are
+            "nearest", "box", "bilinear", "hamming", "bicubic", "lanczos".
             By default, bilinear resampling is used.
 
     # Returns
@@ -335,6 +347,9 @@ def load_img(path, grayscale=False, target_size=None,
     if target_size:
         hw_tuple = (target_size[1], target_size[0])
         if img.size != hw_tuple:
+            if interpolation not in _PIL_INTERPOLATION_METHODS:
+                raise ValueError('Invalid interpolation method specified')
+            resample = _PIL_INTERPOLATION_METHODS[interpolation]
             img = img.resize(hw_tuple, resample)
     return img
 

--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -302,7 +302,8 @@ def img_to_array(img, data_format=None):
     return x
 
 
-def load_img(path, grayscale=False, target_size=None):
+def load_img(path, grayscale=False, target_size=None,
+             resample=pil_image.BILINEAR):
     """Loads an image into PIL format.
 
     # Arguments
@@ -310,6 +311,11 @@ def load_img(path, grayscale=False, target_size=None):
         grayscale: Boolean, whether to load the image as grayscale.
         target_size: Either `None` (default to original size)
             or tuple of ints `(img_height, img_width)`.
+        resample: An optional resampling filter when resizing. This can be one
+            of `PIL.Image.NEAREST`, `PIL.Image.BOX`, `PIL.Image.BILINEAR`,
+            `PIL.Image.HAMMING`, `PIL.Image.BICUBIC` or `PIL.Image.LANCZOS`. If
+            omitted, or if the image has mode "1" or "P",
+            it is set `PIL.Image.NEAREST`.
 
     # Returns
         A PIL Image instance.
@@ -330,7 +336,7 @@ def load_img(path, grayscale=False, target_size=None):
     if target_size:
         hw_tuple = (target_size[1], target_size[0])
         if img.size != hw_tuple:
-            img = img.resize(hw_tuple)
+            img = img.resize(hw_tuple, resample)
     return img
 
 

--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -30,13 +30,15 @@ if pil_image is not None:
         'nearest': pil_image.NEAREST,
         'bilinear': pil_image.BILINEAR,
         'bicubic': pil_image.BICUBIC,
-        'lanczos': pil_image.LANCZOS,
     }
     # These methods were only introduced in version 3.4.0 (2016).
     if hasattr(PIL.Image, "HAMMING"):
         _PIL_INTERPOLATION_METHODS['hamming'] = pil_image.HAMMING
     if hasattr(PIL.Image, "BOX"):
         _PIL_INTERPOLATION_METHODS['box'] = pil_image.BOX
+    # This method is new in version 1.1.3 (2013).
+    if hasattr(PIL.Image, "LANCZOS"):
+        _PIL_INTERPOLATION_METHODS['lanczos'] = pil_image.LANCZOS
 
 
 def random_rotation(x, rg, row_axis=1, col_axis=2, channel_axis=0,
@@ -327,9 +329,10 @@ def load_img(path, grayscale=False, target_size=None,
             or tuple of ints `(img_height, img_width)`.
         interpolation: Interpolation method used to resample the image if the
             target size is different from that of the loaded image.
-            Supported methods are "nearest", "bilinear", "bicubic", "lanczos".
-            If PIL version 3.4.0 or newer is installed, "box" and "hamming" are
-            also supported. By default, "bilinear" resampling is used.
+            Supported methods are "nearest", "bilinear", and "bicubic".
+            If PIL version 1.1.3 or newer is installed, "lanczos" is also
+            supported. If PIL version 3.4.0 or newer is installed, "box" and
+            "hamming" are also supported. By default, "bilinear" is used.
 
     # Returns
         A PIL Image instance.

--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -313,9 +313,8 @@ def load_img(path, grayscale=False, target_size=None,
             or tuple of ints `(img_height, img_width)`.
         resample: An optional resampling filter when resizing. This can be one
             of `PIL.Image.NEAREST`, `PIL.Image.BOX`, `PIL.Image.BILINEAR`,
-            `PIL.Image.HAMMING`, `PIL.Image.BICUBIC` or `PIL.Image.LANCZOS`. If
-            omitted, or if the image has mode "1" or "P",
-            it is set `PIL.Image.NEAREST`.
+            `PIL.Image.HAMMING`, `PIL.Image.BICUBIC` or `PIL.Image.LANCZOS`.
+            By default, bilinear resampling is used.
 
     # Returns
         A PIL Image instance.

--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -315,7 +315,7 @@ def img_to_array(img, data_format=None):
 
 
 def load_img(path, grayscale=False, target_size=None,
-             interpolation="bilinear"):
+             interpolation='bilinear'):
     """Loads an image into PIL format.
 
     # Arguments

--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -351,7 +351,7 @@ def load_img(path, grayscale=False, target_size=None,
     else:
         if img.mode != 'RGB':
             img = img.convert('RGB')
-    if target_size:
+    if target_size is not None:
         width_height_tuple = (target_size[1], target_size[0])
         if img.size != width_height_tuple:
             if interpolation not in _PIL_INTERPOLATION_METHODS:

--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -32,12 +32,12 @@ if pil_image is not None:
         'bicubic': pil_image.BICUBIC,
     }
     # These methods were only introduced in version 3.4.0 (2016).
-    if hasattr(PIL.Image, "HAMMING"):
+    if hasattr(pil_image, 'HAMMING'):
         _PIL_INTERPOLATION_METHODS['hamming'] = pil_image.HAMMING
-    if hasattr(PIL.Image, "BOX"):
+    if hasattr(pil_image, 'BOX'):
         _PIL_INTERPOLATION_METHODS['box'] = pil_image.BOX
     # This method is new in version 1.1.3 (2013).
-    if hasattr(PIL.Image, "LANCZOS"):
+    if hasattr(pil_image, 'LANCZOS'):
         _PIL_INTERPOLATION_METHODS['lanczos'] = pil_image.LANCZOS
 
 

--- a/tests/keras/preprocessing/image_test.py
+++ b/tests/keras/preprocessing/image_test.py
@@ -357,7 +357,6 @@ class TestImage(object):
                                            interpolation="nearest")
         loaded_im_array_nearest = image.img_to_array(loaded_im_nearest)
         assert loaded_im_array_nearest.shape == (25, 25, 3)
-        assert np.all(loaded_im_array_nearest == original_im_array[2::4, 2::4])
         assert np.any(loaded_im_array_nearest != loaded_im_array)
 
         # Check that exception is raised if interpolation not supported.

--- a/tests/keras/preprocessing/image_test.py
+++ b/tests/keras/preprocessing/image_test.py
@@ -307,6 +307,66 @@ class TestImage(object):
                 transformed[i] = generator.random_transform(im)
             transformed = generator.standardize(transformed)
 
+    def test_load_img(self, tmpdir):
+        filename = str(tmpdir / 'image.png')
+
+        original_im_array = np.array(255 * np.random.rand(100, 100, 3),
+                                     dtype=np.uint8)
+        original_im = image.array_to_img(original_im_array, scale=False)
+        original_im.save(filename)
+
+        # Test that loaded image is exactly equal to original.
+
+        loaded_im = image.load_img(filename)
+        loaded_im_array = image.img_to_array(loaded_im)
+        assert loaded_im_array.shape == original_im_array.shape
+        assert np.all(loaded_im_array == original_im_array)
+
+        loaded_im = image.load_img(filename, grayscale=True)
+        loaded_im_array = image.img_to_array(loaded_im)
+        assert loaded_im_array.shape == (original_im_array.shape[0],
+                                         original_im_array.shape[1], 1)
+
+        # Test that nothing is changed when target size is equal to original.
+
+        loaded_im = image.load_img(filename, target_size=(100, 100))
+        loaded_im_array = image.img_to_array(loaded_im)
+        assert loaded_im_array.shape == original_im_array.shape
+        assert np.all(loaded_im_array == original_im_array)
+
+        loaded_im = image.load_img(filename, grayscale=True,
+                                   target_size=(100, 100))
+        loaded_im_array = image.img_to_array(loaded_im)
+        assert loaded_im_array.shape == (original_im_array.shape[0],
+                                         original_im_array.shape[1], 1)
+
+        # Test down-sampling with bilinear interpolation.
+
+        loaded_im = image.load_img(filename, target_size=(25, 25))
+        loaded_im_array = image.img_to_array(loaded_im)
+        assert loaded_im_array.shape == (25, 25, 3)
+
+        loaded_im = image.load_img(filename, grayscale=True,
+                                   target_size=(25, 25))
+        loaded_im_array = image.img_to_array(loaded_im)
+        assert loaded_im_array.shape == (25, 25, 1)
+
+        # Test down-sampling with nearest neighbor interpolation.
+
+        loaded_im_nearest = image.load_img(filename, target_size=(25, 25),
+                                   interpolation="nearest")
+        loaded_im_array_nearest = image.img_to_array(loaded_im_nearest)
+        assert loaded_im_array_nearest.shape == (25, 25, 3)
+        assert np.all(loaded_im_array_nearest == original_im_array[2::4, 2::4])
+        assert np.any(loaded_im_array_nearest != loaded_im_array)
+
+        # Check that exception is raised if interpolation not supported.
+
+        loaded_im = image.load_img(filename, interpolation="unsupported")
+        with pytest.raises(ValueError):
+            loaded_im = image.load_img(filename, target_size=(25, 25),
+                                       interpolation="unsupported")
+
 
 if __name__ == '__main__':
     pytest.main([__file__])

--- a/tests/keras/preprocessing/image_test.py
+++ b/tests/keras/preprocessing/image_test.py
@@ -354,7 +354,7 @@ class TestImage(object):
         # Test down-sampling with nearest neighbor interpolation.
 
         loaded_im_nearest = image.load_img(filename, target_size=(25, 25),
-                                   interpolation="nearest")
+                                           interpolation="nearest")
         loaded_im_array_nearest = image.img_to_array(loaded_im_nearest)
         assert loaded_im_array_nearest.shape == (25, 25, 3)
         assert np.all(loaded_im_array_nearest == original_im_array[2::4, 2::4])


### PR DESCRIPTION
Otherwise, nearest neighbor interpolation is used, which produces awful results. I consider this as a bug. In any case, the old behavior can be recovered using ``load_img(..., resample=PIL.Image.NEAREST)``.