### PR TITLE
Cifar URL fixes

### DIFF
--- a/keras/datasets/cifar10.py
+++ b/keras/datasets/cifar10.py
@@ -13,7 +13,7 @@ def load_data():
         Tuple of Numpy arrays: `(x_train, y_train), (x_test, y_test)`.
     """
     dirname = 'cifar-10-batches-py'
-    origin = 'http://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz'
+    origin = 'https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz'
     path = get_file(dirname, origin=origin, untar=True)
 
     num_train_samples = 50000

--- a/keras/datasets/cifar100.py
+++ b/keras/datasets/cifar100.py
@@ -22,7 +22,7 @@ def load_data(label_mode='fine'):
         raise ValueError('`label_mode` must be one of `"fine"`, `"coarse"`.')
 
     dirname = 'cifar-100-python'
-    origin = 'http://www.cs.toronto.edu/~kriz/cifar-100-python.tar.gz'
+    origin = 'https://www.cs.toronto.edu/~kriz/cifar-100-python.tar.gz'
     path = get_file(dirname, origin=origin, untar=True)
 
     fpath = os.path.join(path, 'train')


### PR DESCRIPTION
http://www.cs.toronto.edu server no longer accepts HTTP connections and requires HTTPS. Using cifar dataset then ends up with this error:

```
Exception: URL fetch failure on http://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz: None -- Internal Server Error
```

This PR fixes the issue.