### PR TITLE
Rethrow original exception in GeneratorEnqueuer.

### DIFF
--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -615,6 +615,7 @@ class GeneratorEnqueuer(SequenceEnqueuer):
         self._use_multiprocessing = use_multiprocessing
         self._threads = []
         self._stop_event = None
+        self._manager = None
         self.queue = None
         self.seed = seed
 
@@ -651,7 +652,8 @@ class GeneratorEnqueuer(SequenceEnqueuer):
 
         try:
             if self._use_multiprocessing:
-                self.queue = multiprocessing.Queue(maxsize=max_queue_size)
+                self._manager = multiprocessing.Manager()
+                self.queue = self._manager.Queue(maxsize=max_queue_size)
                 self._stop_event = multiprocessing.Event()
             else:
                 self.queue = queue.Queue()
@@ -695,9 +697,8 @@ class GeneratorEnqueuer(SequenceEnqueuer):
                 else:
                     thread.join(timeout)
 
-        if self._use_multiprocessing:
-            if self.queue is not None:
-                self.queue.close()
+        if self._manager:
+            self._manager.shutdown()
 
         self._threads = []
         self._stop_event = None

--- a/tests/keras/utils/data_utils_test.py
+++ b/tests/keras/utils/data_utils_test.py
@@ -182,7 +182,7 @@ def test_generator_enqueuer_fail_threads():
         FaultSequence()), use_multiprocessing=False)
     enqueuer.start(3, 10)
     gen_output = enqueuer.get()
-    with pytest.raises(StopIteration):
+    with pytest.raises(IndexError):
         next(gen_output)
 
 
@@ -191,7 +191,7 @@ def test_generator_enqueuer_fail_processes():
         FaultSequence()), use_multiprocessing=True)
     enqueuer.start(3, 10)
     gen_output = enqueuer.get()
-    with pytest.raises(StopIteration):
+    with pytest.raises(IndexError):
         next(gen_output)
 
 

--- a/tests/test_multiprocessing.py
+++ b/tests/test_multiprocessing.py
@@ -241,13 +241,13 @@ def test_multiprocessing_fit_error():
 
     samples = batch_size * (good_batches + 1)
 
-    with pytest.raises(StopIteration):
+    with pytest.raises(RuntimeError):
         model.fit_generator(
             custom_generator(), samples, 1,
             workers=4, use_multiprocessing=True,
         )
 
