### PR TITLE
Add missing abstract method to keras.preprocessing.image.Iterator

### DIFF
--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -717,7 +717,10 @@ class ImageDataGenerator(object):
 
 
 class Iterator(Sequence):
-    """Abstract base class for image data iterators.
+    """Base class for image data iterators.
+
+    Every `Iterator` must implement the `_get_batches_of_transformed_samples`
+    method.
 
     # Arguments
         n: Integer, total number of samples in the dataset to loop over.
@@ -791,6 +794,17 @@ class Iterator(Sequence):
 
     def __next__(self, *args, **kwargs):
         return self.next(*args, **kwargs)
+
+    def _get_batches_of_transformed_samples(self, index_array):
+        """Gets a batch of transformed samples.
+
+        # Arguments
+            index_array: array of sample indices to include in batch.
+
+        # Returns
+            A batch of transformed samples.
+        """
+        raise NotImplementedError
 
 
 class NumpyArrayIterator(Iterator):


### PR DESCRIPTION
Hi,

I noticed that the abstract base class `keras.preprocessing.image.Iterator` was seemingly missing an abstract method definition for `_get_batches_of_transformed_samples` so I added it.