### PR TITLE
hybrid regularizer  as a layer (input, weight)

### DIFF
--- a/docs/autogen.py
+++ b/docs/autogen.py
@@ -157,6 +157,7 @@ PAGES = [
             layers.RepeatVector,
             layers.Lambda,
             layers.ActivityRegularization,
+            layers.HybridRegularization,
             layers.Masking,
         ],
     },

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -2229,6 +2229,9 @@ class Container(Layer):
                         if hasattr(layer, 'activity_regularizer') and layer.activity_regularizer is not None:
                             regularization_losses = [layer.activity_regularizer(x) for x in computed_tensors]
                             layer.add_loss(regularization_losses, computed_tensors)
+                        if hasattr(layer, 'hybrid_regularizer') and layer.hybrid_regularizer is not None:
+                            regularization_losses = [layer.hybrid_regularizer(x,self.weights) for x in computed_tensors]
+                            layer.add_loss(regularization_losses, computed_tensors)
 
                     # Update model updates and losses:
                     # Keep track of updates that depend on the inputs

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -643,6 +643,10 @@ class Layer(object):
             if hasattr(self, 'activity_regularizer') and self.activity_regularizer is not None:
                 regularization_losses = [self.activity_regularizer(x) for x in _to_list(output)]
                 self.add_loss(regularization_losses, _to_list(inputs))
+            # Apply hybrid regularizer if any:
+            if hasattr(self, 'hybrid_regularizer') and self.hybrid_regularizer is not None:
+                regularization_losses = [self.hybrid_regularizer(x,self.weights) for x in _to_list(inputs)]
+                self.add_loss(regularization_losses, _to_list(inputs))
         return output
 
     def _add_inbound_node(self, input_tensors, output_tensors,

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -74,6 +74,9 @@ class _Conv(Layer):
         activity_regularizer: Regularizer function applied to
             the output of the layer (its "activation").
             (see [regularizer](../regularizers.md)).
+        hybrid_regularizer: Regularizer function applied to
+            the inputs of the layer and its weights.
+            (see [regularizer](../regularizers.md)).
         kernel_constraint: Constraint function applied to the kernel matrix
             (see [constraints](../constraints.md)).
         bias_constraint: Constraint function applied to the bias vector
@@ -94,6 +97,7 @@ class _Conv(Layer):
                  kernel_regularizer=None,
                  bias_regularizer=None,
                  activity_regularizer=None,
+                 hybrid_regularizer=None,
                  kernel_constraint=None,
                  bias_constraint=None,
                  **kwargs):
@@ -112,6 +116,7 @@ class _Conv(Layer):
         self.kernel_regularizer = regularizers.get(kernel_regularizer)
         self.bias_regularizer = regularizers.get(bias_regularizer)
         self.activity_regularizer = regularizers.get(activity_regularizer)
+        self.hybrid_regularizer = regularizers.get(hybrid_regularizer)
         self.kernel_constraint = constraints.get(kernel_constraint)
         self.bias_constraint = constraints.get(bias_constraint)
         self.input_spec = InputSpec(ndim=self.rank + 2)
@@ -223,6 +228,7 @@ class _Conv(Layer):
             'kernel_regularizer': regularizers.serialize(self.kernel_regularizer),
             'bias_regularizer': regularizers.serialize(self.bias_regularizer),
             'activity_regularizer': regularizers.serialize(self.activity_regularizer),
+            'hybrid_regularizer': regularizers.serialize(self.hybrid_regularizer),
             'kernel_constraint': constraints.serialize(self.kernel_constraint),
             'bias_constraint': constraints.serialize(self.bias_constraint)
         }
@@ -283,6 +289,8 @@ class Conv1D(_Conv):
             (see [regularizer](../regularizers.md)).
         activity_regularizer: Regularizer function applied to
             the output of the layer (its "activation").
+        hybrid_regularizer: Regularizer function applied to
+            the inputs of the layer and its weights.
             (see [regularizer](../regularizers.md)).
         kernel_constraint: Constraint function applied to the kernel matrix
             (see [constraints](../constraints.md)).
