### PR TITLE
Simplify reporthook-related logic

### DIFF
--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -58,10 +58,10 @@ if sys.version_info[0] == 2:
                 count += 1
                 if reporthook is not None:
                     reporthook(count, chunk_size, total_size)
-                    if not chunk:
-                        break
-
-                yield chunk
+                if chunk:
+                    yield chunk
+                else:
+                    break
 
         response = urlopen(url, data)
         with open(filename, 'wb') as fd:

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -53,15 +53,14 @@ if sys.version_info[0] == 2:
             if content_type is not None:
                 total_size = int(content_type.strip())
             count = 0
-            while 1:
+            while True:
                 chunk = response.read(chunk_size)
                 count += 1
-                if not chunk:
-                    if reporthook:
-                        reporthook(count, total_size, total_size)
-                    break
-                if reporthook:
+                if reporthook is not None:
                     reporthook(count, chunk_size, total_size)
+                    if not chunk:
+                        break
+
                 yield chunk
 
         response = urlopen(url, data)


### PR DESCRIPTION
Remove duplicate logic, reduce line count, fix potential bug if reporthook is convertible to bool by checking "is not None" - i.e. what PR https://github.com/fchollet/keras/pull/8320 title promised, but didn't really do :-)