### PR TITLE
Bug fix: Models with shared layers shouldn't be considered Sequential like

### DIFF
--- a/keras/utils/layer_utils.py
+++ b/keras/utils/layer_utils.py
@@ -48,7 +48,6 @@ def print_summary(model, line_length=None, positions=None, print_fn=print):
                     break
         del nodes
 
-
     if sequential_like:
         line_length = line_length or 65
         positions = positions or [.45, .85, 1.]

--- a/keras/utils/layer_utils.py
+++ b/keras/utils/layer_utils.py
@@ -46,7 +46,6 @@ def print_summary(model, line_length=None, positions=None, print_fn=print):
                             flag = True
                 if not sequential_like:
                     break
-        del nodes
 
     if sequential_like:
         line_length = line_length or 65

--- a/keras/utils/layer_utils.py
+++ b/keras/utils/layer_utils.py
@@ -24,12 +24,30 @@ def print_summary(model, line_length=None, positions=None, print_fn=print):
         sequential_like = True
     else:
         sequential_like = True
-        for v in model.nodes_by_depth.values():
+        nodes_by_depth = model.nodes_by_depth.values()
+        nodes = []
+        for v in nodes_by_depth:
             if (len(v) > 1) or (len(v) == 1 and len(v[0].inbound_layers) > 1):
                 # if the model has multiple nodes or if the nodes have multiple inbound_layers
                 # the model is no longer sequential
                 sequential_like = False
                 break
+            nodes += v
+        if sequential_like:
+            # search for shared layers
+            for layer in model.layers:
+                flag = False
+                for node in layer.inbound_nodes:
+                    if node in nodes:
+                        if flag:
+                            sequential_like = False
+                            break
+                        else:
+                            flag = True
+                if not sequential_like:
+                    break
+        del nodes
+
 
     if sequential_like:
         line_length = line_length or 65


### PR DESCRIPTION
As of now, the following model is being considered as a "Sequential-like":

```python
from keras.layers import *
from keras.models import *

a = Input((5,))
dense = Dense(5)
b = dense(a)
c = dense(b)

model = Model(a, c)
model.summary()
```