@@ -310,6 +318,7 @@ class Conv1D(_Conv):
                  kernel_regularizer=None,
                  bias_regularizer=None,
                  activity_regularizer=None,
+                 hybrid_regularizer=None,
                  kernel_constraint=None,
                  bias_constraint=None,
                  **kwargs):
@@ -328,6 +337,7 @@ class Conv1D(_Conv):
             kernel_regularizer=kernel_regularizer,
             bias_regularizer=bias_regularizer,
             activity_regularizer=activity_regularizer,
+            hybrid_regularizer=hybrid_regularizer,
             kernel_constraint=kernel_constraint,
             bias_constraint=bias_constraint,
             **kwargs)
@@ -401,6 +411,8 @@ class Conv2D(_Conv):
             (see [regularizer](../regularizers.md)).
         activity_regularizer: Regularizer function applied to
             the output of the layer (its "activation").
+        hybrid_regularizer: Regularizer function applied to
+            the inputs of the layer and its weights.
             (see [regularizer](../regularizers.md)).
         kernel_constraint: Constraint function applied to the kernel matrix
             (see [constraints](../constraints.md)).
@@ -435,6 +447,7 @@ class Conv2D(_Conv):
                  kernel_regularizer=None,
                  bias_regularizer=None,
                  activity_regularizer=None,
+                 hybrid_regularizer=None,
                  kernel_constraint=None,
                  bias_constraint=None,
                  **kwargs):
@@ -453,6 +466,7 @@ class Conv2D(_Conv):
             kernel_regularizer=kernel_regularizer,
             bias_regularizer=bias_regularizer,
             activity_regularizer=activity_regularizer,
+            hybrid_regularizer=hybrid_regularizer,
             kernel_constraint=kernel_constraint,
             bias_constraint=bias_constraint,
             **kwargs)
@@ -526,6 +540,8 @@ class Conv3D(_Conv):
             (see [regularizer](../regularizers.md)).
         activity_regularizer: Regularizer function applied to
             the output of the layer (its "activation").
+        hybrid_regularizer: Regularizer function applied to
+            the inputs of the layer and its weights.
             (see [regularizer](../regularizers.md)).
         kernel_constraint: Constraint function applied to the kernel matrix
             (see [constraints](../constraints.md)).
@@ -560,6 +576,7 @@ class Conv3D(_Conv):
                  kernel_regularizer=None,
                  bias_regularizer=None,
                  activity_regularizer=None,
+                 hybrid_regularizer=None,
                  kernel_constraint=None,
                  bias_constraint=None,
                  **kwargs):
@@ -578,6 +595,7 @@ class Conv3D(_Conv):
             kernel_regularizer=kernel_regularizer,
             bias_regularizer=bias_regularizer,
             activity_regularizer=activity_regularizer,
+            hybrid_regularizer=hybrid_regularizer,
             kernel_constraint=kernel_constraint,
             bias_constraint=bias_constraint,
             **kwargs)
@@ -651,6 +669,8 @@ class Conv2DTranspose(Conv2D):
             (see [regularizer](../regularizers.md)).
         activity_regularizer: Regularizer function applied to
             the output of the layer (its "activation").
+        hybrid_regularizer: Regularizer function applied to
+            the inputs of the layer and its weights.
             (see [regularizer](../regularizers.md)).
         kernel_constraint: Constraint function applied to the kernel matrix
             (see [constraints](../constraints.md)).
@@ -688,6 +708,7 @@ class Conv2DTranspose(Conv2D):
                  kernel_regularizer=None,
                  bias_regularizer=None,
                  activity_regularizer=None,
+                 hybrid_regularizer=None,
                  kernel_constraint=None,
                  bias_constraint=None,
                  **kwargs):
@@ -704,6 +725,7 @@ class Conv2DTranspose(Conv2D):
             kernel_regularizer=kernel_regularizer,
             bias_regularizer=bias_regularizer,
             activity_regularizer=activity_regularizer,
+            hybrid_regularizer=hybrid_regularizer,
             kernel_constraint=kernel_constraint,
             bias_constraint=bias_constraint,
             **kwargs)
