### PR TITLE
[API change] "end of epoch" in verbose=2 to match verbose=1

### DIFF
--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -348,7 +348,7 @@ class Progbar(object):
             sys.stdout.flush()
 
         elif self.verbose == 2:
-            if self.target is None or current >= self.target:
+            if self.target is not None and current >= self.target:
                 for k in self.unique_values:
                     info += ' - %s:' % k
                     avg = np.mean(self.sum_values[k][0] / max(1, self.sum_values[k][1]))


### PR DESCRIPTION
Since primordial time, unknown target in verbose=1 meant NOT an end of epoch, while in verbose=2 it meant IS an end of epoch. This changes verbose=2 to match verbose=1.

With this change, it will be much easier to refactor duplicate common portions of verbose=1 and verbose=2. I took a stab at doing it without this change, and the resulting code is too convoluted and not worth it (for my taste)