### PR TITLE
Fixing finite generator race condition

### DIFF
--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -654,7 +654,7 @@ class GeneratorEnqueuer(SequenceEnqueuer):
                     yield inputs
             else:
                 all_finished = all([not thread.is_alive() for thread in self._threads])
-                if all_finished:
+                if all_finished and self.queue.empty():
                     raise StopIteration()
                 else:
                     time.sleep(self.wait_time)

--- a/tests/keras/utils/data_utils_test.py
+++ b/tests/keras/utils/data_utils_test.py
@@ -264,7 +264,7 @@ def test_finite_generator_enqueuer_threads():
     acc = []
     for output in gen_output:
         acc.append(int(output[0, 0, 0, 0]))
-    assert len(set(acc) - set(range(100))) == 0, "Output is not the same"
+    assert set(acc) == set(range(100)), "Output is not the same"
     enqueuer.stop()
 
 


### PR DESCRIPTION
I spotted a race condition on my previous PR https://github.com/fchollet/keras/pull/8104. The problem affects only the case of finite generators and has no effect on the infinite ones. This PR fixes the bug and updates the test to capture similar problems. 

Please check the github comments on the code where I explain where the problem was and how I fixed it. Feedback is always welcome! :)