### PR TITLE
Serialize loss functions with internal state using get_config

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -273,13 +273,13 @@ def _check_loss_and_target_compatibility(targets, loss_fns, output_shapes):
         ValueError: if a loss function or target array
             is incompatible with an output.
     """
-    key_losses = {'mean_squared_error',
-                  'binary_crossentropy',
-                  'categorical_crossentropy'}
+    key_losses = {losses.mean_squared_error,
+                  losses.binary_crossentropy,
+                  losses.categorical_crossentropy}
     for y, loss, shape in zip(targets, loss_fns, output_shapes):
         if loss is None:
             continue
-        if loss.__name__ == 'categorical_crossentropy':
+        if loss is losses.binary_crossentropy:
             if y.shape[-1] == 1:
                 raise ValueError(
                     'You are passing a target array of shape ' + str(y.shape) +
@@ -297,7 +297,7 @@ def _check_loss_and_target_compatibility(targets, loss_fns, output_shapes):
                     'Alternatively, you can use the loss function '
                     '`sparse_categorical_crossentropy` instead, '
                     'which does expect integer targets.')
-        if loss.__name__ in key_losses:
+        if loss in key_losses:
             for target_dim, out_dim in zip(y.shape[1:], shape[1:]):
                 if out_dim is not None and target_dim != out_dim:
                     raise ValueError(
@@ -1396,10 +1396,8 @@ class Model(Container):
 
         output_shapes = []
         for output_shape, loss_fn in zip(self._feed_output_shapes, self._feed_loss_fns):
-            if loss_fn.__name__ == 'sparse_categorical_crossentropy':
+            if loss_fn is losses.sparse_categorical_crossentropy:
                 output_shapes.append(output_shape[:-1] + (1,))
-            elif getattr(losses, loss_fn.__name__, None) is None:
-                output_shapes.append(None)
             else:
                 output_shapes.append(output_shape)
         x = _standardize_input_data(x, self._feed_input_names,

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -279,7 +279,7 @@ def _check_loss_and_target_compatibility(targets, loss_fns, output_shapes):
     for y, loss, shape in zip(targets, loss_fns, output_shapes):
         if loss is None:
             continue
-        if loss is losses.binary_crossentropy:
+        if loss is losses.categorical_crossentropy:
             if y.shape[-1] == 1:
                 raise ValueError(
                     'You are passing a target array of shape ' + str(y.shape) +

--- a/keras/losses.py
+++ b/keras/losses.py
@@ -1,7 +1,8 @@
 from __future__ import absolute_import
 import six
 from . import backend as K
-from .utils.generic_utils import deserialize_keras_object, serialize_keras_object
+from .utils.generic_utils import deserialize_keras_object
+from .utils.generic_utils import serialize_keras_object
 
 
 # noinspection SpellCheckingInspection

--- a/keras/losses.py
+++ b/keras/losses.py
@@ -1,8 +1,7 @@
 from __future__ import absolute_import
 import six
 from . import backend as K
-from .utils.generic_utils import (deserialize_keras_object,
-                                  serialize_keras_object)
+from .utils.generic_utils import deserialize_keras_object, serialize_keras_object
 
 
 # noinspection SpellCheckingInspection
@@ -110,6 +109,8 @@ def get(identifier):
         return None
     if isinstance(identifier, six.string_types):
         identifier = str(identifier)
+        return deserialize(identifier)
+    if isinstance(identifier, dict):
         return deserialize(identifier)
     elif callable(identifier):
         return identifier

--- a/keras/losses.py
+++ b/keras/losses.py
@@ -1,7 +1,8 @@
 from __future__ import absolute_import
 import six
 from . import backend as K
-from .utils.generic_utils import deserialize_keras_object
+from .utils.generic_utils import (deserialize_keras_object,
+                                  serialize_keras_object)
 
 
 # noinspection SpellCheckingInspection
@@ -85,7 +86,7 @@ cosine = cosine_proximity
 
 
 def serialize(loss):
-    return loss.__name__
+    return serialize_keras_object(loss)
 
 
 def deserialize(name, custom_objects=None):

--- a/keras/losses.py
+++ b/keras/losses.py
@@ -42,6 +42,15 @@ def categorical_hinge(y_true, y_pred):
 
 
 def logcosh(y_true, y_pred):
+    """Logarithm of the hyperbolic cosine of the prediction error.
+
+    `log(cosh(x))` is approximately equal to `(x ** 2) / 2` for small `x` and
+    to `abs(x) - log(2)` for large `x`. This means that 'logcosh' works mostly
+    like the mean squared error, but will not be so strongly affected by the
+    occasional wildly incorrect prediction. However, it may return NaNs if the
+    intermediate value `cosh(y_pred - y_true)` is too large to be represented
+    in the chosen precision.
+    """
     def cosh(x):
         return (K.exp(x) + K.exp(-x)) / 2
     return K.mean(K.log(cosh(y_pred - y_true)), axis=-1)

--- a/tests/keras/engine/test_training.py
+++ b/tests/keras/engine/test_training.py
@@ -6,6 +6,7 @@ import sys
 import scipy.sparse as sparse
 
 import keras
+from keras import losses
 from keras.layers import Dense, Dropout
 from keras.engine.topology import Input
 from keras.engine.training import Model
@@ -86,7 +87,7 @@ def test_weighted_masked_objective():
     def mask_dummy(y_true=None, y_pred=None, weight=None):
         return K.placeholder(y_true.shape)
 
-    weighted_function = _weighted_masked_objective(K.categorical_crossentropy)
+    weighted_function = _weighted_masked_objective(losses.categorical_crossentropy)
     weighted_function(a, a, None)
 
 
@@ -470,15 +471,15 @@ def test_trainable_argument():
 @keras_test
 def test_check_not_failing():
     a = np.random.random((2, 1, 3))
-    _check_loss_and_target_compatibility([a], [K.categorical_crossentropy], [a.shape])
-    _check_loss_and_target_compatibility([a], [K.categorical_crossentropy], [(2, None, 3)])
+    _check_loss_and_target_compatibility([a], [losses.categorical_crossentropy], [a.shape])
+    _check_loss_and_target_compatibility([a], [losses.categorical_crossentropy], [(2, None, 3)])
 
 
 @keras_test
 def test_check_last_is_one():
     a = np.random.random((2, 3, 1))
     with pytest.raises(ValueError) as exc:
-        _check_loss_and_target_compatibility([a], [K.categorical_crossentropy], [a.shape])
+        _check_loss_and_target_compatibility([a], [losses.categorical_crossentropy], [a.shape])
 
     assert 'You are passing a target array' in str(exc)
 
@@ -487,7 +488,7 @@ def test_check_last_is_one():
 def test_check_bad_shape():
     a = np.random.random((2, 3, 5))
     with pytest.raises(ValueError) as exc:
-        _check_loss_and_target_compatibility([a], [K.categorical_crossentropy], [(2, 3, 6)])
+        _check_loss_and_target_compatibility([a], [losses.categorical_crossentropy], [(2, 3, 6)])
 
     assert 'targets to have the same shape' in str(exc)
 

--- a/tests/keras/losses_test.py
+++ b/tests/keras/losses_test.py
@@ -1,6 +1,7 @@
 import pytest
 import numpy as np
 
+import keras
 from keras import losses
 from keras import backend as K
 from keras.utils.generic_utils import custom_object_scope
@@ -67,26 +68,45 @@ def test_sparse_categorical_crossentropy():
     assert np.isclose(expected_loss, np.mean(loss))
 
 
+class MSE_MAE_loss:
+    """Loss function with internal state, for testing serialization code."""
+    def __init__(self, mse_fraction):
+        self.mse_fraction = mse_fraction
+
+    def __call__(self, y_true, y_pred):
+        return (self.mse_fraction * losses.mse(y_true, y_pred) +
+                (1 - self.mse_fraction) * losses.mae(y_true, y_pred))
+
+    def get_config(self):
+        return {'mse_fraction': self.mse_fraction}
+
+
 def test_serializing_loss_class():
-    class MSE_MAE_loss:
-        def __init__(self, mse_fraction):
-            self.mse_fraction = mse_fraction
-
-        def __call__(self, y_true, y_pred):
-            return (self.mse_fraction * losses.mse(y_true, y_pred) +
-                    (1 - self.mse_fraction) * losses.mae(y_true, y_pred))
-
-        def get_config(self):
-            return {'mse_fraction': self.mse_fraction}
-
     orig_loss_class = MSE_MAE_loss(0.3)
     with custom_object_scope({'MSE_MAE_loss': MSE_MAE_loss}):
         serialized = losses.serialize(orig_loss_class)
-    
+
     with custom_object_scope({'MSE_MAE_loss': MSE_MAE_loss}):
         deserialized = losses.deserialize(serialized)
     assert isinstance(deserialized, MSE_MAE_loss)
     assert deserialized.mse_fraction == 0.3
+
+
+def test_serializing_model_with_loss_class(tmpdir):
+    model_filename = str(tmpdir / 'custom_loss.hdf')
+
+    with custom_object_scope({'MSE_MAE_loss': MSE_MAE_loss}):
+        loss = MSE_MAE_loss(0.3)
+        inputs = keras.layers.Input((2,))
+        outputs = keras.layers.Dense(1)(inputs)
+        model = keras.models.Model(inputs, outputs)
+        model.compile(optimizer='sgd', loss={'dense_1': loss})
+        model.fit(np.random.rand(256, 2), np.random.rand(256, 1))
+        model.save(model_filename)
+
+    with custom_object_scope({'MSE_MAE_loss': MSE_MAE_loss}):
+        loaded_model = keras.models.load_model(model_filename)
+        loaded_model.predict(np.random.rand(128, 2))
 
 
 if __name__ == '__main__':

--- a/tests/keras/losses_test.py
+++ b/tests/keras/losses_test.py
@@ -98,9 +98,9 @@ def test_serializing_model_with_loss_class(tmpdir):
     with custom_object_scope({'MSE_MAE_loss': MSE_MAE_loss}):
         loss = MSE_MAE_loss(0.3)
         inputs = keras.layers.Input((2,))
-        outputs = keras.layers.Dense(1)(inputs)
+        outputs = keras.layers.Dense(1, name='model_output')(inputs)
         model = keras.models.Model(inputs, outputs)
-        model.compile(optimizer='sgd', loss={'dense_1': loss})
+        model.compile(optimizer='sgd', loss={'model_output': loss})
         model.fit(np.random.rand(256, 2), np.random.rand(256, 1))
         model.save(model_filename)
 


### PR DESCRIPTION
#8033 was rejected because the pinball loss function isn't widely used enough for the main keras package. Nevertheless, in order to use an externally provided class, the main keras package still needs to be able to serialise and deserialise it when saving and loading models. Currently `keras.losses.serialize` simply returns the name of the function, which doesn't allow saving any parameters or internal state.