### PR TITLE
Fix loading LSTM weights without bias

### DIFF
--- a/keras/engine/topology.py
+++ b/keras/engine/topology.py
@@ -3029,9 +3029,10 @@ def preprocess_weights_for_loading(layer, weights,
                 weights[1] = np.transpose(weights[1], (3, 2, 0, 1))
 
     # convert the weights of CuDNNLSTM so that they could be loaded into LSTM
-    if layer.__class__.__name__ == 'LSTM':
+    if layer.__class__.__name__ == 'LSTM' and len(weights) == 3:
         # determine if we're loading a CuDNNLSTM layer from the number of bias weights:
         # CuDNNLSTM has (units * 8) weights; while LSTM has (units * 4)
+        # if there's no bias weight in the file, skip this conversion
         units = weights[1].shape[0]
         bias = weights[2]
         if len(bias) == units * 8:

--- a/tests/test_model_saving.py
+++ b/tests/test_model_saving.py
@@ -370,5 +370,22 @@ def test_saving_recurrent_layer_with_init_state():
     loaded_model = load_model(fname)
     os.remove(fname)
 
+
+@keras_test
+def test_saving_recurrent_layer_without_bias():
+    vector_size = 8
+    input_length = 20
+
+    input_x = Input(shape=(input_length, vector_size))
+    lstm = LSTM(vector_size, use_bias=False)(input_x)
+    model = Model(inputs=[input_x], outputs=[lstm])
+
+    _, fname = tempfile.mkstemp('.h5')
+    model.save(fname)
+
+    loaded_model = load_model(fname)
+    os.remove(fname)
+
+
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
Resolves #8541 by checking `len(weights)` before trying to do the conversion from `CuDNNLSTM` to `LSTM`.

Also added a test in test_model_saving.py for this case.