### PR TITLE
Add missing imports in the multi_gpu_model() example.

### DIFF
--- a/keras/utils/training_utils.py
+++ b/keras/utils/training_utils.py
@@ -47,6 +47,8 @@ def multi_gpu_model(model, gpus):
     ```python
         import tensorflow as tf
         from keras.applications import Xception
+        from keras.utils import multi_gpu_model
+        import numpy as np
 
         num_samples = 1000
         height = 224


### PR DESCRIPTION
Just making the example in the comment runnable without errors. No functional changes.