### PR TITLE
Sync parameter order in boston_housing with reuters

### DIFF
--- a/keras/datasets/boston_housing.py
+++ b/keras/datasets/boston_housing.py
@@ -2,15 +2,15 @@ from ..utils.data_utils import get_file
 import numpy as np
 
 
-def load_data(path='boston_housing.npz', seed=113, test_split=0.2):
+def load_data(path='boston_housing.npz', test_split=0.2, seed=113):
     """Loads the Boston Housing dataset.
 
     # Arguments
         path: path where to cache the dataset locally
             (relative to ~/.keras/datasets).
+        test_split: fraction of the data to reserve as test set.
         seed: Random seed for shuffling the data
             before computing the test split.
-        test_split: fraction of the data to reserve as test set.
 
     # Returns
         Tuple of Numpy arrays: `(x_train, y_train), (x_test, y_test)`.


### PR DESCRIPTION
Those are the only two that have `test_split`. Syncing in that direction, because `boston_housing` is not referenced anywhere in Keras code, while `reuters` is. I think there was some discussion of datasets API in tensorflow, but can't find it now. Should `test_split` be renamed `validation_split` for consistency with the rest of codebase?