### PR TITLE
Remove unintended session initialization on TF backend

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -1,5 +1,4 @@
 import tensorflow as tf
-from tensorflow.python.client import device_lib
 from tensorflow.python.training import moving_averages
 from tensorflow.python.ops import tensor_array_ops
 from tensorflow.python.ops import control_flow_ops
@@ -44,10 +43,6 @@ _GRAPH_UID_DICTS = {}
 # up to the user.
 # Change its value via `manual_variable_initialization(value)`.
 _MANUAL_VAR_INIT = False
-
-# This list queries the devices.
-# We assume our devices don't change during our lifetime.
-_LOCAL_DEVICES = device_lib.list_local_devices()
 
 
 def get_uid(prefix=''):
@@ -174,17 +169,18 @@ def get_session():
             for v in variables:
                 if not getattr(v, '_keras_initialized', False):
                     candidate_vars.append(v)
-            # This step is expensive, so we only run it on variables
-            # not already marked as initialized.
-            is_initialized = session.run(
-                [tf.is_variable_initialized(v) for v in candidate_vars])
-            uninitialized_vars = []
-            for flag, v in zip(is_initialized, candidate_vars):
-                if not flag:
-                    uninitialized_vars.append(v)
-                v._keras_initialized = True
-            if uninitialized_vars:
-                session.run(tf.variables_initializer(uninitialized_vars))
+            if candidate_vars:
+                # This step is expensive, so we only run it on variables
+                # not already marked as initialized.
+                is_initialized = session.run(
+                    [tf.is_variable_initialized(v) for v in candidate_vars])
+                uninitialized_vars = []
+                for flag, v in zip(is_initialized, candidate_vars):
+                    if not flag:
+                        uninitialized_vars.append(v)
+                    v._keras_initialized = True
+                if uninitialized_vars:
+                    session.run(tf.variables_initializer(uninitialized_vars))
     return session
 
 
@@ -250,7 +246,7 @@ def _get_available_gpus():
     # Returns
         A list of available GPU devices.
     """
-    return [x.name for x in _LOCAL_DEVICES if x.device_type == 'GPU']
+    return [x.name for x in get_session().list_devices() if x.device_type == 'GPU']
 
 
 def _has_nchw_support():

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -44,6 +44,11 @@ _GRAPH_UID_DICTS = {}
 # Change its value via `manual_variable_initialization(value)`.
 _MANUAL_VAR_INIT = False
 
+# This list holds the available devices.
+# It is populated when `_get_available_gpus()` is called for the first time.
+# We assume our devices don't change during our lifetime.
+_LOCAL_DEVICES = None
+
 
 def get_uid(prefix=''):
     """Get the uid for the default graph.
@@ -246,7 +251,10 @@ def _get_available_gpus():
     # Returns
         A list of available GPU devices.
     """
-    return [x.name for x in get_session().list_devices() if x.device_type == 'GPU']
+    global _LOCAL_DEVICES
+    if _LOCAL_DEVICES is None:
+        _LOCAL_DEVICES = get_session().list_devices()
+    return [x.name for x in _LOCAL_DEVICES if x.device_type == 'GPU']
 
 
 def _has_nchw_support():

--- a/keras/utils/training_utils.py
+++ b/keras/utils/training_utils.py
@@ -5,13 +5,11 @@ from ..engine.training import Model
 
 
 def _get_available_devices():
-    from tensorflow.python.client import device_lib
-    local_device_protos = device_lib.list_local_devices()
-    return [x.name for x in local_device_protos]
+    return [x.name for x in K.get_session().list_devices()]
 
 
 def _normalize_device_name(name):
-    name = name.lower().replace('device:', '')
+    name = '/' + name.lower().split('device:')[1]
     return name
 
 


### PR DESCRIPTION
This PR tries to address the issues https://github.com/fchollet/keras/issues/8353, https://github.com/fchollet/keras/issues/8311 and https://github.com/fchollet/keras/issues/8374. Unfortunately they affect each other.

A recent PR https://github.com/fchollet/keras/pull/8021 added a check at the beginning of the [tensorflow_backend.py](https://github.com/fchollet/keras/blob/master/keras/backend/tensorflow_backend.py#L50) to determine the number of available GPUs. Unfortunately the `tensorflow.python.client.device_lib.list_local_devices()` method seems to create of a new TF Session and to register of all the available GPUs on the system. To resolve this I replace all the `device_lib.list_local_devices()` calls with `K.get_session().list_devices()`. 

Moreover on commit https://github.com/fchollet/keras/commit/9166733c3c144739868fe0c30d57b861b4947b44 line 174, if the `candidate_vars` is empty we call `session.run()` with an empty list which causes a RuntimeException. This is addressed by checking if the variable is empty.

NOTE: The unit-tests passed on my machine but I've been having issues with timeouts today on Travis. Please check the code, don't merge directly. Happy to update the PR if necessary based on feedback.