### PR TITLE
Epoch is 0 indexed, add one to match from fit

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -394,7 +394,7 @@ class ModelCheckpoint(Callback):
         self.epochs_since_last_save += 1
         if self.epochs_since_last_save >= self.period:
             self.epochs_since_last_save = 0
-            filepath = self.filepath.format(epoch=epoch+1, **logs)
+            filepath = self.filepath.format(epoch=epoch + 1, **logs)
             if self.save_best_only:
                 current = logs.get(self.monitor)
                 if current is None:
@@ -405,7 +405,7 @@ class ModelCheckpoint(Callback):
                         if self.verbose > 0:
                             print('Epoch %05d: %s improved from %0.5f to %0.5f,'
                                   ' saving model to %s'
-                                  % (epoch+1, self.monitor, self.best,
+                                  % (epoch + 1, self.monitor, self.best,
                                      current, filepath))
                         self.best = current
                         if self.save_weights_only:
@@ -415,10 +415,10 @@ class ModelCheckpoint(Callback):
                     else:
                         if self.verbose > 0:
                             print('Epoch %05d: %s did not improve' %
-                                  (epoch+1, self.monitor))
+                                  (epoch + 1, self.monitor))
             else:
                 if self.verbose > 0:
-                    print('Epoch %05d: saving model to %s' % (epoch+1, filepath))
+                    print('Epoch %05d: saving model to %s' % (epoch + 1, filepath))
                 if self.save_weights_only:
                     self.model.save_weights(filepath, overwrite=True)
                 else:
@@ -504,7 +504,7 @@ class EarlyStopping(Callback):
 
     def on_train_end(self, logs=None):
         if self.stopped_epoch > 0 and self.verbose > 0:
-            print('Epoch %05d: early stopping' % (self.stopped_epoch+1))
+            print('Epoch %05d: early stopping' % (self.stopped_epoch + 1))
 
 
 class RemoteMonitor(Callback):
@@ -905,7 +905,7 @@ class ReduceLROnPlateau(Callback):
                         new_lr = max(new_lr, self.min_lr)
                         K.set_value(self.model.optimizer.lr, new_lr)
                         if self.verbose > 0:
-                            print('\nEpoch %05d: reducing learning rate to %s.' % (epoch+1, new_lr))
+                            print('\nEpoch %05d: reducing learning rate to %s.' % (epoch + 1, new_lr))
                         self.cooldown_counter = self.cooldown
                         self.wait = 0
                 self.wait += 1

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -394,7 +394,7 @@ class ModelCheckpoint(Callback):
         self.epochs_since_last_save += 1
         if self.epochs_since_last_save >= self.period:
             self.epochs_since_last_save = 0
-            filepath = self.filepath.format(epoch=epoch, **logs)
+            filepath = self.filepath.format(epoch=epoch+1, **logs)
             if self.save_best_only:
                 current = logs.get(self.monitor)
                 if current is None:
@@ -405,7 +405,7 @@ class ModelCheckpoint(Callback):
                         if self.verbose > 0:
                             print('Epoch %05d: %s improved from %0.5f to %0.5f,'
                                   ' saving model to %s'
-                                  % (epoch, self.monitor, self.best,
+                                  % (epoch+1, self.monitor, self.best,
                                      current, filepath))
                         self.best = current
                         if self.save_weights_only:
@@ -415,10 +415,10 @@ class ModelCheckpoint(Callback):
                     else:
                         if self.verbose > 0:
                             print('Epoch %05d: %s did not improve' %
-                                  (epoch, self.monitor))
+                                  (epoch+1, self.monitor))
             else:
                 if self.verbose > 0:
-                    print('Epoch %05d: saving model to %s' % (epoch, filepath))
+                    print('Epoch %05d: saving model to %s' % (epoch+1, filepath))
                 if self.save_weights_only:
                     self.model.save_weights(filepath, overwrite=True)
                 else:
@@ -504,7 +504,7 @@ class EarlyStopping(Callback):
 
     def on_train_end(self, logs=None):
         if self.stopped_epoch > 0 and self.verbose > 0:
-            print('Epoch %05d: early stopping' % (self.stopped_epoch))
+            print('Epoch %05d: early stopping' % (self.stopped_epoch+1))
 
 
 class RemoteMonitor(Callback):
@@ -905,7 +905,7 @@ class ReduceLROnPlateau(Callback):
                         new_lr = max(new_lr, self.min_lr)
                         K.set_value(self.model.optimizer.lr, new_lr)
                         if self.verbose > 0:
-                            print('\nEpoch %05d: reducing learning rate to %s.' % (epoch, new_lr))
+                            print('\nEpoch %05d: reducing learning rate to %s.' % (epoch+1, new_lr))
                         self.cooldown_counter = self.cooldown
                         self.wait = 0
                 self.wait += 1

--- a/tests/keras/test_callbacks.py
+++ b/tests/keras/test_callbacks.py
@@ -193,12 +193,12 @@ def test_ModelCheckpoint(tmpdir):
                                       period=period)]
     model.fit(X_train, y_train, batch_size=batch_size,
               validation_data=(X_test, y_test), callbacks=cbks, epochs=4)
-    assert os.path.isfile(filepath.format(epoch=1))
-    assert os.path.isfile(filepath.format(epoch=3))
-    assert not os.path.exists(filepath.format(epoch=0))
-    assert not os.path.exists(filepath.format(epoch=2))
-    os.remove(filepath.format(epoch=1))
-    os.remove(filepath.format(epoch=3))
+    assert os.path.isfile(filepath.format(epoch=2))
+    assert os.path.isfile(filepath.format(epoch=4))
+    assert not os.path.exists(filepath.format(epoch=1))
+    assert not os.path.exists(filepath.format(epoch=3))
+    os.remove(filepath.format(epoch=2))
+    os.remove(filepath.format(epoch=4))
     assert not tmpdir.listdir()
 
 


### PR DESCRIPTION
Output from callbacks include epoch, but the epoch is index 0 format. It shows up when callbacks output information about the epoch.

Example:

```
Epoch 1/100
2300/2300 [==============================] - 462s - loss: 3.6914 - acc: 0.7710 - val_loss: 3.7383 - val_acc: 0.7681
Epoch 2/100
2300/2300 [==============================] - 457s - loss: 3.6921 - acc: 0.7709 - val_loss: 3.7442 - val_acc: 0.7677
Epoch 3/100
2299/2300 [============================>.] - ETA: 0s - loss: 3.6904 - acc: 0.7710
Epoch 00002: reducing learning rate to 9.999999747378752e-06.
```

Notice how the lr reduction is showing epoch 2 instead of the correct epoch 3.

The callback `ModelCheckpoint` will also save checkpoints with the correct epoch number in the filename.