### PR TITLE
Fix Input dtype default value to be assigned during function call

### DIFF
--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -1372,7 +1372,7 @@ class InputLayer(Layer):
 
 
 def Input(shape=None, batch_shape=None,
-          name=None, dtype=K.floatx(), sparse=False,
+          name=None, dtype=None, sparse=False,
           tensor=None):
     """`Input()` is used to instantiate a Keras tensor.
 
@@ -1430,6 +1430,8 @@ def Input(shape=None, batch_shape=None,
                        'dimension.')
     if shape and not batch_shape:
         batch_shape = (None,) + tuple(shape)
+    if not dtype:
+        dtype = K.floatx()
     input_layer = InputLayer(batch_input_shape=batch_shape,
                              name=name, dtype=dtype,
                              sparse=sparse,


### PR DESCRIPTION
`model.layers.Input`'s constructor has a default parameter `dtype=K.floatx()`. This just calls `K.floatx()` when Keras is first imported, instead of calling `K.floatx()` at construction time. This is problematic because users call `K.set_floatx(...)` after importing Keras.

Resolves #7951