### PR TITLE
Upgrade Travis testing from Python 3.5 to 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,19 +7,19 @@ matrix:
           env: KERAS_BACKEND=tensorflow TEST_MODE=PEP8
         - python: 2.7
           env: KERAS_BACKEND=tensorflow TEST_MODE=INTEGRATION_TESTS
-        - python: 3.5
+        - python: 3.6
           env: KERAS_BACKEND=tensorflow TEST_MODE=DOC
         - python: 2.7
           env: KERAS_BACKEND=tensorflow
-        - python: 3.5
+        - python: 3.6
           env: KERAS_BACKEND=tensorflow
         - python: 2.7
           env: KERAS_BACKEND=theano THEANO_FLAGS=optimizer=fast_compile
-        - python: 3.5
+        - python: 3.6
           env: KERAS_BACKEND=theano THEANO_FLAGS=optimizer=fast_compile
         - python: 2.7
           env: KERAS_BACKEND=cntk PYTHONWARNINGS=ignore
-        - python: 3.5
+        - python: 3.6
           env: KERAS_BACKEND=cntk PYTHONWARNINGS=ignore
 install:
   # code below is taken from http://conda.pydata.org/docs/travis.html
@@ -48,7 +48,7 @@ install:
   # install PIL for preprocessing tests
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
       conda install pil;
-    elif [[ "$TRAVIS_PYTHON_VERSION" == "3.5" ]]; then
+    elif [[ "$TRAVIS_PYTHON_VERSION" == "3.6" ]]; then
       conda install Pillow;
     fi
 
@@ -60,8 +60,8 @@ install:
   # install cntk
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
       pip install https://cntk.ai/PythonWheel/CPU-Only/cntk-2.2-cp27-cp27mu-linux_x86_64.whl;
-    elif [[ "$TRAVIS_PYTHON_VERSION" == "3.5" ]]; then
-      pip install https://cntk.ai/PythonWheel/CPU-Only/cntk-2.2-cp35-cp35m-linux_x86_64.whl;
+    elif [[ "$TRAVIS_PYTHON_VERSION" == "3.6" ]]; then
+      pip install https://cntk.ai/PythonWheel/CPU-Only/cntk-2.2-cp36-cp36m-linux_x86_64.whl;
     fi
 
   # install pydot for visualization tests


### PR DESCRIPTION
To match [setup.py](https://github.com/fchollet/keras/blob/master/setup.py#L34).  There are a number of questions raised in #7297 about Python 3.6 support so let's test that version.

The Python 3.6 tests all pass.  Only one unrelated Python 2.7 test seems to be failing. 
* https://travis-ci.org/fchollet/keras/builds/288454466