### PR TITLE
acgan: Use same latent vector for all classes in a row

### DIFF
--- a/examples/mnist_acgan.py
+++ b/examples/mnist_acgan.py
@@ -293,8 +293,9 @@ if __name__ == '__main__':
             'params_discriminator_epoch_{0:03d}.hdf5'.format(epoch), True)
 
         # generate some digits to display
-        num_rows = 10
-        noise = np.random.uniform(-1, 1, (num_rows * num_classes, latent_size))
+        num_rows = 40
+        noise = np.tile(np.random.uniform(-1, 1, (num_rows, latent_size)),
+                        (num_classes, 1))
 
         sampled_labels = np.array([
             [i] * num_rows for i in range(num_classes)


### PR DESCRIPTION
Supposedly latent vector encodes "style" or something. Now for all images in a row, latent vector (style) is the same, while class is different. For all images in a column, latent vector (style) is the different, while class is the same.

Before there was 100 latent vectors, now there would be 10. To compensate for it (and make the amount of variability/diversity more apparent), this PR increases the number of rows to 40 (i.e. 40 latent vectors). Here is how the grid(s) looks like now (after fixes in PR https://github.com/fchollet/keras/pull/8383)

Epoch 15 =========================== Epoch 18
![plot_epoch_015_generated](https://user-images.githubusercontent.com/14060629/32455850-6442755a-c2d8-11e7-9ee0-052b5f5e6f12.png)   ![plot_epoch_018_generated](https://user-images.githubusercontent.com/14060629/32455910-9c60722a-c2d8-11e7-8aec-3ea787ce7426.png)

