### PR TITLE
Copy name of outputs in multi_gpu_model.

### DIFF
--- a/keras/utils/training_utils.py
+++ b/keras/utils/training_utils.py
@@ -161,7 +161,7 @@ def multi_gpu_model(model, gpus):
     # Merge outputs on CPU.
     with tf.device('/cpu:0'):
         merged = []
-        for outputs in all_outputs:
+        for name, outputs in zip(model.output_names, all_outputs):
             merged.append(concatenate(outputs,
-                                      axis=0))
+                                      axis=0, name=name))
         return Model(model.inputs, merged)


### PR DESCRIPTION
This PR copies the names of the outputs to the multi_gpu_model output. This allows the use of loss dictionaries, where the name of the output is coupled with a loss function.

ps. I tried to do the same for the input, but it seems that `model.input_names` is not yet created at that time (it is created in the line with `outputs = model(inputs)`). Got any tips to fix this? My issue was with outputs, but it seems other people have the same problem with the inputs (https://github.com/fchollet/keras/issues/8339).