### PR TITLE
Replace default value batch_size=32 with None for Sequential.evaluate(), Sequential.predict(), etc

### DIFF
--- a/keras/models.py
+++ b/keras/models.py
@@ -959,7 +959,7 @@ class Sequential(Model):
                               steps_per_epoch=steps_per_epoch,
                               validation_steps=validation_steps)
 
-    def evaluate(self, x, y, batch_size=32, verbose=1,
+    def evaluate(self, x, y, batch_size=None, verbose=1,
                  sample_weight=None):
         """Computes the loss on some input data, batch by batch.
 
@@ -988,7 +988,7 @@ class Sequential(Model):
                                    verbose=verbose,
                                    sample_weight=sample_weight)
 
-    def predict(self, x, batch_size=32, verbose=0):
+    def predict(self, x, batch_size=None, verbose=0):
         """Generates output predictions for the input samples.
 
         The input samples are processed batch by batch.
@@ -1072,7 +1072,7 @@ class Sequential(Model):
         return self.model.test_on_batch(x, y,
                                         sample_weight=sample_weight)
 
-    def predict_proba(self, x, batch_size=32, verbose=1):
+    def predict_proba(self, x, batch_size=None, verbose=1):
         """Generates class probability predictions for the input samples.
 
         The input samples are processed batch by batch.
@@ -1094,7 +1094,7 @@ class Sequential(Model):
                           '(like softmax or sigmoid would).')
         return preds
 
-    def predict_classes(self, x, batch_size=32, verbose=1):
+    def predict_classes(self, x, batch_size=None, verbose=1):
         """Generate class predictions for the input samples.
 
         The input samples are processed batch by batch.

--- a/keras/models.py
+++ b/keras/models.py
@@ -967,7 +967,7 @@ class Sequential(Model):
             x: input data, as a Numpy array or list of Numpy arrays
                 (if the model has multiple inputs).
             y: labels, as a Numpy array.
-            batch_size: integer. Number of samples per gradient update.
+            batch_size: Integer. If unspecified, it will default to 32.
             verbose: verbosity mode, 0 or 1.
             sample_weight: sample weights, as a Numpy array.
 
@@ -995,7 +995,7 @@ class Sequential(Model):
 
         # Arguments
             x: the input data, as a Numpy array.
-            batch_size: integer.
+            batch_size: Integer. If unspecified, it will default to 32.
             verbose: verbosity mode, 0 or 1.
 
         # Returns
@@ -1080,7 +1080,7 @@ class Sequential(Model):
         # Arguments
             x: input data, as a Numpy array or list of Numpy arrays
                 (if the model has multiple inputs).
-            batch_size: integer.
+            batch_size: Integer. If unspecified, it will default to 32.
             verbose: verbosity mode, 0 or 1.
 
         # Returns
@@ -1102,7 +1102,7 @@ class Sequential(Model):
         # Arguments
             x: input data, as a Numpy array or list of Numpy arrays
                 (if the model has multiple inputs).
-            batch_size: integer.
+            batch_size: Integer. If unspecified, it will default to 32.
             verbose: verbosity mode, 0 or 1.
 
         # Returns


### PR DESCRIPTION
This is more consistent with the rest of the code i.e. `Sequential.fit()` and the corresponding methods in `class Model` to which these methods are delegating.