@@ -868,6 +890,8 @@ class Conv3DTranspose(Conv3D):
             (see [regularizer](../regularizers.md)).
         activity_regularizer: Regularizer function applied to
             the output of the layer (its "activation").
+        hybrid_regularizer: Regularizer function applied to
+            the inputs of the layer and its weights.
             (see [regularizer](../regularizers.md)).
         kernel_constraint: Constraint function applied to the kernel matrix
             (see [constraints](../constraints.md)).
@@ -904,6 +928,7 @@ class Conv3DTranspose(Conv3D):
                  kernel_regularizer=None,
                  bias_regularizer=None,
                  activity_regularizer=None,
+                 hybrid_regularizer=None,
                  kernel_constraint=None,
                  bias_constraint=None,
                  **kwargs):
@@ -920,6 +945,7 @@ class Conv3DTranspose(Conv3D):
             kernel_regularizer=kernel_regularizer,
             bias_regularizer=bias_regularizer,
             activity_regularizer=activity_regularizer,
+            hybrid_regularizer=hybrid_regularizer,
             kernel_constraint=kernel_constraint,
             bias_constraint=bias_constraint,
             **kwargs)
@@ -1100,6 +1126,8 @@ class SeparableConv2D(Conv2D):
             (see [regularizer](../regularizers.md)).
         activity_regularizer: Regularizer function applied to
             the output of the layer (its "activation").
+        hybrid_regularizer: Regularizer function applied to
+            the inputs of the layer and its weights.
             (see [regularizer](../regularizers.md)).
         depthwise_constraint: Constraint function applied to
             the depthwise kernel matrix
@@ -1140,6 +1168,7 @@ class SeparableConv2D(Conv2D):
                  pointwise_regularizer=None,
                  bias_regularizer=None,
                  activity_regularizer=None,
+                 hybrid_regularizer=None,
                  depthwise_constraint=None,
                  pointwise_constraint=None,
                  bias_constraint=None,
@@ -1154,6 +1183,7 @@ class SeparableConv2D(Conv2D):
             use_bias=use_bias,
             bias_regularizer=bias_regularizer,
             activity_regularizer=activity_regularizer,
+           hybrid_regularizer=hybrid_regularizer,
             bias_constraint=bias_constraint,
             **kwargs)
         self.depth_multiplier = depth_multiplier

--- a/keras/layers/convolutional_recurrent.py
+++ b/keras/layers/convolutional_recurrent.py
@@ -223,6 +223,8 @@ class ConvLSTM2D(ConvRecurrent2D):
             (see [regularizer](../regularizers.md)).
         activity_regularizer: Regularizer function applied to
             the output of the layer (its "activation").
+        hybrid_regularizer: Regularizer function applied to
+            the inputs of the layer and its weights.
             (see [regularizer](../regularizers.md)).
         kernel_constraint: Constraint function applied to
             the `kernel` weights matrix
@@ -300,6 +302,7 @@ class ConvLSTM2D(ConvRecurrent2D):
                  recurrent_regularizer=None,
                  bias_regularizer=None,
                  activity_regularizer=None,
+                 hybridregularizer=None,
                  kernel_constraint=None,
                  recurrent_constraint=None,
                  bias_constraint=None,
@@ -332,6 +335,7 @@ class ConvLSTM2D(ConvRecurrent2D):
         self.recurrent_regularizer = regularizers.get(recurrent_regularizer)
         self.bias_regularizer = regularizers.get(bias_regularizer)
         self.activity_regularizer = regularizers.get(activity_regularizer)
+        self.hybrid_regularizer = regularizers.get(hybrid_regularizer)
 
         self.kernel_constraint = constraints.get(kernel_constraint)
         self.recurrent_constraint = constraints.get(recurrent_constraint)
@@ -552,6 +556,7 @@ class ConvLSTM2D(ConvRecurrent2D):
                   'recurrent_regularizer': regularizers.serialize(self.recurrent_regularizer),
                   'bias_regularizer': regularizers.serialize(self.bias_regularizer),
                   'activity_regularizer': regularizers.serialize(self.activity_regularizer),
