### PR TITLE
 Provide option to run generators on main thread

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1969,7 +1969,8 @@ class Model(Container):
                 If unspecified, `max_queue_size` will default to 10.
             workers: Integer. Maximum number of processes to spin up
                 when using process based threading.
-                If unspecified, `workers` will default to 1.
+                If unspecified, `workers` will default to 1. If 0, will
+                execute the generator on the main thread.
             use_multiprocessing: Boolean. If True, use process based threading.
                 If unspecified, `workers` will default to False.
                 Note that because
@@ -2091,16 +2092,19 @@ class Model(Container):
         enqueuer = None
 
         try:
-            if is_sequence:
-                enqueuer = OrderedEnqueuer(generator,
-                                           use_multiprocessing=use_multiprocessing,
-                                           shuffle=shuffle)
+            if workers > 0:
+                if is_sequence:
+                    enqueuer = OrderedEnqueuer(generator,
+                                               use_multiprocessing=use_multiprocessing,
+                                               shuffle=shuffle)
+                else:
+                    enqueuer = GeneratorEnqueuer(generator,
+                                                 use_multiprocessing=use_multiprocessing,
+                                                 wait_time=wait_time)
+                enqueuer.start(workers=workers, max_queue_size=max_queue_size)
+                output_generator = enqueuer.get()
             else:
-                enqueuer = GeneratorEnqueuer(generator,
-                                             use_multiprocessing=use_multiprocessing,
-                                             wait_time=wait_time)
-            enqueuer.start(workers=workers, max_queue_size=max_queue_size)
-            output_generator = enqueuer.get()
+                output_generator = generator
 
             callback_model.stop_training = False
             while epoch < epochs:
@@ -2213,8 +2217,10 @@ class Model(Container):
                 Optional for `Sequence`: if unspecified, will use
                 the `len(generator)` as a number of steps.
             max_queue_size: maximum size for the generator queue
-            workers: maximum number of processes to spin up
-                when using process based threading
+            workers: Integer. Maximum number of processes to spin up
+                when using process based threading.
+                If unspecified, `workers` will default to 1. If 0, will
+                execute the generator on the main thread.
             use_multiprocessing: if True, use process based threading.
                 Note that because
                 this implementation relies on multiprocessing,
@@ -2257,15 +2263,18 @@ class Model(Container):
         enqueuer = None
 
         try:
-            if is_sequence:
-                enqueuer = OrderedEnqueuer(generator,
-                                           use_multiprocessing=use_multiprocessing)
+            if workers > 0:
+                if is_sequence:
+                    enqueuer = OrderedEnqueuer(generator,
+                                               use_multiprocessing=use_multiprocessing)
+                else:
+                    enqueuer = GeneratorEnqueuer(generator,
+                                                 use_multiprocessing=use_multiprocessing,
+                                                 wait_time=wait_time)
+                enqueuer.start(workers=workers, max_queue_size=max_queue_size)
+                output_generator = enqueuer.get()
             else:
-                enqueuer = GeneratorEnqueuer(generator,
-                                             use_multiprocessing=use_multiprocessing,
-                                             wait_time=wait_time)
-            enqueuer.start(workers=workers, max_queue_size=max_queue_size)
-            output_generator = enqueuer.get()
+                output_generator = generator
 
             while steps_done < steps:
                 generator_output = next(output_generator)
@@ -2335,8 +2344,10 @@ class Model(Container):
                 Optional for `Sequence`: if unspecified, will use
                 the `len(generator)` as a number of steps.
             max_queue_size: Maximum size for the generator queue.
-            workers: Maximum number of processes to spin up
-                when using process based threading
+            workers: Integer. Maximum number of processes to spin up
+                when using process based threading.
+                If unspecified, `workers` will default to 1. If 0, will
+                execute the generator on the main thread.
             use_multiprocessing: If `True`, use process based threading.
                 Note that because
                 this implementation relies on multiprocessing,
@@ -2376,15 +2387,18 @@ class Model(Container):
         enqueuer = None
 
         try:
-            if is_sequence:
-                enqueuer = OrderedEnqueuer(generator,
-                                           use_multiprocessing=use_multiprocessing)
+            if workers > 0:
+                if is_sequence:
+                    enqueuer = OrderedEnqueuer(generator,
+                                               use_multiprocessing=use_multiprocessing)
+                else:
+                    enqueuer = GeneratorEnqueuer(generator,
+                                                 use_multiprocessing=use_multiprocessing,
+                                                 wait_time=wait_time)
+                enqueuer.start(workers=workers, max_queue_size=max_queue_size)
+                output_generator = enqueuer.get()
             else:
-                enqueuer = GeneratorEnqueuer(generator,
-                                             use_multiprocessing=use_multiprocessing,
-                                             wait_time=wait_time)
-            enqueuer.start(workers=workers, max_queue_size=max_queue_size)
-            output_generator = enqueuer.get()
+                output_generator = generator
 
             if verbose == 1:
                 progbar = Progbar(target=steps)

--- a/tests/test_multiprocessing.py
+++ b/tests/test_multiprocessing.py
@@ -72,6 +72,12 @@ def test_multiprocessing_training():
                         validation_data=custom_generator(True),
                         validation_steps=1)
 
+    model.fit_generator(custom_generator(True),
+                        steps_per_epoch=5,
+                        validation_data=custom_generator(True),
+                        validation_steps=1,
+                        workers=0)
+
     # Test invalid use cases
     def invalid_generator():
         while True:
@@ -173,6 +179,10 @@ def test_multiprocessing_predicting():
                             steps=5,
                             max_queue_size=10,
                             use_multiprocessing=False)
+    model.predict_generator(custom_generator(),
+                            steps=5,
+                            max_queue_size=10,
+                            workers=0)
 
 
 @keras_test
@@ -206,6 +216,11 @@ def test_multiprocessing_evaluating():
                              steps=5,
                              max_queue_size=10,
                              use_multiprocessing=False)
+    model.evaluate_generator(custom_generator(),
+                             steps=5,
+                             max_queue_size=10,
+                             use_multiprocessing=False,
+                             workers=0)
 
 
 @keras_test


### PR DESCRIPTION
This PR enables callers of `fit_generator()`, `evaluate_generator()`, etc. to specify that they'd like the generator to be called on the main thread by passing `workers = 0`. 

The motivation is to enable use of code within generators that either requires or benefits from being on the main thread. Two concrete examples are:

1) Creating a generator that draws batches from a TF Dataset. There is an existing example of using Keras with TF datasets here (https://github.com/fchollet/keras/blob/master/examples/mnist_dataset_api.py) but it requires wiring the batch tensors directly into the graph and then saving/restoring weights for evaluation. Ideally we could write a generator like this for a dataset:

    ```python
    def dataset_generator(dataset):
      iter = dataset.make_one_shot_iterator()
      batch = iter.get_next()
      while True:
        yield K.batch_get_value(batch)
    ```

    Then use it like this:

    ```python
    history = model.fit_generator(
      dataset_generator(train_dataset),
      steps_per_epoch=steps_per_epoch,
      epochs=epochs,
      validation_data=dataset_generator(validation_dataset)
    )
    ```

    Here is a complete example (a re-write of the [mnist_mlp.py](https://github.com/fchollet/keras/blob/master/examples/mnist_mlp.py) example to use TF datasets):

    https://gist.github.com/jjallaire/e2efacb54cfc91d554aec2db764632ed

    Note that if you try to run this example without the `workers = 0` option there are errors related to distinct sessions / graphs being created for the foreground and background threads. Even working around with by explicitly specifying a single session for all threads results in other errors that I wasn't able to diagnose the cause of. 

2) Creating a generator from an R function. Within the R interface to Keras you can implement a generator with an R function. However, R code must all run on the main thread. We currently work around this problem by marshaling calls to R generator functions back onto the main thread. This works fine but has an overhead of 3ms per call as well as some issues with canceling/interrupting the generator which it would be nice to get rid of.

I'd imagine that having this option may be useful in other instances, as libraries that are sensitive to their threading context are not uncommon.

