### PR TITLE
Fix backwards compatibility issues of #8419

### DIFF
--- a/keras/utils/np_utils.py
+++ b/keras/utils/np_utils.py
@@ -19,6 +19,10 @@ def to_categorical(y, num_classes=None):
     """
     y = np.array(y, dtype='int')
     input_shape = y.shape
+    # Special treatment for the case (None, 1) for backwards compatibility and
+    # sane behaviour
+    if len(input_shape) == 2 and input_shape[1] == 1:
+        input_shape = (input_shape[0],)
     y = y.ravel()
     if not num_classes:
         num_classes = np.max(y) + 1


### PR DESCRIPTION
#8419 made a backwards incompatible change that breaks thousands of lines of other people's code including the **keras examples**!

Code that showcases the problem.

```python
from keras.datasets import cifar10
from keras.utils.np_utils import to_categorical

(x, y), _ = cifar10.load_data()
y = to_categorical(y)
print(y.shape)
# (50000, 10) previous to #8419
# (50000, 1, 10) after #8419
```