### PR TITLE
Allow custom steps_per_epoch for sequences, default to len(generator) if unspecified

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1900,7 +1900,7 @@ class Model(Container):
     @interfaces.legacy_generator_methods_support
     def fit_generator(self,
                       generator,
-                      steps_per_epoch,
+                      steps_per_epoch=None,
                       epochs=1,
                       verbose=1,
                       callbacks=None,
@@ -1942,6 +1942,8 @@ class Model(Container):
                 finished and starting the next epoch. It should typically
                 be equal to the number of samples of your dataset
                 divided by the batch size.
+                Optional for Sequence: if unspecified, will use
+                the `len(generator)` as a number of steps.
             epochs: Integer, total number of iterations on the data.
             verbose: Verbosity mode, 0, 1, or 2.
             callbacks: List of callbacks to be called during training.
@@ -1952,6 +1954,8 @@ class Model(Container):
             validation_steps: Only relevant if `validation_data`
                 is a generator. Total number of steps (batches of samples)
                 to yield from `generator` before stopping.
+                Optional for Sequence: if unspecified, will use
+                the `len(validation_data)` as a number of steps.
             class_weight: Dictionary mapping class indices to a weight
                 for the class.
             max_queue_size: Integer. Maximum size for the generator queue.
@@ -2066,6 +2070,14 @@ class Model(Container):
                             ' and multiple workers may duplicate your data.'
                             ' Please consider using the`keras.utils.Sequence'
                             ' class.'))
+        if steps_per_epoch is None:
+            if is_sequence:
+                steps_per_epoch = len(generator)
+            else:
+                raise ValueError('`steps_per_epoch=None` is only valid for a'
+                                 ' generator based on the `keras.utils.Sequence`'
+                                 ' class. Please specify `steps_per_epoch` or use'
+                                 ' the `keras.utils.Sequence` class.')
         enqueuer = None
 
         try:
@@ -2171,7 +2183,7 @@ class Model(Container):
         return self.history
 
     @interfaces.legacy_generator_methods_support
-    def evaluate_generator(self, generator, steps,
+    def evaluate_generator(self, generator, steps=None,
                            max_queue_size=10,
                            workers=1,
                            use_multiprocessing=False):
@@ -2188,6 +2200,8 @@ class Model(Container):
                     when using multiprocessing.
             steps: Total number of steps (batches of samples)
                 to yield from `generator` before stopping.
+                Optional for Sequence: if unspecified, will use
+                the `len(generator)` as a number of steps.
             max_queue_size: maximum size for the generator queue
             workers: maximum number of processes to spin up
                 when using process based threading
@@ -2222,6 +2236,14 @@ class Model(Container):
                             ' and multiple workers may duplicate your data.'
                             ' Please consider using the`keras.utils.Sequence'
                             ' class.'))
+        if steps is None:
+            if is_sequence:
+                steps = len(generator)
+            else:
+                raise ValueError('`steps=None` is only valid for a generator'
+                                 ' based on the `keras.utils.Sequence` class.'
+                                 ' Please specify `steps` or use the'
+                                 ' `keras.utils.Sequence` class.')
         enqueuer = None
 
         try:
@@ -2283,7 +2305,7 @@ class Model(Container):
             return averages
 
     @interfaces.legacy_generator_methods_support
-    def predict_generator(self, generator, steps,
+    def predict_generator(self, generator, steps=None,
                           max_queue_size=10,
                           workers=1,
                           use_multiprocessing=False,
@@ -2300,6 +2322,8 @@ class Model(Container):
                     when using multiprocessing.
             steps: Total number of steps (batches of samples)
                 to yield from `generator` before stopping.
+                Optional for Sequence: if unspecified, will use
+                the `len(generator)` as a number of steps.
             max_queue_size: Maximum size for the generator queue.
             workers: Maximum number of processes to spin up
                 when using process based threading
@@ -2331,6 +2355,14 @@ class Model(Container):
                             ' and multiple workers may duplicate your data.'
                             ' Please consider using the`keras.utils.Sequence'
                             ' class.'))