+                  'hybrid_regularizer': regularizers.serialize(self.hybrid_regularizer),
                   'kernel_constraint': constraints.serialize(self.kernel_constraint),
                   'recurrent_constraint': constraints.serialize(self.recurrent_constraint),
                   'bias_constraint': constraints.serialize(self.bias_constraint),

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -773,6 +773,10 @@ class Dense(Layer):
         activity_regularizer: Regularizer function applied to
             the output of the layer (its "activation").
             (see [regularizer](../regularizers.md)).
+        hybrid_regularizer: Regularizer function applied to
+            the output of the layer (its "activation") and
+            the `kernel` weights matrix.
+            (see [regularizer](../regularizers.md)).
         kernel_constraint: Constraint function applied to
             the `kernel` weights matrix
             (see [constraints](../constraints.md)).
@@ -799,6 +803,7 @@ class Dense(Layer):
                  kernel_regularizer=None,
                  bias_regularizer=None,
                  activity_regularizer=None,
+                 hybrid_regularizer=None,
                  kernel_constraint=None,
                  bias_constraint=None,
                  **kwargs):
@@ -813,6 +818,7 @@ class Dense(Layer):
         self.kernel_regularizer = regularizers.get(kernel_regularizer)
         self.bias_regularizer = regularizers.get(bias_regularizer)
         self.activity_regularizer = regularizers.get(activity_regularizer)
+        self.hybrid_regularizer = regularizers.get(hybrid_regularizer)
         self.kernel_constraint = constraints.get(kernel_constraint)
         self.bias_constraint = constraints.get(bias_constraint)
         self.input_spec = InputSpec(min_ndim=2)
@@ -897,4 +903,34 @@ class ActivityRegularization(Layer):
         config = {'l1': self.l1,
                   'l2': self.l2}
         base_config = super(ActivityRegularization, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))
+
+
+class HybridRegularization(Layer):
+    """Layer that applies an update to the cost function based input activity.
+
+    # Arguments
+        l1: L1 regularization factor (positive float).
+        l2: L2 regularization factor (positive float).
+
+    # Input shape
+        Arbitrary. Use the keyword argument `input_shape`
+        (tuple of integers, does not include the samples axis)
+        when using this layer as the first layer in a model.
+
+    # Output shape
+        Same shape as input.
+    """
+
+    def __init__(self, l1=0., l2=0., **kwargs):
+        super(HybridRegularization, self).__init__(**kwargs)
+        self.supports_masking = True
+        self.l1 = l1
+        self.l2 = l2
+        self.activity_regularizer = regularizers.L1L2(l1=l1, l2=l2)
+
+    def get_config(self):
+        config = {'l1': self.l1,
+                  'l2': self.l2}
+        base_config = super(HybridRegularization, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -869,6 +869,7 @@ class Dense(Layer):
             'kernel_regularizer': regularizers.serialize(self.kernel_regularizer),
             'bias_regularizer': regularizers.serialize(self.bias_regularizer),
             'activity_regularizer': regularizers.serialize(self.activity_regularizer),
+            'hybrid_regularizer': regularizers.serialize(self.hybrid_regularizer),
             'kernel_constraint': constraints.serialize(self.kernel_constraint),
             'bias_constraint': constraints.serialize(self.bias_constraint)
         }

--- a/keras/layers/core.py
+++ b/keras/layers/core.py
@@ -927,7 +927,7 @@ class HybridRegularization(Layer):
         self.supports_masking = True
         self.l1 = l1
         self.l2 = l2
-        self.activity_regularizer = regularizers.L1L2(l1=l1, l2=l2)
+        self.activity_regularizer = regularizers.HybridL1L2(l1=l1, l2=l2)
 
     def get_config(self):
         config = {'l1': self.l1,

--- a/keras/layers/embeddings.py
+++ b/keras/layers/embeddings.py
@@ -140,6 +140,7 @@ class Embedding(Layer):
                   'embeddings_initializer': initializers.serialize(self.embeddings_initializer),
                   'embeddings_regularizer': regularizers.serialize(self.embeddings_regularizer),
                   'activity_regularizer': regularizers.serialize(self.activity_regularizer),
+                  'hybrid_regularizer': regularizers.serialize(self.hybrid_regularizer),
                   'embeddings_constraint': constraints.serialize(self.embeddings_constraint),
                   'mask_zero': self.mask_zero,
                   'input_length': self.input_length}

