### PR TITLE
Remove "input" from DirectoryIterator.class_mode

### DIFF
--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -1035,11 +1035,10 @@ class DirectoryIterator(Iterator):
                 self.image_shape = (1,) + self.target_size
         self.classes = classes
         if class_mode not in {'categorical', 'binary', 'sparse',
-                              'input', None}:
+                              None}:
             raise ValueError('Invalid class_mode:', class_mode,
                              '; expected one of "categorical", '
-                             '"binary", "sparse", "input"'
-                             ' or None.')
+                             '"binary", "sparse" or None.')
         self.class_mode = class_mode
         self.save_to_dir = save_to_dir
         self.save_prefix = save_prefix


### PR DESCRIPTION
As per the documentation at https://keras.io/preprocessing/image, "input" is not a valid chioce for DirectoryIterator.class_mode.
Fixes #7854.