### PR TITLE
Move from old string interpolation to format

### DIFF
--- a/keras/applications/mobilenet.py
+++ b/keras/applications/mobilenet.py
@@ -651,14 +651,14 @@ def _depthwise_conv_block(inputs, pointwise_conv_filters, alpha,
                         depth_multiplier=depth_multiplier,
                         strides=strides,
                         use_bias=False,
-                        name='conv_dw_%d' % block_id)(inputs)
-    x = BatchNormalization(axis=channel_axis, name='conv_dw_%d_bn' % block_id)(x)
-    x = Activation(relu6, name='conv_dw_%d_relu' % block_id)(x)
+                        name='conv_dw_{0}'.format(block_id))(inputs)
+    x = BatchNormalization(axis=channel_axis, name='conv_dw_{0}_bn'.format(block_id))(x)
+    x = Activation(relu6, name='conv_dw_{0}_relu'.format(block_id))(x)
 
     x = Conv2D(pointwise_conv_filters, (1, 1),
                padding='same',
                use_bias=False,
                strides=(1, 1),
-               name='conv_pw_%d' % block_id)(x)
-    x = BatchNormalization(axis=channel_axis, name='conv_pw_%d_bn' % block_id)(x)
-    return Activation(relu6, name='conv_pw_%d_relu' % block_id)(x)
+               name='conv_pw_{0}'.format(block_id))(x)
+    x = BatchNormalization(axis=channel_axis, name='conv_pw_{0}_bn'.format(block_id))(x)
+    return Activation(relu6, name='conv_pw_{0}_relu'.format(block_id))(x)

