### PR TITLE
Fix ValueError for LSTM(implementation=1, use_bias=False)

### DIFF
--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -1803,10 +1803,15 @@ class LSTMCell(Layer):
                 inputs_f = inputs
                 inputs_c = inputs
                 inputs_o = inputs
-            x_i = K.dot(inputs_i, self.kernel_i) + self.bias_i
-            x_f = K.dot(inputs_f, self.kernel_f) + self.bias_f
-            x_c = K.dot(inputs_c, self.kernel_c) + self.bias_c
-            x_o = K.dot(inputs_o, self.kernel_o) + self.bias_o
+            x_i = K.dot(inputs_i, self.kernel_i)
+            x_f = K.dot(inputs_f, self.kernel_f)
+            x_c = K.dot(inputs_c, self.kernel_c)
+            x_o = K.dot(inputs_o, self.kernel_o)
+            if self.use_bias:
+                x_i = K.bias_add(x_i, self.bias_i)
+                x_f = K.bias_add(x_f, self.bias_f)
+                x_c = K.bias_add(x_c, self.bias_c)
+                x_o = K.bias_add(x_o, self.bias_o)
 
             if 0 < self.recurrent_dropout < 1.:
                 h_tm1_i = h_tm1 * rec_dp_mask[0]

--- a/tests/keras/layers/recurrent_test.py
+++ b/tests/keras/layers/recurrent_test.py
@@ -183,6 +183,12 @@ def test_implementation_mode(layer_class):
                            'dropout': 0.1,
                            'recurrent_dropout': 0.1},
                    input_shape=(num_samples, timesteps, embedding_dim))
+        # Without bias
+        layer_test(layer_class,
+                   kwargs={'units': units,
+                           'implementation': mode,
+                           'use_bias': False},
+                   input_shape=(num_samples, timesteps, embedding_dim))
 
 
 @rnn_test


### PR DESCRIPTION
Fixes `ValueError` for `LSTM(implementation=1, use_bias=False)` where the addition operation fails because `self.bias` is set to `None`.

Also added a test in `test_implementation_mode()` that fails before this fix and passes after this fix.