### PR TITLE
Recurrent Attention (Step 2): Support functional composition of RNN Cells (incl. constants)

### DIFF
--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -185,7 +185,9 @@ class RNN(Layer):
     # Arguments
         cell: A RNN cell instance. A RNN cell is a class that has:
             - a `call(input_at_t, states_at_t)` method, returning
-                `(output_at_t, states_at_t_plus_1)`.
+                `(output_at_t, states_at_t_plus_1)`. The call method of the
+                cell can also take the optional argument `constants`, see
+                section "Note on passing external constants" below.
             - a `state_size` attribute. This can be a single integer
                 (single state) in which case it is
                 the size of the recurrent state
@@ -276,6 +278,14 @@ class RNN(Layer):
         `states` should be a numpy array or list of numpy arrays representing
         the initial state of the RNN layer.
 
+    # Note on passing external constants to RNNs
+        You can pass "external" constants to the cell using the `constants`
+        keyword argument of RNN.__call__ (as well as RNN.call) method. This
+        requires that the `cell.call` method accepts the same keyword argument
+        `constants`. Such constants can be used to condition the cell
+        transformation on additional static inputs (not changing over time)
+        (a.k.a. an attention mechanism).
+
     # Examples
 
     ```python
@@ -354,6 +364,8 @@ class RNN(Layer):
             self.state_spec = InputSpec(shape=(None, self.cell.state_size))
         self._states = None
 
+        self.external_constants_spec = None
+
     @property
     def states(self):
         if self._states is None:
@@ -399,6 +411,14 @@ class RNN(Layer):
             return output_mask
 
     def build(self, input_shape):
+        # Note input_shape will be list of shapes of initial states and
+        # constants if these are passed in __call__.
+        if self.external_constants_spec is not None:
+            # input_shape must be list
+            constants_shape = input_shape[-len(self.external_constants_spec):]
+        else:
+            constants_shape = None
+
         if isinstance(input_shape, list):
             input_shape = input_shape[0]
 
@@ -411,7 +431,10 @@ class RNN(Layer):
 
         if isinstance(self.cell, Layer):
             step_input_shape = (input_shape[0],) + input_shape[2:]
-            self.cell.build(step_input_shape)
+            if constants_shape is not None:
+                self.cell.build([step_input_shape] + constants_shape)
+            else:
+                self.cell.build(step_input_shape)
 
     def get_initial_state(self, inputs):
         # build an all-zero tensor of shape (samples, output_dim)
@@ -424,43 +447,58 @@ class RNN(Layer):
         else:
             return [K.tile(initial_state, [1, self.cell.state_size])]
 
-    def __call__(self, inputs, initial_state=None, **kwargs):
-        # If there are multiple inputs, then
-        # they should be the main input and `initial_state`
-        # e.g. when loading model from file
-        if isinstance(inputs, (list, tuple)) and len(inputs) > 1 and initial_state is None:
-            initial_state = inputs[1:]
-            inputs = inputs[0]
+    def __call__(self, inputs, initial_state=None, constants=None, **kwargs):
+        # If there are multiple inputs, then they should be the main input,
+        # `initial_state` and (optionally) `constants` e.g. when loading model
+        # from file  # TODO ask for clarification
+        inputs, initial_state, constants = self._normalize_args(
+            inputs, initial_state, constants)
 
-        # If `initial_state` is specified,
-        # and if it a Keras tensor,
-        # then add it to the inputs and temporarily
-        # modify the input spec to include the state.
-        if initial_state is None:
+        # we need to know length of constants in build
+        if constants:
+            self.external_constants_spec = [
+                InputSpec(shape=K.int_shape(constant))
+                for constant in constants
+            ]
+
+        if initial_state is None and constants is None:
             return super(RNN, self).__call__(inputs, **kwargs)
 
-        if not isinstance(initial_state, (list, tuple)):
-            initial_state = [initial_state]
+        # If any of `initial_state` or `constants` are specified and are Keras
+        # tensors, then add them to the inputs and temporarily modify the
+        # input_spec to include them.
 
-        is_keras_tensor = hasattr(initial_state[0], '_keras_history')
-        for tensor in initial_state:
+        check_list = []
+        if initial_state:
+            check_list += initial_state
+        if constants:
+            check_list += constants
+        # at this point check_list cannot be empty
+        is_keras_tensor = hasattr(check_list[0], '_keras_history')
+        for tensor in check_list:
             if hasattr(tensor, '_keras_history') != is_keras_tensor:
-                raise ValueError('The initial state of an RNN layer cannot be'
-                                 ' specified with a mix of Keras tensors and'
-                                 ' non-Keras tensors')
+                raise ValueError('The initial state and constants of an RNN'
+                                 ' layer cannot be specified with a mix of'
+                                 ' Keras tensors and non-Keras tensors')
 
         if is_keras_tensor:
-            # Compute the full input spec, including state
+            # Compute the full input spec, including state and constants
             input_spec = self.input_spec
             state_spec = self.state_spec
             if not isinstance(input_spec, list):
                 input_spec = [input_spec]
             if not isinstance(state_spec, list):
                 state_spec = [state_spec]
-            self.input_spec = input_spec + state_spec
-
-            # Compute the full inputs, including state
-            inputs = [inputs] + list(initial_state)
+            self.input_spec = input_spec
+            inputs = [inputs]
+            if initial_state:
+                self.input_spec += state_spec
+                inputs += initial_state
+                kwargs['initial_state'] = initial_state
+            if constants:
+                self.input_spec += self.external_constants_spec
+                inputs += constants
+                kwargs['constants'] = constants
 
             # Perform the call
             output = super(RNN, self).__call__(inputs, **kwargs)
@@ -470,16 +508,22 @@ class RNN(Layer):
             return output
         else:
             kwargs['initial_state'] = initial_state
+            if constants is not None:
+                kwargs['constants'] = constants
             return super(RNN, self).__call__(inputs, **kwargs)
 
-    def call(self, inputs, mask=None, training=None, initial_state=None):
+    def call(self,
+             inputs,
+             mask=None,
+             training=None,
+             initial_state=None,
+             constants=None):
         # input shape: `(samples, time (padded with zeros), input_dim)`
         # note that the .build() method of subclasses MUST define
         # self.input_spec and self.state_spec with complete input shapes.
         if isinstance(inputs, list):
-            initial_state = inputs[1:]
             inputs = inputs[0]
-        elif initial_state is not None:
+        if initial_state is not None:
             pass
         elif self.stateful:
             initial_state = self.states
@@ -508,9 +552,17 @@ class RNN(Layer):
                              '- If using the functional API, specify '
                              'the time dimension by passing a `shape` '
                              'or `batch_shape` argument to your Input layer.')
-
+        cell_kwargs = {}
         if has_arg(self.cell.call, 'training'):
-            step = functools.partial(self.cell.call, training=training)
+            cell_kwargs['training'] = training
+
+        if constants is not None:
+            if not has_arg(self.cell.call, 'constants'):
+                raise TypeError('cell does not take keyword argument constants')
+            cell_kwargs['constants'] = constants
+
+        if cell_kwargs:
+            step = functools.partial(self.cell.call, **cell_kwargs)
         else:
             step = self.cell.call
         last_output, outputs, states = K.rnn(step,
@@ -543,6 +595,52 @@ class RNN(Layer):
             return [output] + states
         else:
             return output
+
+    def _normalize_args(self, inputs, initial_state=None, constants=None):
+        """The inputs `initial_state` and `constants` can be passed to
+        RNN.__call__ either by separate arguments or as part of `inputs`. In
+        this case `inputs` is a list of tensors of which the first one is the
+        actual (sequence) input followed by initial states, followed by
+        constants.
+
+        This method separates and noramlizes the different groups of inputs.
+
+        # Arguments
+            inputs: tensor of list/tuple of tensors
+            initial_state: tensor or list of tensors or None
+            constants: tensor or list of tensors or None
+
+        # Returns
+            inputs: tensor
+            initial_state: list of tensors or None
+            constants: list of tensors or None
+        """
+        if isinstance(inputs, (list, tuple)):
+            remaining_inputs = inputs[1:]
+            inputs = inputs[0]
+            if remaining_inputs and initial_state is None:
+                if isinstance(self.state_spec, list):
+                    n_states = len(self.state_spec)
+                else:
+                    n_states = 1
+                initial_state = remaining_inputs[:n_states]
+                remaining_inputs = remaining_inputs[n_states:]
+            if remaining_inputs and constants is None:
+                constants = remaining_inputs
+            if len(remaining_inputs) > 0:
+                raise ValueError('too many inputs were passed')
+
+        def to_list_or_none(x):  # TODO break out?
+            if x is None or isinstance(x, list):
+                return x
+            if isinstance(x, tuple):
+                return list(x)
+            return [x]
+
+        initial_state = to_list_or_none(initial_state)
+        constants = to_list_or_none(constants)
+
+        return inputs, initial_state, constants
 
     def reset_states(self, states=None):
         if not self.stateful:

--- a/tests/keras/layers/recurrent_test.py
+++ b/tests/keras/layers/recurrent_test.py
@@ -16,624 +16,678 @@ from keras import backend as K
 
 num_samples, timesteps, embedding_dim, units = 2, 5, 4, 3
 embedding_num = 12
-
-
-@keras_test
-def rnn_test(f):
-    """
-    All the recurrent layers share the same interface,
-    so we can run through them with a single function.
-    """
-    f = keras_test(f)
-    return pytest.mark.parametrize('layer_class', [
-        recurrent.SimpleRNN,
-        recurrent.GRU,
-        recurrent.LSTM
-    ])(f)
-
-
-@rnn_test
-def test_return_sequences(layer_class):
-    layer_test(layer_class,
-               kwargs={'units': units,
-                       'return_sequences': True},
-               input_shape=(num_samples, timesteps, embedding_dim))
-
-
-@rnn_test
-def test_dynamic_behavior(layer_class):
-    layer = layer_class(units, input_shape=(None, embedding_dim))
-    model = Sequential()
-    model.add(layer)
-    model.compile('sgd', 'mse')
-    x = np.random.random((num_samples, timesteps, embedding_dim))
-    y = np.random.random((num_samples, units))
-    model.train_on_batch(x, y)
-
-
-@rnn_test
-def test_stateful_invalid_use(layer_class):
-    layer = layer_class(units,
-                        stateful=True,
-                        batch_input_shape=(num_samples,
-                                           timesteps,
-                                           embedding_dim))
-    model = Sequential()
-    model.add(layer)
-    model.compile('sgd', 'mse')
-    x = np.random.random((num_samples * 2, timesteps, embedding_dim))
-    y = np.random.random((num_samples * 2, units))
-    with pytest.raises(ValueError):
-        model.fit(x, y)
-    with pytest.raises(ValueError):
-        model.predict(x, batch_size=num_samples + 1)
-
-
-@rnn_test
-@pytest.mark.skipif((K.backend() == 'cntk'),
-                    reason='Not yet supported.')
-def test_dropout(layer_class):
-    for unroll in [True, False]:
-        layer_test(layer_class,
-                   kwargs={'units': units,
-                           'dropout': 0.1,
-                           'recurrent_dropout': 0.1,
-                           'unroll': unroll},
-                   input_shape=(num_samples, timesteps, embedding_dim))
-
-        # Test that dropout is applied during training
-        x = K.ones((num_samples, timesteps, embedding_dim))
-        layer = layer_class(units, dropout=0.5, recurrent_dropout=0.5,
-                            input_shape=(timesteps, embedding_dim))
-        y = layer(x)
-        assert y._uses_learning_phase
-
-        y = layer(x, training=True)
-        assert not getattr(y, '_uses_learning_phase')
-
-        # Test that dropout is not applied during testing
-        x = np.random.random((num_samples, timesteps, embedding_dim))
-        layer = layer_class(units, dropout=0.5, recurrent_dropout=0.5,
-                            unroll=unroll,
-                            input_shape=(timesteps, embedding_dim))
-        model = Sequential([layer])
-        assert model.uses_learning_phase
-        y1 = model.predict(x)
-        y2 = model.predict(x)
-        assert_allclose(y1, y2)
-
-
-@rnn_test
-def test_statefulness(layer_class):
-    model = Sequential()
-    model.add(embeddings.Embedding(embedding_num, embedding_dim,
-                                   mask_zero=True,
-                                   input_length=timesteps,
-                                   batch_input_shape=(num_samples, timesteps)))
-    layer = layer_class(units, return_sequences=False,
-                        stateful=True,
-                        weights=None)
-    model.add(layer)
-    model.compile(optimizer='sgd', loss='mse')
-    out1 = model.predict(np.ones((num_samples, timesteps)))
-    assert(out1.shape == (num_samples, units))
-
-    # train once so that the states change
-    model.train_on_batch(np.ones((num_samples, timesteps)),
-                         np.ones((num_samples, units)))
-    out2 = model.predict(np.ones((num_samples, timesteps)))
-
-    # if the state is not reset, output should be different
-    assert(out1.max() != out2.max())
-
-    # check that output changes after states are reset
-    # (even though the model itself didn't change)
-    layer.reset_states()
-    out3 = model.predict(np.ones((num_samples, timesteps)))
-    assert(out2.max() != out3.max())
-
-    # check that container-level reset_states() works
-    model.reset_states()
-    out4 = model.predict(np.ones((num_samples, timesteps)))
-    assert_allclose(out3, out4, atol=1e-5)
-
-    # check that the call to `predict` updated the states
-    out5 = model.predict(np.ones((num_samples, timesteps)))
-    assert(out4.max() != out5.max())
-
-
-@rnn_test
-def test_masking_correctness(layer_class):
-    # Check masking: output with left padding and right padding
-    # should be the same.
-    model = Sequential()
-    model.add(embeddings.Embedding(embedding_num, embedding_dim,
-                                   mask_zero=True,
-                                   input_length=timesteps,
-                                   batch_input_shape=(num_samples, timesteps)))
-    layer = layer_class(units, return_sequences=False)
-    model.add(layer)
-    model.compile(optimizer='sgd', loss='mse')
-
-    left_padded_input = np.ones((num_samples, timesteps))
-    left_padded_input[0, :1] = 0
-    left_padded_input[1, :2] = 0
-    out6 = model.predict(left_padded_input)
-
-    right_padded_input = np.ones((num_samples, timesteps))
-    right_padded_input[0, -1:] = 0
-    right_padded_input[1, -2:] = 0
-    out7 = model.predict(right_padded_input)
-
-    assert_allclose(out7, out6, atol=1e-5)
-
-
-@rnn_test
-def test_implementation_mode(layer_class):
-    for mode in [1, 2]:
-        # Without dropout
-        layer_test(layer_class,
-                   kwargs={'units': units,
-                           'implementation': mode},
-                   input_shape=(num_samples, timesteps, embedding_dim))
-        # With dropout
-        layer_test(layer_class,
-                   kwargs={'units': units,
-                           'implementation': mode,
-                           'dropout': 0.1,
-                           'recurrent_dropout': 0.1},
-                   input_shape=(num_samples, timesteps, embedding_dim))
-
-
-@rnn_test
-def test_regularizer(layer_class):
-    layer = layer_class(units, return_sequences=False, weights=None,
-                        input_shape=(timesteps, embedding_dim),
-                        kernel_regularizer=regularizers.l1(0.01),
-                        recurrent_regularizer=regularizers.l1(0.01),
-                        bias_regularizer='l2')
-    layer.build((None, None, embedding_dim))
-    assert len(layer.losses) == 3
-    assert len(layer.cell.losses) == 3
-
-    layer = layer_class(units, return_sequences=False, weights=None,
-                        input_shape=(timesteps, embedding_dim),
-                        activity_regularizer='l2')
-    assert layer.activity_regularizer
-    x = K.variable(np.ones((num_samples, timesteps, embedding_dim)))
-    layer(x)
-    assert len(layer.cell.get_losses_for(x)) == 0
-    assert len(layer.get_losses_for(x)) == 1
-
-
-@keras_test
-def test_masking_layer():
-    ''' This test based on a previously failing issue here:
-    https://github.com/fchollet/keras/issues/1567
-    '''
-    inputs = np.random.random((6, 3, 4))
-    targets = np.abs(np.random.random((6, 3, 5)))
-    targets /= targets.sum(axis=-1, keepdims=True)
-
-    model = Sequential()
-    model.add(Masking(input_shape=(3, 4)))
-    model.add(recurrent.SimpleRNN(units=5, return_sequences=True, unroll=False))
-    model.compile(loss='categorical_crossentropy', optimizer='adam')
-    model.fit(inputs, targets, epochs=1, batch_size=100, verbose=1)
-
-    model = Sequential()
-    model.add(Masking(input_shape=(3, 4)))
-    model.add(recurrent.SimpleRNN(units=5, return_sequences=True, unroll=True))
-    model.compile(loss='categorical_crossentropy', optimizer='adam')
-    model.fit(inputs, targets, epochs=1, batch_size=100, verbose=1)
-
-
-@rnn_test
-def test_from_config(layer_class):
-    stateful_flags = (False, True)
-    for stateful in stateful_flags:
-        l1 = layer_class(units=1, stateful=stateful)
-        l2 = layer_class.from_config(l1.get_config())
-        assert l1.get_config() == l2.get_config()
-
-
-@rnn_test
-def test_specify_initial_state_keras_tensor(layer_class):
-    num_states = 2 if layer_class is recurrent.LSTM else 1
-
-    # Test with Keras tensor
-    inputs = Input((timesteps, embedding_dim))
-    initial_state = [Input((units,)) for _ in range(num_states)]
-    layer = layer_class(units)
-    if len(initial_state) == 1:
-        output = layer(inputs, initial_state=initial_state[0])
-    else:
-        output = layer(inputs, initial_state=initial_state)
-    assert initial_state[0] in layer.inbound_nodes[0].input_tensors
-
-    model = Model([inputs] + initial_state, output)
-    model.compile(loss='categorical_crossentropy', optimizer='adam')
-
-    inputs = np.random.random((num_samples, timesteps, embedding_dim))
-    initial_state = [np.random.random((num_samples, units))
-                     for _ in range(num_states)]
-    targets = np.random.random((num_samples, units))
-    model.fit([inputs] + initial_state, targets)
-
-
-@rnn_test
-def test_specify_initial_state_non_keras_tensor(layer_class):
-    num_states = 2 if layer_class is recurrent.LSTM else 1
-
-    # Test with non-Keras tensor
-    inputs = Input((timesteps, embedding_dim))
-    initial_state = [K.random_normal_variable((num_samples, units), 0, 1)
-                     for _ in range(num_states)]
-    layer = layer_class(units)
-    output = layer(inputs, initial_state=initial_state)
-
-    model = Model(inputs, output)
-    model.compile(loss='categorical_crossentropy', optimizer='adam')
-
-    inputs = np.random.random((num_samples, timesteps, embedding_dim))
-    targets = np.random.random((num_samples, units))
-    model.fit(inputs, targets)
-
-
-@rnn_test
-def test_reset_states_with_values(layer_class):
-    num_states = 2 if layer_class is recurrent.LSTM else 1
-
-    layer = layer_class(units, stateful=True)
-    layer.build((num_samples, timesteps, embedding_dim))
-    layer.reset_states()
-    assert len(layer.states) == num_states
-    assert layer.states[0] is not None
-    np.testing.assert_allclose(K.eval(layer.states[0]),
-                               np.zeros(K.int_shape(layer.states[0])),
-                               atol=1e-4)
-    state_shapes = [K.int_shape(state) for state in layer.states]
-    values = [np.ones(shape) for shape in state_shapes]
-    if len(values) == 1:
-        values = values[0]
-    layer.reset_states(values)
-    np.testing.assert_allclose(K.eval(layer.states[0]),
-                               np.ones(K.int_shape(layer.states[0])),
-                               atol=1e-4)
-
-    # Test fit with invalid data
-    with pytest.raises(ValueError):
-        layer.reset_states([1] * (len(layer.states) + 1))
-
-
-@rnn_test
-def test_initial_states_as_other_inputs(layer_class):
-    num_states = 2 if layer_class is recurrent.LSTM else 1
-
-    # Test with Keras tensor
-    main_inputs = Input((timesteps, embedding_dim))
-    initial_state = [Input((units,)) for _ in range(num_states)]
-    inputs = [main_inputs] + initial_state
-
-    layer = layer_class(units)
-    output = layer(inputs)
-    assert initial_state[0] in layer.inbound_nodes[0].input_tensors
-
-    model = Model(inputs, output)
-    model.compile(loss='categorical_crossentropy', optimizer='adam')
-
-    main_inputs = np.random.random((num_samples, timesteps, embedding_dim))
-    initial_state = [np.random.random((num_samples, units))
-                     for _ in range(num_states)]
-    targets = np.random.random((num_samples, units))
-    model.train_on_batch([main_inputs] + initial_state, targets)
-
-
-@rnn_test
-def test_specify_state_with_masking(layer_class):
-    ''' This test based on a previously failing issue here:
-    https://github.com/fchollet/keras/issues/1567
-    '''
-    num_states = 2 if layer_class is recurrent.LSTM else 1
-
-    inputs = Input((timesteps, embedding_dim))
-    _ = Masking()(inputs)
-    initial_state = [Input((units,)) for _ in range(num_states)]
-    output = layer_class(units)(inputs, initial_state=initial_state)
-
-    model = Model([inputs] + initial_state, output)
-    model.compile(loss='categorical_crossentropy', optimizer='adam')
-
-    inputs = np.random.random((num_samples, timesteps, embedding_dim))
-    initial_state = [np.random.random((num_samples, units))
-                     for _ in range(num_states)]
-    targets = np.random.random((num_samples, units))
-    model.fit([inputs] + initial_state, targets)
-
-
-@rnn_test
-def test_return_state(layer_class):
-    num_states = 2 if layer_class is recurrent.LSTM else 1
-
-    inputs = Input(batch_shape=(num_samples, timesteps, embedding_dim))
-    layer = layer_class(units, return_state=True, stateful=True)
-    outputs = layer(inputs)
-    output, state = outputs[0], outputs[1:]
-    assert len(state) == num_states
-    model = Model(inputs, state[0])
-
-    inputs = np.random.random((num_samples, timesteps, embedding_dim))
-    state = model.predict(inputs)
-    np.testing.assert_allclose(K.eval(layer.states[0]), state, atol=1e-4)
-
-
-@rnn_test
-def test_state_reuse(layer_class):
-    inputs = Input(batch_shape=(num_samples, timesteps, embedding_dim))
-    layer = layer_class(units, return_state=True, return_sequences=True)
-    outputs = layer(inputs)
-    output, state = outputs[0], outputs[1:]
-    output = layer_class(units)(output, initial_state=state)
-    model = Model(inputs, output)
-
-    inputs = np.random.random((num_samples, timesteps, embedding_dim))
-    outputs = model.predict(inputs)
-
-
-def test_minimal_rnn_cell_non_layer():
-
-    class MinimalRNNCell(object):
-
-        def __init__(self, units, input_dim):
-            self.units = units
-            self.state_size = units
-            self.kernel = keras.backend.variable(
-                np.random.random((input_dim, units)))
-
-        def call(self, inputs, states):
-            prev_output = states[0]
-            output = keras.backend.dot(inputs, self.kernel) + prev_output
-            return output, [output]
-
-    # Basic test case.
-    cell = MinimalRNNCell(32, 5)
-    x = keras.Input((None, 5))
-    layer = recurrent.RNN(cell)
-    y = layer(x)
-    model = keras.models.Model(x, y)
-    model.compile(optimizer='rmsprop', loss='mse')
-    model.train_on_batch(np.zeros((6, 5, 5)), np.zeros((6, 32)))
-
-    # Test stacking.
-    cells = [MinimalRNNCell(8, 5),
-             MinimalRNNCell(32, 8),
-             MinimalRNNCell(32, 32)]
-    layer = recurrent.RNN(cells)
-    y = layer(x)
-    model = keras.models.Model(x, y)
-    model.compile(optimizer='rmsprop', loss='mse')
-    model.train_on_batch(np.zeros((6, 5, 5)), np.zeros((6, 32)))
-
-
-def test_minimal_rnn_cell_non_layer_multiple_states():
-
-    class MinimalRNNCell(object):
-
-        def __init__(self, units, input_dim):
-            self.units = units
-            self.state_size = (units, units)
-            self.kernel = keras.backend.variable(
-                np.random.random((input_dim, units)))
-
-        def call(self, inputs, states):
-            prev_output_1 = states[0]
-            prev_output_2 = states[1]
-            output = keras.backend.dot(inputs, self.kernel)
-            output += prev_output_1
-            output -= prev_output_2
-            return output, [output * 2, output * 3]
-
-    # Basic test case.
-    cell = MinimalRNNCell(32, 5)
-    x = keras.Input((None, 5))
-    layer = recurrent.RNN(cell)
-    y = layer(x)
-    model = keras.models.Model(x, y)
-    model.compile(optimizer='rmsprop', loss='mse')
-    model.train_on_batch(np.zeros((6, 5, 5)), np.zeros((6, 32)))
-
-    # Test stacking.
-    cells = [MinimalRNNCell(8, 5),
-             MinimalRNNCell(16, 8),
-             MinimalRNNCell(32, 16)]
-    layer = recurrent.RNN(cells)
-    assert layer.cell.state_size == (32, 32, 16, 16, 8, 8)
-    y = layer(x)
-    model = keras.models.Model(x, y)
-    model.compile(optimizer='rmsprop', loss='mse')
-    model.train_on_batch(np.zeros((6, 5, 5)), np.zeros((6, 32)))
-
-
-def test_minimal_rnn_cell_layer():
-
-    class MinimalRNNCell(keras.layers.Layer):
-
-        def __init__(self, units, **kwargs):
-            self.units = units
-            self.state_size = units
-            super(MinimalRNNCell, self).__init__(**kwargs)
-
-        def build(self, input_shape):
-            self.kernel = self.add_weight(shape=(input_shape[-1], self.units),
-                                          initializer='uniform',
-                                          name='kernel')
-            self.recurrent_kernel = self.add_weight(
-                shape=(self.units, self.units),
-                initializer='uniform',
-                name='recurrent_kernel')
-            self.built = True
-
-        def call(self, inputs, states):
-            prev_output = states[0]
-            h = keras.backend.dot(inputs, self.kernel)
-            output = h + keras.backend.dot(prev_output, self.recurrent_kernel)
-            return output, [output]
-
-        def get_config(self):
-            config = {'units': self.units}
-            base_config = super(MinimalRNNCell, self).get_config()
-            return dict(list(base_config.items()) + list(config.items()))
+#
+#
+# @keras_test
+# def rnn_test(f):
+#     """
+#     All the recurrent layers share the same interface,
+#     so we can run through them with a single function.
+#     """
+#     f = keras_test(f)
+#     return pytest.mark.parametrize('layer_class', [
+#         recurrent.SimpleRNN,
+#         recurrent.GRU,
+#         recurrent.LSTM
+#     ])(f)
+#
+#
+# @rnn_test
+# def test_return_sequences(layer_class):
+#     layer_test(layer_class,
+#                kwargs={'units': units,
+#                        'return_sequences': True},
+#                input_shape=(num_samples, timesteps, embedding_dim))
+#
+#
+# @rnn_test
+# def test_dynamic_behavior(layer_class):
+#     layer = layer_class(units, input_shape=(None, embedding_dim))
+#     model = Sequential()
+#     model.add(layer)
+#     model.compile('sgd', 'mse')
+#     x = np.random.random((num_samples, timesteps, embedding_dim))
+#     y = np.random.random((num_samples, units))
+#     model.train_on_batch(x, y)
+#
+#
+# @rnn_test
+# def test_stateful_invalid_use(layer_class):
+#     layer = layer_class(units,
+#                         stateful=True,
+#                         batch_input_shape=(num_samples,
+#                                            timesteps,
+#                                            embedding_dim))
+#     model = Sequential()
+#     model.add(layer)
+#     model.compile('sgd', 'mse')
+#     x = np.random.random((num_samples * 2, timesteps, embedding_dim))
+#     y = np.random.random((num_samples * 2, units))
+#     with pytest.raises(ValueError):
+#         model.fit(x, y)
+#     with pytest.raises(ValueError):
+#         model.predict(x, batch_size=num_samples + 1)
+#
+#
+# @rnn_test
+# @pytest.mark.skipif((K.backend() == 'cntk'),
+#                     reason='Not yet supported.')
+# def test_dropout(layer_class):
+#     for unroll in [True, False]:
+#         layer_test(layer_class,
+#                    kwargs={'units': units,
+#                            'dropout': 0.1,
+#                            'recurrent_dropout': 0.1,
+#                            'unroll': unroll},
+#                    input_shape=(num_samples, timesteps, embedding_dim))
+#
+#         # Test that dropout is applied during training
+#         x = K.ones((num_samples, timesteps, embedding_dim))
+#         layer = layer_class(units, dropout=0.5, recurrent_dropout=0.5,
+#                             input_shape=(timesteps, embedding_dim))
+#         y = layer(x)
+#         assert y._uses_learning_phase
+#
+#         y = layer(x, training=True)
+#         assert not getattr(y, '_uses_learning_phase')
+#
+#         # Test that dropout is not applied during testing
+#         x = np.random.random((num_samples, timesteps, embedding_dim))
+#         layer = layer_class(units, dropout=0.5, recurrent_dropout=0.5,
+#                             unroll=unroll,
+#                             input_shape=(timesteps, embedding_dim))
+#         model = Sequential([layer])
+#         assert model.uses_learning_phase
+#         y1 = model.predict(x)
+#         y2 = model.predict(x)
+#         assert_allclose(y1, y2)
+#
+#
+# @rnn_test
+# def test_statefulness(layer_class):
+#     model = Sequential()
+#     model.add(embeddings.Embedding(embedding_num, embedding_dim,
+#                                    mask_zero=True,
+#                                    input_length=timesteps,
+#                                    batch_input_shape=(num_samples, timesteps)))
+#     layer = layer_class(units, return_sequences=False,
+#                         stateful=True,
+#                         weights=None)
+#     model.add(layer)
+#     model.compile(optimizer='sgd', loss='mse')
+#     out1 = model.predict(np.ones((num_samples, timesteps)))
+#     assert(out1.shape == (num_samples, units))
+#
+#     # train once so that the states change
+#     model.train_on_batch(np.ones((num_samples, timesteps)),
+#                          np.ones((num_samples, units)))
+#     out2 = model.predict(np.ones((num_samples, timesteps)))
+#
+#     # if the state is not reset, output should be different
+#     assert(out1.max() != out2.max())
+#
+#     # check that output changes after states are reset
+#     # (even though the model itself didn't change)
+#     layer.reset_states()
+#     out3 = model.predict(np.ones((num_samples, timesteps)))
+#     assert(out2.max() != out3.max())
+#
+#     # check that container-level reset_states() works
+#     model.reset_states()
+#     out4 = model.predict(np.ones((num_samples, timesteps)))
+#     assert_allclose(out3, out4, atol=1e-5)
+#
+#     # check that the call to `predict` updated the states
+#     out5 = model.predict(np.ones((num_samples, timesteps)))
+#     assert(out4.max() != out5.max())
+#
+#
+# @rnn_test
+# def test_masking_correctness(layer_class):
+#     # Check masking: output with left padding and right padding
+#     # should be the same.
+#     model = Sequential()
+#     model.add(embeddings.Embedding(embedding_num, embedding_dim,
+#                                    mask_zero=True,
+#                                    input_length=timesteps,
+#                                    batch_input_shape=(num_samples, timesteps)))
+#     layer = layer_class(units, return_sequences=False)
+#     model.add(layer)
+#     model.compile(optimizer='sgd', loss='mse')
+#
+#     left_padded_input = np.ones((num_samples, timesteps))
+#     left_padded_input[0, :1] = 0
+#     left_padded_input[1, :2] = 0
+#     out6 = model.predict(left_padded_input)
+#
+#     right_padded_input = np.ones((num_samples, timesteps))
+#     right_padded_input[0, -1:] = 0
+#     right_padded_input[1, -2:] = 0
+#     out7 = model.predict(right_padded_input)
+#
+#     assert_allclose(out7, out6, atol=1e-5)
+#
+#
+# @rnn_test
+# def test_implementation_mode(layer_class):
+#     for mode in [1, 2]:
+#         # Without dropout
+#         layer_test(layer_class,
+#                    kwargs={'units': units,
+#                            'implementation': mode},
+#                    input_shape=(num_samples, timesteps, embedding_dim))
+#         # With dropout
+#         layer_test(layer_class,
+#                    kwargs={'units': units,
+#                            'implementation': mode,
+#                            'dropout': 0.1,
+#                            'recurrent_dropout': 0.1},
+#                    input_shape=(num_samples, timesteps, embedding_dim))
+#
+#
+# @rnn_test
+# def test_regularizer(layer_class):
+#     layer = layer_class(units, return_sequences=False, weights=None,
+#                         input_shape=(timesteps, embedding_dim),
+#                         kernel_regularizer=regularizers.l1(0.01),
+#                         recurrent_regularizer=regularizers.l1(0.01),
+#                         bias_regularizer='l2')
+#     layer.build((None, None, embedding_dim))
+#     assert len(layer.losses) == 3
+#     assert len(layer.cell.losses) == 3
+#
+#     layer = layer_class(units, return_sequences=False, weights=None,
+#                         input_shape=(timesteps, embedding_dim),
+#                         activity_regularizer='l2')
+#     assert layer.activity_regularizer
+#     x = K.variable(np.ones((num_samples, timesteps, embedding_dim)))
+#     layer(x)
+#     assert len(layer.cell.get_losses_for(x)) == 0
+#     assert len(layer.get_losses_for(x)) == 1
+#
+#
+# @keras_test
+# def test_masking_layer():
+#     ''' This test based on a previously failing issue here:
+#     https://github.com/fchollet/keras/issues/1567
+#     '''
+#     inputs = np.random.random((6, 3, 4))
+#     targets = np.abs(np.random.random((6, 3, 5)))
+#     targets /= targets.sum(axis=-1, keepdims=True)
+#
+#     model = Sequential()
+#     model.add(Masking(input_shape=(3, 4)))
+#     model.add(recurrent.SimpleRNN(units=5, return_sequences=True, unroll=False))
+#     model.compile(loss='categorical_crossentropy', optimizer='adam')
+#     model.fit(inputs, targets, epochs=1, batch_size=100, verbose=1)
+#
+#     model = Sequential()
+#     model.add(Masking(input_shape=(3, 4)))
+#     model.add(recurrent.SimpleRNN(units=5, return_sequences=True, unroll=True))
+#     model.compile(loss='categorical_crossentropy', optimizer='adam')
+#     model.fit(inputs, targets, epochs=1, batch_size=100, verbose=1)
+#
+#
+# @rnn_test
+# def test_from_config(layer_class):
+#     stateful_flags = (False, True)
+#     for stateful in stateful_flags:
+#         l1 = layer_class(units=1, stateful=stateful)
+#         l2 = layer_class.from_config(l1.get_config())
+#         assert l1.get_config() == l2.get_config()
+#
+#
+# @rnn_test
+# def test_specify_initial_state_keras_tensor(layer_class):
+#     num_states = 2 if layer_class is recurrent.LSTM else 1
+#
+#     # Test with Keras tensor
+#     inputs = Input((timesteps, embedding_dim))
+#     initial_state = [Input((units,)) for _ in range(num_states)]
+#     layer = layer_class(units)
+#     if len(initial_state) == 1:
+#         output = layer(inputs, initial_state=initial_state[0])
+#     else:
+#         output = layer(inputs, initial_state=initial_state)
+#     assert initial_state[0] in layer.inbound_nodes[0].input_tensors
+#
+#     model = Model([inputs] + initial_state, output)
+#     model.compile(loss='categorical_crossentropy', optimizer='adam')
+#
+#     inputs = np.random.random((num_samples, timesteps, embedding_dim))
+#     initial_state = [np.random.random((num_samples, units))
+#                      for _ in range(num_states)]
+#     targets = np.random.random((num_samples, units))
+#     model.fit([inputs] + initial_state, targets)
+#
+#
+# @rnn_test
+# def test_specify_initial_state_non_keras_tensor(layer_class):
+#     num_states = 2 if layer_class is recurrent.LSTM else 1
+#
+#     # Test with non-Keras tensor
+#     inputs = Input((timesteps, embedding_dim))
+#     initial_state = [K.random_normal_variable((num_samples, units), 0, 1)
+#                      for _ in range(num_states)]
+#     layer = layer_class(units)
+#     output = layer(inputs, initial_state=initial_state)
+#
+#     model = Model(inputs, output)
+#     model.compile(loss='categorical_crossentropy', optimizer='adam')
+#
+#     inputs = np.random.random((num_samples, timesteps, embedding_dim))
+#     targets = np.random.random((num_samples, units))
+#     model.fit(inputs, targets)
+#
+#
+# @rnn_test
+# def test_reset_states_with_values(layer_class):
+#     num_states = 2 if layer_class is recurrent.LSTM else 1
+#
+#     layer = layer_class(units, stateful=True)
+#     layer.build((num_samples, timesteps, embedding_dim))
+#     layer.reset_states()
+#     assert len(layer.states) == num_states
+#     assert layer.states[0] is not None
+#     np.testing.assert_allclose(K.eval(layer.states[0]),
+#                                np.zeros(K.int_shape(layer.states[0])),
+#                                atol=1e-4)
+#     state_shapes = [K.int_shape(state) for state in layer.states]
+#     values = [np.ones(shape) for shape in state_shapes]
+#     if len(values) == 1:
+#         values = values[0]
+#     layer.reset_states(values)
+#     np.testing.assert_allclose(K.eval(layer.states[0]),
+#                                np.ones(K.int_shape(layer.states[0])),
+#                                atol=1e-4)
+#
+#     # Test fit with invalid data
+#     with pytest.raises(ValueError):
+#         layer.reset_states([1] * (len(layer.states) + 1))
+#
+#
+# @rnn_test
+# def test_initial_states_as_other_inputs(layer_class):
+#     num_states = 2 if layer_class is recurrent.LSTM else 1
+#
+#     # Test with Keras tensor
+#     main_inputs = Input((timesteps, embedding_dim))
+#     initial_state = [Input((units,)) for _ in range(num_states)]
+#     inputs = [main_inputs] + initial_state
+#
+#     layer = layer_class(units)
+#     output = layer(inputs)
+#     assert initial_state[0] in layer.inbound_nodes[0].input_tensors
+#
+#     model = Model(inputs, output)
+#     model.compile(loss='categorical_crossentropy', optimizer='adam')
+#
+#     main_inputs = np.random.random((num_samples, timesteps, embedding_dim))
+#     initial_state = [np.random.random((num_samples, units))
+#                      for _ in range(num_states)]
+#     targets = np.random.random((num_samples, units))
+#     model.train_on_batch([main_inputs] + initial_state, targets)
+#
+#
+# @rnn_test
+# def test_specify_state_with_masking(layer_class):
+#     ''' This test based on a previously failing issue here:
+#     https://github.com/fchollet/keras/issues/1567
+#     '''
+#     num_states = 2 if layer_class is recurrent.LSTM else 1
+#
+#     inputs = Input((timesteps, embedding_dim))
+#     _ = Masking()(inputs)
+#     initial_state = [Input((units,)) for _ in range(num_states)]
+#     output = layer_class(units)(inputs, initial_state=initial_state)
+#
+#     model = Model([inputs] + initial_state, output)
+#     model.compile(loss='categorical_crossentropy', optimizer='adam')
+#
+#     inputs = np.random.random((num_samples, timesteps, embedding_dim))
+#     initial_state = [np.random.random((num_samples, units))
+#                      for _ in range(num_states)]
+#     targets = np.random.random((num_samples, units))
+#     model.fit([inputs] + initial_state, targets)
+#
+#
+# @rnn_test
+# def test_return_state(layer_class):
+#     num_states = 2 if layer_class is recurrent.LSTM else 1
+#
+#     inputs = Input(batch_shape=(num_samples, timesteps, embedding_dim))
+#     layer = layer_class(units, return_state=True, stateful=True)
+#     outputs = layer(inputs)
+#     output, state = outputs[0], outputs[1:]
+#     assert len(state) == num_states
+#     model = Model(inputs, state[0])
+#
+#     inputs = np.random.random((num_samples, timesteps, embedding_dim))
+#     state = model.predict(inputs)
+#     np.testing.assert_allclose(K.eval(layer.states[0]), state, atol=1e-4)
+#
+#
+# @rnn_test
+# def test_state_reuse(layer_class):
+#     inputs = Input(batch_shape=(num_samples, timesteps, embedding_dim))
+#     layer = layer_class(units, return_state=True, return_sequences=True)
+#     outputs = layer(inputs)
+#     output, state = outputs[0], outputs[1:]
+#     output = layer_class(units)(output, initial_state=state)
+#     model = Model(inputs, output)
+#
+#     inputs = np.random.random((num_samples, timesteps, embedding_dim))
+#     outputs = model.predict(inputs)
+#
+#
+# def test_minimal_rnn_cell_non_layer():
+#
+#     class MinimalRNNCell(object):
+#
+#         def __init__(self, units, input_dim):
+#             self.units = units
+#             self.state_size = units
+#             self.kernel = keras.backend.variable(
+#                 np.random.random((input_dim, units)))
+#
+#         def call(self, inputs, states):
+#             prev_output = states[0]
+#             output = keras.backend.dot(inputs, self.kernel) + prev_output
+#             return output, [output]
+#
+#     # Basic test case.
+#     cell = MinimalRNNCell(32, 5)
+#     x = keras.Input((None, 5))
+#     layer = recurrent.RNN(cell)
+#     y = layer(x)
+#     model = keras.models.Model(x, y)
+#     model.compile(optimizer='rmsprop', loss='mse')
+#     model.train_on_batch(np.zeros((6, 5, 5)), np.zeros((6, 32)))
+#
+#     # Test stacking.
+#     cells = [MinimalRNNCell(8, 5),
+#              MinimalRNNCell(32, 8),
+#              MinimalRNNCell(32, 32)]
+#     layer = recurrent.RNN(cells)
+#     y = layer(x)
+#     model = keras.models.Model(x, y)
+#     model.compile(optimizer='rmsprop', loss='mse')
+#     model.train_on_batch(np.zeros((6, 5, 5)), np.zeros((6, 32)))
+#
+#
+# def test_minimal_rnn_cell_non_layer_multiple_states():
+#
+#     class MinimalRNNCell(object):
+#
+#         def __init__(self, units, input_dim):
+#             self.units = units
+#             self.state_size = (units, units)
+#             self.kernel = keras.backend.variable(
+#                 np.random.random((input_dim, units)))
+#
+#         def call(self, inputs, states):
+#             prev_output_1 = states[0]
+#             prev_output_2 = states[1]
+#             output = keras.backend.dot(inputs, self.kernel)
+#             output += prev_output_1
+#             output -= prev_output_2
+#             return output, [output * 2, output * 3]
+#
+#     # Basic test case.
+#     cell = MinimalRNNCell(32, 5)
+#     x = keras.Input((None, 5))
+#     layer = recurrent.RNN(cell)
+#     y = layer(x)
+#     model = keras.models.Model(x, y)
+#     model.compile(optimizer='rmsprop', loss='mse')
+#     model.train_on_batch(np.zeros((6, 5, 5)), np.zeros((6, 32)))
+#
+#     # Test stacking.
+#     cells = [MinimalRNNCell(8, 5),
+#              MinimalRNNCell(16, 8),
+#              MinimalRNNCell(32, 16)]
+#     layer = recurrent.RNN(cells)
+#     assert layer.cell.state_size == (32, 32, 16, 16, 8, 8)
+#     y = layer(x)
+#     model = keras.models.Model(x, y)
+#     model.compile(optimizer='rmsprop', loss='mse')
+#     model.train_on_batch(np.zeros((6, 5, 5)), np.zeros((6, 32)))
+#
+#
+# def test_minimal_rnn_cell_layer():
+#
+#     class MinimalRNNCell(keras.layers.Layer):
+#
+#         def __init__(self, units, **kwargs):
+#             self.units = units
+#             self.state_size = units
+#             super(MinimalRNNCell, self).__init__(**kwargs)
+#
+#         def build(self, input_shape):
+#             self.kernel = self.add_weight(shape=(input_shape[-1], self.units),
+#                                           initializer='uniform',
+#                                           name='kernel')
+#             self.recurrent_kernel = self.add_weight(
+#                 shape=(self.units, self.units),
+#                 initializer='uniform',
+#                 name='recurrent_kernel')
+#             self.built = True
+#
+#         def call(self, inputs, states):
+#             prev_output = states[0]
+#             h = keras.backend.dot(inputs, self.kernel)
+#             output = h + keras.backend.dot(prev_output, self.recurrent_kernel)
+#             return output, [output]
+#
+#         def get_config(self):
+#             config = {'units': self.units}
+#             base_config = super(MinimalRNNCell, self).get_config()
+#             return dict(list(base_config.items()) + list(config.items()))
+#
+#     # Test basic case.
+#     x = keras.Input((None, 5))
+#     cell = MinimalRNNCell(32)
+#     layer = recurrent.RNN(cell)
+#     y = layer(x)
+#     model = keras.models.Model(x, y)
+#     model.compile(optimizer='rmsprop', loss='mse')
+#     model.train_on_batch(np.zeros((6, 5, 5)), np.zeros((6, 32)))
+#
+#     # Test basic case serialization.
+#     x_np = np.random.random((6, 5, 5))
+#     y_np = model.predict(x_np)
+#     weights = model.get_weights()
+#     config = layer.get_config()
+#     with keras.utils.CustomObjectScope({'MinimalRNNCell': MinimalRNNCell}):
+#         layer = recurrent.RNN.from_config(config)
+#     y = layer(x)
+#     model = keras.models.Model(x, y)
+#     model.set_weights(weights)
+#     y_np_2 = model.predict(x_np)
+#     assert_allclose(y_np, y_np_2, atol=1e-4)
+#
+#     # Test stacking.
+#     cells = [MinimalRNNCell(8),
+#              MinimalRNNCell(12),
+#              MinimalRNNCell(32)]
+#     layer = recurrent.RNN(cells)
+#     y = layer(x)
+#     model = keras.models.Model(x, y)
+#     model.compile(optimizer='rmsprop', loss='mse')
+#     model.train_on_batch(np.zeros((6, 5, 5)), np.zeros((6, 32)))
+#
+#     # Test stacked RNN serialization.
+#     x_np = np.random.random((6, 5, 5))
+#     y_np = model.predict(x_np)
+#     weights = model.get_weights()
+#     config = layer.get_config()
+#     with keras.utils.CustomObjectScope({'MinimalRNNCell': MinimalRNNCell}):
+#         layer = recurrent.RNN.from_config(config)
+#     y = layer(x)
+#     model = keras.models.Model(x, y)
+#     model.set_weights(weights)
+#     y_np_2 = model.predict(x_np)
+#     assert_allclose(y_np, y_np_2, atol=1e-4)
+#
+#
+# def test_stacked_rnn_attributes():
+#     cells = [recurrent.LSTMCell(3),
+#              recurrent.LSTMCell(3, kernel_regularizer='l2')]
+#     layer = recurrent.RNN(cells)
+#     layer.build((None, None, 5))
+#
+#     # Test regularization losses
+#     assert len(layer.losses) == 1
+#
+#     # Test weights
+#     assert len(layer.trainable_weights) == 6
+#     cells[0].trainable = False
+#     assert len(layer.trainable_weights) == 3
+#     assert len(layer.non_trainable_weights) == 3
+#
+#     # Test `get_losses_for`
+#     x = keras.Input((None, 5))
+#     y = K.sum(x)
+#     cells[0].add_loss(y, inputs=x)
+#     assert layer.get_losses_for(x) == [y]
+#
+#
+# @rnn_test
+# def test_batch_size_equal_one(layer_class):
+#     inputs = Input(batch_shape=(1, timesteps, embedding_dim))
+#     layer = layer_class(units)
+#     outputs = layer(inputs)
+#     model = Model(inputs, outputs)
+#     model.compile('sgd', 'mse')
+#     x = np.random.random((1, timesteps, embedding_dim))
+#     y = np.random.random((1, units))
+#     model.train_on_batch(x, y)
+#
+#
+# def test_rnn_cell_with_constants_layer():
+#
+#     class RNNCellWithConstants(keras.layers.Layer):
+#
+#         def __init__(self, units, **kwargs):
+#             self.units = units
+#             self.state_size = units
+#             super(RNNCellWithConstants, self).__init__(**kwargs)
+#
+#         def build(self, input_shape):
+#             if not isinstance(input_shape, list):
+#                 raise TypeError('expects constants shape')
+#             [input_shape, constant_shape] = input_shape
+#             # will (and should) raise if more than one constant passed
+#
+#             self.input_kernel = self.add_weight(
+#                 shape=(input_shape[-1], self.units),
+#                 initializer='uniform',
+#                 name='kernel')
+#             self.recurrent_kernel = self.add_weight(
+#                 shape=(self.units, self.units),
+#                 initializer='uniform',
+#                 name='recurrent_kernel')
+#             self.constant_kernel = self.add_weight(
+#                 shape=(constant_shape[-1], self.units),
+#                 initializer='uniform',
+#                 name='constant_kernel')
+#             self.built = True
+#
+#         def call(self, inputs, states, constants):
+#             [prev_output] = states
+#             [constant] = constants
+#             h_input = keras.backend.dot(inputs, self.input_kernel)
+#             h_state = keras.backend.dot(prev_output, self.recurrent_kernel)
+#             h_const = keras.backend.dot(constant, self.constant_kernel)
+#             output = h_input + h_state + h_const
+#             return output, [output]
+#
+#         def get_config(self):
+#             config = {'units': self.units}
+#             base_config = super(RNNCellWithConstants, self).get_config()
+#             return dict(list(base_config.items()) + list(config.items()))
+#
+#     # Test basic case.
+#     x = keras.Input((None, 5))
+#     c = keras.Input((3,))
+#     cell = RNNCellWithConstants(32)
+#     layer = recurrent.RNN(cell)
+#     y = layer(x, constants=c)
+#     model = keras.models.Model([x, c], y)
+#     model.compile(optimizer='rmsprop', loss='mse')
+#     model.train_on_batch(
+#         [np.zeros((6, 5, 5)), np.zeros((6, 3))],
+#         np.zeros((6, 32))
+#     )
+#
+#     # Test basic case serialization.
+#     x_np = np.random.random((6, 5, 5))
+#     c_np = np.random.random((6, 3))
+#     y_np = model.predict([x_np, c_np])
+#     weights = model.get_weights()
+#     config = layer.get_config()
+#     with keras.utils.CustomObjectScope(
+#         {'RNNCellWithConstants': RNNCellWithConstants}):
+#         layer = recurrent.RNN.from_config(config)
+#     y = layer(x, constants=c)
+#     model = keras.models.Model([x, c], y)
+#     model.set_weights(weights)
+#     y_np_2 = model.predict([x_np, c_np])
+#     assert_allclose(y_np, y_np_2, atol=1e-4)
+
+
+def test_functional_rnn_cell():
+    layers = keras.layers
+
+    # Create the cell:
+    units = 8
+    input_size = 5
+    x = Input((input_size,))
+    h_tm1 = Input((units,))
+    h_ = layers.add([layers.Dense(units)(x), layers.Dense(units)(h_tm1)])
+    h = layers.Activation('tanh')(h_)
+    cell = recurrent.FunctionalRNNCell(
+        inputs=x, outputs=h, input_states=h_tm1, output_states=h)
 
     # Test basic case.
-    x = keras.Input((None, 5))
-    cell = MinimalRNNCell(32)
+    x_seq = Input((None, input_size))
     layer = recurrent.RNN(cell)
-    y = layer(x)
-    model = keras.models.Model(x, y)
+    y = layer(x_seq)
+    model = keras.models.Model(x_seq, y)
     model.compile(optimizer='rmsprop', loss='mse')
-    model.train_on_batch(np.zeros((6, 5, 5)), np.zeros((6, 32)))
-
-    # Test basic case serialization.
-    x_np = np.random.random((6, 5, 5))
-    y_np = model.predict(x_np)
-    weights = model.get_weights()
-    config = layer.get_config()
-    with keras.utils.CustomObjectScope({'MinimalRNNCell': MinimalRNNCell}):
-        layer = recurrent.RNN.from_config(config)
-    y = layer(x)
-    model = keras.models.Model(x, y)
-    model.set_weights(weights)
-    y_np_2 = model.predict(x_np)
-    assert_allclose(y_np, y_np_2, atol=1e-4)
-
-    # Test stacking.
-    cells = [MinimalRNNCell(8),
-             MinimalRNNCell(12),
-             MinimalRNNCell(32)]
-    layer = recurrent.RNN(cells)
-    y = layer(x)
-    model = keras.models.Model(x, y)
-    model.compile(optimizer='rmsprop', loss='mse')
-    model.train_on_batch(np.zeros((6, 5, 5)), np.zeros((6, 32)))
-
-    # Test stacked RNN serialization.
-    x_np = np.random.random((6, 5, 5))
-    y_np = model.predict(x_np)
-    weights = model.get_weights()
-    config = layer.get_config()
-    with keras.utils.CustomObjectScope({'MinimalRNNCell': MinimalRNNCell}):
-        layer = recurrent.RNN.from_config(config)
-    y = layer(x)
-    model = keras.models.Model(x, y)
-    model.set_weights(weights)
-    y_np_2 = model.predict(x_np)
-    assert_allclose(y_np, y_np_2, atol=1e-4)
+    model.train_on_batch(np.zeros((6, 5, input_size)), np.zeros((6, units)))
 
 
-def test_stacked_rnn_attributes():
-    cells = [recurrent.LSTMCell(3),
-             recurrent.LSTMCell(3, kernel_regularizer='l2')]
-    layer = recurrent.RNN(cells)
-    layer.build((None, None, 5))
+def test_functional_rnn_cell_with_constants():
+    layers = keras.layers
 
-    # Test regularization losses
-    assert len(layer.losses) == 1
+    # Create the cell:
+    units = 8
+    input_size = 5
+    constant_shape = (10,)
+    x = Input((input_size,))
+    h_tm1 = Input((units,))
+    c = Input(constant_shape)
+    h_ = layers.add([
+        layers.Dense(units)(x),
+        layers.Dense(units)(h_tm1),
+        layers.Dense(units)(c)
+    ])
+    h = layers.Activation('tanh')(h_)
 
-    # Test weights
-    assert len(layer.trainable_weights) == 6
-    cells[0].trainable = False
-    assert len(layer.trainable_weights) == 3
-    assert len(layer.non_trainable_weights) == 3
-
-    # Test `get_losses_for`
-    x = keras.Input((None, 5))
-    y = K.sum(x)
-    cells[0].add_loss(y, inputs=x)
-    assert layer.get_losses_for(x) == [y]
-
-
-@rnn_test
-def test_batch_size_equal_one(layer_class):
-    inputs = Input(batch_shape=(1, timesteps, embedding_dim))
-    layer = layer_class(units)
-    outputs = layer(inputs)
-    model = Model(inputs, outputs)
-    model.compile('sgd', 'mse')
-    x = np.random.random((1, timesteps, embedding_dim))
-    y = np.random.random((1, units))
-    model.train_on_batch(x, y)
-
-
-def test_rnn_cell_with_constants_layer():
-
-    class RNNCellWithConstants(keras.layers.Layer):
-
-        def __init__(self, units, **kwargs):
-            self.units = units
-            self.state_size = units
-            super(RNNCellWithConstants, self).__init__(**kwargs)
-
-        def build(self, input_shape):
-            if not isinstance(input_shape, list):
-                raise TypeError('expects constants shape')
-            [input_shape, constant_shape] = input_shape
-            # will (and should) raise if more than one constant passed
-
-            self.input_kernel = self.add_weight(
-                shape=(input_shape[-1], self.units),
-                initializer='uniform',
-                name='kernel')
-            self.recurrent_kernel = self.add_weight(
-                shape=(self.units, self.units),
-                initializer='uniform',
-                name='recurrent_kernel')
-            self.constant_kernel = self.add_weight(
-                shape=(constant_shape[-1], self.units),
-                initializer='uniform',
-                name='constant_kernel')
-            self.built = True
-
-        def call(self, inputs, states, constants):
-            [prev_output] = states
-            [constant] = constants
-            h_input = keras.backend.dot(inputs, self.input_kernel)
-            h_state = keras.backend.dot(prev_output, self.recurrent_kernel)
-            h_const = keras.backend.dot(constant, self.constant_kernel)
-            output = h_input + h_state + h_const
-            return output, [output]
-
-        def get_config(self):
-            config = {'units': self.units}
-            base_config = super(RNNCellWithConstants, self).get_config()
-            return dict(list(base_config.items()) + list(config.items()))
+    cell = recurrent.FunctionalRNNCell(
+        inputs=x, outputs=h, input_states=h_tm1, output_states=h, constants=c)
 
     # Test basic case.
-    x = keras.Input((None, 5))
-    c = keras.Input((3,))
-    cell = RNNCellWithConstants(32)
+    x_seq = Input((None, input_size))
     layer = recurrent.RNN(cell)
-    y = layer(x, constants=c)
-    model = keras.models.Model([x, c], y)
+    y = layer(x_seq, constants=c)
+    model = keras.models.Model([x_seq, c], y)
     model.compile(optimizer='rmsprop', loss='mse')
     model.train_on_batch(
-        [np.zeros((6, 5, 5)), np.zeros((6, 3))],
-        np.zeros((6, 32))
+        [np.zeros((6, 5, input_size)), np.zeros((6, constant_shape[0]))],
+        np.zeros((6, units))
     )
-
-    # Test basic case serialization.
-    x_np = np.random.random((6, 5, 5))
-    c_np = np.random.random((6, 3))
-    y_np = model.predict([x_np, c_np])
-    weights = model.get_weights()
-    config = layer.get_config()
-    with keras.utils.CustomObjectScope(
-        {'RNNCellWithConstants': RNNCellWithConstants}):
-        layer = recurrent.RNN.from_config(config)
-    y = layer(x, constants=c)
-    model = keras.models.Model([x, c], y)
-    model.set_weights(weights)
-    y_np_2 = model.predict([x_np, c_np])
-    assert_allclose(y_np, y_np_2, atol=1e-4)
 
 
 if __name__ == '__main__':

--- a/tests/keras/layers/recurrent_test.py
+++ b/tests/keras/layers/recurrent_test.py
@@ -16,624 +16,624 @@ from keras import backend as K
 
 num_samples, timesteps, embedding_dim, units = 2, 5, 4, 3
 embedding_num = 12
-#
-#
-# @keras_test
-# def rnn_test(f):
-#     """
-#     All the recurrent layers share the same interface,
-#     so we can run through them with a single function.
-#     """
-#     f = keras_test(f)
-#     return pytest.mark.parametrize('layer_class', [
-#         recurrent.SimpleRNN,
-#         recurrent.GRU,
-#         recurrent.LSTM
-#     ])(f)
-#
-#
-# @rnn_test
-# def test_return_sequences(layer_class):
-#     layer_test(layer_class,
-#                kwargs={'units': units,
-#                        'return_sequences': True},
-#                input_shape=(num_samples, timesteps, embedding_dim))
-#
-#
-# @rnn_test
-# def test_dynamic_behavior(layer_class):
-#     layer = layer_class(units, input_shape=(None, embedding_dim))
-#     model = Sequential()
-#     model.add(layer)
-#     model.compile('sgd', 'mse')
-#     x = np.random.random((num_samples, timesteps, embedding_dim))
-#     y = np.random.random((num_samples, units))
-#     model.train_on_batch(x, y)
-#
-#
-# @rnn_test
-# def test_stateful_invalid_use(layer_class):
-#     layer = layer_class(units,
-#                         stateful=True,
-#                         batch_input_shape=(num_samples,
-#                                            timesteps,
-#                                            embedding_dim))
-#     model = Sequential()
-#     model.add(layer)
-#     model.compile('sgd', 'mse')
-#     x = np.random.random((num_samples * 2, timesteps, embedding_dim))
-#     y = np.random.random((num_samples * 2, units))
-#     with pytest.raises(ValueError):
-#         model.fit(x, y)
-#     with pytest.raises(ValueError):
-#         model.predict(x, batch_size=num_samples + 1)
-#
-#
-# @rnn_test
-# @pytest.mark.skipif((K.backend() == 'cntk'),
-#                     reason='Not yet supported.')
-# def test_dropout(layer_class):
-#     for unroll in [True, False]:
-#         layer_test(layer_class,
-#                    kwargs={'units': units,
-#                            'dropout': 0.1,
-#                            'recurrent_dropout': 0.1,
-#                            'unroll': unroll},
-#                    input_shape=(num_samples, timesteps, embedding_dim))
-#
-#         # Test that dropout is applied during training
-#         x = K.ones((num_samples, timesteps, embedding_dim))
-#         layer = layer_class(units, dropout=0.5, recurrent_dropout=0.5,
-#                             input_shape=(timesteps, embedding_dim))
-#         y = layer(x)
-#         assert y._uses_learning_phase
-#
-#         y = layer(x, training=True)
-#         assert not getattr(y, '_uses_learning_phase')
-#
-#         # Test that dropout is not applied during testing
-#         x = np.random.random((num_samples, timesteps, embedding_dim))
-#         layer = layer_class(units, dropout=0.5, recurrent_dropout=0.5,
-#                             unroll=unroll,
-#                             input_shape=(timesteps, embedding_dim))
-#         model = Sequential([layer])
-#         assert model.uses_learning_phase
-#         y1 = model.predict(x)
-#         y2 = model.predict(x)
-#         assert_allclose(y1, y2)
-#
-#
-# @rnn_test
-# def test_statefulness(layer_class):
-#     model = Sequential()
-#     model.add(embeddings.Embedding(embedding_num, embedding_dim,
-#                                    mask_zero=True,
-#                                    input_length=timesteps,
-#                                    batch_input_shape=(num_samples, timesteps)))
-#     layer = layer_class(units, return_sequences=False,
-#                         stateful=True,
-#                         weights=None)
-#     model.add(layer)
-#     model.compile(optimizer='sgd', loss='mse')
-#     out1 = model.predict(np.ones((num_samples, timesteps)))
-#     assert(out1.shape == (num_samples, units))
-#
-#     # train once so that the states change
-#     model.train_on_batch(np.ones((num_samples, timesteps)),
-#                          np.ones((num_samples, units)))
-#     out2 = model.predict(np.ones((num_samples, timesteps)))
-#
-#     # if the state is not reset, output should be different
-#     assert(out1.max() != out2.max())
-#
-#     # check that output changes after states are reset
-#     # (even though the model itself didn't change)
-#     layer.reset_states()
-#     out3 = model.predict(np.ones((num_samples, timesteps)))
-#     assert(out2.max() != out3.max())
-#
-#     # check that container-level reset_states() works
-#     model.reset_states()
-#     out4 = model.predict(np.ones((num_samples, timesteps)))
-#     assert_allclose(out3, out4, atol=1e-5)
-#
-#     # check that the call to `predict` updated the states
-#     out5 = model.predict(np.ones((num_samples, timesteps)))
-#     assert(out4.max() != out5.max())
-#
-#
-# @rnn_test
-# def test_masking_correctness(layer_class):
-#     # Check masking: output with left padding and right padding
-#     # should be the same.
-#     model = Sequential()
-#     model.add(embeddings.Embedding(embedding_num, embedding_dim,
-#                                    mask_zero=True,
-#                                    input_length=timesteps,
-#                                    batch_input_shape=(num_samples, timesteps)))
-#     layer = layer_class(units, return_sequences=False)
-#     model.add(layer)
-#     model.compile(optimizer='sgd', loss='mse')
-#
-#     left_padded_input = np.ones((num_samples, timesteps))
-#     left_padded_input[0, :1] = 0
-#     left_padded_input[1, :2] = 0
-#     out6 = model.predict(left_padded_input)
-#
-#     right_padded_input = np.ones((num_samples, timesteps))
-#     right_padded_input[0, -1:] = 0
-#     right_padded_input[1, -2:] = 0
-#     out7 = model.predict(right_padded_input)
-#
-#     assert_allclose(out7, out6, atol=1e-5)
-#
-#
-# @rnn_test
-# def test_implementation_mode(layer_class):
-#     for mode in [1, 2]:
-#         # Without dropout
-#         layer_test(layer_class,
-#                    kwargs={'units': units,
-#                            'implementation': mode},
-#                    input_shape=(num_samples, timesteps, embedding_dim))
-#         # With dropout
-#         layer_test(layer_class,
-#                    kwargs={'units': units,
-#                            'implementation': mode,
-#                            'dropout': 0.1,
-#                            'recurrent_dropout': 0.1},
-#                    input_shape=(num_samples, timesteps, embedding_dim))
-#
-#
-# @rnn_test
-# def test_regularizer(layer_class):
-#     layer = layer_class(units, return_sequences=False, weights=None,
-#                         input_shape=(timesteps, embedding_dim),
-#                         kernel_regularizer=regularizers.l1(0.01),
-#                         recurrent_regularizer=regularizers.l1(0.01),
-#                         bias_regularizer='l2')
-#     layer.build((None, None, embedding_dim))
-#     assert len(layer.losses) == 3
-#     assert len(layer.cell.losses) == 3
-#
-#     layer = layer_class(units, return_sequences=False, weights=None,
-#                         input_shape=(timesteps, embedding_dim),
-#                         activity_regularizer='l2')
-#     assert layer.activity_regularizer
-#     x = K.variable(np.ones((num_samples, timesteps, embedding_dim)))
-#     layer(x)
-#     assert len(layer.cell.get_losses_for(x)) == 0
-#     assert len(layer.get_losses_for(x)) == 1
-#
-#
-# @keras_test
-# def test_masking_layer():
-#     ''' This test based on a previously failing issue here:
-#     https://github.com/fchollet/keras/issues/1567
-#     '''
-#     inputs = np.random.random((6, 3, 4))
-#     targets = np.abs(np.random.random((6, 3, 5)))
-#     targets /= targets.sum(axis=-1, keepdims=True)
-#
-#     model = Sequential()
-#     model.add(Masking(input_shape=(3, 4)))
-#     model.add(recurrent.SimpleRNN(units=5, return_sequences=True, unroll=False))
-#     model.compile(loss='categorical_crossentropy', optimizer='adam')
-#     model.fit(inputs, targets, epochs=1, batch_size=100, verbose=1)
-#
-#     model = Sequential()
-#     model.add(Masking(input_shape=(3, 4)))
-#     model.add(recurrent.SimpleRNN(units=5, return_sequences=True, unroll=True))
-#     model.compile(loss='categorical_crossentropy', optimizer='adam')
-#     model.fit(inputs, targets, epochs=1, batch_size=100, verbose=1)
-#
-#
-# @rnn_test
-# def test_from_config(layer_class):
-#     stateful_flags = (False, True)
-#     for stateful in stateful_flags:
-#         l1 = layer_class(units=1, stateful=stateful)
-#         l2 = layer_class.from_config(l1.get_config())
-#         assert l1.get_config() == l2.get_config()
-#
-#
-# @rnn_test
-# def test_specify_initial_state_keras_tensor(layer_class):
-#     num_states = 2 if layer_class is recurrent.LSTM else 1
-#
-#     # Test with Keras tensor
-#     inputs = Input((timesteps, embedding_dim))
-#     initial_state = [Input((units,)) for _ in range(num_states)]
-#     layer = layer_class(units)
-#     if len(initial_state) == 1:
-#         output = layer(inputs, initial_state=initial_state[0])
-#     else:
-#         output = layer(inputs, initial_state=initial_state)
-#     assert initial_state[0] in layer.inbound_nodes[0].input_tensors
-#
-#     model = Model([inputs] + initial_state, output)
-#     model.compile(loss='categorical_crossentropy', optimizer='adam')
-#
-#     inputs = np.random.random((num_samples, timesteps, embedding_dim))
-#     initial_state = [np.random.random((num_samples, units))
-#                      for _ in range(num_states)]
-#     targets = np.random.random((num_samples, units))
-#     model.fit([inputs] + initial_state, targets)
-#
-#
-# @rnn_test
-# def test_specify_initial_state_non_keras_tensor(layer_class):
-#     num_states = 2 if layer_class is recurrent.LSTM else 1
-#
-#     # Test with non-Keras tensor
-#     inputs = Input((timesteps, embedding_dim))
-#     initial_state = [K.random_normal_variable((num_samples, units), 0, 1)
-#                      for _ in range(num_states)]
-#     layer = layer_class(units)
-#     output = layer(inputs, initial_state=initial_state)
-#
-#     model = Model(inputs, output)
-#     model.compile(loss='categorical_crossentropy', optimizer='adam')
-#
-#     inputs = np.random.random((num_samples, timesteps, embedding_dim))
-#     targets = np.random.random((num_samples, units))
-#     model.fit(inputs, targets)
-#
-#
-# @rnn_test
-# def test_reset_states_with_values(layer_class):
-#     num_states = 2 if layer_class is recurrent.LSTM else 1
-#
-#     layer = layer_class(units, stateful=True)
-#     layer.build((num_samples, timesteps, embedding_dim))
-#     layer.reset_states()
-#     assert len(layer.states) == num_states
-#     assert layer.states[0] is not None
-#     np.testing.assert_allclose(K.eval(layer.states[0]),
-#                                np.zeros(K.int_shape(layer.states[0])),
-#                                atol=1e-4)
-#     state_shapes = [K.int_shape(state) for state in layer.states]
-#     values = [np.ones(shape) for shape in state_shapes]
-#     if len(values) == 1:
-#         values = values[0]
-#     layer.reset_states(values)
-#     np.testing.assert_allclose(K.eval(layer.states[0]),
-#                                np.ones(K.int_shape(layer.states[0])),
-#                                atol=1e-4)
-#
-#     # Test fit with invalid data
-#     with pytest.raises(ValueError):
-#         layer.reset_states([1] * (len(layer.states) + 1))
-#
-#
-# @rnn_test
-# def test_initial_states_as_other_inputs(layer_class):
-#     num_states = 2 if layer_class is recurrent.LSTM else 1
-#
-#     # Test with Keras tensor
-#     main_inputs = Input((timesteps, embedding_dim))
-#     initial_state = [Input((units,)) for _ in range(num_states)]
-#     inputs = [main_inputs] + initial_state
-#
-#     layer = layer_class(units)
-#     output = layer(inputs)
-#     assert initial_state[0] in layer.inbound_nodes[0].input_tensors
-#
-#     model = Model(inputs, output)
-#     model.compile(loss='categorical_crossentropy', optimizer='adam')
-#
-#     main_inputs = np.random.random((num_samples, timesteps, embedding_dim))
-#     initial_state = [np.random.random((num_samples, units))
-#                      for _ in range(num_states)]
-#     targets = np.random.random((num_samples, units))
-#     model.train_on_batch([main_inputs] + initial_state, targets)
-#
-#
-# @rnn_test
-# def test_specify_state_with_masking(layer_class):
-#     ''' This test based on a previously failing issue here:
-#     https://github.com/fchollet/keras/issues/1567
-#     '''
-#     num_states = 2 if layer_class is recurrent.LSTM else 1
-#
-#     inputs = Input((timesteps, embedding_dim))
-#     _ = Masking()(inputs)
-#     initial_state = [Input((units,)) for _ in range(num_states)]
-#     output = layer_class(units)(inputs, initial_state=initial_state)
-#
-#     model = Model([inputs] + initial_state, output)
-#     model.compile(loss='categorical_crossentropy', optimizer='adam')
-#
-#     inputs = np.random.random((num_samples, timesteps, embedding_dim))
-#     initial_state = [np.random.random((num_samples, units))
-#                      for _ in range(num_states)]
-#     targets = np.random.random((num_samples, units))
-#     model.fit([inputs] + initial_state, targets)
-#
-#
-# @rnn_test
-# def test_return_state(layer_class):
-#     num_states = 2 if layer_class is recurrent.LSTM else 1
-#
-#     inputs = Input(batch_shape=(num_samples, timesteps, embedding_dim))
-#     layer = layer_class(units, return_state=True, stateful=True)
-#     outputs = layer(inputs)
-#     output, state = outputs[0], outputs[1:]
-#     assert len(state) == num_states
-#     model = Model(inputs, state[0])
-#
-#     inputs = np.random.random((num_samples, timesteps, embedding_dim))
-#     state = model.predict(inputs)
-#     np.testing.assert_allclose(K.eval(layer.states[0]), state, atol=1e-4)
-#
-#
-# @rnn_test
-# def test_state_reuse(layer_class):
-#     inputs = Input(batch_shape=(num_samples, timesteps, embedding_dim))
-#     layer = layer_class(units, return_state=True, return_sequences=True)
-#     outputs = layer(inputs)
-#     output, state = outputs[0], outputs[1:]
-#     output = layer_class(units)(output, initial_state=state)
-#     model = Model(inputs, output)
-#
-#     inputs = np.random.random((num_samples, timesteps, embedding_dim))
-#     outputs = model.predict(inputs)
-#
-#
-# def test_minimal_rnn_cell_non_layer():
-#
-#     class MinimalRNNCell(object):
-#
-#         def __init__(self, units, input_dim):
-#             self.units = units
-#             self.state_size = units
-#             self.kernel = keras.backend.variable(
-#                 np.random.random((input_dim, units)))
-#
-#         def call(self, inputs, states):
-#             prev_output = states[0]
-#             output = keras.backend.dot(inputs, self.kernel) + prev_output
-#             return output, [output]
-#
-#     # Basic test case.
-#     cell = MinimalRNNCell(32, 5)
-#     x = keras.Input((None, 5))
-#     layer = recurrent.RNN(cell)
-#     y = layer(x)
-#     model = keras.models.Model(x, y)
-#     model.compile(optimizer='rmsprop', loss='mse')
-#     model.train_on_batch(np.zeros((6, 5, 5)), np.zeros((6, 32)))
-#
-#     # Test stacking.
-#     cells = [MinimalRNNCell(8, 5),
-#              MinimalRNNCell(32, 8),
-#              MinimalRNNCell(32, 32)]
-#     layer = recurrent.RNN(cells)
-#     y = layer(x)
-#     model = keras.models.Model(x, y)
-#     model.compile(optimizer='rmsprop', loss='mse')
-#     model.train_on_batch(np.zeros((6, 5, 5)), np.zeros((6, 32)))
-#
-#
-# def test_minimal_rnn_cell_non_layer_multiple_states():
-#
-#     class MinimalRNNCell(object):
-#
-#         def __init__(self, units, input_dim):
-#             self.units = units
-#             self.state_size = (units, units)
-#             self.kernel = keras.backend.variable(
-#                 np.random.random((input_dim, units)))
-#
-#         def call(self, inputs, states):
-#             prev_output_1 = states[0]
-#             prev_output_2 = states[1]
-#             output = keras.backend.dot(inputs, self.kernel)
-#             output += prev_output_1
-#             output -= prev_output_2
-#             return output, [output * 2, output * 3]
-#
-#     # Basic test case.
-#     cell = MinimalRNNCell(32, 5)
-#     x = keras.Input((None, 5))
-#     layer = recurrent.RNN(cell)
-#     y = layer(x)
-#     model = keras.models.Model(x, y)
-#     model.compile(optimizer='rmsprop', loss='mse')
-#     model.train_on_batch(np.zeros((6, 5, 5)), np.zeros((6, 32)))
-#
-#     # Test stacking.
-#     cells = [MinimalRNNCell(8, 5),
-#              MinimalRNNCell(16, 8),
-#              MinimalRNNCell(32, 16)]
-#     layer = recurrent.RNN(cells)
-#     assert layer.cell.state_size == (32, 32, 16, 16, 8, 8)
-#     y = layer(x)
-#     model = keras.models.Model(x, y)
-#     model.compile(optimizer='rmsprop', loss='mse')
-#     model.train_on_batch(np.zeros((6, 5, 5)), np.zeros((6, 32)))
-#
-#
-# def test_minimal_rnn_cell_layer():
-#
-#     class MinimalRNNCell(keras.layers.Layer):
-#
-#         def __init__(self, units, **kwargs):
-#             self.units = units
-#             self.state_size = units
-#             super(MinimalRNNCell, self).__init__(**kwargs)
-#
-#         def build(self, input_shape):
-#             self.kernel = self.add_weight(shape=(input_shape[-1], self.units),
-#                                           initializer='uniform',
-#                                           name='kernel')
-#             self.recurrent_kernel = self.add_weight(
-#                 shape=(self.units, self.units),
-#                 initializer='uniform',
-#                 name='recurrent_kernel')
-#             self.built = True
-#
-#         def call(self, inputs, states):
-#             prev_output = states[0]
-#             h = keras.backend.dot(inputs, self.kernel)
-#             output = h + keras.backend.dot(prev_output, self.recurrent_kernel)
-#             return output, [output]
-#
-#         def get_config(self):
-#             config = {'units': self.units}
-#             base_config = super(MinimalRNNCell, self).get_config()
-#             return dict(list(base_config.items()) + list(config.items()))
-#
-#     # Test basic case.
-#     x = keras.Input((None, 5))
-#     cell = MinimalRNNCell(32)
-#     layer = recurrent.RNN(cell)
-#     y = layer(x)
-#     model = keras.models.Model(x, y)
-#     model.compile(optimizer='rmsprop', loss='mse')
-#     model.train_on_batch(np.zeros((6, 5, 5)), np.zeros((6, 32)))
-#
-#     # Test basic case serialization.
-#     x_np = np.random.random((6, 5, 5))
-#     y_np = model.predict(x_np)
-#     weights = model.get_weights()
-#     config = layer.get_config()
-#     with keras.utils.CustomObjectScope({'MinimalRNNCell': MinimalRNNCell}):
-#         layer = recurrent.RNN.from_config(config)
-#     y = layer(x)
-#     model = keras.models.Model(x, y)
-#     model.set_weights(weights)
-#     y_np_2 = model.predict(x_np)
-#     assert_allclose(y_np, y_np_2, atol=1e-4)
-#
-#     # Test stacking.
-#     cells = [MinimalRNNCell(8),
-#              MinimalRNNCell(12),
-#              MinimalRNNCell(32)]
-#     layer = recurrent.RNN(cells)
-#     y = layer(x)
-#     model = keras.models.Model(x, y)
-#     model.compile(optimizer='rmsprop', loss='mse')
-#     model.train_on_batch(np.zeros((6, 5, 5)), np.zeros((6, 32)))
-#
-#     # Test stacked RNN serialization.
-#     x_np = np.random.random((6, 5, 5))
-#     y_np = model.predict(x_np)
-#     weights = model.get_weights()
-#     config = layer.get_config()
-#     with keras.utils.CustomObjectScope({'MinimalRNNCell': MinimalRNNCell}):
-#         layer = recurrent.RNN.from_config(config)
-#     y = layer(x)
-#     model = keras.models.Model(x, y)
-#     model.set_weights(weights)
-#     y_np_2 = model.predict(x_np)
-#     assert_allclose(y_np, y_np_2, atol=1e-4)
-#
-#
-# def test_stacked_rnn_attributes():
-#     cells = [recurrent.LSTMCell(3),
-#              recurrent.LSTMCell(3, kernel_regularizer='l2')]
-#     layer = recurrent.RNN(cells)
-#     layer.build((None, None, 5))
-#
-#     # Test regularization losses
-#     assert len(layer.losses) == 1
-#
-#     # Test weights
-#     assert len(layer.trainable_weights) == 6
-#     cells[0].trainable = False
-#     assert len(layer.trainable_weights) == 3
-#     assert len(layer.non_trainable_weights) == 3
-#
-#     # Test `get_losses_for`
-#     x = keras.Input((None, 5))
-#     y = K.sum(x)
-#     cells[0].add_loss(y, inputs=x)
-#     assert layer.get_losses_for(x) == [y]
-#
-#
-# @rnn_test
-# def test_batch_size_equal_one(layer_class):
-#     inputs = Input(batch_shape=(1, timesteps, embedding_dim))
-#     layer = layer_class(units)
-#     outputs = layer(inputs)
-#     model = Model(inputs, outputs)
-#     model.compile('sgd', 'mse')
-#     x = np.random.random((1, timesteps, embedding_dim))
-#     y = np.random.random((1, units))
-#     model.train_on_batch(x, y)
-#
-#
-# def test_rnn_cell_with_constants_layer():
-#
-#     class RNNCellWithConstants(keras.layers.Layer):
-#
-#         def __init__(self, units, **kwargs):
-#             self.units = units
-#             self.state_size = units
-#             super(RNNCellWithConstants, self).__init__(**kwargs)
-#
-#         def build(self, input_shape):
-#             if not isinstance(input_shape, list):
-#                 raise TypeError('expects constants shape')
-#             [input_shape, constant_shape] = input_shape
-#             # will (and should) raise if more than one constant passed
-#
-#             self.input_kernel = self.add_weight(
-#                 shape=(input_shape[-1], self.units),
-#                 initializer='uniform',
-#                 name='kernel')
-#             self.recurrent_kernel = self.add_weight(
-#                 shape=(self.units, self.units),
-#                 initializer='uniform',
-#                 name='recurrent_kernel')
-#             self.constant_kernel = self.add_weight(
-#                 shape=(constant_shape[-1], self.units),
-#                 initializer='uniform',
-#                 name='constant_kernel')
-#             self.built = True
-#
-#         def call(self, inputs, states, constants):
-#             [prev_output] = states
-#             [constant] = constants
-#             h_input = keras.backend.dot(inputs, self.input_kernel)
-#             h_state = keras.backend.dot(prev_output, self.recurrent_kernel)
-#             h_const = keras.backend.dot(constant, self.constant_kernel)
-#             output = h_input + h_state + h_const
-#             return output, [output]
-#
-#         def get_config(self):
-#             config = {'units': self.units}
-#             base_config = super(RNNCellWithConstants, self).get_config()
-#             return dict(list(base_config.items()) + list(config.items()))
-#
-#     # Test basic case.
-#     x = keras.Input((None, 5))
-#     c = keras.Input((3,))
-#     cell = RNNCellWithConstants(32)
-#     layer = recurrent.RNN(cell)
-#     y = layer(x, constants=c)
-#     model = keras.models.Model([x, c], y)
-#     model.compile(optimizer='rmsprop', loss='mse')
-#     model.train_on_batch(
-#         [np.zeros((6, 5, 5)), np.zeros((6, 3))],
-#         np.zeros((6, 32))
-#     )
-#
-#     # Test basic case serialization.
-#     x_np = np.random.random((6, 5, 5))
-#     c_np = np.random.random((6, 3))
-#     y_np = model.predict([x_np, c_np])
-#     weights = model.get_weights()
-#     config = layer.get_config()
-#     with keras.utils.CustomObjectScope(
-#         {'RNNCellWithConstants': RNNCellWithConstants}):
-#         layer = recurrent.RNN.from_config(config)
-#     y = layer(x, constants=c)
-#     model = keras.models.Model([x, c], y)
-#     model.set_weights(weights)
-#     y_np_2 = model.predict([x_np, c_np])
-#     assert_allclose(y_np, y_np_2, atol=1e-4)
+
+
+@keras_test
+def rnn_test(f):
+    """
+    All the recurrent layers share the same interface,
+    so we can run through them with a single function.
+    """
+    f = keras_test(f)
+    return pytest.mark.parametrize('layer_class', [
+        recurrent.SimpleRNN,
+        recurrent.GRU,
+        recurrent.LSTM
+    ])(f)
+
+
+@rnn_test
+def test_return_sequences(layer_class):
+    layer_test(layer_class,
+               kwargs={'units': units,
+                       'return_sequences': True},
+               input_shape=(num_samples, timesteps, embedding_dim))
+
+
+@rnn_test
+def test_dynamic_behavior(layer_class):
+    layer = layer_class(units, input_shape=(None, embedding_dim))
+    model = Sequential()
+    model.add(layer)
+    model.compile('sgd', 'mse')
+    x = np.random.random((num_samples, timesteps, embedding_dim))
+    y = np.random.random((num_samples, units))
+    model.train_on_batch(x, y)
+
+
+@rnn_test
+def test_stateful_invalid_use(layer_class):
+    layer = layer_class(units,
+                        stateful=True,
+                        batch_input_shape=(num_samples,
+                                           timesteps,
+                                           embedding_dim))
+    model = Sequential()
+    model.add(layer)
+    model.compile('sgd', 'mse')
+    x = np.random.random((num_samples * 2, timesteps, embedding_dim))
+    y = np.random.random((num_samples * 2, units))
+    with pytest.raises(ValueError):
+        model.fit(x, y)
+    with pytest.raises(ValueError):
+        model.predict(x, batch_size=num_samples + 1)
+
+
+@rnn_test
+@pytest.mark.skipif((K.backend() == 'cntk'),
+                    reason='Not yet supported.')
+def test_dropout(layer_class):
+    for unroll in [True, False]:
+        layer_test(layer_class,
+                   kwargs={'units': units,
+                           'dropout': 0.1,
+                           'recurrent_dropout': 0.1,
+                           'unroll': unroll},
+                   input_shape=(num_samples, timesteps, embedding_dim))
+
+        # Test that dropout is applied during training
+        x = K.ones((num_samples, timesteps, embedding_dim))
+        layer = layer_class(units, dropout=0.5, recurrent_dropout=0.5,
+                            input_shape=(timesteps, embedding_dim))
+        y = layer(x)
+        assert y._uses_learning_phase
+
+        y = layer(x, training=True)
+        assert not getattr(y, '_uses_learning_phase')
+
+        # Test that dropout is not applied during testing
+        x = np.random.random((num_samples, timesteps, embedding_dim))
+        layer = layer_class(units, dropout=0.5, recurrent_dropout=0.5,
+                            unroll=unroll,
+                            input_shape=(timesteps, embedding_dim))
+        model = Sequential([layer])
+        assert model.uses_learning_phase
+        y1 = model.predict(x)
+        y2 = model.predict(x)
+        assert_allclose(y1, y2)
+
+
+@rnn_test
+def test_statefulness(layer_class):
+    model = Sequential()
+    model.add(embeddings.Embedding(embedding_num, embedding_dim,
+                                   mask_zero=True,
+                                   input_length=timesteps,
+                                   batch_input_shape=(num_samples, timesteps)))
+    layer = layer_class(units, return_sequences=False,
+                        stateful=True,
+                        weights=None)
+    model.add(layer)
+    model.compile(optimizer='sgd', loss='mse')
+    out1 = model.predict(np.ones((num_samples, timesteps)))
+    assert(out1.shape == (num_samples, units))
+
+    # train once so that the states change
+    model.train_on_batch(np.ones((num_samples, timesteps)),
+                         np.ones((num_samples, units)))
+    out2 = model.predict(np.ones((num_samples, timesteps)))
+
+    # if the state is not reset, output should be different
+    assert(out1.max() != out2.max())
+
+    # check that output changes after states are reset
+    # (even though the model itself didn't change)
+    layer.reset_states()
+    out3 = model.predict(np.ones((num_samples, timesteps)))
+    assert(out2.max() != out3.max())
+
+    # check that container-level reset_states() works
+    model.reset_states()
+    out4 = model.predict(np.ones((num_samples, timesteps)))
+    assert_allclose(out3, out4, atol=1e-5)
+
+    # check that the call to `predict` updated the states
+    out5 = model.predict(np.ones((num_samples, timesteps)))
+    assert(out4.max() != out5.max())
+
+
+@rnn_test
+def test_masking_correctness(layer_class):
+    # Check masking: output with left padding and right padding
+    # should be the same.
+    model = Sequential()
+    model.add(embeddings.Embedding(embedding_num, embedding_dim,
+                                   mask_zero=True,
+                                   input_length=timesteps,
+                                   batch_input_shape=(num_samples, timesteps)))
+    layer = layer_class(units, return_sequences=False)
+    model.add(layer)
+    model.compile(optimizer='sgd', loss='mse')
+
+    left_padded_input = np.ones((num_samples, timesteps))
+    left_padded_input[0, :1] = 0
+    left_padded_input[1, :2] = 0
+    out6 = model.predict(left_padded_input)
+
+    right_padded_input = np.ones((num_samples, timesteps))
+    right_padded_input[0, -1:] = 0
+    right_padded_input[1, -2:] = 0
+    out7 = model.predict(right_padded_input)
+
+    assert_allclose(out7, out6, atol=1e-5)
+
+
+@rnn_test
+def test_implementation_mode(layer_class):
+    for mode in [1, 2]:
+        # Without dropout
+        layer_test(layer_class,
+                   kwargs={'units': units,
+                           'implementation': mode},
+                   input_shape=(num_samples, timesteps, embedding_dim))
+        # With dropout
+        layer_test(layer_class,
+                   kwargs={'units': units,
+                           'implementation': mode,
+                           'dropout': 0.1,
+                           'recurrent_dropout': 0.1},
+                   input_shape=(num_samples, timesteps, embedding_dim))
+
+
+@rnn_test
+def test_regularizer(layer_class):
+    layer = layer_class(units, return_sequences=False, weights=None,
+                        input_shape=(timesteps, embedding_dim),
+                        kernel_regularizer=regularizers.l1(0.01),
+                        recurrent_regularizer=regularizers.l1(0.01),
+                        bias_regularizer='l2')
+    layer.build((None, None, embedding_dim))
+    assert len(layer.losses) == 3
+    assert len(layer.cell.losses) == 3
+
+    layer = layer_class(units, return_sequences=False, weights=None,
+                        input_shape=(timesteps, embedding_dim),
+                        activity_regularizer='l2')
+    assert layer.activity_regularizer
+    x = K.variable(np.ones((num_samples, timesteps, embedding_dim)))
+    layer(x)
+    assert len(layer.cell.get_losses_for(x)) == 0
+    assert len(layer.get_losses_for(x)) == 1
+
+
+@keras_test
+def test_masking_layer():
+    ''' This test based on a previously failing issue here:
+    https://github.com/fchollet/keras/issues/1567
+    '''
+    inputs = np.random.random((6, 3, 4))
+    targets = np.abs(np.random.random((6, 3, 5)))
+    targets /= targets.sum(axis=-1, keepdims=True)
+
+    model = Sequential()
+    model.add(Masking(input_shape=(3, 4)))
+    model.add(recurrent.SimpleRNN(units=5, return_sequences=True, unroll=False))
+    model.compile(loss='categorical_crossentropy', optimizer='adam')
+    model.fit(inputs, targets, epochs=1, batch_size=100, verbose=1)
+
+    model = Sequential()
+    model.add(Masking(input_shape=(3, 4)))
+    model.add(recurrent.SimpleRNN(units=5, return_sequences=True, unroll=True))
+    model.compile(loss='categorical_crossentropy', optimizer='adam')
+    model.fit(inputs, targets, epochs=1, batch_size=100, verbose=1)
+
+
+@rnn_test
+def test_from_config(layer_class):
+    stateful_flags = (False, True)
+    for stateful in stateful_flags:
+        l1 = layer_class(units=1, stateful=stateful)
+        l2 = layer_class.from_config(l1.get_config())
+        assert l1.get_config() == l2.get_config()
+
+
+@rnn_test
+def test_specify_initial_state_keras_tensor(layer_class):
+    num_states = 2 if layer_class is recurrent.LSTM else 1
+
+    # Test with Keras tensor
+    inputs = Input((timesteps, embedding_dim))
+    initial_state = [Input((units,)) for _ in range(num_states)]
+    layer = layer_class(units)
+    if len(initial_state) == 1:
+        output = layer(inputs, initial_state=initial_state[0])
+    else:
+        output = layer(inputs, initial_state=initial_state)
+    assert initial_state[0] in layer.inbound_nodes[0].input_tensors
+
+    model = Model([inputs] + initial_state, output)
+    model.compile(loss='categorical_crossentropy', optimizer='adam')
+
+    inputs = np.random.random((num_samples, timesteps, embedding_dim))
+    initial_state = [np.random.random((num_samples, units))
+                     for _ in range(num_states)]
+    targets = np.random.random((num_samples, units))
+    model.fit([inputs] + initial_state, targets)
+
+
+@rnn_test
+def test_specify_initial_state_non_keras_tensor(layer_class):
+    num_states = 2 if layer_class is recurrent.LSTM else 1
+
+    # Test with non-Keras tensor
+    inputs = Input((timesteps, embedding_dim))
+    initial_state = [K.random_normal_variable((num_samples, units), 0, 1)
+                     for _ in range(num_states)]
+    layer = layer_class(units)
+    output = layer(inputs, initial_state=initial_state)
+
+    model = Model(inputs, output)
+    model.compile(loss='categorical_crossentropy', optimizer='adam')
+
+    inputs = np.random.random((num_samples, timesteps, embedding_dim))
+    targets = np.random.random((num_samples, units))
+    model.fit(inputs, targets)
+
+
+@rnn_test
+def test_reset_states_with_values(layer_class):
+    num_states = 2 if layer_class is recurrent.LSTM else 1
+
+    layer = layer_class(units, stateful=True)
+    layer.build((num_samples, timesteps, embedding_dim))
+    layer.reset_states()
+    assert len(layer.states) == num_states
+    assert layer.states[0] is not None
+    np.testing.assert_allclose(K.eval(layer.states[0]),
+                               np.zeros(K.int_shape(layer.states[0])),
+                               atol=1e-4)
+    state_shapes = [K.int_shape(state) for state in layer.states]
+    values = [np.ones(shape) for shape in state_shapes]
+    if len(values) == 1:
+        values = values[0]
+    layer.reset_states(values)
+    np.testing.assert_allclose(K.eval(layer.states[0]),
+                               np.ones(K.int_shape(layer.states[0])),
+                               atol=1e-4)
+
+    # Test fit with invalid data
+    with pytest.raises(ValueError):
+        layer.reset_states([1] * (len(layer.states) + 1))
+
+
+@rnn_test
+def test_initial_states_as_other_inputs(layer_class):
+    num_states = 2 if layer_class is recurrent.LSTM else 1
+
+    # Test with Keras tensor
+    main_inputs = Input((timesteps, embedding_dim))
+    initial_state = [Input((units,)) for _ in range(num_states)]
+    inputs = [main_inputs] + initial_state
+
+    layer = layer_class(units)
+    output = layer(inputs)
+    assert initial_state[0] in layer.inbound_nodes[0].input_tensors
+
+    model = Model(inputs, output)
+    model.compile(loss='categorical_crossentropy', optimizer='adam')
+
+    main_inputs = np.random.random((num_samples, timesteps, embedding_dim))
+    initial_state = [np.random.random((num_samples, units))
+                     for _ in range(num_states)]
+    targets = np.random.random((num_samples, units))
+    model.train_on_batch([main_inputs] + initial_state, targets)
+
+
+@rnn_test
+def test_specify_state_with_masking(layer_class):
+    ''' This test based on a previously failing issue here:
+    https://github.com/fchollet/keras/issues/1567
+    '''
+    num_states = 2 if layer_class is recurrent.LSTM else 1
+
+    inputs = Input((timesteps, embedding_dim))
+    _ = Masking()(inputs)
+    initial_state = [Input((units,)) for _ in range(num_states)]
+    output = layer_class(units)(inputs, initial_state=initial_state)
+
+    model = Model([inputs] + initial_state, output)
+    model.compile(loss='categorical_crossentropy', optimizer='adam')
+
+    inputs = np.random.random((num_samples, timesteps, embedding_dim))
+    initial_state = [np.random.random((num_samples, units))
+                     for _ in range(num_states)]
+    targets = np.random.random((num_samples, units))
+    model.fit([inputs] + initial_state, targets)
+
+
+@rnn_test
+def test_return_state(layer_class):
+    num_states = 2 if layer_class is recurrent.LSTM else 1
+
+    inputs = Input(batch_shape=(num_samples, timesteps, embedding_dim))
+    layer = layer_class(units, return_state=True, stateful=True)
+    outputs = layer(inputs)
+    output, state = outputs[0], outputs[1:]
+    assert len(state) == num_states
+    model = Model(inputs, state[0])
+
+    inputs = np.random.random((num_samples, timesteps, embedding_dim))
+    state = model.predict(inputs)
+    np.testing.assert_allclose(K.eval(layer.states[0]), state, atol=1e-4)
+
+
+@rnn_test
+def test_state_reuse(layer_class):
+    inputs = Input(batch_shape=(num_samples, timesteps, embedding_dim))
+    layer = layer_class(units, return_state=True, return_sequences=True)
+    outputs = layer(inputs)
+    output, state = outputs[0], outputs[1:]
+    output = layer_class(units)(output, initial_state=state)
+    model = Model(inputs, output)
+
+    inputs = np.random.random((num_samples, timesteps, embedding_dim))
+    outputs = model.predict(inputs)
+
+
+def test_minimal_rnn_cell_non_layer():
+
+    class MinimalRNNCell(object):
+
+        def __init__(self, units, input_dim):
+            self.units = units
+            self.state_size = units
+            self.kernel = keras.backend.variable(
+                np.random.random((input_dim, units)))
+
+        def call(self, inputs, states):
+            prev_output = states[0]
+            output = keras.backend.dot(inputs, self.kernel) + prev_output
+            return output, [output]
+
+    # Basic test case.
+    cell = MinimalRNNCell(32, 5)
+    x = keras.Input((None, 5))
+    layer = recurrent.RNN(cell)
+    y = layer(x)
+    model = keras.models.Model(x, y)
+    model.compile(optimizer='rmsprop', loss='mse')
+    model.train_on_batch(np.zeros((6, 5, 5)), np.zeros((6, 32)))
+
+    # Test stacking.
+    cells = [MinimalRNNCell(8, 5),
+             MinimalRNNCell(32, 8),
+             MinimalRNNCell(32, 32)]
+    layer = recurrent.RNN(cells)
+    y = layer(x)
+    model = keras.models.Model(x, y)
+    model.compile(optimizer='rmsprop', loss='mse')
+    model.train_on_batch(np.zeros((6, 5, 5)), np.zeros((6, 32)))
+
+
+def test_minimal_rnn_cell_non_layer_multiple_states():
+
+    class MinimalRNNCell(object):
+
+        def __init__(self, units, input_dim):
+            self.units = units
+            self.state_size = (units, units)
+            self.kernel = keras.backend.variable(
+                np.random.random((input_dim, units)))
+
+        def call(self, inputs, states):
+            prev_output_1 = states[0]
+            prev_output_2 = states[1]
+            output = keras.backend.dot(inputs, self.kernel)
+            output += prev_output_1
+            output -= prev_output_2
+            return output, [output * 2, output * 3]
+
+    # Basic test case.
+    cell = MinimalRNNCell(32, 5)
+    x = keras.Input((None, 5))
+    layer = recurrent.RNN(cell)
+    y = layer(x)
+    model = keras.models.Model(x, y)
+    model.compile(optimizer='rmsprop', loss='mse')
+    model.train_on_batch(np.zeros((6, 5, 5)), np.zeros((6, 32)))
+
+    # Test stacking.
+    cells = [MinimalRNNCell(8, 5),
+             MinimalRNNCell(16, 8),
+             MinimalRNNCell(32, 16)]
+    layer = recurrent.RNN(cells)
+    assert layer.cell.state_size == (32, 32, 16, 16, 8, 8)
+    y = layer(x)
+    model = keras.models.Model(x, y)
+    model.compile(optimizer='rmsprop', loss='mse')
+    model.train_on_batch(np.zeros((6, 5, 5)), np.zeros((6, 32)))
+
+
+def test_minimal_rnn_cell_layer():
+
+    class MinimalRNNCell(keras.layers.Layer):
+
+        def __init__(self, units, **kwargs):
+            self.units = units
+            self.state_size = units
+            super(MinimalRNNCell, self).__init__(**kwargs)
+
+        def build(self, input_shape):
+            self.kernel = self.add_weight(shape=(input_shape[-1], self.units),
+                                          initializer='uniform',
+                                          name='kernel')
+            self.recurrent_kernel = self.add_weight(
+                shape=(self.units, self.units),
+                initializer='uniform',
+                name='recurrent_kernel')
+            self.built = True
+
+        def call(self, inputs, states):
+            prev_output = states[0]
+            h = keras.backend.dot(inputs, self.kernel)
+            output = h + keras.backend.dot(prev_output, self.recurrent_kernel)
+            return output, [output]
+
+        def get_config(self):
+            config = {'units': self.units}
+            base_config = super(MinimalRNNCell, self).get_config()
+            return dict(list(base_config.items()) + list(config.items()))
+
+    # Test basic case.
+    x = keras.Input((None, 5))
+    cell = MinimalRNNCell(32)
+    layer = recurrent.RNN(cell)
+    y = layer(x)
+    model = keras.models.Model(x, y)
+    model.compile(optimizer='rmsprop', loss='mse')
+    model.train_on_batch(np.zeros((6, 5, 5)), np.zeros((6, 32)))
+
+    # Test basic case serialization.
+    x_np = np.random.random((6, 5, 5))
+    y_np = model.predict(x_np)
+    weights = model.get_weights()
+    config = layer.get_config()
+    with keras.utils.CustomObjectScope({'MinimalRNNCell': MinimalRNNCell}):
+        layer = recurrent.RNN.from_config(config)
+    y = layer(x)
+    model = keras.models.Model(x, y)
+    model.set_weights(weights)
+    y_np_2 = model.predict(x_np)
+    assert_allclose(y_np, y_np_2, atol=1e-4)
+
+    # Test stacking.
+    cells = [MinimalRNNCell(8),
+             MinimalRNNCell(12),
+             MinimalRNNCell(32)]
+    layer = recurrent.RNN(cells)
+    y = layer(x)
+    model = keras.models.Model(x, y)
+    model.compile(optimizer='rmsprop', loss='mse')
+    model.train_on_batch(np.zeros((6, 5, 5)), np.zeros((6, 32)))
+
+    # Test stacked RNN serialization.
+    x_np = np.random.random((6, 5, 5))
+    y_np = model.predict(x_np)
+    weights = model.get_weights()
+    config = layer.get_config()
+    with keras.utils.CustomObjectScope({'MinimalRNNCell': MinimalRNNCell}):
+        layer = recurrent.RNN.from_config(config)
+    y = layer(x)
+    model = keras.models.Model(x, y)
+    model.set_weights(weights)
+    y_np_2 = model.predict(x_np)
+    assert_allclose(y_np, y_np_2, atol=1e-4)
+
+
+def test_stacked_rnn_attributes():
+    cells = [recurrent.LSTMCell(3),
+             recurrent.LSTMCell(3, kernel_regularizer='l2')]
+    layer = recurrent.RNN(cells)
+    layer.build((None, None, 5))
+
+    # Test regularization losses
+    assert len(layer.losses) == 1
+
+    # Test weights
+    assert len(layer.trainable_weights) == 6
+    cells[0].trainable = False
+    assert len(layer.trainable_weights) == 3
+    assert len(layer.non_trainable_weights) == 3
+
+    # Test `get_losses_for`
+    x = keras.Input((None, 5))
+    y = K.sum(x)
+    cells[0].add_loss(y, inputs=x)
+    assert layer.get_losses_for(x) == [y]
+
+
+@rnn_test
+def test_batch_size_equal_one(layer_class):
+    inputs = Input(batch_shape=(1, timesteps, embedding_dim))
+    layer = layer_class(units)
+    outputs = layer(inputs)
+    model = Model(inputs, outputs)
+    model.compile('sgd', 'mse')
+    x = np.random.random((1, timesteps, embedding_dim))
+    y = np.random.random((1, units))
+    model.train_on_batch(x, y)
+
+
+def test_rnn_cell_with_constants_layer():
+
+    class RNNCellWithConstants(keras.layers.Layer):
+
+        def __init__(self, units, **kwargs):
+            self.units = units
+            self.state_size = units
+            super(RNNCellWithConstants, self).__init__(**kwargs)
+
+        def build(self, input_shape):
+            if not isinstance(input_shape, list):
+                raise TypeError('expects constants shape')
+            [input_shape, constant_shape] = input_shape
+            # will (and should) raise if more than one constant passed
+
+            self.input_kernel = self.add_weight(
+                shape=(input_shape[-1], self.units),
+                initializer='uniform',
+                name='kernel')
+            self.recurrent_kernel = self.add_weight(
+                shape=(self.units, self.units),
+                initializer='uniform',
+                name='recurrent_kernel')
+            self.constant_kernel = self.add_weight(
+                shape=(constant_shape[-1], self.units),
+                initializer='uniform',
+                name='constant_kernel')
+            self.built = True
+
+        def call(self, inputs, states, constants):
+            [prev_output] = states
+            [constant] = constants
+            h_input = keras.backend.dot(inputs, self.input_kernel)
+            h_state = keras.backend.dot(prev_output, self.recurrent_kernel)
+            h_const = keras.backend.dot(constant, self.constant_kernel)
+            output = h_input + h_state + h_const
+            return output, [output]
+
+        def get_config(self):
+            config = {'units': self.units}
+            base_config = super(RNNCellWithConstants, self).get_config()
+            return dict(list(base_config.items()) + list(config.items()))
+
+    # Test basic case.
+    x = keras.Input((None, 5))
+    c = keras.Input((3,))
+    cell = RNNCellWithConstants(32)
+    layer = recurrent.RNN(cell)
+    y = layer(x, constants=c)
+    model = keras.models.Model([x, c], y)
+    model.compile(optimizer='rmsprop', loss='mse')
+    model.train_on_batch(
+        [np.zeros((6, 5, 5)), np.zeros((6, 3))],
+        np.zeros((6, 32))
+    )
+
+    # Test basic case serialization.
+    x_np = np.random.random((6, 5, 5))
+    c_np = np.random.random((6, 3))
+    y_np = model.predict([x_np, c_np])
+    weights = model.get_weights()
+    config = layer.get_config()
+    with keras.utils.CustomObjectScope(
+        {'RNNCellWithConstants': RNNCellWithConstants}):
+        layer = recurrent.RNN.from_config(config)
+    y = layer(x, constants=c)
+    model = keras.models.Model([x, c], y)
+    model.set_weights(weights)
+    y_np_2 = model.predict([x_np, c_np])
+    assert_allclose(y_np, y_np_2, atol=1e-4)
 
 
 def test_functional_rnn_cell():

--- a/tests/keras/layers/recurrent_test.py
+++ b/tests/keras/layers/recurrent_test.py
@@ -564,5 +564,77 @@ def test_batch_size_equal_one(layer_class):
     model.train_on_batch(x, y)
 
 
+def test_rnn_cell_with_constants_layer():
+
+    class RNNCellWithConstants(keras.layers.Layer):
+
+        def __init__(self, units, **kwargs):
+            self.units = units
+            self.state_size = units
+            super(RNNCellWithConstants, self).__init__(**kwargs)
+
+        def build(self, input_shape):
+            if not isinstance(input_shape, list):
+                raise TypeError('expects constants shape')
+            [input_shape, constant_shape] = input_shape
+            # will (and should) raise if more than one constant passed
+
+            self.input_kernel = self.add_weight(
+                shape=(input_shape[-1], self.units),
+                initializer='uniform',
+                name='kernel')
+            self.recurrent_kernel = self.add_weight(
+                shape=(self.units, self.units),
+                initializer='uniform',
+                name='recurrent_kernel')
+            self.constant_kernel = self.add_weight(
+                shape=(constant_shape[-1], self.units),
+                initializer='uniform',
+                name='constant_kernel')
+            self.built = True
+
+        def call(self, inputs, states, constants):
+            [prev_output] = states
+            [constant] = constants
+            h_input = keras.backend.dot(inputs, self.input_kernel)
+            h_state = keras.backend.dot(prev_output, self.recurrent_kernel)
+            h_const = keras.backend.dot(constant, self.constant_kernel)
+            output = h_input + h_state + h_const
+            return output, [output]
+
+        def get_config(self):
+            config = {'units': self.units}
+            base_config = super(RNNCellWithConstants, self).get_config()
+            return dict(list(base_config.items()) + list(config.items()))
+
+    # Test basic case.
+    x = keras.Input((None, 5))
+    c = keras.Input((3,))
+    cell = RNNCellWithConstants(32)
+    layer = recurrent.RNN(cell)
+    y = layer(x, constants=c)
+    model = keras.models.Model([x, c], y)
+    model.compile(optimizer='rmsprop', loss='mse')
+    model.train_on_batch(
+        [np.zeros((6, 5, 5)), np.zeros((6, 3))],
+        np.zeros((6, 32))
+    )
+
+    # Test basic case serialization.
+    x_np = np.random.random((6, 5, 5))
+    c_np = np.random.random((6, 3))
+    y_np = model.predict([x_np, c_np])
+    weights = model.get_weights()
+    config = layer.get_config()
+    with keras.utils.CustomObjectScope(
+        {'RNNCellWithConstants': RNNCellWithConstants}):
+        layer = recurrent.RNN.from_config(config)
+    y = layer(x, constants=c)
+    model = keras.models.Model([x, c], y)
+    model.set_weights(weights)
+    y_np_2 = model.predict([x_np, c_np])
+    assert_allclose(y_np, y_np_2, atol=1e-4)
+
+
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
This PR is the second step to support recurrent attention mechanisms as suggested in #7633.

In short, it adds the possibility to compose RNN Cells using keras functional API, including support of constants, by introducing the `Model`-like wrapper class `FunctionalRNNCell`. 

Note: this is an extension of https://github.com/fchollet/keras/pull/7980