### PR TITLE
Use int_shape() instead of get_variable_shape()

### DIFF
--- a/docs/autogen.py
+++ b/docs/autogen.py
@@ -98,6 +98,7 @@ EXCLUDE = {
     'get',
     'set_image_dim_ordering',
     'image_dim_ordering',
+    'get_variable_shape',
 }
 
 PAGES = [

--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -493,13 +493,13 @@ def ones_like(x, dtype=None, name=None):
 
 
 def count_params(x):
-    for _ in get_variable_shape(x):
+    for _ in x.shape:
         if _ == C.InferredDimension or _ == C.FreeDimension:
             raise ValueError('CNTK backend: `count_params` with dynamic '
                              'shape is not supported. Please provide '
                              'fixed dimension instead of `None`.')
 
-    return np.prod(get_variable_shape(x))
+    return np.prod(int_shape(x))
 
 
 def cast(x, dtype):
@@ -887,7 +887,7 @@ def binary_crossentropy(target, output, from_logits=False):
 
 
 def get_variable_shape(x):
-    return x.shape
+    return int_shape(x)
 
 
 def update(x, new_x):

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -888,7 +888,7 @@ def count_params(x):
                [ 0.,  0.,  0.]], dtype=float32)
     ```
     """
-    return np.prod(get_variable_shape(x))
+    return np.prod(int_shape(x))
 
 
 def cast(x, dtype):

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -2247,14 +2247,6 @@ def batch_set_value(tuples):
 
 
 def get_variable_shape(x):
-    """Returns the shape of a variable.
-
-    # Arguments
-        x: A variable.
-
-    # Returns
-        A tuple of integers.
-    """
     return int_shape(x)
 
 

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -2247,6 +2247,14 @@ def batch_set_value(tuples):
 
 
 def get_variable_shape(x):
+    """Returns the shape of a variable.
+
+    # Arguments
+        x: A variable.
+
+    # Returns
+        A tuple of integers.
+    """
     return int_shape(x)
 
 

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -349,7 +349,8 @@ class TestBackend(object):
 
     def test_value_manipulation(self):
         val = np.random.random((4, 2))
-        for function_name in ['get_value', 'count_params', 'get_variable_shape']:
+        for function_name in ['get_value', 'count_params',
+                              'int_shape', 'get_variable_shape']:
             v_list = [getattr(k, function_name)(k.variable(val))
                       for k in BACKENDS]
 


### PR DESCRIPTION
and add `int_shape()` to tests. See https://github.com/fchollet/keras/issues/8230

Now `get_variable_shape()` is unused anywhere in Keras codebase, and could be removed. Leaving for backward compatibility only. In TF and CNTK, `get_variable_shape()` simply returns `int_shape()`.