### PR TITLE
Refactor preprocess_input so I can use it in the functional API

### DIFF
--- a/keras/applications/imagenet_utils.py
+++ b/keras/applications/imagenet_utils.py
@@ -8,6 +8,11 @@ from .. import backend as K
 CLASS_INDEX = None
 CLASS_INDEX_PATH = 'https://s3.amazonaws.com/deep-learning-models/image-models/imagenet_class_index.json'
 
+_IMAGENET_MEAN_CF = None
+_IMAGENET_MEAN_CF_4D = None
+_IMAGENET_MEAN_CL = None
+
+
 
 def preprocess_input(x, data_format=None, mode='caffe'):
     """Preprocesses a tensor encoding a batch of images.
@@ -26,6 +31,10 @@ def preprocess_input(x, data_format=None, mode='caffe'):
     # Returns
         Preprocessed tensor.
     """
+    global _IMAGENET_MEAN_CF
+    global _IMAGENET_MEAN_CF_4D
+    global _IMAGENET_MEAN_CL
+
     if data_format is None:
         data_format = K.image_data_format()
     assert data_format in {'channels_last', 'channels_first'}
@@ -42,15 +51,21 @@ def preprocess_input(x, data_format=None, mode='caffe'):
             # 'RGB'->'BGR'
             x = x[::-1, ...]
             # Zero-center by mean pixel
-            x = x - np.array(vgg_mean, dtype=np.float32).reshape((3, 1, 1))
+            if _IMAGENET_MEAN_CF is None:
+                _IMAGENET_MEAN_CF = np.array(vgg_mean, dtype=np.float32).reshape((3, 1, 1))
+            x = x - _IMAGENET_MEAN_CF
         else:
             x = x[:, ::-1, ...]
-            x = x - np.array(vgg_mean, dtype=np.float32).reshape((1, 3, 1, 1))
+            if _IMAGENET_MEAN_CF_4D is None:
+                _IMAGENET_MEAN_CF_4D = np.array(vgg_mean, dtype=np.float32).reshape((1, 3, 1, 1))
+            x = x - _IMAGENET_MEAN_CF_4D
     else:
         # 'RGB'->'BGR'
         x = x[..., ::-1]
         # Zero-center by mean pixel
-        x = x - np.array(vgg_mean, dtype=np.float32).reshape((1, 1, 3))
+        if _IMAGENET_MEAN_CL is None:
+            _IMAGENET_MEAN_CL = np.array(vgg_mean, dtype=np.float32).reshape((1, 1, 3))
+        x = x - _IMAGENET_MEAN_CL
     return x
 
 

--- a/keras/applications/imagenet_utils.py
+++ b/keras/applications/imagenet_utils.py
@@ -81,8 +81,7 @@ def _preprocess_symbolic_input(x, data_format, mode):
         # Zero-center by mean pixel
         if _IMAGENET_MEAN_CHW is None:
             _IMAGENET_MEAN_CHW = K.constant(
-                -np.array(imagenet_mean).reshape((3, 1, 1))
-                )
+                -np.array(imagenet_mean).reshape((3, 1, 1)))
         x = _bias_add_match_type(x, _IMAGENET_MEAN_CHW)
     else:
         # 'RGB'->'BGR'
@@ -90,8 +89,7 @@ def _preprocess_symbolic_input(x, data_format, mode):
         # Zero-center by mean pixel
         if _IMAGENET_MEAN_HWC is None:
             _IMAGENET_MEAN_HWC = K.constant(
-               -np.array(imagenet_mean).reshape((1, 1, 3))
-               )
+                -np.array(imagenet_mean).reshape((1, 1, 3)))
         x = _bias_add_match_type(x, _IMAGENET_MEAN_HWC)
     return x
 

--- a/keras/applications/imagenet_utils.py
+++ b/keras/applications/imagenet_utils.py
@@ -13,11 +13,6 @@ _IMAGENET_MEAN = None
 
 
 def _preprocess_numpy_input(x, data_format, mode):
-    if data_format is None:
-        data_format = K.image_data_format()
-    if data_format not in {'channels_first', 'channels_last'}:
-        raise ValueError('Unknown data_format ' + str(data_format))
-
     if mode == 'tf':
         x /= 255.
         x -= 0.5
@@ -49,10 +44,6 @@ def _preprocess_numpy_input(x, data_format, mode):
 
 def _preprocess_symbolic_input(x, data_format, mode):
     global _IMAGENET_MEAN
