### PR TITLE
Add missing numpy library

### DIFF
--- a/keras/legacy/layers.py
+++ b/keras/legacy/layers.py
@@ -1,3 +1,4 @@
+import numpy as np
 import types as python_types
 import warnings
 


### PR DESCRIPTION
numpy is used at line 1090, but never imported
https://github.com/Danielhiversen/keras/blob/f7a150f035a2bd2a9fe419da3c2c3943fc7ed52f/keras/legacy/layers.py#L1090