### PR TITLE
reduce transfers between host and gpus. 

### DIFF
--- a/keras/utils/training_utils.py
+++ b/keras/utils/training_utils.py
@@ -126,7 +126,7 @@ def multi_gpu_model(model, gpus):
     # Place a copy of the model on each GPU,
     # each getting a slice of the inputs.
     for i in range(gpus):
-        with tf.device('/cpu:%d' % i):
+        with tf.device('/cpu:0'):
             with tf.name_scope('replica_%d' % i):
                 inputs = []
                 # Retrieve a slice of the input.

--- a/keras/utils/training_utils.py
+++ b/keras/utils/training_utils.py
@@ -126,7 +126,7 @@ def multi_gpu_model(model, gpus):
     # Place a copy of the model on each GPU,
     # each getting a slice of the inputs.
     for i in range(gpus):
-        with tf.device('/gpu:%d' % i):
+        with tf.device('/cpu:%d' % i):
             with tf.name_scope('replica_%d' % i):
                 inputs = []
                 # Retrieve a slice of the input.
@@ -140,13 +140,14 @@ def multi_gpu_model(model, gpus):
 
                 # Apply model on slice
                 # (creating a model replica on the target device).
-                outputs = model(inputs)
-                if not isinstance(outputs, list):
-                    outputs = [outputs]
+                with tf.device('/gpu:%d' % i):
+                    outputs = model(inputs)
+                    if not isinstance(outputs, list):
+                        outputs = [outputs]
 
-                # Save the outputs for merging back together later.
-                for o in range(len(outputs)):
-                    all_outputs[o].append(outputs[o])
+                    # Save the outputs for merging back together later.
+                    for o in range(len(outputs)):
+                        all_outputs[o].append(outputs[o])
 
     # Merge outputs on CPU.
     with tf.device('/cpu:0'):


### PR DESCRIPTION
The host is responsible for splitting the batch and each GPU gets only the data it will work on (as opposed to the entire batch).

This also probably has the benefit of saving some memory on the GPU side.