--- a/keras/layers/local.py
+++ b/keras/layers/local.py
@@ -169,6 +169,7 @@ class LocallyConnected1D(Layer):
             'kernel_regularizer': regularizers.serialize(self.kernel_regularizer),
             'bias_regularizer': regularizers.serialize(self.bias_regularizer),
             'activity_regularizer': regularizers.serialize(self.activity_regularizer),
+            'hybrid_regularizer': regularizers.serialize(self.hybrid_regularizer),
             'kernel_constraint': constraints.serialize(self.kernel_constraint),
             'bias_constraint': constraints.serialize(self.bias_constraint)
         }
@@ -382,6 +383,7 @@ class LocallyConnected2D(Layer):
             'kernel_regularizer': regularizers.serialize(self.kernel_regularizer),
             'bias_regularizer': regularizers.serialize(self.bias_regularizer),
             'activity_regularizer': regularizers.serialize(self.activity_regularizer),
+            'hybrid_regularizer': regularizers.serialize(self.hybrid_regularizer),
             'kernel_constraint': constraints.serialize(self.kernel_constraint),
             'bias_constraint': constraints.serialize(self.bias_constraint)
         }

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -451,6 +451,8 @@ class SimpleRNN(Recurrent):
             (see [regularizer](../regularizers.md)).
         activity_regularizer: Regularizer function applied to
             the output of the layer (its "activation").
+        hybrid_regularizer: Regularizer function applied to
+            the inputs of the layer and its weights.
             (see [regularizer](../regularizers.md)).
         kernel_constraint: Constraint function applied to
             the `kernel` weights matrix
@@ -482,6 +484,7 @@ class SimpleRNN(Recurrent):
                  recurrent_regularizer=None,
                  bias_regularizer=None,
                  activity_regularizer=None,
+                 hybrid_regularizer=None,
                  kernel_constraint=None,
                  recurrent_constraint=None,
                  bias_constraint=None,
@@ -501,6 +504,7 @@ class SimpleRNN(Recurrent):
         self.recurrent_regularizer = regularizers.get(recurrent_regularizer)
         self.bias_regularizer = regularizers.get(bias_regularizer)
         self.activity_regularizer = regularizers.get(activity_regularizer)
+        self.hybrid_regularizer = regularizers.get(hybrid_regularizer)
 
         self.kernel_constraint = constraints.get(kernel_constraint)
         self.recurrent_constraint = constraints.get(recurrent_constraint)
@@ -625,6 +629,7 @@ class SimpleRNN(Recurrent):
                   'recurrent_regularizer': regularizers.serialize(self.recurrent_regularizer),
                   'bias_regularizer': regularizers.serialize(self.bias_regularizer),
                   'activity_regularizer': regularizers.serialize(self.activity_regularizer),
+                  'hybrid_regularizer': regularizers.serialize(self.hybrid_regularizer),
                   'kernel_constraint': constraints.serialize(self.kernel_constraint),
                   'recurrent_constraint': constraints.serialize(self.recurrent_constraint),
                   'bias_constraint': constraints.serialize(self.bias_constraint),
@@ -666,6 +671,8 @@ class GRU(Recurrent):
             (see [regularizer](../regularizers.md)).
         activity_regularizer: Regularizer function applied to
             the output of the layer (its "activation").
+        hybrid_regularizer: Regularizer function applied to
+            the inputs of the layer and its weights.
             (see [regularizer](../regularizers.md)).
         kernel_constraint: Constraint function applied to
             the `kernel` weights matrix
@@ -700,6 +707,7 @@ class GRU(Recurrent):
                  recurrent_regularizer=None,
                  bias_regularizer=None,
                  activity_regularizer=None,
+                 hybrid_regularizer=None,
                  kernel_constraint=None,
                  recurrent_constraint=None,
                  bias_constraint=None,
