### PR TITLE
add custom gpu id support for multi_gpu_model

### DIFF
--- a/keras/utils/training_utils.py
+++ b/keras/utils/training_utils.py
@@ -95,24 +95,24 @@ def multi_gpu_model(model, gpus):
     if K.backend() != 'tensorflow':
         raise ValueError('`multi_gpu_model` is only available '
                          'with the TensorFlow backend.')
-    if isinstance(gpus, int):
+    if isinstance(gpus, (list, tuple)):
+        if len(gpus) <= 1:
+            raise ValueError('For multi-gpu usage to be effective, '
+                             'call `multi_gpu_model` with `len(gpus) >= 2`. '
+                             'Received: `gpus=%s`' % gpus)
+        num_gpus = len(gpus)
+        target_gpu_ids = gpus
+    else:
         if gpus <= 1:
             raise ValueError('For multi-gpu usage to be effective, '
                              'call `multi_gpu_model` with `gpus >= 2`. '
                              'Received: `gpus=%d`' % gpus)
-        n_gpu = gpus
-        target_gpu_id = list(range(n_gpu))
-    elif isinstance(gpus, list):
-        if len(gpus) <= 1:
-            raise ValueError('For multi-gpu usage to be effective, '
-                             'call `multi_gpu_model` with `len(gpus) >= 2`. '
-                             'Received: `gpus=%d`' % gpus)
-        n_gpu = len(gpus)
-        target_gpu_id = gpus
+        num_gpus = gpus
+        target_gpu_ids = range(num_gpus)
 
     import tensorflow as tf
 
-    target_devices = ['/cpu:0'] + ['/gpu:%d' % i for i in target_gpu_id]
+    target_devices = ['/cpu:0'] + ['/gpu:%d' % i for i in target_gpu_ids]
     available_devices = _get_available_devices()
     available_devices = [_normalize_device_name(name) for name in available_devices]
     for device in target_devices:
@@ -130,7 +130,7 @@ def multi_gpu_model(model, gpus):
         batch_size = shape[:1]
         input_shape = shape[1:]
         step = batch_size // parts
-        if i == n_gpu - 1:
+        if i == num_gpus - 1:
             size = batch_size - step * i
         else:
             size = step
@@ -145,9 +145,9 @@ def multi_gpu_model(model, gpus):
 
     # Place a copy of the model on each GPU,
     # each getting a slice of the inputs.
-    for i, id in enumerate(target_gpu_id):
-        with tf.device('/gpu:%d' % id):
-            with tf.name_scope('replica_%d' % id):
+    for i, gpu_id in enumerate(target_gpu_ids):
+        with tf.device('/gpu:%d' % gpu_id):
+            with tf.name_scope('replica_%d' % gpu_id):
                 inputs = []
                 # Retrieve a slice of the input.
                 for x in model.inputs:
@@ -155,7 +155,7 @@ def multi_gpu_model(model, gpus):
                     slice_i = Lambda(get_slice,
                                      output_shape=input_shape,
                                      arguments={'i': i,
-                                                'parts': n_gpu})(x)
+                                                'parts': num_gpus})(x)
                     inputs.append(slice_i)
 
                 # Apply model on slice

--- a/tests/keras/utils/multi_gpu_test.py
+++ b/tests/keras/utils/multi_gpu_test.py
@@ -20,6 +20,7 @@ def multi_gpu_test_simple_model():
     output_dim = 1
     hidden_dim = 10
     gpus = 8
+    target_gpu_id = [0, 2, 4]
     epochs = 2
     model = keras.models.Sequential()
     model.add(keras.layers.Dense(hidden_dim,
@@ -28,8 +29,12 @@ def multi_gpu_test_simple_model():
 
     x = np.random.random((num_samples, input_dim))
     y = np.random.random((num_samples, output_dim))
-    parallel_model = multi_gpu_model(model, gpus=gpus)
 
+    parallel_model = multi_gpu_model(model, gpus=gpus)
+    parallel_model.compile(loss='mse', optimizer='rmsprop')
+    parallel_model.fit(x, y, epochs=epochs)
+
+    parallel_model = multi_gpu_model(model, gpus=target_gpu_id)
     parallel_model.compile(loss='mse', optimizer='rmsprop')
     parallel_model.fit(x, y, epochs=epochs)
 
@@ -43,6 +48,7 @@ def multi_gpu_test_multi_io_model():
     output_dim_b = 2
     hidden_dim = 10
     gpus = 8
+    target_gpu_id = [0, 2, 4]
     epochs = 2
 
     input_a = keras.Input((input_dim_a,))
@@ -63,6 +69,10 @@ def multi_gpu_test_multi_io_model():
     parallel_model.compile(loss='mse', optimizer='rmsprop')
     parallel_model.fit([a_x, b_x], [a_y, b_y], epochs=epochs)
 
+    parallel_model = multi_gpu_model(model, gpus=target_gpu_id)
+    parallel_model.compile(loss='mse', optimizer='rmsprop')
+    parallel_model.fit([a_x, b_x], [a_y, b_y], epochs=epochs)
+
 
 def multi_gpu_test_invalid_devices():
     input_shape = (1000, 10)
@@ -77,6 +87,10 @@ def multi_gpu_test_invalid_devices():
     y = np.random.random((input_shape[0], 1))
     with pytest.raises(ValueError):
         parallel_model = multi_gpu_model(model, gpus=10)
+        parallel_model.fit(x, y, epochs=2)
+
+    with pytest.raises(ValueError):
+        parallel_model = multi_gpu_model(model, gpus=[0, 2, 4, 6, 8])
         parallel_model.fit(x, y, epochs=2)
 
 

--- a/tests/keras/utils/multi_gpu_test.py
+++ b/tests/keras/utils/multi_gpu_test.py
@@ -93,6 +93,14 @@ def multi_gpu_test_invalid_devices():
         parallel_model = multi_gpu_model(model, gpus=[0, 2, 4, 6, 8])
         parallel_model.fit(x, y, epochs=2)
 
+    with pytest.raises(ValueError):
+        parallel_model = multi_gpu_model(model, gpus=1)
+        parallel_model.fit(x, y, epochs=2)
+
+    with pytest.raises(ValueError):
+        parallel_model = multi_gpu_model(model, gpus=[0])
+        parallel_model.fit(x, y, epochs=2)
+
 
 def multi_gpu_application_np_array_benchmark():
     print('####### Xception benchmark - np i/o')


### PR DESCRIPTION
This PR will try to add custom GPU ID support for `keras.utils.training_utils.multi_gpu_model`.

For example, such model will be trained at `/device:GPU:1` and `/device:GPU:3`.
```python
parallel_model = multi_gpu_model(model, gpus=[1, 3])
```