+        if steps is None:
+            if is_sequence:
+                steps = len(generator)
+            else:
+                raise ValueError('`steps=None` is only valid for a generator'
+                                 ' based on the `keras.utils.Sequence` class.'
+                                 ' Please specify `steps` or use the'
+                                 ' `keras.utils.Sequence` class.')
         enqueuer = None
 
         try:

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1941,7 +1941,7 @@ class Model(Container):
                 to yield from `generator` before declaring one epoch
                 finished and starting the next epoch. It should typically
                 be equal to the number of samples of your dataset
-                divided by the batch size. Not used if using `Sequence`.
+                divided by the batch size.
             epochs: Integer, total number of iterations on the data.
             verbose: Verbosity mode, 0, 1, or 2.
             callbacks: List of callbacks to be called during training.
@@ -2066,8 +2066,6 @@ class Model(Container):
                             ' and multiple workers may duplicate your data.'
                             ' Please consider using the`keras.utils.Sequence'
                             ' class.'))
-        if is_sequence:
-            steps_per_epoch = len(generator)
         enqueuer = None
 
         try:
@@ -2190,7 +2188,6 @@ class Model(Container):
                     when using multiprocessing.
             steps: Total number of steps (batches of samples)
                 to yield from `generator` before stopping.
-                Not used if using Sequence.
             max_queue_size: maximum size for the generator queue
             workers: maximum number of processes to spin up
                 when using process based threading
@@ -2225,8 +2222,6 @@ class Model(Container):
                             ' and multiple workers may duplicate your data.'
                             ' Please consider using the`keras.utils.Sequence'
                             ' class.'))
-        if is_sequence:
-            steps = len(generator)
         enqueuer = None
 
         try:
@@ -2305,7 +2300,6 @@ class Model(Container):
                     when using multiprocessing.
             steps: Total number of steps (batches of samples)
                 to yield from `generator` before stopping.
-                Not used if using Sequence.
             max_queue_size: Maximum size for the generator queue.
             workers: Maximum number of processes to spin up
                 when using process based threading
@@ -2337,8 +2331,6 @@ class Model(Container):
                             ' and multiple workers may duplicate your data.'
                             ' Please consider using the`keras.utils.Sequence'
                             ' class.'))
-        if is_sequence:
-            steps = len(generator)
         enqueuer = None
 
         try:

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1942,7 +1942,7 @@ class Model(Container):
                 finished and starting the next epoch. It should typically
                 be equal to the number of samples of your dataset
                 divided by the batch size.
-                Optional for Sequence: if unspecified, will use
+                Optional for `Sequence`: if unspecified, will use
                 the `len(generator)` as a number of steps.
             epochs: Integer, total number of iterations on the data.
             verbose: Verbosity mode, 0, 1, or 2.
@@ -1954,7 +1954,7 @@ class Model(Container):
             validation_steps: Only relevant if `validation_data`
                 is a generator. Total number of steps (batches of samples)
                 to yield from `generator` before stopping.
-                Optional for Sequence: if unspecified, will use
+                Optional for `Sequence`: if unspecified, will use
                 the `len(validation_data)` as a number of steps.
             class_weight: Dictionary mapping class indices to a weight
                 for the class.
@@ -2203,7 +2203,7 @@ class Model(Container):
                     when using multiprocessing.
             steps: Total number of steps (batches of samples)
                 to yield from `generator` before stopping.
-                Optional for Sequence: if unspecified, will use
+                Optional for `Sequence`: if unspecified, will use
                 the `len(generator)` as a number of steps.
             max_queue_size: maximum size for the generator queue
             workers: maximum number of processes to spin up
@@ -2325,7 +2325,7 @@ class Model(Container):
                     when using multiprocessing.
             steps: Total number of steps (batches of samples)
                 to yield from `generator` before stopping.
-                Optional for Sequence: if unspecified, will use
+                Optional for `Sequence`: if unspecified, will use
                 the `len(generator)` as a number of steps.
             max_queue_size: Maximum size for the generator queue.
             workers: Maximum number of processes to spin up

