### PR TITLE
Skip newlines in TTY AND ipykernel.

### DIFF
--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -297,7 +297,7 @@ class Progbar(object):
                 return
 
             prev_total_width = self.total_width
-            if sys.stdout.isatty() or self.is_jupyter
+            if sys.stdout.isatty() or self.is_jupyter:
                 sys.stdout.write('\b' * prev_total_width)
                 sys.stdout.write('\r')
             else:

--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -296,7 +296,7 @@ class Progbar(object):
                 return
 
             prev_total_width = self.total_width
-            if sys.stdout.isatty():
+            if sys.stdout.isatty() or 'ipykernel' in sys.modules:
                 sys.stdout.write('\b' * prev_total_width)
                 sys.stdout.write('\r')
             else:

--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -266,7 +266,8 @@ class Progbar(object):
         self.interval = interval
         self.total_width = 0
         self.seen_so_far = 0
-        self.verbose = verbose
+        self.verbose = verbose 
+        self.is_jupyter = 'ipykernel' in sys.modules
 
     def update(self, current, values=None, force=False):
         """Updates the progress bar.
@@ -296,7 +297,7 @@ class Progbar(object):
                 return
 
             prev_total_width = self.total_width
-            if sys.stdout.isatty() or 'ipykernel' in sys.modules:
+            if sys.stdout.isatty() or self.is_jupyter
                 sys.stdout.write('\b' * prev_total_width)
                 sys.stdout.write('\r')
             else:


### PR DESCRIPTION
#8171 checks to see if there is a tty available and if there is one update the same terminal line. This fixes when you wan't to pipe the output to a file for example. But it also breaks `fit` output in jupyter notebook. In jupyter you get a newline with a update.

This will add a check to see if `ipykernel` is loaded and output with `\b\r`. (Does not affect IPython)