### PR TITLE
Fix error where total run time isn't shown

### DIFF
--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -326,7 +326,7 @@ class Progbar(object):
                 time_per_unit = (now - self.start) / current
             else:
                 time_per_unit = 0
-            if self.target is not None and current <= self.target:
+            if self.target is not None and current < self.target:
                 eta = time_per_unit * (self.target - current)
 
                 if eta > 3600:


### PR DESCRIPTION
After a few updates to ETA output when training a model epoch run time isn't outputted. This will show the epoch total run time after each epoch and not just `ETA: 0s`.