--- a/keras/models.py
+++ b/keras/models.py
@@ -1116,7 +1116,7 @@ class Sequential(Model):
 
     @interfaces.legacy_generator_methods_support
     def fit_generator(self, generator,
-                      steps_per_epoch,
+                      steps_per_epoch=None,
                       epochs=1,
                       verbose=1,
                       callbacks=None,
@@ -1148,6 +1148,8 @@ class Sequential(Model):
                 finished and starting the next epoch. It should typically
                 be equal to the number of samples of your dataset
                 divided by the batch size.
+                Optional for Sequence: if unspecified, will use
+                the `len(generator)` as a number of steps.
             epochs: Integer, total number of iterations on the data.
                 Note that in conjunction with initial_epoch, the parameter
                 epochs is to be understood as "final epoch". The model is
@@ -1165,6 +1167,8 @@ class Sequential(Model):
                 at the end of every epoch. It should typically
                 be equal to the number of samples of your
                 validation dataset divided by the batch size.
+                Optional for Sequence: if unspecified, will use
+                the `len(validation_data)` as a number of steps.
             class_weight: Dictionary mapping class indices to a weight
                 for the class.
             max_queue_size: Maximum size for the generator queue
@@ -1223,7 +1227,7 @@ class Sequential(Model):
                                         initial_epoch=initial_epoch)
 
     @interfaces.legacy_generator_methods_support
