### PR TITLE
Separate num_classes and num_rows

### DIFF
--- a/examples/mnist_acgan.py
+++ b/examples/mnist_acgan.py
@@ -294,7 +294,7 @@ if __name__ == '__main__':
 
         # generate some digits to display
         num_rows = 10
-        noise = np.random.uniform(-1, 1, (num_rows*num_classes, latent_size))
+        noise = np.random.uniform(-1, 1, (num_rows * num_classes, latent_size))
 
         sampled_labels = np.array([
             [i] * num_rows for i in range(num_classes)

--- a/examples/mnist_acgan.py
+++ b/examples/mnist_acgan.py
@@ -293,10 +293,11 @@ if __name__ == '__main__':
             'params_discriminator_epoch_{0:03d}.hdf5'.format(epoch), True)
 
         # generate some digits to display
-        noise = np.random.uniform(-1, 1, (100, latent_size))
+        num_rows = 10
+        noise = np.random.uniform(-1, 1, (num_rows*num_classes, latent_size))
 
         sampled_labels = np.array([
-            [i] * num_classes for i in range(num_classes)
+            [i] * num_rows for i in range(num_classes)
         ]).reshape(-1, 1)
 
         # get a batch to display


### PR DESCRIPTION
Generated image is a 10x10 grid. This cleanly separates `num_classes` (columns) and `num_rows`, while removing literal `100`.