-
-    if data_format is None:
-        data_format = K.image_data_format()
-    assert data_format in {'channels_last', 'channels_first'}
 
     if mode == 'tf':
         x /= 255.
@@ -97,6 +88,11 @@ def preprocess_input(x, data_format=None, mode='caffe'):
     # Returns
         Preprocessed tensor.
     """
+    if data_format is None:
+        data_format = K.image_data_format()
+    if data_format not in {'channels_first', 'channels_last'}:
+        raise ValueError('Unknown data_format ' + str(data_format))
+
     if isinstance(x, np.ndarray):
         return _preprocess_numpy_input(x, data_format=data_format, mode=mode)
     else:

--- a/keras/applications/imagenet_utils.py
+++ b/keras/applications/imagenet_utils.py
@@ -45,27 +45,27 @@ def preprocess_input(x, data_format=None, mode='caffe'):
         x *= 2.
         return x
 
-    vgg_mean = [103.939, 116.779, 123.68]
+    imagenet_mean = [103.939, 116.779, 123.68]
     if data_format == 'channels_first':
         if x.ndim == 3:
             # 'RGB'->'BGR'
             x = x[::-1, ...]
             # Zero-center by mean pixel
             if _IMAGENET_MEAN_CF is None:
-                _IMAGENET_MEAN_CF = np.array(vgg_mean, dtype=np.float32).reshape((3, 1, 1))
-            x = x - _IMAGENET_MEAN_CF
+                _IMAGENET_MEAN_CF = np.array(imagenet_mean, dtype=K.floatx()).reshape((3, 1, 1))
+            x -= _IMAGENET_MEAN_CF
         else:
             x = x[:, ::-1, ...]
             if _IMAGENET_MEAN_CF_4D is None:
-                _IMAGENET_MEAN_CF_4D = np.array(vgg_mean, dtype=np.float32).reshape((1, 3, 1, 1))
-            x = x - _IMAGENET_MEAN_CF_4D
+                _IMAGENET_MEAN_CF_4D = np.array(imagenet_mean, dtype=K.floatx()).reshape((1, 3, 1, 1))
+            x -= _IMAGENET_MEAN_CF_4D
     else:
         # 'RGB'->'BGR'
         x = x[..., ::-1]
         # Zero-center by mean pixel
         if _IMAGENET_MEAN_CL is None:
-            _IMAGENET_MEAN_CL = np.array(vgg_mean, dtype=np.float32).reshape((1, 1, 3))
-        x = x - _IMAGENET_MEAN_CL
+            _IMAGENET_MEAN_CL = np.array(imagenet_mean, dtype=K.floatx()).reshape((1, 1, 3))
+        x -= _IMAGENET_MEAN_CL
     return x
 
 

--- a/keras/applications/imagenet_utils.py
+++ b/keras/applications/imagenet_utils.py
@@ -1,5 +1,6 @@
 import json
 import warnings
+import numpy as np
 
 from ..utils.data_utils import get_file
 from .. import backend as K
@@ -35,26 +36,21 @@ def preprocess_input(x, data_format=None, mode='caffe'):
         x *= 2.
         return x
 
+    vgg_mean = [103.939, 116.779, 123.68]
     if data_format == 'channels_first':
         if x.ndim == 3:
             # 'RGB'->'BGR'
             x = x[::-1, ...]
             # Zero-center by mean pixel
-            x[0, :, :] -= 103.939
-            x[1, :, :] -= 116.779
-            x[2, :, :] -= 123.68
+            x = x - np.array(vgg_mean, dtype=np.float32).reshape((3, 1, 1))
         else:
             x = x[:, ::-1, ...]
-            x[:, 0, :, :] -= 103.939
-            x[:, 1, :, :] -= 116.779
-            x[:, 2, :, :] -= 123.68
+            x = x - np.array(vgg_mean, dtype=np.float32).reshape((1, 3, 1, 1))
     else:
         # 'RGB'->'BGR'
         x = x[..., ::-1]
         # Zero-center by mean pixel
-        x[..., 0] -= 103.939
-        x[..., 1] -= 116.779
-        x[..., 2] -= 123.68
+        x = x - np.array(vgg_mean, dtype=np.float32).reshape((1, 1, 3))
     return x
 
 

--- a/tests/keras/applications/imagenet_utils_test.py
+++ b/tests/keras/applications/imagenet_utils_test.py
@@ -3,6 +3,8 @@ import numpy as np
 from numpy.testing import assert_allclose
 
 from keras.applications import imagenet_utils as utils
+from keras.models import Model
+from keras.layers import Input, Lambda
 
 
 def test_preprocess_input():
@@ -22,6 +24,46 @@ def test_preprocess_input():
     out1 = utils.preprocess_input(x, 'channels_last')
     out2 = utils.preprocess_input(np.transpose(x, (2, 0, 1)),
                                   'channels_first')
+    assert_allclose(out1, out2.transpose(1, 2, 0))
+
+
+def test_preprocess_input_symbolic():
+    # Test image batch
+    x = np.random.uniform(0, 255, (2, 10, 10, 3))
+    inputs = Input(shape=x.shape[1:])
+    outputs = Lambda(utils.preprocess_input, output_shape=x.shape[1:])(inputs)
+    model = Model(inputs, outputs)
+    assert model.predict(x).shape == x.shape
+
+    outputs1 = Lambda(lambda x: utils.preprocess_input(x, 'channels_last'),
+                      output_shape=x.shape[1:])(inputs)
+    model1 = Model(inputs, outputs1)
+    out1 = model1.predict(x)
+    x2 = np.transpose(x, (0, 3, 1, 2))
+    inputs2 = Input(shape=x2.shape[1:])
+    outputs2 = Lambda(lambda x: utils.preprocess_input(x, 'channels_first'),
+                      output_shape=x2.shape[1:])(inputs2)
+    model2 = Model(inputs2, outputs2)
+    out2 = model2.predict(x2)
+    assert_allclose(out1, out2.transpose(0, 2, 3, 1))
+
+    # Test single image
+    x = np.random.uniform(0, 255, (10, 10, 3))
+    inputs = Input(shape=x.shape)
+    outputs = Lambda(utils.preprocess_input, output_shape=x.shape)(inputs)
+    model = Model(inputs, outputs)
+    assert model.predict(x[np.newaxis])[0].shape == x.shape
+
+    outputs1 = Lambda(lambda x: utils.preprocess_input(x, 'channels_last'),
+                      output_shape=x.shape)(inputs)
+    model1 = Model(inputs, outputs1)
+    out1 = model1.predict(x[np.newaxis])[0]
+    x2 = np.transpose(x, (2, 0, 1))
+    inputs2 = Input(shape=x2.shape)
+    outputs2 = Lambda(lambda x: utils.preprocess_input(x, 'channels_first'),
+                      output_shape=x2.shape)(inputs2)
+    model2 = Model(inputs2, outputs2)
+    out2 = model2.predict(x2[np.newaxis])[0]
     assert_allclose(out1, out2.transpose(1, 2, 0))
 
 


### PR DESCRIPTION
I tried to use preprocess_input in imagenet_utils.py in the Lambda layer of the functional API.
This works fine:
```py
from keras.layers import Input, Lambda
from keras.applications import vgg16, xception

inputs = Input(shape=(299, 299, 3))
x = Lambda(xception.preprocess_input)(inputs)
```

But this does not:
```py
inputs = Input(shape=(224, 224, 3))
x = Lambda(vgg16.preprocess_input)(inputs)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-27-daaad9201e0b> in <module>()
      1 inputs = Input(shape=(224, 224, 3))
----> 2 x = Lambda(vgg16.preprocess_input)(inputs)

/opt/conda/lib/python3.6/site-packages/keras/engine/topology.py in __call__(self, inputs, **kwargs)
    601 
    602             # Actually call the layer, collecting output(s), mask(s), and shape(s).
--> 603             output = self.call(inputs, **kwargs)
    604             output_mask = self.compute_mask(inputs, previous_mask)
    605 

/opt/conda/lib/python3.6/site-packages/keras/layers/core.py in call(self, inputs, mask)
    649         if has_arg(self.function, 'mask'):
    650             arguments['mask'] = mask
--> 651         return self.function(inputs, **arguments)
    652 
    653     def compute_mask(self, inputs, mask=None):

/opt/conda/lib/python3.6/site-packages/keras/applications/imagenet_utils.py in preprocess_input(x, data_format, mode)
     53         x = x[..., ::-1]
     54         # Zero-center by mean pixel
---> 55         x[..., 0] -= 103.939
     56         x[..., 1] -= 116.779
     57         x[..., 2] -= 123.68

TypeError: 'Tensor' object does not support item assignment
```
This PR attempts to fix the issue by vectoring the part of "Zero-center by mean pixel". 

