### PR TITLE
Fix code snippet

### DIFF
--- a/docs/templates/constraints.md
+++ b/docs/templates/constraints.md
@@ -11,7 +11,7 @@ These layers expose 2 keyword arguments:
 
 
 ```python
-from keras.constraints import maxnorm
+from keras.constraints import max_norm
 model.add(Dense(64, kernel_constraint=max_norm(2.)))
 ```
 


### PR DESCRIPTION
The current code doesn't work since `maxnorm` doesn't match called name `max_norm` in the next line.
