### PR TITLE
fix device names for multi_gpu_model

### DIFF
--- a/keras/utils/training_utils.py
+++ b/keras/utils/training_utils.py
@@ -89,7 +89,7 @@ def multi_gpu_model(model, gpus):
 
     target_devices = ['/cpu:0'] + ['/gpu:%d' % i for i in range(gpus)]
     target_devices = list(map(
-        lambda x: tf.DeviceSpec.from_string(x).to_string() if x.find('gpu') != -1 else x,
+        lambda x: tf.DeviceSpec.from_string(x).to_string(),
         target_devices
     ))
     available_devices = _get_available_devices()

--- a/keras/utils/training_utils.py
+++ b/keras/utils/training_utils.py
@@ -88,6 +88,10 @@ def multi_gpu_model(model, gpus):
     import tensorflow as tf
 
     target_devices = ['/cpu:0'] + ['/gpu:%d' % i for i in range(gpus)]
+    target_devices = list(map(
+        lambda x: tf.DeviceSpec.from_string(x).to_string() if x.find('gpu') != -1 else x,
+        target_devices
+    ))
     available_devices = _get_available_devices()
     for device in target_devices:
         if device not in available_devices:


### PR DESCRIPTION
This PR will try to fix #8213.

`DeviceSpec.from_string(device).to_string()` is used by tensorflow. ([Ref](https://github.com/tensorflow/tensorflow/blob/40c475b48c091a70ad8061c1508dff6ded2d2af6/tensorflow/python/framework/device.py#L251))