### PR TITLE
reduce unnecessary transfers to gpu, spread split operation load to cpus

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -3283,6 +3283,181 @@ def separable_conv2d(x, depthwise_kernel, pointwise_kernel, strides=(1, 1),
     return x
 
 
+from tensorflow.python.ops import nn_ops,array_ops
+import tensorflow.python.ops
+
+def depthwise_conv3d(input, filter, strides, padding, name=None):
+  """Depthwise 3-D convolution.
+  Given an input tensor of shape `[batch, in_height, in_width, in_channels]`
+  and a filter tensor of shape
+  `[filter_height, filter_width, in_channels, channel_multiplier]`
+  containing `in_channels` convolutional filters of depth 1, `depthwise_conv3d`
+  applies a different filter to each input channel (expanding from 1 channel
+  to `channel_multiplier` channels for each), then concatenates the results
+  together.  The output has `in_channels * channel_multiplier` channels.
+  In detail,
+      output[b, i, j, k * channel_multiplier + q] =
+          sum_{di, dj} input[b, strides[1] * i + di, strides[2] * j + dj, k] *
+                       filter[di, dj, k, q]
+  Must have `strides[0] = strides[3] = 1`.  For the most common case of the
+  same horizontal and vertical strides, `strides = [1, stride, stride, 1]`.
+  Args:
+    input: 4-D with shape `[batch, in_height, in_width, in_channels]`.
+    filter: 4-D with shape
+      `[filter_height, filter_width, in_channels, channel_multiplier]`.
+    strides: 1-D of size 4.  The stride of the sliding window for each
+      dimension of `input`.
+    padding: A string, either `'VALID'` or `'SAME'`.  The padding algorithm.
+    name: A name for this operation (optional).
+  Returns:
+    A 4-D `Tensor` of shape
+    `[batch, out_height, out_width, in_channels * channel_multiplier].`
+  """
+  with tf.name_scope(name, "depthwise", [input, filter]) as name:
+    input = tf.convert_to_tensor(input, name="tensor_in")
+    filter = tf.convert_to_tensor(filter, name="filter_in")
+    # A shape is required to statically compute the number of separable filters.
+    if filter.get_shape().ndims is not None:
+      assert len(filter.get_shape()) == 5
+      in_channels = filter.get_shape()[3]
+      # Sanity checks, if shape information is available for the inputs.
+      if input.get_shape().ndims is not None:
+        assert len(input.get_shape()) == 5
+        assert input.get_shape()[4] == in_channels, (
+            "Mismatched input depth %d and number of depthwise filters %d." % (
+                input.get_shape()[4].value, in_channels))
+    else:
+      assert input.get_shape().ndims is not None, (
+          "Either tensor must provide static shape information.")
+      assert input.get_shape().ndims == 5
+      in_channels = input.get_shape()[4]
+
+    if in_channels == 1:
+      return nn_ops.conv3d(input, filter, strides, padding, name=name)
+    else:
+      # Create one separate convolution per channel.
+      convs = []
+      for channel in xrange(in_channels):
+        with tf.name_scope("depth%d" % channel) as channel_scope:
+          t_in = array_ops.slice(input, [0, 0, 0, 0, channel], [-1, -1, -1, -1, 1],
+                                 name="slice_inputs")
+          f_in = array_ops.slice(filter, [0, 0, 0, channel, 0], [-1, -1, -1, 1, -1],
+                                 name="slice_params")
+          #print(strides)
+          convs.append(nn_ops.conv3d(t_in, f_in,
+                                     strides, padding, name=channel_scope))
+      # Concatenate the per-channel convolutions along the channel dimension.
+      return array_ops.concat(convs, 4, name=name)
+
+
+def tf_separable_conv3d(input, depthwise_filter, pointwise_filter, strides,
+                     padding,
+                     name=None):
+  """3-D convolution with separable filters.
+  Performs a depthwise convolution that acts separately on channels followed by
+  a pointwise convolution that mixes channels.  Note that this is separability
+  between dimensions `[1, 2]` and `3`, not spatial separability between
+  dimensions `1` and `2`.
+  In detail,
+      output[b, i, j, k] = sum_{di, dj, q, r]
+          input[b, strides[1] * i + di, strides[2] * j + dj, q] *
+          depthwise_filter[di, dj, q, r] *
+          pointwise_filter[0, 0, q * channel_multiplier + r, k]
+  `strides` controls the strides for the depthwise convolution only, since
+  the pointwise convolution has implicit strides of `[1, 1, 1, 1]`.  Must have
+  `strides[0] = strides[3] = 1`.  For the most common case of the same
+  horizontal and vertical strides, `strides = [1, stride, stride, 1]`.
+  Args:
+    input: 4-D `Tensor` with shape `[batch, in_height, in_width, in_channels]`.
+    depthwise_filter: 4-D `Tensor` with shape
+      `[filter_height, filter_width, in_channels, channel_multiplier]`.
+      Contains `in_channels` convolutional filters of depth 1.
+    pointwise_filter: 4-D `Tensor` with shape
+      `[1, 1, channel_multiplier * in_channels, out_channels]`.  Pointwise
+      filter to mix channels after `depthwise_filter` has convolved spatially.
+    strides: 1-D of size 4.  The strides for the depthwise convolution for
+      each dimension of `input`.
+    padding: A string, either `'VALID'` or `'SAME'`.  The padding algorithm.
+    name: A name for this operation (optional).
+  Returns:
+    A 4-D `Tensor` of shape `[batch, out_height, out_width, out_channels]`.
+  """
+  #GV
+  #print(depthwise_filter.shape, pointwise_filter.shape, strides)
+  with tf.name_scope(name, "separable_conv3d", [input, depthwise_filter, pointwise_filter]) as name:
+    input = tf.convert_to_tensor(input, name="tensor_in")
+    depthwise_filter = tf.convert_to_tensor(depthwise_filter,
+                                             name="depthwise_filter")
+    pointwise_filter = tf.convert_to_tensor(pointwise_filter,
+                                             name="pointwise_filter")
+
+    if pointwise_filter.get_shape().ndims is not None:
+      assert len(pointwise_filter.get_shape()) == 5
+      assert pointwise_filter.get_shape()[0] == 1
+      assert pointwise_filter.get_shape()[1] == 1
+      assert pointwise_filter.get_shape()[2] == 1
+      if depthwise_filter.get_shape().ndims and input.get_shape().ndims:
+        channel_multiplier = depthwise_filter.get_shape()[4]
+        in_channels = input.get_shape()[4]
+        out_channels = pointwise_filter.get_shape()[4]
+        # This would mean the separable convolutions is over-parametrized.
+        #print(channel_multiplier,in_channels,out_channels)
+        assert channel_multiplier * in_channels <= out_channels
+    # The layout of the ops in the graph are expected to be as follows:
+    # separable_conv3d  // Conv3d op corresponding to the pointwise conv.
+    # separable_conv3d/depthwise  // Concat op for the deptwise outputs.
+    # separable_conv3d/depthwise/depth0  // Conv3d op for depth 0
+    # separable_conv3d/depthwise/depth1  // Conv3d op for depth 1
+    # separable_conv3d/depthwise/depth2  // Conv3d op for depth 2
+    depthwise = depthwise_conv3d(input, depthwise_filter, strides,
+                                 padding, name="depthwise")
+    return nn_ops.conv3d(depthwise, pointwise_filter, [1, 1, 1, 1, 1],
+                         padding="VALID", name=name)
+
+
+def separable_conv3d(x, depthwise_kernel, pointwise_kernel, strides=(1, 1, 1),
+                     padding='valid', data_format=None, dilation_rate=(1, 1, 1)):
+    """3d convolution with separable filters.
+
+    # Arguments
+        x: input tensor
+        depthwise_kernel: convolution kernel for the depthwise convolution.
+        pointwise_kernel: kernel for the 1x1 convolution.
+        strides: strides tuple (length 2).
+        padding: string, `"same"` or `"valid"`.
+        data_format: string, `"channels_last"` or `"channels_first"`.
+        dilation_rate: tuple of integers,
+            dilation rates for the separable convolution.
+
+    # Returns
+        Output tensor.
+
+    # Raises
+        ValueError: if `data_format` is neither `channels_last` or `channels_first`.
+    """
+    if data_format is None:
+        data_format = image_data_format()
+    if data_format not in {'channels_first', 'channels_last'}:
+        raise ValueError('Unknown data_format ' + str(data_format))
+
+    x, tf_data_format = _preprocess_conv3d_input(x, data_format)
+    padding = _preprocess_padding(padding)
+    #print(tf_data_format)
+    if tf_data_format == 'NDHWC':
+        strides = (1,) + strides + (1,)
+    else:
+        strides = (1, 1) + strides
+
+    x = tf_separable_conv3d(x, depthwise_kernel, pointwise_kernel,
+                               strides=strides,
+                               padding=padding)#,
+                               #rate=dilation_rate,
+                               #data_format=tf_data_format)
+    if data_format == 'channels_first' and tf_data_format == 'NDHWC':
+        x = tf.transpose(x, (0, 3, 1, 2))  # NHWC -> NCHW
+    return x
+
+
 def depthwise_conv2d(x, depthwise_kernel, strides=(1, 1), padding='valid',
                      data_format=None, dilation_rate=(1, 1)):
     """2D convolution with separable filters.

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -1245,6 +1245,214 @@ class SeparableConv2D(Conv2D):
         return config
 
 
+class SeparableConv3D(Conv3D):
+    """Depthwise separable 3D convolution.
+
+    Separable convolutions consist in first performing
+    a depthwise spatial convolution
+    (which acts on each input channel separately)
+    followed by a pointwise convolution which mixes together the resulting
+    output channels. The `depth_multiplier` argument controls how many
+    output channels are generated per input channel in the depthwise step.
+
+    Intuitively, separable convolutions can be understood as
+    a way to factorize a convolution kernel into two smaller kernels,
+    or as an extreme version of an Inception block.
+
+    # Arguments
+        filters: Integer, the dimensionality of the output space
+            (i.e. the number output of filters in the convolution).
+        kernel_size: An integer or tuple/list of 2 integers, specifying the
+            width and height of the 3D convolution window.
+            Can be a single integer to specify the same value for
+            all spatial dimensions.
+        strides: An integer or tuple/list of 2 integers,
+            specifying the strides of the convolution along the width and height.
+            Can be a single integer to specify the same value for
+            all spatial dimensions.
+            Specifying any stride value != 1 is incompatible with specifying
+            any `dilation_rate` value != 1.
+        padding: one of `"valid"` or `"same"` (case-insensitive).
+        data_format: A string,
+            one of `channels_last` (default) or `channels_first`.
+            The ordering of the dimensions in the inputs.
+            `channels_last` corresponds to inputs with shape
+            `(batch, height, width, channels)` while `channels_first`
+            corresponds to inputs with shape
+            `(batch, channels, height, width)`.
+            It defaults to the `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json`.
+            If you never set it, then it will be "channels_last".
+        depth_multiplier: The number of depthwise convolution output channels
+            for each input channel.
+            The total number of depthwise convolution output
+            channels will be equal to `filterss_in * depth_multiplier`.
+        activation: Activation function to use
+            (see [activations](../activations.md)).
+            If you don't specify anything, no activation is applied
+            (ie. "linear" activation: `a(x) = x`).
+        use_bias: Boolean, whether the layer uses a bias vector.
+        depthwise_initializer: Initializer for the depthwise kernel matrix
+            (see [initializers](../initializers.md)).
+        pointwise_initializer: Initializer for the pointwise kernel matrix
+            (see [initializers](../initializers.md)).
+        bias_initializer: Initializer for the bias vector
+            (see [initializers](../initializers.md)).
+        depthwise_regularizer: Regularizer function applied to
+            the depthwise kernel matrix
+            (see [regularizer](../regularizers.md)).
+        pointwise_regularizer: Regularizer function applied to
+            the pointwise kernel matrix
+            (see [regularizer](../regularizers.md)).
+        bias_regularizer: Regularizer function applied to the bias vector
+            (see [regularizer](../regularizers.md)).
+        activity_regularizer: Regularizer function applied to
+            the output of the layer (its "activation").
+            (see [regularizer](../regularizers.md)).
+        depthwise_constraint: Constraint function applied to
+            the depthwise kernel matrix
+            (see [constraints](../constraints.md)).
+        pointwise_constraint: Constraint function applied to
+            the pointwise kernel matrix
+            (see [constraints](../constraints.md)).
+        bias_constraint: Constraint function applied to the bias vector
+            (see [constraints](../constraints.md)).
+
+    # Input shape
+        5D tensor with shape:
+        `(batch, channels, rows, cols)` if data_format='channels_first'
+        or 5D tensor with shape:
+        `(batch, rows, cols, channels)` if data_format='channels_last'.
+
+    # Output shape
+        5D tensor with shape:
+        `(batch, filters, new_rows, new_cols)` if data_format='channels_first'
+        or 5D tensor with shape:
+        `(batch, new_rows, new_cols, filters)` if data_format='channels_last'.
+        `rows` and `cols` values might have changed due to padding.
+    """
+
+    @interfaces.legacy_separable_conv3D_support
+    def __init__(self, filters,
+                 kernel_size,
+                 strides=(1, 1, 1),
+                 padding='valid',
+                 data_format=None,
+                 depth_multiplier=1,
+                 activation=None,
+                 use_bias=True,
+                 depthwise_initializer='glorot_uniform',
+                 pointwise_initializer='glorot_uniform',
+                 bias_initializer='zeros',
+                 depthwise_regularizer=None,
+                 pointwise_regularizer=None,
+                 bias_regularizer=None,
+                 activity_regularizer=None,
+                 depthwise_constraint=None,
+                 pointwise_constraint=None,
+                 bias_constraint=None,
+                 **kwargs):
+        super(SeparableConv3D, self).__init__(
+            filters=filters,
+            kernel_size=kernel_size,
+            strides=strides,
+            padding=padding,
+            data_format=data_format,
+            activation=activation,
+            use_bias=use_bias,
+            bias_regularizer=bias_regularizer,
+            activity_regularizer=activity_regularizer,
+            bias_constraint=bias_constraint,
+            **kwargs)
+        self.depth_multiplier = depth_multiplier
+        self.depthwise_initializer = initializers.get(depthwise_initializer)
+        self.pointwise_initializer = initializers.get(pointwise_initializer)
+        self.depthwise_regularizer = regularizers.get(depthwise_regularizer)
+        self.pointwise_regularizer = regularizers.get(pointwise_regularizer)
+        self.depthwise_constraint = constraints.get(depthwise_constraint)
+        self.pointwise_constraint = constraints.get(pointwise_constraint)
+
+    def build(self, input_shape):
+        if len(input_shape) < 5:
+            raise ValueError('Inputs to `SeparableConv3D` should have rank 5. '
+                             'Received input shape:', str(input_shape))
+        if self.data_format == 'channels_first':
+            channel_axis = 1
+        else:
+            channel_axis = 4
+        if input_shape[channel_axis] is None:
+            raise ValueError('The channel dimension of the inputs to '
+                             '`SeparableConv3D` '
+                             'should be defined. Found `None`.')
+        input_dim = int(input_shape[channel_axis])
+        depthwise_kernel_shape = (self.kernel_size[0],
+                                  self.kernel_size[1],
+                                  self.kernel_size[2],
+                                  input_dim,
+                                  self.depth_multiplier)
+        pointwise_kernel_shape = (1, 1, 1,
+                                  self.depth_multiplier * input_dim,
+                                  self.filters)
+        self.depthwise_kernel = self.add_weight(
+            shape=depthwise_kernel_shape,
+            initializer=self.depthwise_initializer,
+            name='depthwise_kernel',
+            regularizer=self.depthwise_regularizer,
+            constraint=self.depthwise_constraint)
+        self.pointwise_kernel = self.add_weight(
+            shape=pointwise_kernel_shape,
+            initializer=self.pointwise_initializer,
+            name='pointwise_kernel',
+            regularizer=self.pointwise_regularizer,
+            constraint=self.pointwise_constraint)
+
+        if self.use_bias:
+            self.bias = self.add_weight(shape=(self.filters,),
+                                        initializer=self.bias_initializer,
+                                        name='bias',
+                                        regularizer=self.bias_regularizer,
+                                        constraint=self.bias_constraint)
+        else:
+            self.bias = None
+        # Set input spec.
+        self.input_spec = InputSpec(ndim=5, axes={channel_axis: input_dim})
+        self.built = True
+
+    def call(self, inputs):
+        outputs = K.separable_conv3d(
+            inputs,
+            self.depthwise_kernel,
+            self.pointwise_kernel,
+            data_format=self.data_format,
+            strides=self.strides,
+            padding=self.padding,
+            dilation_rate=self.dilation_rate)
+
+        if self.bias:
+            outputs = K.bias_add(
+                outputs,
+                self.bias,
+                data_format=self.data_format)
+
+        if self.activation is not None:
+            return self.activation(outputs)
+        return outputs
+
+    def get_config(self):
+        config = super(SeparableConv3D, self).get_config()
+        config.pop('kernel_initializer')
+        config.pop('kernel_regularizer')
+        config.pop('kernel_constraint')
+        config['depth_multiplier'] = self.depth_multiplier
+        config['depthwise_initializer'] = initializers.serialize(self.depthwise_initializer)
+        config['pointwise_initializer'] = initializers.serialize(self.pointwise_initializer)
+        config['depthwise_regularizer'] = regularizers.serialize(self.depthwise_regularizer)
+        config['pointwise_regularizer'] = regularizers.serialize(self.pointwise_regularizer)
+        config['depthwise_constraint'] = constraints.serialize(self.depthwise_constraint)
+        config['pointwise_constraint'] = constraints.serialize(self.pointwise_constraint)
+        return config
+
+
 class UpSampling1D(Layer):
     """Upsampling layer for 1D inputs.
 

--- a/keras/legacy/interfaces.py
+++ b/keras/legacy/interfaces.py
@@ -339,6 +339,31 @@ legacy_separable_conv2d_support = generate_legacy_interface(
     preprocessor=separable_conv2d_args_preprocessor)
 
 
+def separable_conv3d_args_preprocessor(args, kwargs):
+    converted = []
+    if 'init' in kwargs:
+        init = kwargs.pop('init')
+        kwargs['depthwise_initializer'] = init
+        kwargs['pointwise_initializer'] = init
+        converted.append(('init', 'depthwise_initializer/pointwise_initializer'))
+    args, kwargs, _converted = conv3d_args_preprocessor(args, kwargs)
+    return args, kwargs, converted + _converted
+
+
+legacy_separable_conv3D_support = generate_legacy_interface(
+    allowed_positional_args=['filters', 'kernel_size'],
+    conversions=[('nb_filter', 'filters'),
+                 ('subsample', 'strides'),
+                 ('border_mode', 'padding'),
+                 ('dim_ordering', 'data_format'),
+                 ('b_regularizer', 'bias_regularizer'),
+                 ('b_constraint', 'bias_constraint'),
+                 ('bias', 'use_bias')],
+    value_conversions={'dim_ordering': {'tf': 'channels_last',
+                                        'th': 'channels_first',
+                                        'default': None}},
+    preprocessor=separable_conv3d_args_preprocessor)
+
 def deconv2d_args_preprocessor(args, kwargs):
     converted = []
     if len(args) == 5:

--- a/keras/utils/training_utils.py
+++ b/keras/utils/training_utils.py
@@ -14,6 +14,7 @@ def _normalize_device_name(name):
     name = name.lower().replace('device:', '')
     return name
 
+
 def multi_gpu_model(model, gpus):
     """Replicates a model on different GPUs.
 

--- a/keras/utils/training_utils.py
+++ b/keras/utils/training_utils.py
@@ -14,7 +14,6 @@ def _normalize_device_name(name):
     name = name.lower().replace('device:', '')
     return name
 
-
 def multi_gpu_model(model, gpus):
     """Replicates a model on different GPUs.
 
@@ -126,7 +125,7 @@ def multi_gpu_model(model, gpus):
     # Place a copy of the model on each GPU,
     # each getting a slice of the inputs.
     for i in range(gpus):
-        with tf.device('/gpu:%d' % i):
+        with tf.device('/cpu:%d' % i):
             with tf.name_scope('replica_%d' % i):
                 inputs = []
                 # Retrieve a slice of the input.
@@ -140,13 +139,14 @@ def multi_gpu_model(model, gpus):
 
                 # Apply model on slice
                 # (creating a model replica on the target device).
-                outputs = model(inputs)
-                if not isinstance(outputs, list):
-                    outputs = [outputs]
+                with tf.device('/gpu:%d' % i):
+                    outputs = model(inputs)
+                    if not isinstance(outputs, list):
+                        outputs = [outputs]
 
-                # Save the outputs for merging back together later.
-                for o in range(len(outputs)):
-                    all_outputs[o].append(outputs[o])
+                    # Save the outputs for merging back together later.
+                    for o in range(len(outputs)):
+                        all_outputs[o].append(outputs[o])
 
     # Merge outputs on CPU.
     with tf.device('/cpu:0'):


### PR DESCRIPTION
It seems we are transferring the batch over to every GPU and then letting them slice out the data they'll use. I've experienced speed gains in my application by making the following modification: Have the batch slicing operation done on the host side using multiple cpus, and then each GPU can pull its own relevant slice of data.

what do you think ?