### PR TITLE
Simplify and fix count_params()

### DIFF
--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -493,13 +493,13 @@ def ones_like(x, name=None):
 
 
 def count_params(x):
-    for _ in x.shape:
+    for _ in get_variable_shape(x):
         if _ == C.InferredDimension or _ == C.FreeDimension:
             raise ValueError('CNTK backend: `count_params` with dynamic '
                              'shape is not supported. Please provide '
                              'fixed dimension instead of `None`.')
 
-    return np.prod([x.shape[i] for i in range(len(x.shape))])
+    return np.prod(get_variable_shape(x))
 
 
 def cast(x, dtype):

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -541,7 +541,7 @@ def shape(x):
 
 
 def int_shape(x):
-    """Returns the shape tensor or variable as a tuple of int or None entries.
+    """Returns the shape of tensor or variable as a tuple of int or None entries.
 
     # Arguments
         x: Tensor or variable.
@@ -865,13 +865,14 @@ def random_normal_variable(shape, mean, scale, dtype=None,
 
 
 def count_params(x):
-    """Returns the number of scalars in a Keras variable.
+    """Returns the static number of elements in a Keras variable or tensor.
 
     # Arguments
-        x: Keras variable.
+        x: Keras variable or tensor.
 
     # Returns
-        Integer, the number of scalars in `x`.
+        Integer, the number of elements in `x`, i.e., the product of the
+        array’s static dimensions.
 
     # Example
     ```python
@@ -883,8 +884,7 @@ def count_params(x):
                [ 0.,  0.,  0.]], dtype=float32)
     ```
     """
-    shape = x.get_shape()
-    return np.prod([shape[i]._value for i in range(len(shape))])
+    return np.prod(get_variable_shape(x))
 
 
 def cast(x, dtype):

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -872,7 +872,7 @@ def count_params(x):
 
     # Returns
         Integer, the number of elements in `x`, i.e., the product of the
-        array’s static dimensions.
+        array's static dimensions.
 
     # Example
     ```python


### PR DESCRIPTION
also use existing abstraction get_variable_shape(x), instead of using .shape attribute directly. Also improve docstrings.

I think this fixes a bug in TF backend, because int_shape(x) returns x.get_shape() only if x._keras_shape is not set, for example if x is np.ndarray, or a sparse tensor/ndarray.