### PR TITLE
Add a model.check_trainable_weights_consistency

### DIFF
--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -16,6 +16,7 @@ from .. import backend as K
 from .. import initializers
 from ..utils.io_utils import ask_to_proceed_with_overwrite
 from ..utils.layer_utils import print_summary as print_layer_summary
+from ..utils.layer_utils import count_params
 from ..utils.generic_utils import has_arg
 from ..utils import conv_utils
 from ..legacy import interfaces
@@ -1269,7 +1270,7 @@ class Layer(object):
                                    self.name + ', but the layer isn\'t built. '
                                    'You can build it manually via: `' +
                                    self.name + '.build(batch_input_shape)`.')
-        return sum([K.count_params(p) for p in self.weights])
+        return count_params(self.weights)
 
 
 class InputLayer(Layer):

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -954,12 +954,12 @@ class Model(Container):
         if not hasattr(self, '_collected_trainable_weights'):
             return
 
-        if count_params(self.trainable_weights) != \
-           count_params(self._collected_trainable_weights):
+        if (count_params(self.trainable_weights) !=
+                count_params(self._collected_trainable_weights)):
             warnings.warn(UserWarning(
                 'Discrepancy between trainable weights and collected trainable'
-                ' weights, did you set model.trainable without calling'
-                ' model.compile after ?'))
+                ' weights, did you set `model.trainable` without calling'
+                ' `model.compile` after ?'))
 
     def _make_train_function(self):
         if not hasattr(self, 'train_function'):

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -22,6 +22,7 @@ from .. import optimizers
 from .. import losses
 from .. import metrics as metrics_module
 from ..utils.generic_utils import Progbar
+from ..utils.layer_utils import count_params
 from .. import callbacks as cbks
 from ..legacy import interfaces
 
@@ -945,9 +946,25 @@ class Model(Container):
         trainable_weights = self.trainable_weights
         self._collected_trainable_weights = trainable_weights
 
+    def check_trainable_weights_consistency(self):
+        """
+        Checks that trainable_weights and _collected_trainable_weights are
+        consistent
+        """
+        if not hasattr(self, '_collected_trainable_weights'):
+            return
+
+        if count_params(self.trainable_weights) != \
+           count_params(self._collected_trainable_weights):
+            warnings.warn(UserWarning(
+                'Discrepancy between trainable weights and collected trainable'
+                ' weights, did you set model.trainable without calling'
+                ' model.compile after ?'))
+
     def _make_train_function(self):
         if not hasattr(self, 'train_function'):
             raise RuntimeError('You must compile your model before using it.')
+        self.check_trainable_weights_consistency()
         if self.train_function is None:
             inputs = self._feed_inputs + self._feed_targets + self._feed_sample_weights
             if self.uses_learning_phase and not isinstance(K.learning_phase(), int):

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -946,10 +946,14 @@ class Model(Container):
         trainable_weights = self.trainable_weights
         self._collected_trainable_weights = trainable_weights
 
-    def check_trainable_weights_consistency(self):
-        """
-        Checks that trainable_weights and _collected_trainable_weights are
-        consistent
+    def _check_trainable_weights_consistency(self):
+        """Check trainable weights count consistency.
+
+        This will raise a warning if `trainable_weights` and
+        `_collected_trainable_weights` are consistent (i.e. have the same
+        number of parameters).
+        Inconsistency will typically arise when one modifies `model.trainable`
+        without calling `model.compile` again.
         """
         if not hasattr(self, '_collected_trainable_weights'):
             return
@@ -964,7 +968,7 @@ class Model(Container):
     def _make_train_function(self):
         if not hasattr(self, 'train_function'):
             raise RuntimeError('You must compile your model before using it.')
-        self.check_trainable_weights_consistency()
+        self._check_trainable_weights_consistency()
         if self.train_function is None:
             inputs = self._feed_inputs + self._feed_targets + self._feed_sample_weights
             if self.uses_learning_phase and not isinstance(K.learning_phase(), int):

--- a/keras/utils/layer_utils.py
+++ b/keras/utils/layer_utils.py
@@ -6,7 +6,14 @@ import numpy as np
 
 
 def count_params(weights):
-    """Count the total number of scalars composing the weights"""
+    """Count the total number of scalars composing the weights.
+
+    # Arguments
+        weights: An iterable containing the weights on which to compute params
+
+    # Returns
+        The total number of scalars composing the weights
+    """
     return int(np.sum([K.count_params(p) for p in set(weights)]))
 
 

--- a/keras/utils/layer_utils.py
+++ b/keras/utils/layer_utils.py
@@ -146,7 +146,7 @@ def print_summary(model, line_length=None, positions=None, print_fn=print):
         else:
             print_fn('_' * line_length)
 
-    model.check_trainable_weights_consistency()
+    model._check_trainable_weights_consistency()
     if hasattr(model, '_collected_trainable_weights'):
         trainable_count = count_params(model._collected_trainable_weights)
     else:

--- a/keras/utils/layer_utils.py
+++ b/keras/utils/layer_utils.py
@@ -5,6 +5,11 @@ from .. import backend as K
 import numpy as np
 
 
+def count_params(weights):
+    """Count the total number of scalars composing the weights"""
+    return int(np.sum([K.count_params(p) for p in set(weights)]))
+
+
 def print_summary(model, line_length=None, positions=None, print_fn=print):
     """Prints a summary of a model.
 
@@ -134,8 +139,12 @@ def print_summary(model, line_length=None, positions=None, print_fn=print):
         else:
             print_fn('_' * line_length)
 
-    trainable_count = int(
-        np.sum([K.count_params(p) for p in set(model.trainable_weights)]))
+    model.check_trainable_weights_consistency()
+    if hasattr(model, '_collected_trainable_weights'):
+        trainable_count = count_params(model._collected_trainable_weights)
+    else:
+        trainable_count = count_params(model.trainable_weights)
+
     non_trainable_count = int(
         np.sum([K.count_params(p) for p in set(model.non_trainable_weights)]))
 

--- a/tests/keras/engine/test_training.py
+++ b/tests/keras/engine/test_training.py
@@ -926,7 +926,8 @@ def test_model_custom_target_tensors():
 @pytest.mark.skipif(sys.version_info < (3,), reason='Cannot catch warnings in python 2')
 @keras_test
 def test_trainable_weights_count_consistency():
-    """
+    """Tests the trainable weights consistency check of Model.
+
     This verifies that a warning is shown if model.trainable is modified
     and the model is summarized/run without a new call to .compile()
 


### PR DESCRIPTION
This will raise a UserWarning when the user modifies model.trainable
and tries to print a model summary or launch a fit without having
called .compile.

Calling .compile() is necessary because trainable weights are collected
in compile (model._collected_trainable_weights).

Fixes #8121 