### PR TITLE
use 'nearest' rather than 'bilinear' as default interpolation method when resizing images

### DIFF
--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -319,7 +319,7 @@ def img_to_array(img, data_format=None):
 
 
 def load_img(path, grayscale=False, target_size=None,
-             interpolation='bilinear'):
+             interpolation='nearest'):
     """Loads an image into PIL format.
 
     # Arguments
@@ -332,7 +332,7 @@ def load_img(path, grayscale=False, target_size=None,
             Supported methods are "nearest", "bilinear", and "bicubic".
             If PIL version 1.1.3 or newer is installed, "lanczos" is also
             supported. If PIL version 3.4.0 or newer is installed, "box" and
-            "hamming" are also supported. By default, "bilinear" is used.
+            "hamming" are also supported. By default, "nearest" is used.
 
     # Returns
         A PIL Image instance.


### PR DESCRIPTION
Addresses: https://github.com/fchollet/keras/issues/8426

In versions prior to 2.0.9 there was no `interpolation` option so we always used the default interpolation mode of 'nearest'. With 2.0.9 `interpolation` can be specified however the default is `bilinear`, which can lead to subtly different results than in previous versions. This PR ensures that the image resizing behavior remains identical for code that doesn't specify an `interpolation` explicitly.