### PR TITLE
Fix incorrect __len__ method in CIFAR10Sequence example

### DIFF
--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -315,6 +315,7 @@ class Sequence(object):
         from skimage.io import imread
         from skimage.transform import resize
         import numpy as np
+        import math
 
         # Here, `x_set` is list of path to the images
         # and `y_set` are the associated classes.
@@ -326,7 +327,7 @@ class Sequence(object):
                 self.batch_size = batch_size
 
             def __len__(self):
-                return len(self.x) // self.batch_size
+                return math.ceil(len(self.x) / self.batch_size)
 
             def __getitem__(self, idx):
                 batch_x = self.x[idx * self.batch_size:(idx + 1) * self.batch_size]


### PR DESCRIPTION
For example, if len(x) is 3 and the batch size is 2, 3//2 == 1 but there really is 2 batches.