### PR TITLE
Increase file save hash size

### DIFF
--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -1104,7 +1104,7 @@ class DirectoryIterator(Iterator):
                 img = array_to_img(batch_x[i], self.data_format, scale=True)
                 fname = '{prefix}_{index}_{hash}.{format}'.format(prefix=self.save_prefix,
                                                                   index=j,
-                                                                  hash=np.random.randint(1e4),
+                                                                  hash=np.random.randint(2**31 - 1),
                                                                   format=self.save_format)
                 img.save(os.path.join(self.save_to_dir, fname))
         # build batch of labels

--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -1104,7 +1104,7 @@ class DirectoryIterator(Iterator):
                 img = array_to_img(batch_x[i], self.data_format, scale=True)
                 fname = '{prefix}_{index}_{hash}.{format}'.format(prefix=self.save_prefix,
                                                                   index=j,
-                                                                  hash=np.random.randint(2**31 - 1),
+                                                                  hash=np.random.randint(1e7),
                                                                   format=self.save_format)
                 img.save(os.path.join(self.save_to_dir, fname))
         # build batch of labels


### PR DESCRIPTION
Issue #8249 runs into a problem where the max hash size is low, resulting in files being potentially overwritten.

The behavior of this functionality is as such:
As batch size increases, the probability that any given file will have a conflict in the hash reduces. However, when the author wants to save images with a batch size of one, the probability of a conflict increases since {index} is always 1. This seems to just be an unforeseen bug because a batch size of one is uncommon.