### PR TITLE
fix list_devices() function is not available issue

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -5,6 +5,7 @@ from tensorflow.python.ops import control_flow_ops
 from tensorflow.python.ops import functional_ops
 from tensorflow.python.ops import ctc_ops as ctc
 from tensorflow.python.ops import variables as tf_variables
+from tensorflow.python.client import device_lib
 
 from collections import defaultdict
 
@@ -186,6 +187,10 @@ def get_session():
                     v._keras_initialized = True
                 if uninitialized_vars:
                     session.run(tf.variables_initializer(uninitialized_vars))
+    # hotfix for list_devices() function. 
+    # list_devices() function is not available under tensorflow r1.3
+    if hasattr(session, 'list_devices') is False:
+        session.list_devices = lambda: device_lib.list_local_devices()
     return session
 
 

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -189,7 +189,7 @@ def get_session():
                     session.run(tf.variables_initializer(uninitialized_vars))
     # hack for list_devices() function.
     # list_devices() function is not available under tensorflow r1.3.
-    if hasattr(session, 'list_devices') is False:
+    if not hasattr(session, 'list_devices'):
         session.list_devices = lambda: device_lib.list_local_devices()
     return session
 

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -187,8 +187,8 @@ def get_session():
                     v._keras_initialized = True
                 if uninitialized_vars:
                     session.run(tf.variables_initializer(uninitialized_vars))
-    # hotfix for list_devices() function. 
-    # list_devices() function is not available under tensorflow r1.3
+    # hack for list_devices() function.
+    # list_devices() function is not available under tensorflow r1.3.
     if hasattr(session, 'list_devices') is False:
         session.list_devices = lambda: device_lib.list_local_devices()
     return session


### PR DESCRIPTION
When using tensorflow as backend and the version of tensorflow is under r1.3, the list_devices() function is not available of Session instance. This may cause some issue like keras.utils.multi_gpu_model(model, gpus) function can not work under r1.3 of tensorflow. This change is a hack to fix that issue.