### PR TITLE
Faster sequence

### DIFF
--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -537,7 +537,7 @@ class OrderedEnqueuer(SequenceEnqueuer):
             # Threads are from the same process so they already share the sequence.
             return
         shared_dict.clear()
-        while len(shared_dict) < self.workers:
+        while len(shared_dict) < self.workers and not self.stop_signal.is_set():
             # Ask the pool to update till everyone is updated.
             self.executor.apply(update_sequence, args=(self.sequence,))
         # We're done with the update

--- a/tests/keras/utils/data_utils_test.py
+++ b/tests/keras/utils/data_utils_test.py
@@ -111,7 +111,7 @@ def threadsafe_generator(f):
     return g
 
 
-class TestSequence(Sequence):
+class DummySequence(Sequence):
     def __init__(self, shape):
         self.shape = shape
 
@@ -149,7 +149,7 @@ def create_generator_from_sequence_pcs(ds):
 
 def test_generator_enqueuer_threads():
     enqueuer = GeneratorEnqueuer(create_generator_from_sequence_threads(
-        TestSequence([3, 200, 200, 3])), use_multiprocessing=False)
+        DummySequence([3, 200, 200, 3])), use_multiprocessing=False)
     enqueuer.start(3, 10)
     gen_output = enqueuer.get()
     acc = []
@@ -166,7 +166,7 @@ def test_generator_enqueuer_threads():
 
 def test_generator_enqueuer_processes():
     enqueuer = GeneratorEnqueuer(create_generator_from_sequence_pcs(
-        TestSequence([3, 200, 200, 3])), use_multiprocessing=True)
+        DummySequence([3, 200, 200, 3])), use_multiprocessing=True)
     enqueuer.start(3, 10)
     gen_output = enqueuer.get()
     acc = []
@@ -195,7 +195,7 @@ def test_generator_enqueuer_fail_processes():
 
 
 def test_ordered_enqueuer_threads():
-    enqueuer = OrderedEnqueuer(TestSequence([3, 200, 200, 3]), use_multiprocessing=False)
+    enqueuer = OrderedEnqueuer(DummySequence([3, 200, 200, 3]), use_multiprocessing=False)
     enqueuer.start(3, 10)
     gen_output = enqueuer.get()
     acc = []
@@ -206,7 +206,7 @@ def test_ordered_enqueuer_threads():
 
 
 def test_ordered_enqueuer_threads_not_ordered():
-    enqueuer = OrderedEnqueuer(TestSequence([3, 200, 200, 3]),
+    enqueuer = OrderedEnqueuer(DummySequence([3, 200, 200, 3]),
                                use_multiprocessing=False,
                                shuffle=True)
     enqueuer.start(3, 10)
@@ -219,7 +219,7 @@ def test_ordered_enqueuer_threads_not_ordered():
 
 
 def test_ordered_enqueuer_processes():
-    enqueuer = OrderedEnqueuer(TestSequence([3, 200, 200, 3]), use_multiprocessing=True)
+    enqueuer = OrderedEnqueuer(DummySequence([3, 200, 200, 3]), use_multiprocessing=True)
     enqueuer.start(3, 10)
     gen_output = enqueuer.get()
     acc = []


### PR DESCRIPTION
During the initial implementation of Sequence, there have been some issues when using large objects inside of the Sequence like a list of paths. This PR solves these issues by caching the Sequence in each process instead of copying it everytime we need it. Between epochs, we update the Sequence since it may get modified by the `on_epoch_end`.

I could have done it in a simpler way by direction accessing `self.pool._processes`, but it would be accessing a private member.

Example :  
Let's say that we keep a list `x` inside a Sequence where `x = [('abc', 512)] * 100000`.

```
Old way : 1.8216075897216797 seconds
New way : 0.22916626930236816 seconds
```
