### PR TITLE
Change default value of shuffle parameter of Sequential.fit_generator() from True to False

### DIFF
--- a/keras/models.py
+++ b/keras/models.py
@@ -1037,7 +1037,7 @@ class Sequential(Model):
                       max_queue_size=10,
                       workers=1,
                       use_multiprocessing=False,
-                      shuffle=False,
+                      shuffle=True,
                       initial_epoch=0):
         """Fits the model on data generated batch-by-batch by a Python generator.
 


### PR DESCRIPTION
...to sync it with that of Model.fit_generator(), which was there first, and modifying it would be an API change. shuffle was added to Sequential.fit_generator() only 7 days ago in https://github.com/fchollet/keras/pull/8023. The discrepancy was pointed out in https://github.com/fchollet/keras/pull/8023#discussion_r142943710