### PR TITLE
TensorFlow K.Function() additional ops via fetches

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -2282,17 +2282,18 @@ class Function(object):
     """Runs a computation graph.
 
     It's possible to pass arguments to `tf.Session.run()` via `session_kwargs`.
-    In particular additonal operations via `fetches` argument and additional
-    tensor substitutions via `feed_dict` arguments. Note that given
-    substitutions are merged with substitutions from `inputs`.
+    In particular additonal operations via `fetches` argument, `options` and
+    `run_metadata`. Note that custom substitutions via `feed_dict` cannot be
+    passed here since it would make them constant. Instead just pass them via
+    `standard` inputs.
 
     # Arguments
         inputs: Feed placeholders to the computation graph.
         outputs: Output tensors to fetch.
         updates: Additional update ops to be run at function call.
         name: a name to help users identify what this function does.
-        session_kwargs: arguments to `tf.Session.run()`: fetches, feed_dict,
-        options, run_metadata
+        session_kwargs: arguments to `tf.Session.run()`: fetches, options,
+        run_metadata
     """
 
     def __init__(self, inputs, outputs, updates=None, name=None, **session_kwargs):
@@ -2319,8 +2320,6 @@ class Function(object):
                     updates_ops.append(update)
             self.updates_op = tf.group(*updates_ops)
         self.name = name
-        # additional tensor substitutions
-        self.feed_dict = session_kwargs.pop('feed_dict', {})
         # additional operations
         self.fetches = session_kwargs.pop('fetches', [])
         if not isinstance(self.fetches, list):
@@ -2330,7 +2329,7 @@ class Function(object):
     def __call__(self, inputs):
         if not isinstance(inputs, (list, tuple)):
             raise TypeError('`inputs` should be a list or tuple.')
-        feed_dict = self.feed_dict.copy()
+        feed_dict = {}
         for tensor, value in zip(self.inputs, inputs):
             if is_sparse(tensor):
                 sparse_coo = value.tocoo()
@@ -2338,7 +2337,7 @@ class Function(object):
                                           np.expand_dims(sparse_coo.col, 1)), 1)
                 value = (indices, sparse_coo.data, sparse_coo.shape)
             feed_dict[tensor] = value
-        fetches = self.outputs + [self.updates_op] + self.fetches[:]
+        fetches = self.outputs + [self.updates_op] + self.fetches
         session = get_session()
         updated = session.run(fetches=fetches, feed_dict=feed_dict,
                               **self.session_kwargs)

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -2284,15 +2284,18 @@ class Function(object):
     It's possible to pass arguments to `tf.Session.run()` via `session_kwargs`.
     In particular additonal operations via `fetches` argument and additional
     tensor substitutions via `feed_dict` arguments. Note that given
-    substitutions are merged with substitutions from `inputs`.
+    substitutions are merged with substitutions from `inputs`. Even though
+    `feed_dict` is passed once in the constructor (called in `model.compile()`)
+    we can modify the values in the dictionary. Through this feed_dict we can
+    provide additional substitutions besides Keras inputs.
 
     # Arguments
         inputs: Feed placeholders to the computation graph.
         outputs: Output tensors to fetch.
         updates: Additional update ops to be run at function call.
         name: a name to help users identify what this function does.
-        session_kwargs: arguments to `tf.Session.run()`: fetches, feed_dict,
-        options, run_metadata
+        session_kwargs: arguments to `tf.Session.run()`: `fetches`, `feed_dict`,
+        `options`, `run_metadata`
     """
 
     def __init__(self, inputs, outputs, updates=None, name=None, **session_kwargs):
@@ -2338,7 +2341,7 @@ class Function(object):
                                           np.expand_dims(sparse_coo.col, 1)), 1)
                 value = (indices, sparse_coo.data, sparse_coo.shape)
             feed_dict[tensor] = value
-        fetches = self.outputs + [self.updates_op] + self.fetches[:]
+        fetches = self.outputs + [self.updates_op] + self.fetches
         session = get_session()
         updated = session.run(fetches=fetches, feed_dict=feed_dict,
                               **self.session_kwargs)

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -2282,18 +2282,17 @@ class Function(object):
     """Runs a computation graph.
 
     It's possible to pass arguments to `tf.Session.run()` via `session_kwargs`.
