### PR TITLE
Replace erroneous num_classes with batch_size in examples/mnist_tfrecord.py

### DIFF
--- a/examples/mnist_tfrecord.py
+++ b/examples/mnist_tfrecord.py
@@ -153,5 +153,5 @@ test_model.summary()
 
 loss, acc = test_model.evaluate(x_test,
                                 keras.utils.to_categorical(y_test),
-                                num_classes)
+                                batch_size=batch_size)
 print('\nTest accuracy: {0}'.format(acc))


### PR DESCRIPTION
the bug was there from the very first commit of the file.