### PR TITLE
Allow custom losses to have mismatching target shapes.

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1399,6 +1399,8 @@ class Model(Container):
         for output_shape, loss_fn in zip(self._feed_output_shapes, self._feed_loss_fns):
             if loss_fn is losses.sparse_categorical_crossentropy:
                 output_shapes.append(output_shape[:-1] + (1,))
+            elif getattr(losses, loss_fn.__name__, None) is None:
+                output_shapes.append(None)
             else:
                 output_shapes.append(output_shape)
         x = _standardize_input_data(x, self._feed_input_names,


### PR DESCRIPTION
In response to [these](https://github.com/fchollet/keras/pull/8056#pullrequestreview-76745344) comments, this PR partly reverts the changes made in https://github.com/fchollet/keras/pull/8056 . That PR had the unintended side effect of forcing target blobs to have the same shape as output blobs for custom loss functions, which is currently frequently used as a workaround ([discussion](https://github.com/fchollet/keras/issues/7395)).