### PR TITLE
Fix off-by-one display errors for batch and epoch

### DIFF
--- a/examples/mnist_acgan.py
+++ b/examples/mnist_acgan.py
@@ -182,8 +182,8 @@ if __name__ == '__main__':
     train_history = defaultdict(list)
     test_history = defaultdict(list)
 
-    for epoch in range(epochs):
-        print('Epoch {} of {}'.format(epoch + 1, epochs))
+    for epoch in range(1, epochs + 1):
+        print('Epoch {} of {}'.format(epoch, epochs))
 
         num_batches = int(X_train.shape[0] / batch_size)
         progress_bar = Progbar(target=num_batches)
@@ -192,7 +192,6 @@ if __name__ == '__main__':
         epoch_disc_loss = []
 
         for index in range(num_batches):
-            progress_bar.update(index)
             # generate a new batch of noise
             noise = np.random.uniform(-1, 1, (batch_size, latent_size))
 
@@ -232,7 +231,9 @@ if __name__ == '__main__':
                 [noise, sampled_labels.reshape((-1, 1))],
                 [trick, sampled_labels]))
 
-        print('\nTesting for epoch {}:'.format(epoch + 1))
+            progress_bar.update(index + 1)
+
+        print('Testing for epoch {}:'.format(epoch))
 
         # evaluate the testing loss here
 


### PR DESCRIPTION
Before:
```
Epoch 1 of 50
599/600 [============================>.] - ETA: 0s  
Testing for epoch 1:
```
After:
```
Epoch 1 of 50
600/600 [==============================] - ETA: 0s   
Testing for epoch 1:
```

Also, before, saved file had names: 
```
params_discriminator_epoch_000.hdf5
params_generator_epoch_000.hdf5
plot_epoch_000_generated.png
```
even though there is no "epoch 0".