### PR TITLE
Print current iteration even if target is unknown

### DIFF
--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -314,9 +314,7 @@ class Progbar(object):
                 bar += ('.' * (self.width - prog_width))
                 bar += ']'
             else:
-                numdigits = 7
-                barstr = '%%%dd/Unknown' % numdigits
-                bar = barstr % current
+                bar = '%7d/Unknown' % current
 
             sys.stdout.write(bar)
             self.total_width = len(bar)

--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -313,8 +313,13 @@ class Progbar(object):
                         bar += '='
                 bar += ('.' * (self.width - prog_width))
                 bar += ']'
-                sys.stdout.write(bar)
-                self.total_width = len(bar)
+            else:
+                numdigits = 7
+                barstr = '%%%dd/Unknown' % numdigits
+                bar = barstr % current
+
+            sys.stdout.write(bar)
+            self.total_width = len(bar)
 
             if current:
                 time_per_unit = (now - self.start) / current

--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -301,8 +301,8 @@ class Progbar(object):
 
             if self.target is not -1:
                 numdigits = int(np.floor(np.log10(self.target))) + 1
-                barstr = '%%%dd/%%%dd [' % (numdigits, numdigits)
-                bar = barstr % (current, self.target)
+                barstr = '%%%dd/%d [' % (numdigits, self.target)
+                bar = barstr % current
                 prog = float(current) / self.target
                 prog_width = int(self.width * prog)
                 if prog_width > 0:


### PR DESCRIPTION
```
Before:
 - 2s
After:
 19600/Unknown - 2s
```

Also fixes unbounded growth of Progbar.total_width when target==None as described in https://github.com/fchollet/keras/pull/8076

```
Before:
^M - 0s
^H^H^H^H^H^M - 0s
^H^H^H^H^H^H^H^H^H^H^M - 0s
^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^M - 0s

After:
^M - 0s
^H^H^H^H^H^M - 0s
^H^H^H^H^H^M - 0s
^H^H^H^H^H^M - 0s
```