### PR TITLE
Replace float ops with faster integer ops

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -380,7 +380,7 @@ def _make_batches(size, batch_size):
     # Returns
         A list of tuples of array indices.
     """
-    num_batches = (size + batch_size - 1) // batch_size # round up
+    num_batches = (size + batch_size - 1) // batch_size  # round up
     return [(i * batch_size, min(size, (i + 1) * batch_size))
             for i in range(num_batches)]
 

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -380,7 +380,7 @@ def _make_batches(size, batch_size):
     # Returns
         A list of tuples of array indices.
     """
-    num_batches = int(np.ceil(size / float(batch_size)))
+    num_batches = (size + batch_size - 1) // batch_size # round up
     return [(i * batch_size, min(size, (i + 1) * batch_size))
             for i in range(num_batches)]
 

--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -759,7 +759,7 @@ class Iterator(Sequence):
         return self._get_batches_of_transformed_samples(index_array)
 
     def __len__(self):
-        return (self.n + self.batch_size - 1) // self.batch_size # round up
+        return (self.n + self.batch_size - 1) // self.batch_size  # round up
 
     def on_epoch_end(self):
         self._set_index_array()

--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -759,7 +759,7 @@ class Iterator(Sequence):
         return self._get_batches_of_transformed_samples(index_array)
 
     def __len__(self):
-        return int(np.ceil(self.n / float(self.batch_size)))
+        return (self.n + self.batch_size - 1) // self.batch_size # round up
 
     def on_epoch_end(self):
         self._set_index_array()


### PR DESCRIPTION
It's 63 times faster on my box:
```
$ python -m timeit -s 'import numpy as np' 'int(np.ceil(10 / float(3)))'
1000000 loops, best of 3: 1.17 usec per loop
$ python -m timeit -s 'import numpy as np' '(10 + 3 - 1) // 3'
10000000 loops, best of 3: 0.0185 usec per loop
```

Also see https://github.com/fchollet/keras/pull/8284#issuecomment-343029412