@@ -720,6 +728,7 @@ class GRU(Recurrent):
         self.recurrent_regularizer = regularizers.get(recurrent_regularizer)
         self.bias_regularizer = regularizers.get(bias_regularizer)
         self.activity_regularizer = regularizers.get(activity_regularizer)
+        self.hybrid_regularizer = regularizers.get(hybrid_regularizer)
 
         self.kernel_constraint = constraints.get(kernel_constraint)
         self.recurrent_constraint = constraints.get(recurrent_constraint)
@@ -895,6 +904,7 @@ class GRU(Recurrent):
                   'recurrent_regularizer': regularizers.serialize(self.recurrent_regularizer),
                   'bias_regularizer': regularizers.serialize(self.bias_regularizer),
                   'activity_regularizer': regularizers.serialize(self.activity_regularizer),
+                  'hybrid_regularizer': regularizers.serialize(self.hybrid_regularizer),
                   'kernel_constraint': constraints.serialize(self.kernel_constraint),
                   'recurrent_constraint': constraints.serialize(self.recurrent_constraint),
                   'bias_constraint': constraints.serialize(self.bias_constraint),
@@ -943,6 +953,8 @@ class LSTM(Recurrent):
             (see [regularizer](../regularizers.md)).
         activity_regularizer: Regularizer function applied to
             the output of the layer (its "activation").
+        hybrid_regularizer: Regularizer function applied to
+            the inputs and the weights of the layer .
             (see [regularizer](../regularizers.md)).
         kernel_constraint: Constraint function applied to
             the `kernel` weights matrix
@@ -978,6 +990,7 @@ class LSTM(Recurrent):
                  recurrent_regularizer=None,
                  bias_regularizer=None,
                  activity_regularizer=None,
+                 hybrid_regularizer=None,
                  kernel_constraint=None,
                  recurrent_constraint=None,
                  bias_constraint=None,
@@ -999,6 +1012,7 @@ class LSTM(Recurrent):
         self.recurrent_regularizer = regularizers.get(recurrent_regularizer)
         self.bias_regularizer = regularizers.get(bias_regularizer)
         self.activity_regularizer = regularizers.get(activity_regularizer)
+        self.hybrid_regularizer = regularizers.get(hybrid_regularizer)
 
         self.kernel_constraint = constraints.get(kernel_constraint)
         self.recurrent_constraint = constraints.get(recurrent_constraint)
@@ -1188,6 +1202,7 @@ class LSTM(Recurrent):
                   'recurrent_regularizer': regularizers.serialize(self.recurrent_regularizer),
                   'bias_regularizer': regularizers.serialize(self.bias_regularizer),
                   'activity_regularizer': regularizers.serialize(self.activity_regularizer),
+                  'hybrid_regularizer': regularizers.serialize(self.hybrid_regularizer),
                   'kernel_constraint': constraints.serialize(self.kernel_constraint),
                   'recurrent_constraint': constraints.serialize(self.recurrent_constraint),
                   'bias_constraint': constraints.serialize(self.bias_constraint),

--- a/keras/layers/wrappers.py
+++ b/keras/layers/wrappers.py
@@ -39,6 +39,13 @@ class Wrapper(Layer):
             return None
 
     @property
+    def hybrid_regularizer(self):
+        if hasattr(self.layer, 'hybrid_regularizer'):
+            return self.layer.hybrid_regularizer
+        else:
+            return None
+
+    @property
     def trainable_weights(self):
         return self.layer.trainable_weights
 
@@ -207,11 +214,16 @@ class TimeDistributed(Wrapper):
             output_shape = self.compute_output_shape(input_shape)
             y = K.reshape(y, (-1, input_length) + output_shape[2:])
 
