### PR TITLE
Normalize device names in multi_gpu_model

### DIFF
--- a/keras/utils/training_utils.py
+++ b/keras/utils/training_utils.py
@@ -9,6 +9,9 @@ def _get_available_devices():
     local_device_protos = device_lib.list_local_devices()
     return [x.name for x in local_device_protos]
 
+def _normalize_device_name(name):
+    name = name.lower().replace('device:', '')
+    return name 
 
 def multi_gpu_model(model, gpus):
     """Replicates a model on different GPUs.
@@ -89,6 +92,7 @@ def multi_gpu_model(model, gpus):
 
     target_devices = ['/cpu:0'] + ['/gpu:%d' % i for i in range(gpus)]
     available_devices = _get_available_devices()
+    available_devices = [_normalize_device_name(name) for name in available_devices]
     for device in target_devices:
         if device not in available_devices:
             raise ValueError(

--- a/keras/utils/training_utils.py
+++ b/keras/utils/training_utils.py
@@ -9,9 +9,11 @@ def _get_available_devices():
     local_device_protos = device_lib.list_local_devices()
     return [x.name for x in local_device_protos]
 
+
 def _normalize_device_name(name):
     name = name.lower().replace('device:', '')
-    return name 
+    return name
+
 
 def multi_gpu_model(model, gpus):
     """Replicates a model on different GPUs.


### PR DESCRIPTION
* added _normalize_device_name function to training_utils.py --> convert "/device:GPU:0" to "/gpu:0"
* call _normalize_device_name() after obtaining available devices in multi_gpu_model() before verifying against target_devices.
* Successfully run tests in tests/keras/utils/multi_gpu_test.py
* Should work in both nightly and stable versions of tensorflow as all device names are shortened. 

Related Issues: 
fixes #8213  : converts all to "/xpu:0" representation  
fixes #8220  
fixes #8222   : This PR suggests converting to "/device:GPU:0" format for gpu and "/cpu:0" for cpu. 

Source: 
Uses code snippet suggested by @fchollet in https://github.com/fchollet/keras/pull/8222