### PR TITLE
fixed loading custom losses and metrics for load_model

### DIFF
--- a/keras/models.py
+++ b/keras/models.py
@@ -11,6 +11,8 @@ import numpy as np
 
 from . import backend as K
 from . import optimizers
+from . import losses
+from . import metrics
 from . import layers as layer_module
 from .utils.io_utils import ask_to_proceed_with_overwrite
 from .utils.generic_utils import has_arg
@@ -206,30 +208,6 @@ def load_model(filepath, custom_objects=None, compile=True):
     if not custom_objects:
         custom_objects = {}
 
-    def convert_custom_objects(obj):
-        """Handles custom object lookup.
-
-        # Arguments
-            obj: object, dict, or list.
-
-        # Returns
-            The same structure, where occurrences
-                of a custom object name have been replaced
-                with the custom object.
-        """
-        if isinstance(obj, list):
-            deserialized = []
-            for value in obj:
-                deserialized.append(convert_custom_objects(value))
-            return deserialized
-        if isinstance(obj, dict):
-            deserialized = {}
-            for key, value in obj.items():
-                deserialized[key] = convert_custom_objects(value)
-            return deserialized
-        if obj in custom_objects:
-            return custom_objects[obj]
-        return obj
     with h5py.File(filepath, mode='r') as f:
         # instantiate model
         model_config = f.attrs.get('model_config')
@@ -257,15 +235,31 @@ def load_model(filepath, custom_objects=None, compile=True):
                                            custom_objects=custom_objects)
 
         # Recover loss functions and metrics.
-        loss = convert_custom_objects(training_config['loss'])
-        metrics = convert_custom_objects(training_config['metrics'])
+        loss_config = training_config['loss'] 
+        if isinstance(loss_config,list):
+            loss = [losses.deserialize(los,custom_objects=custom_objects)
+                    for los
+                    in loss_config]
+        else:
+            loss = losses.deserialize(loss_config,
+                                      custom_objects=custom_objects)
+
+        metric_config = training_config['metrics']
+        if isinstance(metric_config,list):
+            metric = [metrics.deserialize(met,custom_objects=custom_objects)
+                    for met
+                    in metric_config]
+        else:
+            metric = metrics.deserialize(metric_config,
+                                         custom_objects=custom_objects)
+
         sample_weight_mode = training_config['sample_weight_mode']
         loss_weights = training_config['loss_weights']
 
         # Compile model.
         model.compile(optimizer=optimizer,
                       loss=loss,
-                      metrics=metrics,
+                      metrics=metric,
                       loss_weights=loss_weights,
                       sample_weight_mode=sample_weight_mode)
 


### PR DESCRIPTION
the `convert_custom_objects` function currently only used
to deserialize losses and metrics in `load_model` cannot handle
custom losses and metrics that are formatted in the
same conventions as other keras objects.
Changed to directly call `deserialize` from the appropriate
module and allow for the case that the losses and metrics
can be a list of deserializable keras objects.

This will allow for the writing of losses as keras objects/ classes with get_config() . Can be executed with the __call__ function, see constraints.py. By allowing this kind of object, loss functions can have extra attributes outside of the function parameters `y_true` and `y_pred`.
Also matches the deserialization of all other keras objects.