### PR TITLE
Enable loading CuDNNLSTM weights into an LSTM layer

### DIFF
--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -3027,6 +3027,15 @@ def preprocess_weights_for_loading(layer, weights,
             weights[0] = np.transpose(weights[0], (3, 2, 0, 1))
             if layer.__class__.__name__ == 'ConvLSTM2D':
                 weights[1] = np.transpose(weights[1], (3, 2, 0, 1))
+
+    # 2 biases are used in CuDNNLSTM, sum them into one when loading into an LSTM layer
+    if layer.__class__.__name__ == 'LSTM':
+        # determine if we're loading a CuDNNLSTM layer from the shape of bias
+        cols = weights[0].shape[1]
+        bias = weights[2]
+        if bias.shape[0] == 2 * cols:
+            weights[2] = bias[:cols] + bias[cols:]
+
     return weights
 
 

--- a/keras/layers/cudnn_recurrent.py
+++ b/keras/layers/cudnn_recurrent.py
@@ -47,7 +47,7 @@ class _CuDNNRNN(RNN):
 
     def _canonical_to_params(self, weights, biases):
         import tensorflow as tf
-        weights = [tf.reshape(x, (-1,)) for x in weights]
+        weights = [tf.reshape(tf.transpose(x), (-1,)) for x in weights]
         biases = [tf.reshape(x, (-1,)) for x in biases]
         return tf.concat(weights + biases, 0)
 

--- a/keras/layers/cudnn_recurrent.py
+++ b/keras/layers/cudnn_recurrent.py
@@ -47,7 +47,7 @@ class _CuDNNRNN(RNN):
 
     def _canonical_to_params(self, weights, biases):
         import tensorflow as tf
-        weights = [tf.reshape(tf.transpose(x), (-1,)) for x in weights]
+        weights = [tf.reshape(x, (-1,)) for x in weights]
         biases = [tf.reshape(x, (-1,)) for x in biases]
         return tf.concat(weights + biases, 0)
 


### PR DESCRIPTION
This PR fixes a `ValueError` when trying to load weights from a `CuDNNLSTM` layer into an `LSTM` layer. Because `CuDNNLSTM` uses two biases, the size of `self.bias` is doubled comparing to that of an `LSTM` layer.

From the equations on the cuDNN user guide, by summing the two biases into one, the resulting bias term will be the same one used by `LSTM`.
![screenshot 2017-10-31 2 09 17](https://user-images.githubusercontent.com/3875581/32187622-9bdd180e-bd73-11e7-93a2-3207580781c8.png)

However, there's no such relationship between `CuDNNGRU` and `GRU` (see the third equation in the image below, also from the cuDNN user guide). So this PR only deals with loading `CuDNNLSTM` weights.
![screenshot 2017-10-31 2 11 38](https://user-images.githubusercontent.com/3875581/32187737-e6e5ffa0-bd73-11e7-8cd0-44fa48b5cea0.png)

Changes:

1. In `preprocess_weights_for_loading()`, check if we're loading `CuDNNLSTM` weights into `LSTM` by checking the shape of bias. If the size of bias is twice as large as `kernel.shape[1]`, then the weights are from an `CuDNNLSTM` layer.
2. Fix an issue in `_canonical_to_params()` where the kernel should be transposed before getting flattened.
I couldn't find it on the cuDNN user guide, but without transposing, the predictions from the two layers will be quite different. The kernel is also transposed [in TF](https://github.com/tensorflow/tensorflow/blob/r1.3/tensorflow/contrib/cudnn_rnn/python/ops/cudnn_rnn_ops.py#L393-L403) before being fed into `_canonical_to_params()`.
3. Add a test to verify that `CuDNNLSTM` gives the same prediction as `LSTM` if the weights are the same.