### PR TITLE
Extending GeneratorEnqueuer to handle finite generators.

### DIFF
--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -536,7 +536,9 @@ class OrderedEnqueuer(SequenceEnqueuer):
 
 class GeneratorEnqueuer(SequenceEnqueuer):
     """Builds a queue out of a data generator.
-    The provided generator can be finite in which case the class will throw a StopIteration exception.
+    
+    The provided generator can be finite in which case the class will throw 
+    a `StopIteration` exception.
 
     Used in `fit_generator`, `evaluate_generator`, `predict_generator`.
 

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -651,7 +651,7 @@ class GeneratorEnqueuer(SequenceEnqueuer):
                 if inputs is not None:
                     yield inputs
             else:
-                all_finished = all([thread.is_alive() == False for thread in self._threads])
+                all_finished = all([not thread.is_alive() for thread in self._threads])
                 if all_finished:
                     raise StopIteration()
                 else:

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -651,7 +651,7 @@ class GeneratorEnqueuer(SequenceEnqueuer):
                 if inputs is not None:
                     yield inputs
             else:
-                all_finished = all([thread.is_alive()==False for thread in self._threads])
+                all_finished = all([thread.is_alive() == False for thread in self._threads])
                 if all_finished:
                     raise StopIteration()
                 else:

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -536,11 +536,12 @@ class OrderedEnqueuer(SequenceEnqueuer):
 
 class GeneratorEnqueuer(SequenceEnqueuer):
     """Builds a queue out of a data generator.
+    The provided generator can be finite in which case the class will throw a StopIteration exception.
 
     Used in `fit_generator`, `evaluate_generator`, `predict_generator`.
 
     # Arguments
-        generator: a generator function which endlessly yields data
+        generator: a generator function which yields data
         use_multiprocessing: use multiprocessing if True, otherwise threading
         wait_time: time to sleep in-between calls to `put()`
         random_seed: Initial seed for workers,
@@ -576,6 +577,8 @@ class GeneratorEnqueuer(SequenceEnqueuer):
                         self.queue.put(generator_output)
                     else:
                         time.sleep(self.wait_time)
+                except StopIteration:
+                    break
                 except Exception:
                     self._stop_event.set()
                     raise
@@ -648,4 +651,8 @@ class GeneratorEnqueuer(SequenceEnqueuer):
                 if inputs is not None:
                     yield inputs
             else:
-                time.sleep(self.wait_time)
+                all_finished = all([thread.is_alive()==False for thread in self._threads])
+                if all_finished:
+                    raise StopIteration()
+                else:
+                    time.sleep(self.wait_time)

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -536,7 +536,7 @@ class OrderedEnqueuer(SequenceEnqueuer):
 
 class GeneratorEnqueuer(SequenceEnqueuer):
     """Builds a queue out of a data generator.
-    
+
     The provided generator can be finite in which case the class will throw
     a `StopIteration` exception.
 

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -537,7 +537,7 @@ class OrderedEnqueuer(SequenceEnqueuer):
 class GeneratorEnqueuer(SequenceEnqueuer):
     """Builds a queue out of a data generator.
     
-    The provided generator can be finite in which case the class will throw 
+    The provided generator can be finite in which case the class will throw
     a `StopIteration` exception.
 
     Used in `fit_generator`, `evaluate_generator`, `predict_generator`.

--- a/tests/keras/utils/data_utils_test.py
+++ b/tests/keras/utils/data_utils_test.py
@@ -245,5 +245,40 @@ def test_ordered_enqueuer_fail_processes():
         next(gen_output)
 
 
+@threadsafe_generator
+def create_finite_generator_from_sequence_threads(ds):
+    for i in range(len(ds)):
+        yield ds[i]
+
+
+def create_finite_generator_from_sequence_pcs(ds):
+    for i in range(len(ds)):
+        yield ds[i]
+
+
+def test_finite_generator_enqueuer_threads():
+    enqueuer = GeneratorEnqueuer(create_finite_generator_from_sequence_threads(
+        TestSequence([3, 200, 200, 3])), use_multiprocessing=False)
+    enqueuer.start(3, 10)
+    gen_output = enqueuer.get()
+    acc = []
+    for output in gen_output:
+        acc.append(int(output[0, 0, 0, 0]))
+    assert len(set(acc) - set(range(100))) == 0, "Output is not the same"
+    enqueuer.stop()
+
+
+def test_finite_generator_enqueuer_processes():
+    enqueuer = GeneratorEnqueuer(create_finite_generator_from_sequence_pcs(
+        TestSequence([3, 200, 200, 3])), use_multiprocessing=True)
+    enqueuer.start(3, 10)
+    gen_output = enqueuer.get()
+    acc = []
+    for output in gen_output:
+        acc.append(int(output[0, 0, 0, 0]))
+    assert acc != list(range(100)), "Order was keep in GeneratorEnqueuer with processes"
+    enqueuer.stop()
+
+
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
The GeneratorEnqueuer class is used by Keras to generate batches of data. Even though it's an internal class, it can be used for building fast training and prediction pipelines that do not use the *_generator() methods. One core assumption of the class is that the underlying generator must be able to produce infinite amount of data. This is useful when we perform training but can be limiting when we want to make predictions (especially when you combine Spark + Keras).

This PR extends GeneratorEnqueuer to handle finite generators and it was tested both with threads and processes. The main idea is that we catch the StopIteration which is raised when the underlying generator is exhausted and gracefully exit the thread. When we call get() on the enqueuer instead of sleeping directly when the queue is empty, we check if any of the threads are active. If all of them are inactive we raise a StopIteration exception, else if at least one thread is still running we sleep. 

The changes should have no effect if the underlying iterator is infinite. When it is finite, we raise a StopIteration exception once the underlying generator is exhausted to inform the user of the class that the data have been processed.