-    with pytest.raises(StopIteration):
+    with pytest.raises(RuntimeError):
         model.fit_generator(
             custom_generator(), samples, 1,
             use_multiprocessing=False,
@@ -271,13 +271,13 @@ def test_multiprocessing_evaluate_error():
     model.add(Dense(1, input_shape=(2, )))
     model.compile(loss='mse', optimizer='adadelta')
 
-    with pytest.raises(StopIteration):
+    with pytest.raises(RuntimeError):
         model.evaluate_generator(
             custom_generator(), good_batches * workers + 1, 1,
             workers=workers, use_multiprocessing=True,
         )
 
-    with pytest.raises(StopIteration):
+    with pytest.raises(RuntimeError):
         model.evaluate_generator(
             custom_generator(), good_batches + 1, 1,
             use_multiprocessing=False,
@@ -300,13 +300,13 @@ def test_multiprocessing_predict_error():
     model.add(Dense(1, input_shape=(5,)))
     model.compile(loss='mse', optimizer='adadelta')
 
-    with pytest.raises(StopIteration):
+    with pytest.raises(RuntimeError):
         model.predict_generator(
             custom_generator(), good_batches * workers + 1, 1,
             workers=workers, use_multiprocessing=True,
         )
 
-    with pytest.raises(StopIteration):
+    with pytest.raises(RuntimeError):
         model.predict_generator(
             custom_generator(), good_batches + 1, 1,
             use_multiprocessing=False,

--- a/tests/test_multiprocessing.py
+++ b/tests/test_multiprocessing.py
@@ -232,7 +232,7 @@ def test_multiprocessing_fit_error():
         """Raises an exception after a few good batches"""
         for i in range(good_batches):
             yield (np.random.randint(batch_size, 256, (50, 2)),
-                   np.random.randint(batch_size, 2, 50))
+                   np.random.randint(batch_size, 12, 50))
         raise RuntimeError
 
     model = Sequential()
@@ -258,12 +258,13 @@ def test_multiprocessing_fit_error():
 def test_multiprocessing_evaluate_error():
     batch_size = 10
     good_batches = 3
+    workers = 4
 
     def custom_generator():
         """Raises an exception after a few good batches"""
         for i in range(good_batches):
             yield (np.random.randint(batch_size, 256, (50, 2)),
-                   np.random.randint(batch_size, 2, 50))
+                   np.random.randint(batch_size, 12, 50))
         raise RuntimeError
 
     model = Sequential()
@@ -272,8 +273,8 @@ def test_multiprocessing_evaluate_error():
 
     with pytest.raises(StopIteration):
         model.evaluate_generator(
-            custom_generator(), good_batches + 1, 1,
-            workers=4, use_multiprocessing=True,
+            custom_generator(), good_batches * workers + 1, 1,
+            workers=workers, use_multiprocessing=True,
         )
 
     with pytest.raises(StopIteration):


### PR DESCRIPTION
`GeneratorEnqueuer` executes the generator in either background threads or worker processes. If an exception occurs in the generator, the thread/worker prints a traceback and is killed. The consumer of the data receives a `StopIteration` exception instead of the exception thrown by the generator.

This causes a lot of confusion on our issue tracker where people quote only the `StopIterator` error and not the interesting exception thrown by the generator. Often if they had seen the original error they could have solved the problem on their own.

This PR attempts to solve this by putting `(bool, value)` tuples the data queue currently used for communicating the generator results. Normal values are put in the queue as `(True, generator_output)` while exceptions are put in as `(False, exception)`.

There is also some glue code to hide the differences between python2 and python3 in the way backtraces are accessed.

This doesn't currently work with `use_multiprocessing=True`. It is not possible to pickle traceback objects, so they can not be put in a `multiprocessing.Queue`. The current workaround for that in this PR is to just print the backtrace in the child process and pickle the exception with backtrace `None`.

An alternative would be to use `tblib`, which can pickle/unpickle tracebacks. That would allow the same technique to be used with `use_multiprocessing=True`. I wasn't sure if an extra dependency would be a problem or not.

Example of an error in a generator with this PR:
```
Epoch 1/50
1/2 [==============>...............] - ETA: 3s - loss: 1.6380 - regression_loss: 0.4514 - classification_loss: 1.1866Traceback (most recent call last):
  File "../keras-retinanet/examples/train_pascal.py", line 109, in <module>
    keras.callbacks.ReduceLROnPlateau(monitor='val_loss', factor=0.1, patience=10, verbose=1, mode='auto', epsilon=0.0001, cooldown=0, min_lr=0),
  File "/home/de-vri-es/dev/keras/keras/legacy/interfaces.py", line 87, in wrapper
    return func(*args, **kwargs)
  File "/home/de-vri-es/dev/keras/keras/engine/training.py", line 2046, in fit_generator
    generator_output = next(output_generator)
  File "/home/de-vri-es/dev/keras/keras/utils/data_utils.py", line 678, in get
    six.reraise(value.__class__, value, value.__traceback__)
  File "/usr/lib/python3.6/site-packages/six.py", line 693, in reraise
    raise value
  File "/home/de-vri-es/dev/keras/keras/utils/data_utils.py", line 580, in data_generator_task
    generator_output = next(self._generator)
  File "/home/de-vri-es/dev/keras_retinanet/keras_retinanet/preprocessing/generator.py", line 117, in __next__
    return self.next()
  File "/home/de-vri-es/dev/keras_retinanet/keras_retinanet/preprocessing/generator.py", line 130, in next
    annotations_group = self.load_annotations_group(group_index)
  File "/home/de-vri-es/dev/keras_retinanet/keras_retinanet/preprocessing/generator.py", line 70, in load_annotations_group
    return [self.load_annotations(image_index) for image_index in self.groups[group_index]]
  File "/home/de-vri-es/dev/keras_retinanet/keras_retinanet/preprocessing/generator.py", line 70, in <listcomp>
    return [self.load_annotations(image_index) for image_index in self.groups[group_index]]
  File "/home/de-vri-es/dev/keras_retinanet/keras_retinanet/preprocessing/pascal_voc.py", line 161, in load_annotations
    raise_from(ValueError('invalid annotations file: {}: {}'.format(filename, e)), None)
  File "/usr/lib/python3.6/site-packages/future/utils/__init__.py", line 398, in raise_from
    exec(execstr, myglobals, mylocals)
  File "<string>", line 1, in <module>
ValueError: invalid annotations file: a.xml: could not parse object #1: illegal value for 'truncated': invalid literal for int() with base 10: 'not-an-int'
```

Same situation without this PR:
```
Epoch 1/50
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/lib/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.6/threading.py", line 864, in run
    self._target(*self._args, **self._kwargs)
  File "/home/de-vri-es/dev/keras/keras/utils/data_utils.py", line 579, in data_generator_task
    generator_output = next(self._generator)
  File "/home/de-vri-es/dev/keras_retinanet/keras_retinanet/preprocessing/generator.py", line 117, in __next__
    return self.next()
  File "/home/de-vri-es/dev/keras_retinanet/keras_retinanet/preprocessing/generator.py", line 130, in next
    annotations_group = self.load_annotations_group(group_index)
  File "/home/de-vri-es/dev/keras_retinanet/keras_retinanet/preprocessing/generator.py", line 70, in load_annotations_group
    return [self.load_annotations(image_index) for image_index in self.groups[group_index]]
  File "/home/de-vri-es/dev/keras_retinanet/keras_retinanet/preprocessing/generator.py", line 70, in <listcomp>
    return [self.load_annotations(image_index) for image_index in self.groups[group_index]]
  File "/home/de-vri-es/dev/keras_retinanet/keras_retinanet/preprocessing/pascal_voc.py", line 161, in load_annotations
    raise_from(ValueError('invalid annotations file: {}: {}'.format(filename, e)), None)
  File "/usr/lib/python3.6/site-packages/future/utils/__init__.py", line 398, in raise_from
    exec(execstr, myglobals, mylocals)
  File "<string>", line 1, in <module>
ValueError: invalid annotations file: a.xml: could not parse object #1: illegal value for 'truncated': invalid literal for int() with base 10: 'not-an-int'

1/2 [==============>...............] - ETA: 3s - loss: 1.6544 - regression_loss: 0.4738 - classification_loss: 1.1806Traceback (most recent call last):
  File "../keras-retinanet/examples/train_pascal.py", line 109, in <module>
    keras.callbacks.ReduceLROnPlateau(monitor='val_loss', factor=0.1, patience=10, verbose=1, mode='auto', epsilon=0.0001, cooldown=0, min_lr=0),
  File "/home/de-vri-es/dev/keras/keras/legacy/interfaces.py", line 87, in wrapper
    return func(*args, **kwargs)
  File "/home/de-vri-es/dev/keras/keras/engine/training.py", line 2046, in fit_generator
    generator_output = next(output_generator)
StopIteration
```