### PR TITLE
Fix off-by-one bug in predict/evaluate progress bar

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1249,7 +1249,7 @@ class Model(Container):
                 for i, batch_out in enumerate(batch_outs):
                     unconcatenated_outs[i].append(batch_out)
                 if verbose == 1:
-                    progbar.update(step+1)
+                    progbar.update(step + 1)
             if len(unconcatenated_outs) == 1:
                 return np.concatenate(unconcatenated_outs[0], axis=0)
             return [np.concatenate(unconcatenated_outs[i], axis=0)
@@ -1323,7 +1323,7 @@ class Model(Container):
                         outs.append(0.)
                     outs[0] += batch_outs
                 if verbose == 1:
-                    progbar.update(step+1)
+                    progbar.update(step + 1)
             for i in range(len(outs)):
                 outs[i] /= steps
         else:

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1249,7 +1249,7 @@ class Model(Container):
                 for i, batch_out in enumerate(batch_outs):
                     unconcatenated_outs[i].append(batch_out)
                 if verbose == 1:
-                    progbar.update(step)
+                    progbar.update(step+1)
             if len(unconcatenated_outs) == 1:
                 return np.concatenate(unconcatenated_outs[0], axis=0)
             return [np.concatenate(unconcatenated_outs[i], axis=0)
@@ -1304,9 +1304,12 @@ class Model(Container):
                                               steps,
                                               'steps')
         outs = []
-        if steps is not None:
-            if verbose == 1:
+        if verbose == 1:
+            if steps is not None:
                 progbar = Progbar(target=steps)
+            else:
+                progbar = Progbar(target=num_samples)
+        if steps is not None:
             for step in range(steps):
                 batch_outs = f(ins)
                 if isinstance(batch_outs, list):
@@ -1320,12 +1323,10 @@ class Model(Container):
                         outs.append(0.)
                     outs[0] += batch_outs
                 if verbose == 1:
-                    progbar.update(step)
+                    progbar.update(step+1)
             for i in range(len(outs)):
                 outs[i] /= steps
         else:
-            if verbose == 1:
-                progbar = Progbar(target=num_samples)
             batches = _make_batches(num_samples, batch_size)
             index_array = np.arange(num_samples)
             for batch_index, (batch_start, batch_end) in enumerate(batches):


### PR DESCRIPTION
Fix off-by-one bug in predict/evaluate progress bar
```
Before:
0/1 [..............................] - ETA: 0s
0/1 [..............................] - ETA: 0s

After:
1/1 [==============================] - ETA: 0s
1/1 [==============================] - ETA: 0s
```


Also sync (make identical) portions of the code in _predict_loop() and _test_loop()