### PR TITLE
Added finite generator support for training, evaluating, prediction.

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -277,7 +277,9 @@ class ProgbarLogger(Callback):
         self.seen = 0
 
     def on_batch_begin(self, batch, logs=None):
-        if self.seen < self.target:
+        if self.target is None:
+            self.log_values = []
+        elif self.seen < self.target:
             self.log_values = []
 
     def on_batch_end(self, batch, logs=None):
@@ -292,9 +294,7 @@ class ProgbarLogger(Callback):
             if k in logs:
                 self.log_values.append((k, logs[k]))
 
-        # Skip progbar update for the last batch;
-        # will be handled by on_epoch_end.
-        if self.verbose and self.seen < self.target:
+        if self.verbose:
             self.progbar.update(self.seen, self.log_values)
 
     def on_epoch_end(self, epoch, logs=None):

--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -277,6 +277,11 @@ class Progbar(object):
                 The progress bar will display averages for these values.
             force: Whether to force visual progress update.
         """
+
+        updated = False
+        if current > self.seen_so_far:
+            # On epoch end was called
+            updated = True
         values = values or []
         for k, v in values:
             if k not in self.sum_values:
@@ -345,6 +350,8 @@ class Progbar(object):
                 info += (' ' * (prev_total_width - self.total_width))
 
             if self.target is not None and current >= self.target:
+                info += '\n'
+            elif self.target is None and not updated:
                 info += '\n'
 
             sys.stdout.write(info)


### PR DESCRIPTION
My experiments require data with different number of samples per epoch (different number of batches) and I prefer not to predict (or set up with some constants) this number.
Thus I use generators for batch composition and sampling for training. Epoch in such experiment refer to using all available data samples for batch generation.

However in python you cannot use generator in successive loops and need to use some [hacks](https://stackoverflow.com/questions/1271320/resetting-generator-object-in-python). But this hacks are incompatible with training loops in keras but rather easy to tweak.

My modifications touches ProgbarLogger and Progbar for compatibility when steps_per_epoch are set to None in fit_generator and evaluate_generator.
I tested this PR on infinite generators and haven't seen changes in behaviour.