### PR TITLE
Fix attribute error for using isatty() by sys.stdout 

### DIFF
--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -267,7 +267,8 @@ class Progbar(object):
         self.total_width = 0
         self.seen_so_far = 0
         self.verbose = verbose
-        self._dynamic_display = (sys.stdout.isatty() or
+        self._dynamic_display = ((hasattr(sys.stdout, 'isatty') and
+                                  sys.stdout.isatty()) or
                                  'ipykernel' in sys.modules)
 
     def update(self, current, values=None, force=False):


### PR DESCRIPTION
Add an attribute check for sys.stdout before using isatty().
In some cases, sys.stdout is replaced and may miss this attribute.