### PR TITLE
Assert that steps per epoch needs to be a positive number

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -2042,6 +2042,9 @@ class Model(Container):
                 callbacks.on_epoch_begin(epoch)
                 steps_done = 0
                 batch_index = 0
+
+                assert steps_per_epoch > 0, "steps_per_epoch needs to be " \
+                    "greater than 0"
                 while steps_done < steps_per_epoch:
                     generator_output = next(output_generator)
 


### PR DESCRIPTION
Referencing issue #450, specifically the very last comment, in which `steps_per_epoch` can be 0, resulting in a non-sensical error message. This is due to variables that are only declared and initialized in the following for loop, resulting in an error that is non-obvious for this case.