### PR TITLE
Hide imagenet_utils.preprocess_input function from user

### DIFF
--- a/keras/applications/imagenet_utils.py
+++ b/keras/applications/imagenet_utils.py
@@ -8,7 +8,7 @@ CLASS_INDEX = None
 CLASS_INDEX_PATH = 'https://s3.amazonaws.com/deep-learning-models/image-models/imagenet_class_index.json'
 
 
-def preprocess_input(x, data_format=None, mode='caffe'):
+def _preprocess_input(x, data_format=None, mode='caffe'):
     """Preprocesses a tensor encoding a batch of images.
 
     # Arguments

--- a/keras/applications/inception_resnet_v2.py
+++ b/keras/applications/inception_resnet_v2.py
@@ -50,7 +50,7 @@ def preprocess_input(x):
     # Returns
         Preprocessed array.
     """
-    return imagenet_utils.preprocess_input(x, mode='tf')
+    return imagenet_utils._preprocess_input(x, mode='tf')
 
 
 def conv2d_bn(x,

--- a/keras/applications/inception_v3.py
+++ b/keras/applications/inception_v3.py
@@ -397,4 +397,4 @@ def preprocess_input(x):
     # Returns
         Preprocessed array.
     """
-    return imagenet_utils.preprocess_input(x, mode='tf')
+    return imagenet_utils._preprocess_input(x, mode='tf')

--- a/keras/applications/mobilenet.py
+++ b/keras/applications/mobilenet.py
@@ -93,7 +93,7 @@ def preprocess_input(x):
     # Returns
         Preprocessed array.
     """
-    return imagenet_utils.preprocess_input(x, mode='tf')
+    return imagenet_utils._preprocess_input(x, mode='tf')
 
 
 class DepthwiseConv2D(Conv2D):

--- a/keras/applications/resnet50.py
+++ b/keras/applications/resnet50.py
@@ -29,7 +29,7 @@ from ..engine.topology import get_source_inputs
 from ..utils import layer_utils
 from ..utils.data_utils import get_file
 from .imagenet_utils import decode_predictions
-from .imagenet_utils import preprocess_input
+from .imagenet_utils import _preprocess_input as preprocess_input
 from .imagenet_utils import _obtain_input_shape
 
 

--- a/keras/applications/vgg16.py
+++ b/keras/applications/vgg16.py
@@ -24,7 +24,7 @@ from ..utils import layer_utils
 from ..utils.data_utils import get_file
 from .. import backend as K
 from .imagenet_utils import decode_predictions
-from .imagenet_utils import preprocess_input
+from .imagenet_utils import _preprocess_input as preprocess_input
 from .imagenet_utils import _obtain_input_shape
 
 

--- a/keras/applications/vgg19.py
+++ b/keras/applications/vgg19.py
@@ -24,7 +24,7 @@ from ..utils import layer_utils
 from ..utils.data_utils import get_file
 from .. import backend as K
 from .imagenet_utils import decode_predictions
-from .imagenet_utils import preprocess_input
+from .imagenet_utils import _preprocess_input as preprocess_input
 from .imagenet_utils import _obtain_input_shape
 
 

--- a/keras/applications/xception.py
+++ b/keras/applications/xception.py
@@ -270,4 +270,4 @@ def preprocess_input(x):
     # Returns
         Preprocessed array.
     """
-    return imagenet_utils.preprocess_input(x, mode='tf')
+    return imagenet_utils._preprocess_input(x, mode='tf')

--- a/tests/keras/applications/imagenet_utils_test.py
+++ b/tests/keras/applications/imagenet_utils_test.py
@@ -8,20 +8,20 @@ from keras.applications import imagenet_utils as utils
 def test_preprocess_input():
     # Test image batch
     x = np.random.uniform(0, 255, (2, 10, 10, 3))
-    assert utils.preprocess_input(x).shape == x.shape
+    assert utils._preprocess_input(x).shape == x.shape
 
-    out1 = utils.preprocess_input(x, 'channels_last')
-    out2 = utils.preprocess_input(np.transpose(x, (0, 3, 1, 2)),
-                                  'channels_first')
+    out1 = utils._preprocess_input(x, 'channels_last')
+    out2 = utils._preprocess_input(np.transpose(x, (0, 3, 1, 2)),
+                                   'channels_first')
     assert_allclose(out1, out2.transpose(0, 2, 3, 1))
 
     # Test single image
     x = np.random.uniform(0, 255, (10, 10, 3))
-    assert utils.preprocess_input(x).shape == x.shape
+    assert utils._preprocess_input(x).shape == x.shape
 
-    out1 = utils.preprocess_input(x, 'channels_last')
-    out2 = utils.preprocess_input(np.transpose(x, (2, 0, 1)),
-                                  'channels_first')
+    out1 = utils._preprocess_input(x, 'channels_last')
+    out2 = utils._preprocess_input(np.transpose(x, (2, 0, 1)),
+                                   'channels_first')
     assert_allclose(out1, out2.transpose(1, 2, 0))
 
 


### PR DESCRIPTION
Each model exposes its custom preprocess_input function that should be used.
To prevent users from using the wrong function, this function is now hidden
from the user using a underscore prefix.