### PR TITLE
Fix summary about models

### DIFF
--- a/docs/autogen.py
+++ b/docs/autogen.py
@@ -361,7 +361,7 @@ def get_class_signature(cls):
     try:
         class_signature = get_function_signature(cls.__init__)
         class_signature = class_signature.replace('__init__', cls.__name__)
-    except TypeError:
+    except (TypeError, AttributeError):
         # in case the class inherits from object and does not
         # define __init__
         class_signature = cls.__module__ + '.' + cls.__name__ + '()'

--- a/docs/autogen.py
+++ b/docs/autogen.py
@@ -284,6 +284,7 @@ PAGES = [
         'functions': [utils.to_categorical,
                       utils.normalize,
                       utils.get_file,
+                      utils.print_summary,
                       utils.plot_model,
                       utils.multi_gpu_model],
         'classes': [utils.CustomObjectScope,

--- a/docs/autogen.py
+++ b/docs/autogen.py
@@ -407,8 +407,8 @@ def code_snippet(snippet):
 
 
 def process_class_docstring(docstring):
-    docstring = re.sub(r'\n    # (.*)\n',
-                       r'\n    __\1__\n\n',
+    docstring = re.sub(r'\n(\s+)# (.*)\n',
+                       r'\n\1__\2__\n\n',
                        docstring)
     docstring = re.sub(r'    ([^\s\\\(]+):(.*)\n',
                        r'    - __\1__:\2\n',
@@ -421,8 +421,8 @@ def process_class_docstring(docstring):
 
 
 def process_function_docstring(docstring):
-    docstring = re.sub(r'\n    # (.*)\n',
-                       r'\n    __\1__\n\n',
+    docstring = re.sub(r'\n(\s+)# (.*)\n',
+                       r'\n\1__\2__\n\n',
                        docstring)
     docstring = re.sub(r'    ([^\s\\\(]+):(.*)\n',
                        r'    - __\1__:\2\n',

--- a/docs/templates/models/about-keras-models.md
+++ b/docs/templates/models/about-keras-models.md
@@ -4,7 +4,7 @@ There are two types of models available in Keras: [the Sequential model](/models
 
 These models have a number of methods in common:
 
-- `model.summary()`: prints a summary representation of your model.
+- `model.summary()`: prints a summary representation of your model. Shortcut for [utils.print_summary](/utils/#print_summary)
 - `model.get_config()`: returns a dictionary containing the configuration of the model. The model can be reinstantiated from its config via:
 ```python
 config = model.get_config()

--- a/keras/utils/__init__.py
+++ b/keras/utils/__init__.py
@@ -18,6 +18,7 @@ from .generic_utils import serialize_keras_object
 from .generic_utils import deserialize_keras_object
 from .generic_utils import Progbar
 from .layer_utils import convert_all_kernels_in_model
+from .layer_utils import print_summary
 from .vis_utils import plot_model
 from .np_utils import to_categorical
 from .np_utils import normalize


### PR DESCRIPTION
This expose `utils.layer_utils.print_summary()` as `utils.print_summary()` and therefore document it, fixing #8105 .

This also fixes an issue with the `process_XXX_docstring` functions in `docs/autogen.py` which led to incorrect docstring formatting, making Arguments and Returns top-level markdown sections. The current doc on [keras.io](https://keras.io/models/sequential/#the-sequential-model-api) looks like this : 

<img width="256" alt="before" src="https://user-images.githubusercontent.com/506602/32023254-f366fe62-b9d8-11e7-8e64-683d19a5ecc5.png">

This fixes it to look like this

<img width="272" alt="after" src="https://user-images.githubusercontent.com/506602/32023261-fab4927e-b9d8-11e7-8b25-b12ad6067de1.png">
