### PR TITLE
Fix scikit-learn API docs

### DIFF
--- a/docs/templates/scikit-learn-api.md
+++ b/docs/templates/scikit-learn-api.md
@@ -15,17 +15,17 @@ There are two wrappers available:
 
 `build_fn` should construct, compile and return a Keras model, which
 will then be used to fit/predict. One of the following
-three values could be passed to build_fn:
+three values could be passed to `build_fn`:
 
 1. A function
-2. An instance of a class that implements the __call__ method
+2. An instance of a class that implements the `__call__` method
 3. None. This means you implement a class that inherits from either
-`KerasClassifier` or `KerasRegressor`. The __call__ method of the
-present class will then be treated as the default build_fn.
+`KerasClassifier` or `KerasRegressor`. The `__call__` method of the
+present class will then be treated as the default `build_fn`.
 
 `sk_params` takes both model parameters and fitting parameters. Legal model
 parameters are the arguments of `build_fn`. Note that like all other
-estimators in scikit-learn, 'build_fn' should provide default values for
+estimators in scikit-learn, `build_fn` should provide default values for
 its arguments, so that you could create the estimator without passing any
 values to `sk_params`.
 

--- a/keras/wrappers/scikit_learn.py
+++ b/keras/wrappers/scikit_learn.py
@@ -20,18 +20,18 @@ class BaseWrapper(object):
         build_fn: callable function or class instance
         **sk_params: model parameters & fitting parameters
 
-    The build_fn should construct, compile and return a Keras model, which
+    The `build_fn` should construct, compile and return a Keras model, which
     will then be used to fit/predict. One of the following
-    three values could be passed to build_fn:
+    three values could be passed to `build_fn`:
     1. A function
-    2. An instance of a class that implements the __call__ method
+    2. An instance of a class that implements the `__call__` method
     3. None. This means you implement a class that inherits from either
-    `KerasClassifier` or `KerasRegressor`. The __call__ method of the
-    present class will then be treated as the default build_fn.
+    `KerasClassifier` or `KerasRegressor`. The `__call__` method of the
+    present class will then be treated as the default `build_fn`.
 
     `sk_params` takes both model parameters and fitting parameters. Legal model
     parameters are the arguments of `build_fn`. Note that like all other
-    estimators in scikit-learn, 'build_fn' should provide default values for
+    estimators in scikit-learn, `build_fn` should provide default values for
     its arguments, so that you could create the estimator without passing any
     values to `sk_params`.
 


### PR DESCRIPTION
Currently ``__call__ `` is not wrapped with backquotes, so on the webpage it's rendered in boldface (__call__).  A class that inherits `KerasClassifier` should implement `__call__()` instead of `call()`.

Also wraps all `build_fn` with backquotes.