--- a/keras/applications/mobilenet.py
+++ b/keras/applications/mobilenet.py
@@ -427,7 +427,7 @@ def MobileNet(input_shape=None,
             raise ValueError('If imagenet weights are being loaded, '
                              'input must have a static square shape (one of '
                              '(128,128), (160,160), (192,192), or (224, 224)).'
-                             ' Input shape provided = %s' % (input_shape,))
+                             ' Input shape provided = {}'.format(input_shape,))
 
     if K.image_data_format() != 'channels_last':
         warnings.warn('The MobileNet family of models is only available '
@@ -502,7 +502,7 @@ def MobileNet(input_shape=None,
         inputs = img_input
 
     # Create model.
-    model = Model(inputs, x, name='mobilenet_%0.2f_%s' % (alpha, rows))
+    model = Model(inputs, x, name='mobilenet_%{0:2f}_{1}'.format(alpha, rows))
 
     # load weights
     if weights == 'imagenet':
@@ -519,13 +519,13 @@ def MobileNet(input_shape=None,
             alpha_text = '2_5'
 
         if include_top:
-            model_name = 'mobilenet_%s_%d_tf.h5' % (alpha_text, rows)
+            model_name = 'mobilenet_{0}_{1}_tf.h5'.format(alpha_text, rows)
             weigh_path = BASE_WEIGHT_PATH + model_name
             weights_path = get_file(model_name,
                                     weigh_path,
                                     cache_subdir='models')
         else:
-            model_name = 'mobilenet_%s_%d_tf_no_top.h5' % (alpha_text, rows)
+            model_name = 'mobilenet_{0}_{1}_tf_no_top.h5'.format(alpha_text, rows)
             weigh_path = BASE_WEIGHT_PATH + model_name
             weights_path = get_file(model_name,
                                     weigh_path,

--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -54,8 +54,8 @@ def set_learning_phase(value):
     global _LEARNING_PHASE
     if value not in {0, 1}:
         raise ValueError('CNTK Backend: Set learning phase '
-                         'with value %s is not supported, '
-                         'expected 0 or 1.' % value)
+                         'with value {0} is not supported, '
+                         'expected 0 or 1.'.format(value))
     v = np.asarray(value)
     _LEARNING_PHASE.value = v
 
@@ -114,9 +114,9 @@ def _convert_dtype_string(dtype):
     elif dtype == np.float64:
         return 'float64'
     else:
-        raise ValueError('CNTK Backend: Unsupported dtype: %s. '
+        raise ValueError('CNTK Backend: Unsupported dtype: {0}. '
                          'CNTK only supports float32 and '
-                         'float64.' % dtype)
+                         'float64.'.format(dtype))
 
 
 def variable(value, dtype=None, name=None, constraint=None):
@@ -223,10 +223,10 @@ def eval(x):
         return x.value
     else:
         raise ValueError('CNTK Backend: `eval` method on '
-                         '`%s` type is not supported. '
+                         '`{0}` type is not supported. '
                          'CNTK only supports `eval` with '
                          '`Function`, `Constant` or '
-                         '`Parameter`.' % type(x))
+                         '`Parameter`.'.format(type(x)))
 
 
 def placeholder(
@@ -1109,10 +1109,10 @@ def permute_dimensions(x, pattern):
     current_layout = tuple([i for i in range(dims)])
 
     if num_dynamic_axis > 0 and pattern[:num_dynamic_axis] != current_layout[:num_dynamic_axis]:
-        raise ValueError('CNTK backend: the permute pattern %s '
+        raise ValueError('CNTK backend: the permute pattern {0} '
                          'requested permute on dynamic axis, '
                          'which is not supported. Please do permute '
-                         'on static axis.' % pattern)
+                         'on static axis.'.format(pattern))
 
     axis = list(pattern)
     axis = axis[num_dynamic_axis:]
@@ -1202,10 +1202,10 @@ def _static_rnn(step_function, inputs, initial_states,
     # if the second axis is static axis, CNTK will do unroll by default
     if shape[1] is None:
         raise ValueError('CNTK Backend: the input of static rnn '
-                         'has shape `%s`, the second axis '
+                         'has shape `{0}`, the second axis '
                          'is not static. If you want to run '
                          'rnn with non-static axis, please try '
-                         'dynamic rnn with sequence axis.' % shape)
+                         'dynamic rnn with sequence axis.'.format(shape))
     if constants is None:
         constants = []
 
@@ -1309,8 +1309,8 @@ def rnn(step_function, inputs, initial_states,
     uses_learning_phase = False
 
     if dims < 3:
-        raise ValueError('CNTK Backend: the input of rnn has only rank %d '
-                         'Need at least rank 3 to run RNN.' % dims)
+        raise ValueError('CNTK Backend: the input of rnn has only rank {0} '
+                         'Need at least rank 3 to run RNN.'.format(dims))
 
     if _get_dynamic_axis_num(inputs) == 0 or unroll:
         return _static_rnn(
@@ -1647,8 +1647,8 @@ def relu(x, alpha=0., max_value=None):
 
 def dropout(x, level, noise_shape=None, seed=None):
     if level < 0. or level >= 1:
-        raise ValueError('CNTK Backend: Invalid dropout level %s, '
-                         'must be in interval [0, 1].' % level)
+        raise ValueError('CNTK Backend: Invalid dropout level {0}, '
+                         'must be in interval [0, 1].'.format(level))
     return C.dropout(x, level)
 
 
@@ -1732,10 +1732,10 @@ class Function(object):
                 else:
                     raise ValueError(
                         'CNTK backend: when constructing trainer, '
-                        'found gradient node `%s` which is not '
+                        'found gradient node `{0}` which is not '
                         'related to any parameters in the model. '
                         'Please double check how the gradient node '
-                        'is constructed.' % g)
+                        'is constructed.'.format(g))
 
             if len(u_list) > 0:
                 learner = C.cntk_py.universal_learner(p_list, u_list, update_func)
@@ -1809,9 +1809,9 @@ class Function(object):
                     input_dict[argument] = feed_dict[argument]
                 else:
                     raise ValueError(
-                        'CNTK backend: argument %s is not found in inputs. '
+                        'CNTK backend: argument {0} is not found in inputs. '
                         'Please double check the model and inputs in '
-                        '`train_function`.' % argument.name)
+                        '`train_function`.'.format(argument.name))
 
             result = self.trainer.train_minibatch(
                 input_dict, self.trainer_output)
@@ -1827,9 +1827,9 @@ class Function(object):
                 if argument in feed_dict:
                     input_dict[argument] = feed_dict[argument]
                 else:
-                    raise ValueError('CNTK backend: metrics argument %s '
+                    raise ValueError('CNTK backend: metrics argument {0} '
                                      'is not found in inputs. Please double '
-                                     'check the model and inputs.' % argument.name)
+                                     'check the model and inputs.'.format(argument.name))
             # Some ops (like dropout) won't be applied during "eval" in cntk.
             # They only evaluated in training phase. To make it work, call
             # "forward" method to let cntk know we want to evaluate them.from
@@ -1860,9 +1860,9 @@ class Function(object):
                     input_dict[argument] = feed_dict[argument]
                 else:
                     raise ValueError(
-                        'CNTK backend: assign ops argument %s '
+                        'CNTK backend: assign ops argument {0} '
                         'is not found in inputs. Please double '
-                        'check the model and inputs.' % argument.name)
+                        'check the model and inputs.'.format(argument.name))
             self.unrelated_updates.eval(input_dict, as_numpy=False)
         return updated
 
@@ -1894,9 +1894,9 @@ def _padding(x, pattern, axis):
     base_shape = x.shape
     if b_any([dim < 0 for dim in base_shape]):
         raise ValueError('CNTK Backend: padding input tensor with '
-                         'shape `%s` contains non-specified dimension, '
+                         'shape `{0}` contains non-specified dimension, '
                          'which is not supported. Please give fixed '
-                         'dimension to enable padding.' % base_shape)
+                         'dimension to enable padding.'.format(base_shape))
     if pattern[0] > 0:
         prefix_shape = list(base_shape)
         prefix_shape[axis] = pattern[0]
@@ -2135,7 +2135,7 @@ def conv2d_transpose(x, kernel, output_shape, strides=(1, 1),
 
 def identity(x, name=None):
     if name is None:
-        name = '%s_alias' % x.name
+        name = '{0}_alias'.format(x.name)
     return C.alias(x, name=name)
 
 

--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -250,8 +250,8 @@ def placeholder(
         raise ValueError('CNTK backend: creating placeholder with '
                          '{0} dimension is not supported, at least '
                          '{1} dimensions are needed.'.format(
-                                                          (len(cntk_shape,
-                                                           dynamic_axis_num))))
+                                                          len(cntk_shape,
+                                                          dynamic_axis_num)))
 
     if name is None:
         name = ''
@@ -1797,8 +1797,8 @@ class Function(object):
                                      'to shape `{0}`, but input shape is `{1}`. Currently '
                                      'CNTK can not take variable length inputs. Please '
                                      'pass inputs that have a static shape.'.format(
-                                                                                 (str(tensor.shape),
-                                                                                  str(value.shape))))
+                                                                                 str(tensor.shape),
+                                                                                 str(value.shape)))
             feed_dict[tensor] = value
 
         updated = []