-    In particular additonal operations via `fetches` argument, `options` and
-    `run_metadata`. Note that custom substitutions via `feed_dict` cannot be
-    passed here since it would make them constant. Instead just pass them via
-    `standard` inputs.
+    In particular additonal operations via `fetches` argument and additional
+    tensor substitutions via `feed_dict` arguments. Note that given
+    substitutions are merged with substitutions from `inputs`.
 
     # Arguments
         inputs: Feed placeholders to the computation graph.
         outputs: Output tensors to fetch.
         updates: Additional update ops to be run at function call.
         name: a name to help users identify what this function does.
-        session_kwargs: arguments to `tf.Session.run()`: fetches, options,
-        run_metadata
+        session_kwargs: arguments to `tf.Session.run()`: fetches, feed_dict,
+        options, run_metadata
     """
 
     def __init__(self, inputs, outputs, updates=None, name=None, **session_kwargs):
@@ -2320,6 +2319,8 @@ class Function(object):
                     updates_ops.append(update)
             self.updates_op = tf.group(*updates_ops)
         self.name = name
+        # additional tensor substitutions
+        self.feed_dict = session_kwargs.pop('feed_dict', {})
         # additional operations
         self.fetches = session_kwargs.pop('fetches', [])
         if not isinstance(self.fetches, list):
@@ -2329,7 +2330,7 @@ class Function(object):
     def __call__(self, inputs):
         if not isinstance(inputs, (list, tuple)):
             raise TypeError('`inputs` should be a list or tuple.')
-        feed_dict = {}
+        feed_dict = self.feed_dict.copy()
         for tensor, value in zip(self.inputs, inputs):
             if is_sparse(tensor):
                 sparse_coo = value.tocoo()
@@ -2337,7 +2338,7 @@ class Function(object):
                                           np.expand_dims(sparse_coo.col, 1)), 1)
                 value = (indices, sparse_coo.data, sparse_coo.shape)
             feed_dict[tensor] = value
-        fetches = self.outputs + [self.updates_op] + self.fetches
+        fetches = self.outputs + [self.updates_op] + self.fetches[:]
         session = get_session()
         updated = session.run(fetches=fetches, feed_dict=feed_dict,
                               **self.session_kwargs)

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -2281,11 +2281,18 @@ def print_tensor(x, message=''):
 class Function(object):
     """Runs a computation graph.
 
+    It's possible to pass arguments to `tf.Session.run()` via `session_kwargs`.
+    In particular additonal operations via `fetches` argument and additional
+    tensor substitutions via `feed_dict` arguments. Note that given
+    substitutions are merged with substitutions from `inputs`.
+
     # Arguments
         inputs: Feed placeholders to the computation graph.
         outputs: Output tensors to fetch.
         updates: Additional update ops to be run at function call.
         name: a name to help users identify what this function does.
