### PR TITLE
In Tensorflow backend, assign expected shape to rnn() output

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -2625,7 +2625,7 @@ def rnn(step_function, inputs, initial_states,
         outputs = output_ta.stack()
 
         # TF while_loop removed 0-th dimension from the outputs
-        # but we actually have expected shape for the output
+        # but we actually know the expected shape of the output
         output_shape = list(outputs.get_shape())
         output_shape[0] = inputs.get_shape()[0]
         outputs.set_shape(output_shape)

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -2623,6 +2623,13 @@ def rnn(step_function, inputs, initial_states,
         new_states = final_outputs[2:]
 
         outputs = output_ta.stack()
+
+        # TF while_loop removed 0-th dimension from the outputs
+        # but we actually have expected shape for the output
+        output_shape = list(outputs.get_shape())
+        output_shape[0] = inputs.get_shape()[0]
+        outputs.set_shape(output_shape)
+
         last_output = output_ta.read(last_time - 1)
 
     axes = [1, 0] + list(range(2, len(outputs.get_shape())))

--- a/tests/keras/layers/recurrent_test.py
+++ b/tests/keras/layers/recurrent_test.py
@@ -380,9 +380,8 @@ def test_state_reuse(layer_class):
     outputs = model.predict(inputs)
 
 
-
 @rnn_test
-def test_state_reuse(layer_class):
+def test_expected_output_shape(layer_class):
     inputs = Input(batch_shape=(num_samples, timesteps, embedding_dim))
 
     layer = layer_class(units, return_sequences=True, unroll=True)

--- a/tests/keras/layers/recurrent_test.py
+++ b/tests/keras/layers/recurrent_test.py
@@ -380,6 +380,17 @@ def test_state_reuse(layer_class):
     outputs = model.predict(inputs)
 
 
+
+@rnn_test
+def test_state_reuse(layer_class):
+    inputs = Input(batch_shape=(num_samples, timesteps, embedding_dim))
+
+    layer = layer_class(units, return_sequences=True, unroll=True)
+    assert layer(inputs).shape == (num_samples, timesteps, units)
+
+    layer = layer_class(units, return_sequences=True, unroll=False)
+    assert layer(inputs).shape == (num_samples, timesteps, units)
+
 @keras_test
 def test_minimal_rnn_cell_non_layer():
 


### PR DESCRIPTION
In Tensorflow backend's Recurrent Layer, the output's sequence length will be missing when creating the layer with `return_sequences=True` and `unroll=True`.

```Python
from keras.layers import Input, LSTM
inputs = Input(batch_shape=(None, 10, 16))

unrolled_rnn = LSTM(32, return_sequences=True, unroll=True)(inputs)
# <tf.Tensor 'lstm_2/transpose_1:0' shape=(?, 10, 32) dtype=float32>

rolled_rnn = LSTM(32, return_sequences=True, unroll=False)(inputs)
# <tf.Tensor 'lstm_1/transpose_1:0' shape=(?, ?, 32) dtype=float32>
```

This can cause a problem if we try to do further calculation the require knowing the sequence output dimension:
```python
from keras.layers import Input, LSTM, dot
inputs = Input(batch_shape=(None, 10, 16))
rnn_a = LSTM(32, return_sequences=True, unroll=False)(inputs)
rnn_b = LSTM(32, return_sequences=True, unroll=False)(inputs)

# this should produce 10 * 10 matrix but throw an error
alignment = dot([rnn_a, rnn_a], axes=[2, 2])

```