### PR TITLE
Rename X=>x to sync with the rest of codebase.

### DIFF
--- a/examples/lstm_text_generation.py
+++ b/examples/lstm_text_generation.py
@@ -40,11 +40,11 @@ for i in range(0, len(text) - maxlen, step):
 print('nb sequences:', len(sentences))
 
 print('Vectorization...')
-X = np.zeros((len(sentences), maxlen, len(chars)), dtype=np.bool)
+x = np.zeros((len(sentences), maxlen, len(chars)), dtype=np.bool)
 y = np.zeros((len(sentences), len(chars)), dtype=np.bool)
 for i, sentence in enumerate(sentences):
     for t, char in enumerate(sentence):
-        X[i, t, char_indices[char]] = 1
+        x[i, t, char_indices[char]] = 1
     y[i, char_indices[next_chars[i]]] = 1
 
 
@@ -73,7 +73,7 @@ for iteration in range(1, 60):
     print()
     print('-' * 50)
     print('Iteration', iteration)
-    model.fit(X, y,
+    model.fit(x, y,
               batch_size=128,
               epochs=1)
 

--- a/examples/mnist_acgan.py
+++ b/examples/mnist_acgan.py
@@ -170,14 +170,14 @@ if __name__ == '__main__':
 
     # get our mnist data, and force it to be of shape (..., 1, 28, 28) with
     # range [-1, 1]
-    (X_train, y_train), (X_test, y_test) = mnist.load_data()
-    X_train = (X_train.astype(np.float32) - 127.5) / 127.5
-    X_train = np.expand_dims(X_train, axis=1)
+    (x_train, y_train), (x_test, y_test) = mnist.load_data()
+    x_train = (x_train.astype(np.float32) - 127.5) / 127.5
+    x_train = np.expand_dims(x_train, axis=1)
 
-    X_test = (X_test.astype(np.float32) - 127.5) / 127.5
-    X_test = np.expand_dims(X_test, axis=1)
+    x_test = (x_test.astype(np.float32) - 127.5) / 127.5
+    x_test = np.expand_dims(x_test, axis=1)
 
-    num_train, num_test = X_train.shape[0], X_test.shape[0]
+    num_train, num_test = x_train.shape[0], x_test.shape[0]
 
     train_history = defaultdict(list)
     test_history = defaultdict(list)
@@ -185,7 +185,7 @@ if __name__ == '__main__':
     for epoch in range(1, epochs + 1):
         print('Epoch {} of {}'.format(epoch, epochs))
 
-        num_batches = int(X_train.shape[0] / batch_size)
+        num_batches = int(x_train.shape[0] / batch_size)
         progress_bar = Progbar(target=num_batches)
 
         epoch_gen_loss = []
@@ -196,7 +196,7 @@ if __name__ == '__main__':
             noise = np.random.uniform(-1, 1, (batch_size, latent_size))
 
             # get a batch of real images
-            image_batch = X_train[index * batch_size:(index + 1) * batch_size]
+            image_batch = x_train[index * batch_size:(index + 1) * batch_size]
             label_batch = y_train[index * batch_size:(index + 1) * batch_size]
 
             # sample some labels from p_c
@@ -209,12 +209,12 @@ if __name__ == '__main__':
             generated_images = generator.predict(
                 [noise, sampled_labels.reshape((-1, 1))], verbose=0)
 
-            X = np.concatenate((image_batch, generated_images))
+            x = np.concatenate((image_batch, generated_images))
             y = np.array([1] * batch_size + [0] * batch_size)
             aux_y = np.concatenate((label_batch, sampled_labels), axis=0)
 
             # see if the discriminator can figure itself out...
-            epoch_disc_loss.append(discriminator.train_on_batch(X, [y, aux_y]))
+            epoch_disc_loss.append(discriminator.train_on_batch(x, [y, aux_y]))
 
             # make new noise. we generate 2 * batch size here such that we have
             # the generator optimize over an identical number of images as the
@@ -245,13 +245,13 @@ if __name__ == '__main__':
         generated_images = generator.predict(
             [noise, sampled_labels.reshape((-1, 1))], verbose=False)
 
-        X = np.concatenate((X_test, generated_images))
+        x = np.concatenate((x_test, generated_images))
         y = np.array([1] * num_test + [0] * num_test)
         aux_y = np.concatenate((y_test, sampled_labels), axis=0)
 
         # see if the discriminator can figure itself out...
         discriminator_test_loss = discriminator.evaluate(
-            X, [y, aux_y], verbose=False)
+            x, [y, aux_y], verbose=False)
 
         discriminator_train_loss = np.mean(np.array(epoch_disc_loss), axis=0)
 


### PR DESCRIPTION
All-cap identifiers are reserved for constants.