### PR TITLE
Output \b and \r only if stdout is a tty

### DIFF
--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -296,8 +296,11 @@ class Progbar(object):
                 return
 
             prev_total_width = self.total_width
-            sys.stdout.write('\b' * prev_total_width)
-            sys.stdout.write('\r')
+            if sys.stdout.isatty():
+                sys.stdout.write('\b' * prev_total_width)
+                sys.stdout.write('\r')
+            else:
+                sys.stdout.write('\n')
 
             if self.target is not None:
                 numdigits = int(np.floor(np.log10(self.target))) + 1


### PR DESCRIPTION
When stdout is redirected to a pipe or a file, for example, `python examples/mnist_cnn.py |& less -U` the output is unreadable.

Before:
```
Epoch 1/12
^M  128/60000 [..............................] - ETA: 265s - loss: 2.3164 - acc: 0.0703^H^H
^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H
^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^M  768/60000 [
..............................] - ETA: 48s - loss: 2.1636 - acc: 0.2865 ^H^H^H^H^H^H^H^H^H
^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H
^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^M 1408/60000 [...............
...............] - ETA: 28s - loss: 1.9688 - acc: 0.3764^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H
^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^
^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^M 
```

After:
```
Epoch 1/12

  128/60000 [..............................] - ETA: 264s - loss: 2.3258 - acc: 0.0938
  768/60000 [..............................] - ETA: 48s - loss: 2.2004 - acc: 0.2318 
 1408/60000 [..............................] - ETA: 28s - loss: 2.0169 - acc: 0.3459
```