### PR TITLE
Fix doc string for _check_trainable_weights_consistency()

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -958,7 +958,7 @@ class Model(Container):
         """Check trainable weights count consistency.
 
         This will raise a warning if `trainable_weights` and
-        `_collected_trainable_weights` are consistent (i.e. have the same
+        `_collected_trainable_weights` are inconsistent (i.e. have different
         number of parameters).
         Inconsistency will typically arise when one modifies `model.trainable`
         without calling `model.compile` again.


### PR DESCRIPTION
The doc string is the negation of the code implementation. 