--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -175,8 +175,8 @@ def bias_add(x, bias, data_format=None):
 
     bias_dims = len(bias.shape)
     if bias_dims != 1 and bias_dims != dims:
-        raise ValueError('Unexpected bias dimensions %d, '
-                         'expected 1 or %d dimensions' % (bias_dims, dims))
+        raise ValueError('Unexpected bias dimensions {0}, '
+                         'expected 1 or {1} dimensions'.format(bias_dims, dims))
 
     if dims == 4:
         if data_format == 'channels_first':
@@ -248,9 +248,10 @@ def placeholder(
 
     if dynamic_axis_num > len(cntk_shape):
         raise ValueError('CNTK backend: creating placeholder with '
-                         '%d dimension is not supported, at least '
-                         '%d dimensions are needed.'
-                         % (len(cntk_shape, dynamic_axis_num)))
+                         '{0} dimension is not supported, at least '
+                         '{1} dimensions are needed.'.format(
+                                                          (len(cntk_shape,
+                                                           dynamic_axis_num))))
 
     if name is None:
         name = ''
@@ -705,9 +706,9 @@ def _normalize_axis(axis, x):
     nones = _get_dynamic_axis_num(x)
 
     if nones > ndim:
-        raise ValueError('CNTK Backend: tensor with keras shape: `%s` has '
-                         '%d cntk dynamic axis, this is not expected, please '
-                         'double check the keras shape history.' % (str(shape), nones))
+        raise ValueError('CNTK Backend: tensor with keras shape: `{0}` has '
+                         '{1} cntk dynamic axis, this is not expected, please '
+                         'double check the keras shape history.'.format(str(shape), nones))
 
     # Current cntk does not support shape like (1, batch). so using the workaround
     # here to mapping the correct axis. Will remove this tricky after we add support
@@ -1793,10 +1794,11 @@ class Function(object):
                 # length. Will support it in next release.
                 if not self._is_input_shape_compatible(value, tensor):
                     raise ValueError('CNTK backend: The placeholder has been resolved '
-                                     'to shape `%s`, but input shape is `%s`. Currently '
+                                     'to shape `{0}`, but input shape is `{1}`. Currently '
                                      'CNTK can not take variable length inputs. Please '
-                                     'pass inputs that have a static shape.'
-                                     % (str(tensor.shape), str(value.shape)))
+                                     'pass inputs that have a static shape.'.format(
+                                                                                 (str(tensor.shape),
+                                                                                  str(value.shape))))
             feed_dict[tensor] = value
 
         updated = []

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -3542,8 +3542,7 @@ def bias_add(x, bias, data_format=None):
         raise ValueError('Unknown data_format ' + str(data_format))
     bias_shape = int_shape(bias)
     if len(bias_shape) != 1 and len(bias_shape) != ndim(x) - 1:
-        raise ValueError('Unexpected bias dimensions %d, expect to be 1 or %d dimensions'
-                         % (len(bias_shape), ndim(x)))
+        raise ValueError('Unexpected bias dimensions {0}, expect to be 1 or {1} dimensions'.format(len(bias_shape), ndim(x)))
     if ndim(x) == 5:
         if data_format == 'channels_first':
             if len(bias_shape) == 1:

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -2354,7 +2354,7 @@ def function(inputs, outputs, updates=None, **kwargs):
     if kwargs:
         for key in kwargs:
             if not (has_arg(tf.Session.run, key, True) or has_arg(Function.__init__, key, True)):
-                msg = 'Invalid argument "%s" passed to K.function with TensorFlow backend' % key
+                msg = 'Invalid argument "{0}" passed to K.function with TensorFlow backend'.format(key)
                 raise ValueError(msg)
     return Function(inputs, outputs, updates=updates, **kwargs)
 

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1227,7 +1227,7 @@ def function(inputs, outputs, updates=[], **kwargs):
     if len(kwargs) > 0:
         for key in kwargs.keys():
             if not has_arg(theano.function, key, True):
-                msg = 'Invalid argument "%s" passed to K.function with Theano backend' % key
+                msg = 'Invalid argument "{0}" passed to K.function with Theano backend'.format(key)
                 raise ValueError(msg)
     return Function(inputs, outputs, updates=updates, **kwargs)
 

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -2185,9 +2185,9 @@ def bias_add(x, bias, data_format=None):
     if data_format not in {'channels_first', 'channels_last'}:
         raise ValueError('Unknown data_format ' + str(data_format))
     if ndim(bias) != 1 and ndim(bias) != ndim(x) - 1:
-        raise ValueError('Unexpected bias dimensions %d, '
-                         'expect to be 1 or %d dimensions'
-                         % (ndim(bias), ndim(x) - 1))
+        raise ValueError('Unexpected bias dimensions {0}, '
+                         'expect to be 1 or {1} dimensions'.format(ndim(bias),
+                                                                   ndim(x) - 1))
     bias_shape = tuple(bias.shape)
     if ndim(x) == 5:
         if data_format == 'channels_first':

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -235,7 +235,7 @@ class TerminateOnNaN(Callback):
         loss = logs.get('loss')
         if loss is not None:
             if np.isnan(loss) or np.isinf(loss):
-                print('Batch %d: Invalid loss, terminating training' % (batch))
+                print('Batch {0}: Invalid loss, terminating training'.format(batch))
                 self.model.stop_training = True
 
 
@@ -266,7 +266,7 @@ class ProgbarLogger(Callback):
 
     def on_epoch_begin(self, epoch, logs=None):
         if self.verbose:
-            print('Epoch %d/%d' % (epoch + 1, self.epochs))
+            print('Epoch {0}/{1}'.format(epoch + 1, self.epochs))
             if self.use_steps:
                 target = self.params['steps']
             else:
@@ -370,8 +370,8 @@ class ModelCheckpoint(Callback):
         self.epochs_since_last_save = 0
 
         if mode not in ['auto', 'min', 'max']:
