### PR TITLE
acgan: Fix generator producing pure black images

### DIFF
--- a/examples/mnist_acgan.py
+++ b/examples/mnist_acgan.py
@@ -232,9 +232,6 @@ if __name__ == '__main__':
                 [noise, sampled_labels.reshape((-1, 1))],
                 [trick, sampled_labels]))
 
-            if epoch_gen_loss[-1][1] <= epoch_disc_loss[-1][1]:
-                break
-
             progress_bar.update(index + 1)
 
         print('Testing for epoch {}:'.format(epoch))

--- a/examples/mnist_acgan.py
+++ b/examples/mnist_acgan.py
@@ -209,7 +209,7 @@ if __name__ == '__main__':
 
             x = np.concatenate((image_batch, generated_images))
 
-            #use soft real/fake labels
+            # use soft real/fake labels
             soft_zero, soft_one = 0.25, 0.75
             y = np.array([soft_one] * batch_size + [soft_zero] * batch_size)
             aux_y = np.concatenate((label_batch, sampled_labels), axis=0)

--- a/examples/mnist_acgan.py
+++ b/examples/mnist_acgan.py
@@ -214,20 +214,24 @@ if __name__ == '__main__':
             # see if the discriminator can figure itself out...
             epoch_disc_loss.append(discriminator.train_on_batch(x, [y, aux_y]))
 
-            # make new noise. we generate 2 * batch size here such that we have
-            # the generator optimize over an identical number of images as the
-            # discriminator
-            noise = np.random.uniform(-1, 1, (2 * batch_size, latent_size))
-            sampled_labels = np.random.randint(0, num_classes, 2 * batch_size)
+            for i in range(32):
+                # make new noise. we generate 2 * batch size here such that we have
+                # the generator optimize over an identical number of images as the
+                # discriminator
+                noise = np.random.uniform(-1, 1, (2 * batch_size, latent_size))
+                sampled_labels = np.random.randint(0, num_classes, 2 * batch_size)
 
-            # we want to train the generator to trick the discriminator
-            # For the generator, we want all the {fake, not-fake} labels to say
-            # not-fake
-            trick = np.ones(2 * batch_size)
+                # we want to train the generator to trick the discriminator
+                # For the generator, we want all the {fake, not-fake} labels to say
+                # not-fake
+                trick = np.ones(2 * batch_size)
 
-            epoch_gen_loss.append(combined.train_on_batch(
-                [noise, sampled_labels.reshape((-1, 1))],
-                [trick, sampled_labels]))
+                epoch_gen_loss.append(combined.train_on_batch(
+                    [noise, sampled_labels.reshape((-1, 1))],
+                    [trick, sampled_labels]))
+
+                if epoch_gen_loss[-1][1] <= epoch_disc_loss[-1][1]:
+                    break
 
             progress_bar.update(index + 1)
 


### PR DESCRIPTION
Resolves https://github.com/fchollet/keras/issues/8373. Variability (within same epoch) is not as good as @lukedeo's https://github.com/lukedeo/keras-acgan/blob/master/acgan-analysis.ipynb

Greatest hits:

Epoch 13 =========================== Epoch 16
![plot_epoch_013_generated](https://user-images.githubusercontent.com/14060629/32402568-9cc39968-c0e4-11e7-9d3c-1ada902dc389.png)  ![plot_epoch_016_generated](https://user-images.githubusercontent.com/14060629/32402569-b34bf8e2-c0e4-11e7-85e9-b4b4c9e662f6.png)

Epoch 40 =========================== Epoch 50
![plot_epoch_040_generated](https://user-images.githubusercontent.com/14060629/32402574-d4c5aeaa-c0e4-11e7-994d-7d548d99e64a.png) ![plot_epoch_050_generated](https://user-images.githubusercontent.com/14060629/32402578-dd5b02ea-c0e4-11e7-804a-97411f695e14.png)
