### PR TITLE
Simplify _to_tensor(), reduce graph ops.

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -279,10 +279,7 @@ def _to_tensor(x, dtype):
     # Returns
         A tensor.
     """
-    x = tf.convert_to_tensor(x)
-    if x.dtype != dtype:
-        x = tf.cast(x, dtype)
-    return x
+    return tf.convert_to_tensor(x, dtype=dtype)
 
 
 def is_sparse(tensor):


### PR DESCRIPTION
Maybe _to_tensor() should be renamed and exposed (made public) as K.convert_to_tensor(), with API changed to match (will be backward compatible)?