-            warnings.warn('ModelCheckpoint mode %s is unknown, '
-                          'fallback to auto mode.' % (mode),
+            warnings.warn('ModelCheckpoint mode {0} is unknown, '
+                          'fallback to auto mode.'.format(mode),
                           RuntimeWarning)
             mode = 'auto'
 
@@ -398,14 +398,13 @@ class ModelCheckpoint(Callback):
             if self.save_best_only:
                 current = logs.get(self.monitor)
                 if current is None:
-                    warnings.warn('Can save best model only with %s available, '
-                                  'skipping.' % (self.monitor), RuntimeWarning)
+                    warnings.warn('Can save best model only with {0} available, '
+                                  'skipping.'.format(self.monitor), RuntimeWarning)
                 else:
                     if self.monitor_op(current, self.best):
                         if self.verbose > 0:
-                            print('Epoch %05d: %s improved from %0.5f to %0.5f,'
-                                  ' saving model to %s'
-                                  % (epoch + 1, self.monitor, self.best,
+                            print('Epoch {0:05d}: {1} improved from {2:.5f} to {3:.5f},'
+                                  ' saving model to {4}'.format(epoch + 1, self.monitor, self.best,
                                      current, filepath))
                         self.best = current
                         if self.save_weights_only:
@@ -414,11 +413,11 @@ class ModelCheckpoint(Callback):
                             self.model.save(filepath, overwrite=True)
                     else:
                         if self.verbose > 0:
-                            print('Epoch %05d: %s did not improve' %
-                                  (epoch + 1, self.monitor))
+                            print('Epoch {0:05d}: {1} did not improve'.format(epoch + 1,
+                                                                              self.monitor))
             else:
                 if self.verbose > 0:
-                    print('Epoch %05d: saving model to %s' % (epoch + 1, filepath))
+                    print('Epoch {0:05d}: saving model to {1}'.format(epoch + 1, filepath))
                 if self.save_weights_only:
                     self.model.save_weights(filepath, overwrite=True)
                 else:
@@ -458,8 +457,8 @@ class EarlyStopping(Callback):
         self.stopped_epoch = 0
 
         if mode not in ['auto', 'min', 'max']:
-            warnings.warn('EarlyStopping mode %s is unknown, '
-                          'fallback to auto mode.' % mode,
+            warnings.warn('EarlyStopping mode {0} is unknown, '
+                          'fallback to auto mode.'.format(mode),
                           RuntimeWarning)
             mode = 'auto'
 
@@ -488,10 +487,10 @@ class EarlyStopping(Callback):
         current = logs.get(self.monitor)
         if current is None:
             warnings.warn(
-                'Early stopping conditioned on metric `%s` '
-                'which is not available. Available metrics are: %s' %
-                (self.monitor, ','.join(list(logs.keys()))), RuntimeWarning
-            )
+                'Early stopping conditioned on metric `{0}` '
+                'which is not available. Available metrics are: {1}'.format(self.monitor,
+                                                                            ','.join(list(logs.keys()))),
+                RuntimeWarning)
             return
         if self.monitor_op(current - self.min_delta, self.best):
             self.best = current
@@ -504,7 +503,7 @@ class EarlyStopping(Callback):
 
     def on_train_end(self, logs=None):
         if self.stopped_epoch > 0 and self.verbose > 0:
-            print('Epoch %05d: early stopping' % (self.stopped_epoch + 1))
+            print('Epoch {0:05d}: early stopping'.format(self.stopped_epoch + 1))
 
 
 class RemoteMonitor(Callback):
@@ -860,8 +859,8 @@ class ReduceLROnPlateau(Callback):
         """Resets wait counter and cooldown counter.
         """
         if self.mode not in ['auto', 'min', 'max']:
-            warnings.warn('Learning Rate Plateau Reducing mode %s is unknown, '
-                          'fallback to auto mode.' % (self.mode),
+            warnings.warn('Learning Rate Plateau Reducing mode {0} is unknown, '
+                          'fallback to auto mode.'.format(self.mode),
                           RuntimeWarning)
             self.mode = 'auto'
         if (self.mode == 'min' or
@@ -884,10 +883,10 @@ class ReduceLROnPlateau(Callback):
         current = logs.get(self.monitor)
         if current is None:
             warnings.warn(
-                'Reduce LR on plateau conditioned on metric `%s` '
-                'which is not available. Available metrics are: %s' %
-                (self.monitor, ','.join(list(logs.keys()))), RuntimeWarning
-            )
+                'Reduce LR on plateau conditioned on metric `{0}` '
+                'which is not available. Available metrics are: {1}'.format(self.monitor,
+                                                                            ','.join(list(logs.keys()))),
+                RuntimeWarning)
 
         else:
             if self.in_cooldown():
@@ -905,7 +904,7 @@ class ReduceLROnPlateau(Callback):
                         new_lr = max(new_lr, self.min_lr)
                         K.set_value(self.model.optimizer.lr, new_lr)
                         if self.verbose > 0:
-                            print('\nEpoch %05d: reducing learning rate to %s.' % (epoch + 1, new_lr))
+                            print('\nEpoch {0:05d}: reducing learning rate to {1}.'.format(epoch + 1, new_lr))
                         self.cooldown_counter = self.cooldown
                         self.wait = 0
                 self.wait += 1
@@ -960,7 +959,7 @@ class CSVLogger(Callback):
             if isinstance(k, six.string_types):
                 return k
             elif isinstance(k, Iterable) and not is_zero_dim_ndarray:
-                return '"[%s]"' % (', '.join(map(str, k)))
+                return '"[{0}]"'.format(', '.join(map(str, k)))
             else:
                 return k
 

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -2119,7 +2119,7 @@ class Container(Layer):
                             inbound_layer = node.inbound_layers[j]
                             node_index = node.node_indices[j]
                             tensor_index = node.tensor_indices[j]
-                            shape_key = inbound_layer.name + '_%s_%s' % (node_index, tensor_index)
+                            shape_key = inbound_layer.name + '_{0}_{0}'.format(node_index, tensor_index)
                             input_shape = layers_to_output_shapes[shape_key]
                             input_shapes.append(input_shape)
 
@@ -2131,7 +2131,7 @@ class Container(Layer):
                         output_shapes = _to_list(output_shape)
                         node_index = layer.inbound_nodes.index(node)
                         for j in range(len(output_shapes)):
-                            shape_key = layer.name + '_%s_%s' % (node_index, j)
+                            shape_key = layer.name + '_{0}_{0}'.format(node_index, j)
                             layers_to_output_shapes[shape_key] = output_shapes[j]
 
             # Read final output shapes from layers_to_output_shapes.
@@ -2141,7 +2141,7 @@ class Container(Layer):
                 layer = self.output_layers[i]
                 node_index = self.output_layers_node_indices[i]
                 tensor_index = self.output_layers_tensor_indices[i]
-                shape_key = layer.name + '_%s_%s' % (node_index, tensor_index)
+                shape_key = layer.name + '_{0}_{0}'.format(node_index, tensor_index)
                 output_shape_keys.append(shape_key)
 
             for i, key in enumerate(output_shape_keys):

--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -2119,7 +2119,7 @@ class Container(Layer):
                             inbound_layer = node.inbound_layers[j]
                             node_index = node.node_indices[j]
                             tensor_index = node.tensor_indices[j]
-                            shape_key = inbound_layer.name + '_{0}_{0}'.format(node_index, tensor_index)
+                            shape_key = inbound_layer.name + '_{0}_{1}'.format(node_index, tensor_index)
                             input_shape = layers_to_output_shapes[shape_key]
                             input_shapes.append(input_shape)
 
@@ -2131,7 +2131,7 @@ class Container(Layer):
                         output_shapes = _to_list(output_shape)
                         node_index = layer.inbound_nodes.index(node)
                         for j in range(len(output_shapes)):
-                            shape_key = layer.name + '_{0}_{0}'.format(node_index, j)
+                            shape_key = layer.name + '_{0}_{1}'.format(node_index, j)
                             layers_to_output_shapes[shape_key] = output_shapes[j]
 
             # Read final output shapes from layers_to_output_shapes.
@@ -2141,7 +2141,7 @@ class Container(Layer):
                 layer = self.output_layers[i]
                 node_index = self.output_layers_node_indices[i]
                 tensor_index = self.output_layers_tensor_indices[i]
-                shape_key = layer.name + '_{0}_{0}'.format(node_index, tensor_index)
+                shape_key = layer.name + '_{0}_{1}'.format(node_index, tensor_index)
                 output_shape_keys.append(shape_key)
 
             for i, key in enumerate(output_shape_keys):

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1108,8 +1108,8 @@ class Model(Container):
         if val_f and val_ins:
             do_validation = True
             if verbose and ins and hasattr(ins[0], 'shape') and hasattr(val_ins[0], 'shape'):
-                print('Train on %d samples, validate on %d samples' %
-                      (ins[0].shape[0], val_ins[0].shape[0]))
+                print('Train on %d samples, validate on {0} samples'.format(ins[0].shape[0],
+                                                                            val_ins[0].shape[0]))
         if validation_steps:
             do_validation = True
             if steps_per_epoch is None:
@@ -1566,8 +1566,7 @@ class Model(Container):
                 raise ValueError('When passing validation_data, '
                                  'it must contain 2 (x_val, y_val) '
                                  'or 3 (x_val, y_val, val_sample_weights) '
-                                 'items, however it contains %d items' %
-                                 len(validation_data))
+                                 'items, however it contains {0} items'.format(len(validation_data)))
 
             val_x, val_y, val_sample_weights = self._standardize_user_data(
                 val_x, val_y,

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1108,7 +1108,7 @@ class Model(Container):
         if val_f and val_ins:
             do_validation = True
             if verbose and ins and hasattr(ins[0], 'shape') and hasattr(val_ins[0], 'shape'):
-                print('Train on %d samples, validate on {0} samples'.format(ins[0].shape[0],
+                print('Train on {0} samples, validate on {1} samples'.format(ins[0].shape[0],
                                                                             val_ins[0].shape[0]))
         if validation_steps:
             do_validation = True

--- a/keras/layers/embeddings.py
+++ b/keras/layers/embeddings.py
@@ -117,12 +117,12 @@ class Embedding(Layer):
             else:
                 in_lens = [self.input_length]
             if len(in_lens) != len(input_shape) - 1:
-                ValueError('"input_length" is %s, but received input has shape {0}'.format(str(self.input_length),
+                ValueError('"input_length" is {0}, but received input has shape {1}'.format(str(self.input_length),
                                                                                            str(input_shape)))
             else:
                 for i, (s1, s2) in enumerate(zip(in_lens, input_shape[1:])):
                     if s1 is not None and s2 is not None and s1 != s2:
-                        ValueError('"input_length" is %s, but received input has shape {0}'.format(str(self.input_length),
+                        ValueError('"input_length" is {0}, but received input has shape {1}'.format(str(self.input_length),
                                                                                                    str(input_shape)))
                     elif s1 is None:
                         in_lens[i] = s2

--- a/keras/layers/embeddings.py
+++ b/keras/layers/embeddings.py
@@ -117,13 +117,13 @@ class Embedding(Layer):
             else:
                 in_lens = [self.input_length]
             if len(in_lens) != len(input_shape) - 1:
-                ValueError('"input_length" is %s, but received input has shape %s' %
-                           (str(self.input_length), str(input_shape)))
+                ValueError('"input_length" is %s, but received input has shape {0}'.format(str(self.input_length),
+                                                                                           str(input_shape)))
             else:
                 for i, (s1, s2) in enumerate(zip(in_lens, input_shape[1:])):
                     if s1 is not None and s2 is not None and s1 != s2:
-                        ValueError('"input_length" is %s, but received input has shape %s' %
-                                   (str(self.input_length), str(input_shape)))
+                        ValueError('"input_length" is %s, but received input has shape {0}'.format(str(self.input_length),
+                                                                                                   str(input_shape)))
                     elif s1 is None:
                         in_lens[i] = s2
             return (input_shape[0],) + tuple(in_lens) + (self.output_dim,)

--- a/keras/layers/merge.py
+++ b/keras/layers/merge.py
@@ -338,7 +338,7 @@ class Concatenate(_Merge):
             raise ValueError('`Concatenate` layer requires '
                              'inputs with matching shapes '
                              'except for the concat axis. '
-                             'Got inputs shapes: %s' % (input_shape))
+                             'Got inputs shapes: {0}'.format(input_shape))
 
     def call(self, inputs):
         if not isinstance(inputs, list):
@@ -448,8 +448,8 @@ class Dot(_Merge):
         if shape1[axes[0]] != shape2[axes[1]]:
             raise ValueError(
                 'Dimension incompatibility '
-                '%s != %s. ' % (shape1[axes[0]], shape2[axes[1]]) +
-                'Layer shapes: %s, %s' % (shape1, shape2))
+                '{0} != {0}. '.format(shape1[axes[0]], shape2[axes[1]]) +
+                'Layer shapes: {0}, {0}'.format(shape1, shape2))
 
     def call(self, inputs):
         x1 = inputs[0]

--- a/keras/legacy/layers.py
+++ b/keras/legacy/layers.py
@@ -152,7 +152,7 @@ class Merge(Layer):
             if len(input_shapes_set) > 1:
                 raise ValueError('Only layers of same output shape can '
                                  'be merged using ' + mode + ' mode. ' +
-                                 'Layer shapes: %s' % input_shapes)
+                                 'Layer shapes: {0}'.format(input_shapes))
         if mode in {'cos', 'dot'}:
             if len(layers) > 2:
                 raise ValueError(mode + ' merge takes exactly 2 layers')
@@ -176,8 +176,8 @@ class Merge(Layer):
                                  'list elements should be "int".')
             if shape1[self.dot_axes[0]] != shape2[self.dot_axes[1]]:
                 raise ValueError('Dimension incompatibility using dot mode: '
-                                 '%s != %s. ' % (shape1[self.dot_axes[0]], shape2[self.dot_axes[1]]) +
-                                 'Layer shapes: %s, %s' % (shape1, shape2))
+                                 '{0} != {1}. '.format(shape1[self.dot_axes[0]], shape2[self.dot_axes[1]]) +
+                                 'Layer shapes: {0}, {1}'.format(shape1, shape2))
         elif mode == 'concat':
             reduced_inputs_shapes = [list(shape) for shape in input_shapes]
             shape_set = set()
@@ -188,7 +188,7 @@ class Merge(Layer):
                 raise ValueError('"concat" mode can only merge '
                                  'layers with matching '
                                  'output shapes except for the concat axis. '
-                                 'Layer shapes: %s' % (input_shapes))
+                                 'Layer shapes: {0}'.format(input_shapes))
 
     def call(self, inputs, mask=None):
         if not isinstance(inputs, list) or len(inputs) <= 1:

--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -834,8 +834,8 @@ class NumpyArrayIterator(Iterator):
         if y is not None and len(x) != len(y):
             raise ValueError('X (images tensor) and y (labels) '
                              'should have the same length. '
-                             'Found: X.shape = %s, y.shape = %s' %
-                             (np.asarray(x).shape, np.asarray(y).shape))
+                             'Found: X.shape = {0}, y.shape = {1}'.format(np.asarray(x).shape,
+                                                                          np.asarray(y).shape))
 
         if data_format is None:
             data_format = K.image_data_format()
@@ -1064,7 +1064,7 @@ class DirectoryIterator(Iterator):
                                     (os.path.join(directory, subdir)
                                      for subdir in classes)))
 
-        print('Found %d images belonging to %d classes.' % (self.samples, self.num_classes))
+        print('Found {0} images belonging to {1} classes.'.format(self.samples, self.num_classes))
 
         # second, build an index of the images in the different class subfolders
         results = []

--- a/keras/preprocessing/sequence.py
+++ b/keras/preprocessing/sequence.py
@@ -63,20 +63,21 @@ def pad_sequences(sequences, maxlen=None, dtype='int32',
         elif truncating == 'post':
             trunc = s[:maxlen]
         else:
-            raise ValueError('Truncating type "%s" not understood' % truncating)
+            raise ValueError('Truncating type "{0}" not understood'.format(truncating))
 
         # check `trunc` has expected shape
         trunc = np.asarray(trunc, dtype=dtype)
         if trunc.shape[1:] != sample_shape:
-            raise ValueError('Shape of sample %s of sequence at position %s is different from expected shape %s' %
-                             (trunc.shape[1:], idx, sample_shape))
+            raise ValueError('Shape of sample {0} of sequence at position {1} is different from expected shape {2}'.format(trunc.shape[1:],
+                                                                                                                           idx,
+                                                                                                                           sample_shape))
 
         if padding == 'post':
             x[idx, :len(trunc)] = trunc
         elif padding == 'pre':
             x[idx, -len(trunc):] = trunc
         else:
-            raise ValueError('Padding type "%s" not understood' % padding)
+            raise ValueError('Padding type "{0}" not understood'.format(padding))
     return x
 
 

--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -289,7 +289,7 @@ class Progbar(object):
         self.seen_so_far = current
 
         now = time.time()
-        info = ' - %.0fs' % (now - self.start)
+        info = ' - {0:.0f}s'.format(now - self.start)
         if self.verbose == 1:
             if (not force and (now - self.last_update) < self.interval and
                     current < self.target):
@@ -304,7 +304,7 @@ class Progbar(object):
 
             if self.target is not None:
                 numdigits = int(np.floor(np.log10(self.target))) + 1
-                barstr = '%%%dd/%d [' % (numdigits, self.target)
+                barstr = '%{0}d/{1} ['.format(numdigits, self.target)
                 bar = barstr % current
                 prog = float(current) / self.target
                 prog_width = int(self.width * prog)
@@ -317,7 +317,7 @@ class Progbar(object):
                 bar += ('.' * (self.width - prog_width))
                 bar += ']'
             else:
-                bar = '%7d/Unknown' % current
+                bar = '{0:7d}/Unknown'.format(current)
 
             self.total_width = len(bar)
             sys.stdout.write(bar)
@@ -330,23 +330,23 @@ class Progbar(object):
                 eta = time_per_unit * (self.target - current)
 
                 if eta > 3600:
-                    eta_format = '%d:%02d:%02d' % (eta // 3600, (eta % 3600) // 60, eta % 60)
+                    eta_format = '{0}:{1:02d}:{2:02d}'.format(eta // 3600, (eta % 3600) // 60, eta % 60)
                 elif eta > 60:
-                    eta_format = '%d:%02d' % (eta // 60, eta % 60)
+                    eta_format = '{0}:{1:02d}'.format(eta // 60, eta % 60)
                 else:
-                    eta_format = '%ds' % eta
+                    eta_format = '{0}s'.format(eta)
 
-                info = ' - ETA: %s' % eta_format
+                info = ' - ETA: {0}'.format(eta_format)
             for k in self.unique_values:
-                info += ' - %s:' % k
+                info += ' - {0}:'.format(k)
                 if isinstance(self.sum_values[k], list):
                     avg = np.mean(self.sum_values[k][0] / max(1, self.sum_values[k][1]))
                     if abs(avg) > 1e-3:
-                        info += ' %.4f' % avg
+                        info += ' {0:.4f}'.format(avg)
                     else:
-                        info += ' %.4e' % avg
+                        info += ' {0:.4e}'.format(avg)
                 else:
-                    info += ' %s' % self.sum_values[k]
+                    info += ' {0}'.format(self.sum_values[k])
 
             self.total_width += len(info)
             if prev_total_width > self.total_width:
@@ -361,12 +361,12 @@ class Progbar(object):
         elif self.verbose == 2:
             if self.target is None or current >= self.target:
                 for k in self.unique_values:
-                    info += ' - %s:' % k
+                    info += ' - {0}:'.format(k)
                     avg = np.mean(self.sum_values[k][0] / max(1, self.sum_values[k][1]))
                     if avg > 1e-3:
-                        info += ' %.4f' % avg
+                        info += ' {0:.4f}'.format(avg)
                     else:
-                        info += ' %.4e' % avg
+                        info += ' {0:.4e}'.format(avg)
                 info += '\n'
 
                 sys.stdout.write(info)

--- a/keras/utils/io_utils.py
+++ b/keras/utils/io_utils.py
@@ -143,8 +143,8 @@ def ask_to_proceed_with_overwrite(filepath):
     get_input = input
     if sys.version_info[:2] <= (2, 7):
         get_input = raw_input
-    overwrite = get_input('[WARNING] %s already exists - overwrite? '
-                          '[y/n]' % (filepath))
+    overwrite = get_input('[WARNING] {0} already exists - overwrite? '
+                          '[y/n]'.format(filepath))
     while overwrite not in ['y', 'n']:
         overwrite = get_input('Enter "y" (overwrite) or "n" (cancel).')
     if overwrite == 'n':

--- a/keras/utils/training_utils.py
+++ b/keras/utils/training_utils.py
@@ -88,22 +88,22 @@ def multi_gpu_model(model, gpus):
     if gpus <= 1:
         raise ValueError('For multi-gpu usage to be effective, '
                          'call `multi_gpu_model` with `gpus >= 2`. '
-                         'Received: `gpus=%d`' % gpus)
+                         'Received: `gpus={0}`'.format(gpus))
 
     import tensorflow as tf
 
-    target_devices = ['/cpu:0'] + ['/gpu:%d' % i for i in range(gpus)]
+    target_devices = ['/cpu:0'] + ['/gpu:{0}'.format(i for i in range(gpus))]
     available_devices = _get_available_devices()
     available_devices = [_normalize_device_name(name) for name in available_devices]
     for device in target_devices:
         if device not in available_devices:
             raise ValueError(
-                'To call `multi_gpu_model` with `gpus=%d`, '
-                'we expect the following devices to be available: %s. '
-                'However this machine only has: %s. '
-                'Try reducing `gpus`.' % (gpus,
-                                          target_devices,
-                                          available_devices))
+                'To call `multi_gpu_model` with `gpus={0}`, '
+                'we expect the following devices to be available: {1}. '
+                'However this machine only has: {2}. '
+                'Try reducing `gpus`.'.format(gpus,
+                                              target_devices,
+                                              available_devices))
 
     def get_slice(data, i, parts):
         shape = tf.shape(data)
@@ -126,8 +126,8 @@ def multi_gpu_model(model, gpus):
     # Place a copy of the model on each GPU,
     # each getting a slice of the inputs.
     for i in range(gpus):
-        with tf.device('/gpu:%d' % i):
-            with tf.name_scope('replica_%d' % i):
+        with tf.device('/gpu:{0}'.format(i)):
+            with tf.name_scope('replica_{0}'.format(i)):
                 inputs = []
                 # Retrieve a slice of the input.
                 for x in model.inputs:

--- a/keras/utils/vis_utils.py
+++ b/keras/utils/vis_utils.py
@@ -92,9 +92,9 @@ def model_to_dot(model,
                     [str(ishape) for ishape in layer.input_shapes])
             else:
                 inputlabels = 'multiple'
-            label = '%s\n|{input:|output:}|{{%s}|{%s}}' % (label,
-                                                           inputlabels,
-                                                           outputlabels)
+            label = '{0}\n|{input:|output:}|{{{1}}|{{2}}}'.format(label,
+                                                                  inputlabels,
+                                                                  outputlabels)
         node = pydot.Node(layer_id, label=label)
         dot.add_node(node)
 


### PR DESCRIPTION
This PR removes all instances of the old string formatting method (via `%`) and replaces it with the newer, more flexible `format()` API.