### PR TITLE
Load data directly into Nympy array

### DIFF
--- a/keras/datasets/cifar10.py
+++ b/keras/datasets/cifar10.py
@@ -18,14 +18,13 @@ def load_data():
 
     num_train_samples = 50000
 
-    x_train = np.zeros((num_train_samples, 3, 32, 32), dtype='uint8')
-    y_train = np.zeros((num_train_samples,), dtype='uint8')
+    x_train = np.empty((num_train_samples, 3, 32, 32), dtype='uint8')
+    y_train = np.empty((num_train_samples,), dtype='uint8')
 
     for i in range(1, 6):
         fpath = os.path.join(path, 'data_batch_' + str(i))
-        data, labels = load_batch(fpath)
-        x_train[(i - 1) * 10000: i * 10000, :, :, :] = data
-        y_train[(i - 1) * 10000: i * 10000] = labels
+        (x_train[(i - 1) * 10000: i * 10000, :, :, :],
+         y_train[(i - 1) * 10000: i * 10000]) = load_batch(fpath)
 
     fpath = os.path.join(path, 'test_batch')
     x_test, y_test = load_batch(fpath)


### PR DESCRIPTION
This makes it marginally faster, and avoids cache thrashing. 50,000*3*32*32=150 MBytes.

Also eliminates variables `data`, `labels`, which are not entirely consistent with the rest of the code, and makes logic marginally clearer (i.e. why initialize with zeros?, etc).