### PR TITLE
Remove lstm_benchmark from examples/README.md

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -42,9 +42,6 @@ Trains a FastText model on the IMDB sentiment classification task.
 [imdb_lstm.py](imdb_lstm.py)
 Trains an LSTM model on the IMDB sentiment classification task.
 
-[lstm_benchmark.py](lstm_benchmark.py)
-Compares different LSTM implementations on the IMDB sentiment classification task.
-
 [lstm_text_generation.py](lstm_text_generation.py)
 Generates text from Nietzsche's writings.
 


### PR DESCRIPTION
File was removed in https://github.com/fchollet/keras/pull/7943