### PR TITLE
Fix post_process_signature for floating point

### DIFF
--- a/docs/autogen.py
+++ b/docs/autogen.py
@@ -369,7 +369,7 @@ def get_class_signature(cls):
 
 
 def post_process_signature(signature):
-    parts = signature.split('.')
+    parts = re.split('\.(?!\d)', signature)
     if len(parts) >= 4:
         if parts[1] == 'layers':
             signature = 'keras.layers.' + '.'.join(parts[3:])


### PR DESCRIPTION
Current `post_process_signature` function generates broken signatures for some classes including a floating point in default argument such like [GRU](https://keras.io/layers/recurrent/#gru), [ELU](https://keras.io/layers/advanced-activations/#elu).