-        # Apply activity regularizer if any:
-        if (hasattr(self.layer, 'activity_regularizer') and
-           self.layer.activity_regularizer is not None):
-            regularization_loss = self.layer.activity_regularizer(y)
-            self.add_loss(regularization_loss, inputs)
+            # Apply activity regularizer if any:
+            if (hasattr(self.layer, 'activity_regularizer') and
+                        self.layer.activity_regularizer is not None):
+                regularization_loss = self.layer.activity_regularizer(y)
+                self.add_loss(regularization_loss, inputs)
+            # Apply hybrid regularizer if any:
+            if (hasattr(self.layer, 'hybrid_regularizer') and
+                       self.layer.hybrid_regularizer is not None):
+                regularization_loss = self.layer.hybrid_regularizer(y,self.weights)
+                self.add_loss(regularization_loss, inputs)
 
         if uses_learning_phase:
             y._uses_learning_phase = True

--- a/keras/regularizers.py
+++ b/keras/regularizers.py
@@ -95,7 +95,7 @@ class HybridL1L2(BiRegularizer):
                 'l2': float(self.l2),
                 'sx': float(self.sx),
                 'sw': float(self.sw),
-                'level': float(self.level)}
+                'sl': float(self.sl)}
 
 
 # Aliases.
@@ -108,17 +108,12 @@ def l1(l=0.01):
 def l2(l=0.01):
     return L1L2(l2=l)
 
-def l1h(l=0.01):
-    return HybridL1L2(l1=l)
+def ll1(l,l1=0.01):
+    return HybridL1L2(l1=l1,sl=l)
 
-def l2h(l=0.01):
-    return HybridL1L2(l2=l)
+def ll2(l,l2=0.01):
+    return HybridL1L2(l2=l2,sl=l)
 
-def l1g(l=0.01):
-    return HybridL1L2(l1=l)
-
-def l2g(l=0.01):
-    return HybridL1L2(l2=l)
 
 def l1_l2(l1=0.01, l2=0.01):
     return L1L2(l1=l1, l2=l2)

--- a/keras/regularizers.py
+++ b/keras/regularizers.py
@@ -65,11 +65,17 @@ class HybridL1L2(BiRegularizer):
 
     def __call__(self, x, weights):
         regularization = 0.
-        minusone=K.constant(-1,shape=x.shape())
+        OutputDim=K.int_shape(weights)[-1]
+        batchlength=K.int_shape(x)[0]
+
+        minusone = K.constant(-1, shape=K.int_shape(x), dtype='float32')
+        A = K.repeat_elements(K.expand_dims(K.prod(K.stack([minusone, K.log(x)],
+                    axis=0), axis=0), axis=2), OutputDim,2)
+        B = K.repeat_elements(K.expand_dims(K.log(weights), axis=0), batchlength, axis=0)
         if self.l1:
-            regularization += K.sum(self.l1 * K.abs(K.sum(K.prod(K.log(x), minusone), K.log(weights))))
+            regularization += K.sum(self.l1 *K.sum(K.abs(K.sum(K.stack([A, B],axis=2),axis=2)),axis=2),axis=1)
         if self.l2:
-            regularization += K.sum(self.l2 * K.square(K.sum(K.prod(K.log(x), minusone), K.log(weights))))
+            regularization += K.sum(self.l2 *K.sum(K.square(K.sum(K.stack([A, B],axis=2),axis=2)),axis=2),axis=1)
         return regularization
 
     def get_config(self):

--- a/keras/regularizers.py
+++ b/keras/regularizers.py
@@ -69,9 +69,16 @@ class HybridL1L2(BiRegularizer):
         batchlength=K.int_shape(x)[0]
 
         minusone = K.constant(-1, shape=K.int_shape(x), dtype='float32')
