### PR TITLE
Move Flatten layer into create_base_network()

### DIFF
--- a/examples/mnist_siamese.py
+++ b/examples/mnist_siamese.py
@@ -17,11 +17,12 @@ import numpy as np
 import random
 from keras.datasets import mnist
 from keras.models import Model
-from keras.layers import Dense, Dropout, Input, Lambda
+from keras.layers import Input, Flatten, Dense, Dropout, Lambda
 from keras.optimizers import RMSprop
 from keras import backend as K
 
 num_classes = 10
+epochs = 20
 
 
 def euclidean_distance(vects):
@@ -62,11 +63,12 @@ def create_pairs(x, digit_indices):
     return np.array(pairs), np.array(labels)
 
 
-def create_base_network(input_dim):
+def create_base_network(input_shape):
     '''Base network to be shared (eq. to feature extraction).
     '''
-    input = Input(shape=(input_dim,))
-    x = Dense(128, activation='relu')(input)
+    input = Input(shape=input_shape)
+    x = Flatten()(input)
+    x = Dense(128, activation='relu')(x)
     x = Dropout(0.1)(x)
     x = Dense(128, activation='relu')(x)
     x = Dropout(0.1)(x)
@@ -89,14 +91,11 @@ def accuracy(y_true, y_pred):
 
 # the data, shuffled and split between train and test sets
 (x_train, y_train), (x_test, y_test) = mnist.load_data()
-x_train = x_train.reshape(60000, 784)
-x_test = x_test.reshape(10000, 784)
 x_train = x_train.astype('float32')
 x_test = x_test.astype('float32')
 x_train /= 255
 x_test /= 255
-input_dim = 784
-epochs = 20
+input_shape = x_train.shape[1:]
 
 # create training+test positive and negative pairs
 digit_indices = [np.where(y_train == i)[0] for i in range(num_classes)]
@@ -106,10 +105,10 @@ digit_indices = [np.where(y_test == i)[0] for i in range(num_classes)]
 te_pairs, te_y = create_pairs(x_test, digit_indices)
 
 # network definition
-base_network = create_base_network(input_dim)
+base_network = create_base_network(input_shape)
 
-input_a = Input(shape=(input_dim,))
-input_b = Input(shape=(input_dim,))
+input_a = Input(shape=input_shape)
+input_b = Input(shape=input_shape)
 
 # because we re-use the same instance `base_network`,
 # the weights of the network


### PR DESCRIPTION
...and remove 4 hardcoded constants. This makes the code structure more logical. For example, after replacing mnist with cifar10 training still works (reaching 60% validation accuracy in 7 epochs), while before it was raising an exception.