### PR TITLE
Rename num_class => num_classes

### DIFF
--- a/examples/mnist_net2net.py
+++ b/examples/mnist_net2net.py
@@ -67,7 +67,7 @@ if keras.backend.image_data_format() == 'channels_first':
     input_shape = (1, 28, 28)  # image shape
 else:
     input_shape = (28, 28, 1)  # image shape
-num_class = 10  # number of class
+num_classes = 10  # number of classes
 
 
 # load and pre-process data
@@ -225,7 +225,7 @@ def make_teacher_model(train_data, validation_data, epochs=3):
     model.add(MaxPooling2D(2, name='pool2'))
     model.add(Flatten(name='flatten'))
     model.add(Dense(64, activation='relu', name='fc1'))
-    model.add(Dense(num_class, activation='softmax', name='fc2'))
+    model.add(Dense(num_classes, activation='softmax', name='fc2'))
     model.compile(loss='categorical_crossentropy',
                   optimizer=SGD(lr=0.01, momentum=0.9),
                   metrics=['accuracy'])
@@ -255,7 +255,7 @@ def make_wider_student_model(teacher_model, train_data,
     model.add(Flatten(name='flatten'))
     # a wider fc1 compared to teacher model
     model.add(Dense(new_fc1_width, activation='relu', name='fc1'))
-    model.add(Dense(num_class, activation='softmax', name='fc2'))
+    model.add(Dense(num_classes, activation='softmax', name='fc2'))
 
     # The weights for other layers need to be copied from teacher_model
     # to student_model, except for widened layers
@@ -319,7 +319,7 @@ def make_deeper_student_model(teacher_model, train_data,
         model.add(Dense(64, activation='relu', name='fc1-deeper'))
     else:
         raise ValueError('Unsupported weight initializer: %s' % init)
-    model.add(Dense(num_class, activation='softmax', name='fc2'))
+    model.add(Dense(num_classes, activation='softmax', name='fc2'))
 
     # copy weights for other layers
     copy_weights(teacher_model, model, layer_names=[

--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -566,8 +566,8 @@ def gather(reference, indices):
     if _get_cntk_version() >= 2.2:
         return C.ops.gather(reference, indices)
     else:
-        num_class = reference.shape[0]
-        one_hot_matrix = C.ops.one_hot(indices, num_class)
+        num_classes = reference.shape[0]
+        one_hot_matrix = C.ops.one_hot(indices, num_classes)
         return C.times(one_hot_matrix, reference, output_rank=len(reference.shape) - 1)
 
 

--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -1041,7 +1041,7 @@ class DirectoryIterator(Iterator):
             for subdir in sorted(os.listdir(directory)):
                 if os.path.isdir(os.path.join(directory, subdir)):
                     classes.append(subdir)
-        self.num_class = len(classes)
+        self.num_classes = len(classes)
         self.class_indices = dict(zip(classes, range(len(classes))))
 
         pool = multiprocessing.pool.ThreadPool()
@@ -1052,7 +1052,7 @@ class DirectoryIterator(Iterator):
                                     (os.path.join(directory, subdir)
                                      for subdir in classes)))
 
-        print('Found %d images belonging to %d classes.' % (self.samples, self.num_class))
+        print('Found %d images belonging to %d classes.' % (self.samples, self.num_classes))
 
         # second, build an index of the images in the different class subfolders
         results = []
@@ -1103,7 +1103,7 @@ class DirectoryIterator(Iterator):
         elif self.class_mode == 'binary':
             batch_y = self.classes[index_array].astype(K.floatx())
         elif self.class_mode == 'categorical':
-            batch_y = np.zeros((len(batch_x), self.num_class), dtype=K.floatx())
+            batch_y = np.zeros((len(batch_x), self.num_classes), dtype=K.floatx())
             for i, label in enumerate(self.classes[index_array]):
                 batch_y[i, label] = 1.
         else:

--- a/keras/utils/test_utils.py
+++ b/keras/utils/test_utils.py
@@ -17,7 +17,7 @@ def get_test_data(num_train=1000, num_test=500, input_shape=(10,),
 
     classification=True overrides output_shape
     (i.e. output_shape is set to (1,)) and the output
-    consists in integers in [0, num_class-1].
+    consists in integers in [0, num_classes-1].
 
     Otherwise: float output with shape output_shape.
     """


### PR DESCRIPTION
Outside of tests/ directory "num_class" is used 10 times, "num_classes" is used 106 times. This makes it all consistent, and also fixes a docstring bug in test_util.get_test_data()

Inside tests/ directory, the score is 53:62 in favor of num_classes. I can do the renaming there as well, if there is interest.