-        A = K.repeat_elements(K.expand_dims(K.prod(K.stack([minusone, K.log(x)],
+
+        minx =  K.constant(0.000001, shape=K.int_shape(x), dtype='float32')
+        x_effectif = K.maximum(K.abs(x),minx)
+
+        minweights = K.constant(0.000001, shape=K.int_shape(weights), dtype='float32')
+        weights_effectif = K.maximum(K.abs(weights), minweights)
+
+        A = K.repeat_elements(K.expand_dims(K.prod(K.stack([minusone, K.log(x_effectif)],
                     axis=0), axis=0), axis=2), OutputDim,2)
-        B = K.repeat_elements(K.expand_dims(K.log(weights), axis=0), batchlength, axis=0)
+        B = K.repeat_elements(K.expand_dims(K.log(weights_effectif), axis=0), batchlength, axis=0)
         if self.l1:
             regularization += K.sum(self.l1 *K.sum(K.abs(K.sum(K.stack([A, B],axis=2),axis=2)),axis=2),axis=1)
         if self.l2:

--- a/keras/regularizers.py
+++ b/keras/regularizers.py
@@ -16,10 +16,20 @@ class Regularizer(object):
     def from_config(cls, config):
         return cls(**config)
 
+class BiRegularizer(object):
+    """BiRegularizer base class.
+    """
+
+    def __call__(self, x,w):
+        return 0.
+
+    @classmethod
+    def from_config(cls, config):
+            return cls(**config)
+
 
 class L1L2(Regularizer):
-    """Regularizer for L1 and L2 regularization.
-
+    """ Regularizer for L1 and L2 regularization.
     # Arguments
         l1: Float; L1 regularization factor.
         l2: Float; L2 regularization factor.
@@ -35,6 +45,31 @@ class L1L2(Regularizer):
             regularization += K.sum(self.l1 * K.abs(x))
         if self.l2:
             regularization += K.sum(self.l2 * K.square(x))
+        return regularization
+
+    def get_config(self):
+        return {'l1': float(self.l1),
+                'l2': float(self.l2)}
+
+class HybridL1L2(BiRegularizer):
+    """BiRegularizer for L1 and L2 regularization.
+
+    # Arguments
+        l1: Float; L1 regularization factor.
+        l2: Float; L2 regularization factor.
+    """
+
+    def __init__(self, l1=0., l2=0.):
+        self.l1 = K.cast_to_floatx(l1)
+        self.l2 = K.cast_to_floatx(l2)
+
+    def __call__(self, x, weights):
+        regularization = 0.
+        minusone=K.constant(-1,shape=x.shape())
+        if self.l1:
+            regularization += K.sum(self.l1 * K.abs(K.sum(K.prod(K.log(x), minusone), K.log(weights))))
+        if self.l2:
+            regularization += K.sum(self.l2 * K.square(K.sum(K.prod(K.log(x), minusone), K.log(weights))))
         return regularization
 
     def get_config(self):

--- a/tests/keras/regularizers_test.py
+++ b/tests/keras/regularizers_test.py
@@ -25,11 +25,12 @@ def get_data():
     return (x_train, y_train), (x_test, y_test)
 
 
-def create_model(kernel_regularizer=None, activity_regularizer=None):
+def create_model(kernel_regularizer=None, activity_regularizer=None, hybrid_regularizer=None):
     model = Sequential()
     model.add(Dense(num_classes,
                     kernel_regularizer=kernel_regularizer,
                     activity_regularizer=activity_regularizer,
+                    hybrid_regularizer=hybrid_regularizer,
                     input_shape=(data_dim,)))
     return model
 

--- a/tests/keras/regularizers_test.py
+++ b/tests/keras/regularizers_test.py
@@ -57,5 +57,14 @@ def test_activity_regularization():
                   epochs=epochs, verbose=0)
 
 
+def test_hybrid_regularization():
+    (x_train, y_train), (x_test, y_test) = get_data()
+    for reg in [regularizers.l1(), regularizers.l2(),regularizers.ll1(), regularizers.ll2()]:
+        model = create_model(hybrid_regularizer=reg)
+        model.compile(loss='categorical_crossentropy', optimizer='sgd')
+        assert len(model.losses) == 1
+        model.fit(x_train, y_train, batch_size=batch_size,
+                  epochs=epochs, verbose=0)
+
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
A way to create an incentive for the neuron to fly toward potential problems through their weights, is to add a regularization term that implements this attraction.
A simple idea is to force the weights to be important where  in average inputs are important.
So we need a regularizer that depends on inputs and weights
A simple formula is  : 
Sum over inputs of weights^2 / Max((inputs^2), floor)
the floor is here in case the inputs are 0
the 2 power is purely arbitrary, and can be replaced with any function: abs or other.
A first implementation has been tried through a fork and seems to work;