+        session_kwargs: arguments to `tf.Session.run()`: fetches, feed_dict,
+        options, run_metadata
     """
 
     def __init__(self, inputs, outputs, updates=None, name=None, **session_kwargs):
@@ -2312,12 +2319,18 @@ class Function(object):
                     updates_ops.append(update)
             self.updates_op = tf.group(*updates_ops)
         self.name = name
+        # additional tensor substitutions
+        self.feed_dict = session_kwargs.pop('feed_dict', {})
+        # additional operations
+        self.fetches = session_kwargs.pop('fetches', [])
+        if not isinstance(self.fetches, list):
+            self.fetches = [self.fetches]
         self.session_kwargs = session_kwargs
 
     def __call__(self, inputs):
         if not isinstance(inputs, (list, tuple)):
             raise TypeError('`inputs` should be a list or tuple.')
-        feed_dict = {}
+        feed_dict = self.feed_dict.copy()
         for tensor, value in zip(self.inputs, inputs):
             if is_sparse(tensor):
                 sparse_coo = value.tocoo()
@@ -2325,9 +2338,9 @@ class Function(object):
                                           np.expand_dims(sparse_coo.col, 1)), 1)
                 value = (indices, sparse_coo.data, sparse_coo.shape)
             feed_dict[tensor] = value
+        fetches = self.outputs + [self.updates_op] + self.fetches[:]
         session = get_session()
-        updated = session.run(self.outputs + [self.updates_op],
-                              feed_dict=feed_dict,
+        updated = session.run(fetches=fetches, feed_dict=feed_dict,
                               **self.session_kwargs)
         return updated[:len(self.outputs)]
 

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -480,7 +480,7 @@ class TestBackend(object):
         new_val_list = [k.get_value(x) for x, k in zip(x_list, test_backend)]
         assert_list_pairwise(new_val_list)
 
-    def test_function_fetches(self):
+    def test_function_tf_fetches(self):
         # Additional operations can be passed to tf.Session().run() via its
         # `fetches` arguments. In contrast to `updates` argument of
         # KTF.function() these do not have control dependency on `outputs`, so
@@ -499,6 +499,35 @@ class TestBackend(object):
         output = f([10., 20.])
         assert output == [30.]
         assert KTF.get_session().run(fetches=[x, y]) == [11., 5.]
+
+    def test_function_tf_feed_dict(self):
+        # Additional substitutions can be passed to `tf.Session().run()` via its
+        # `feed_dict` arguments. Note that the feed_dict is passed once in the
+        # constructor but we can modify the values in the dictionary. Through
+        # this feed_dict we can provide additional substitutions besides Keras
+        # inputs.
+
+        x = KTF.variable(0.)
+        y = KTF.variable(0.)
+        x_placeholder = KTF.placeholder(shape=())
+        y_placeholder = KTF.placeholder(shape=())
+
+        feed_dict = {y_placeholder: 3.}
+
+        f = KTF.function(inputs=[x_placeholder],
+                         outputs=[x_placeholder + 1.],
+                         updates=[(x, x_placeholder + 10.)],
+                         feed_dict=feed_dict,
+                         fetches=[KTF.update(y, y_placeholder * 10.)])
+        output = f([10.])
+        assert output == [11.]
+        assert KTF.get_session().run(fetches=[x, y]) == [20., 30.]
+
+        # updated value in feed_dict will be modified within the K.function()
+        feed_dict[y_placeholder] = 4.
+        output = f([20.])
+        assert output == [21.]
+        assert KTF.get_session().run(fetches=[x, y]) == [30., 40.]
 
     def test_rnn(self):
         # implement a simple RNN


### PR DESCRIPTION
Allow passing fetches to tf.Session.run() in K.Function() in TensorFlow backend.

- allow passing additional operations, such as StagingArea.put()
- previously (#6693) only options and run_metadata could have been passed
- note that providing `feed_dict` substitutions doesn't make much sense here since:
  - they can be passed in the `input` argument
  - if they're passes via kwargs in model.compile() the values would be constant

The main reason is to allow using TensorFlow StagingArea for copying input data to GPU asynchronously. A working implementation of such as pipeline is in [StagingAreaCallback](https://github.com/rossumai/keras-multi-gpu/blob/master/keras_tf_multigpu/callbacks.py#L10). [Several examples are provided](https://github.com/rossumai/keras-multi-gpu/tree/master/keras_tf_multigpu/examples/bzamecnik/staging_area) (MNIST, CIFAR10, ResNet50.

Example usage (pseudocode):

```
features_tensor, labels_tensor = ... next batch ...
area = tf.contrib.staging.StagingArea(
    dtypes=[tf.float32, tf.float32])
area_put = area.put([features_tensor, labels_tensor])
area_get_features, area_get_labels = area.get()

input = Model(tensor=area_get_features)
model = ... create model ...
model.compile(optimizer='sgd', loss='categorical_crossentropy',
      target_tensors=[area_get_labels], fetches=[area_put])
```

This approach is inspired by https://github.com/avolkov1/keras_experiments/blob/master/keras_exp/_patch_tf_backend.py by @avolkov1, but the additional operations are passed uniformly via session_kwargs and there's better documentation.