### PR TITLE
Change default value verbose=1 to verbose=0 for Sequential.predict_proba() and Sequential.predict_classes()

### DIFF
--- a/keras/models.py
+++ b/keras/models.py
@@ -1072,7 +1072,7 @@ class Sequential(Model):
         return self.model.test_on_batch(x, y,
                                         sample_weight=sample_weight)
 
-    def predict_proba(self, x, batch_size=32, verbose=1):
+    def predict_proba(self, x, batch_size=32, verbose=0):
         """Generates class probability predictions for the input samples.
 
         The input samples are processed batch by batch.
@@ -1094,7 +1094,7 @@ class Sequential(Model):
                           '(like softmax or sigmoid would).')
         return preds
 
-    def predict_classes(self, x, batch_size=32, verbose=1):
+    def predict_classes(self, x, batch_size=32, verbose=0):
         """Generate class predictions for the input samples.
 
         The input samples are processed batch by batch.


### PR DESCRIPTION
Change default value verbose=1 to verbose=0 in `Sequential.predict_proba()` and `Sequential.predict_classes()` for consistency with `Sequential.predict()`, for which the same change was introduced in https://github.com/fchollet/keras/commit/f30223096eb2d16a65e0e99cb5c31b1f8dfe0980, but not for these two functions.