### PR TITLE
Use tf.eye(), instead of np.eye()

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -725,7 +725,10 @@ def eye(size, dtype=None, name=None):
     ```
 
     """
-    return variable(np.eye(size), dtype, name)
+    if dtype is None:
+        dtype = floatx()
+    tf_dtype = tf.as_dtype(dtype)
+    return variable(tf.eye(size, dtype=tf_dtype), dtype, name)
 
 
 def zeros_like(x, dtype=None, name=None):


### PR DESCRIPTION
Resolves https://github.com/fchollet/keras/issues/8232

Now in TF backend, `K.eye()` is consistent with `K.zeros()` and `K.ones()` (all returning Keras variable constructed from tf.Tensor), but still inconsistent with `K.zeros_like()` and `K.ones_like()` (returning raw `tf.Tensor`).

I didn't change `.eye()` in Theano and CNTK because `.zeros(), .ones(), .eye()` were already mutually consistent (all returning Keras variable constructed from `np.ndarray`), but inconsistent with `.zeros_like()` and `ones_like()` (returning `TH/CNTK Tensor`). 

TH/CNTK  `.zeros(), .ones(), .eye()`  (constructed from `np.ndarray`) are inconsistent with those of TF (constructed from `tf.Tensor`).

All this looks weird, but intentional.