-    def evaluate_generator(self, generator, steps,
+    def evaluate_generator(self, generator, steps=None,
                            max_queue_size=10, workers=1,
                            use_multiprocessing=False):
         """Evaluates the model on a data generator.
@@ -1236,6 +1240,8 @@ class Sequential(Model):
                 or (inputs, targets, sample_weights)
             steps: Total number of steps (batches of samples)
                 to yield from `generator` before stopping.
+                Optional for Sequence: if unspecified, will use
+                the `len(generator)` as a number of steps.
             max_queue_size: maximum size for the generator queue
             workers: maximum number of processes to spin up
             use_multiprocessing: if True, use process based threading.
@@ -1263,7 +1269,7 @@ class Sequential(Model):
                                              use_multiprocessing=use_multiprocessing)
 
     @interfaces.legacy_generator_methods_support
-    def predict_generator(self, generator, steps,
+    def predict_generator(self, generator, steps=None,
                           max_queue_size=10, workers=1,
                           use_multiprocessing=False, verbose=0):
         """Generates predictions for the input samples from a data generator.
@@ -1275,6 +1281,8 @@ class Sequential(Model):
             generator: generator yielding batches of input samples.
             steps: Total number of steps (batches of samples)
                 to yield from `generator` before stopping.
+                Optional for Sequence: if unspecified, will use
+                the `len(generator)` as a number of steps.
             max_queue_size: maximum size for the generator queue
             workers: maximum number of processes to spin up
             use_multiprocessing: if True, use process based threading.

--- a/keras/models.py
+++ b/keras/models.py
@@ -1148,7 +1148,7 @@ class Sequential(Model):
                 finished and starting the next epoch. It should typically
                 be equal to the number of samples of your dataset
                 divided by the batch size.
-                Optional for Sequence: if unspecified, will use
+                Optional for `Sequence`: if unspecified, will use
                 the `len(generator)` as a number of steps.
             epochs: Integer, total number of iterations on the data.
                 Note that in conjunction with initial_epoch, the parameter
@@ -1167,7 +1167,7 @@ class Sequential(Model):
                 at the end of every epoch. It should typically
                 be equal to the number of samples of your
                 validation dataset divided by the batch size.
-                Optional for Sequence: if unspecified, will use
+                Optional for `Sequence`: if unspecified, will use
                 the `len(validation_data)` as a number of steps.
             class_weight: Dictionary mapping class indices to a weight
                 for the class.
@@ -1240,7 +1240,7 @@ class Sequential(Model):
                 or (inputs, targets, sample_weights)
             steps: Total number of steps (batches of samples)
                 to yield from `generator` before stopping.
-                Optional for Sequence: if unspecified, will use
+                Optional for `Sequence`: if unspecified, will use
                 the `len(generator)` as a number of steps.
             max_queue_size: maximum size for the generator queue
             workers: maximum number of processes to spin up
@@ -1281,7 +1281,7 @@ class Sequential(Model):
             generator: generator yielding batches of input samples.
             steps: Total number of steps (batches of samples)
                 to yield from `generator` before stopping.
-                Optional for Sequence: if unspecified, will use
+                Optional for `Sequence`: if unspecified, will use
                 the `len(generator)` as a number of steps.
             max_queue_size: maximum size for the generator queue
             workers: maximum number of processes to spin up

--- a/tests/keras/engine/test_training.py
+++ b/tests/keras/engine/test_training.py
@@ -233,12 +233,17 @@ def test_model_methods():
 
     # test starting from non-zero initial epoch
     trained_epochs = []
+    trained_batches = []
 
     # define tracer callback
     def on_epoch_begin(epoch, logs):
         trained_epochs.append(epoch)
 
-    tracker_cb = LambdaCallback(on_epoch_begin=on_epoch_begin)
+    def on_batch_begin(batch, logs):
+        trained_batches.append(batch)
+
+    tracker_cb = LambdaCallback(on_epoch_begin=on_epoch_begin,
+                                on_batch_begin=on_batch_begin)
 
     out = model.fit([input_a_np, input_b_np],
                     [output_a_np, output_b_np], epochs=5, batch_size=4,
@@ -380,10 +385,30 @@ def test_model_methods():
     model.compile(optimizer, loss, metrics=[], loss_weights=loss_weights,
                   sample_weight_mode=None)
     trained_epochs = []
-    out = model.fit_generator(generator=RandomSequence(3), steps_per_epoch=12, epochs=5,
+    trained_batches = []
+    out = model.fit_generator(generator=RandomSequence(3), steps_per_epoch=3, epochs=5,
                               initial_epoch=0, validation_data=RandomSequence(4),
-                              validation_steps=12, callbacks=[tracker_cb])
+                              validation_steps=3, callbacks=[tracker_cb])
     assert trained_epochs == [0, 1, 2, 3, 4]
+    assert trained_batches == range(3) * 5
+
+    # steps_per_epoch will be equal to len of sequence if it's unspecified
+    trained_epochs = []
+    trained_batches = []
+    out = model.fit_generator(generator=RandomSequence(3), epochs=5,
+                              initial_epoch=0, validation_data=RandomSequence(4),
+                              callbacks=[tracker_cb])
+    assert trained_epochs == [0, 1, 2, 3, 4]
+    assert trained_batches == range(12) * 5
+
+    # fit_generator will throw an exception if steps is unspecified for regular generator
+    with pytest.raises(ValueError):
+        def gen_data():
+            while True:
+                yield (np.asarray([]), np.asarray([]))
+        out = model.fit_generator(generator=gen_data(), epochs=5,
+                                  initial_epoch=0, validation_data=gen_data(),
+                                  callbacks=[tracker_cb])
 
 
 @pytest.mark.skipif(sys.version_info < (3,), reason='Cannot catch warnings in python 2')

--- a/tests/keras/engine/test_training.py
+++ b/tests/keras/engine/test_training.py
@@ -390,7 +390,7 @@ def test_model_methods():
                               initial_epoch=0, validation_data=RandomSequence(4),
                               validation_steps=3, callbacks=[tracker_cb])
     assert trained_epochs == [0, 1, 2, 3, 4]
-    assert trained_batches == range(3) * 5
+    assert trained_batches == list(range(3)) * 5
 
     # steps_per_epoch will be equal to len of sequence if it's unspecified
     trained_epochs = []
@@ -399,7 +399,7 @@ def test_model_methods():
                               initial_epoch=0, validation_data=RandomSequence(4),
                               callbacks=[tracker_cb])
     assert trained_epochs == [0, 1, 2, 3, 4]
-    assert trained_batches == range(12) * 5
+    assert trained_batches == list(range(12)) * 5
 
     # fit_generator will throw an exception if steps is unspecified for regular generator
     with pytest.raises(ValueError):


### PR DESCRIPTION
`steps_per_epoch` forced to `len(generator)` causes problems to the logic of having less number of steps for special occasions, like [distributed training](https://github.com/uber/horovod/blob/master/examples/keras_mnist_advanced.py#L116), artificially smaller epochs (e.g. use 10% of data per "epoch" to get epoch-end callbacks called more frequently) or some other scenarios.

The `steps_per_epoch = len(generator)` rule was introduced by https://github.com/fchollet/keras/pull/8052, I propose that we roll it back.