### PR TITLE
Return model output during training

### DIFF
--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -974,7 +974,7 @@ class Model(Container):
                 ' weights, did you set `model.trainable` without calling'
                 ' `model.compile` after ?'))
 
-    def _make_train_function(self):
+    def _make_train_function(self, return_output=False):
         if not hasattr(self, 'train_function'):
             raise RuntimeError('You must compile your model before using it.')
         self._check_trainable_weights_consistency()
@@ -989,9 +989,13 @@ class Model(Container):
                         params=self._collected_trainable_weights,
                         loss=self.total_loss)
                 updates = self.updates + training_updates
+                if return_output:
+                    outputs = [self.total_loss] + self.metrics_tensors + self.outputs
+                else:
+                    outputs = [self.total_loss] + self.metrics_tensors
                 # Gets loss and metrics. Updates weights at each call.
                 self.train_function = K.function(inputs,
-                                                 [self.total_loss] + self.metrics_tensors,
+                                                 outputs,
                                                  updates=updates,
                                                  name='train_function',
                                                  **self._function_kwargs)

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -974,7 +974,7 @@ class Model(Container):
                 ' weights, did you set `model.trainable` without calling'
                 ' `model.compile` after ?'))
 
-    def _make_train_function(self, return_output=False):
+    def _make_train_function(self, return_model_output=False):
         if not hasattr(self, 'train_function'):
             raise RuntimeError('You must compile your model before using it.')
         self._check_trainable_weights_consistency()
@@ -989,7 +989,7 @@ class Model(Container):
                         params=self._collected_trainable_weights,
                         loss=self.total_loss)
                 updates = self.updates + training_updates
-                if return_output:
+                if return_model_output:
                     outputs = [self.total_loss] + self.metrics_tensors + self.outputs
                 else:
                     outputs = [self.total_loss] + self.metrics_tensors
@@ -1795,7 +1795,8 @@ class Model(Container):
 
     def train_on_batch(self, x, y,
                        sample_weight=None,
-                       class_weight=None):
+                       class_weight=None,
+                       return_model_output=False):
         """Runs a single gradient update on a single batch of data.
 
         # Arguments
@@ -1822,6 +1823,8 @@ class Model(Container):
                 from this class during training.
                 This can be useful to tell the model to "pay more attention" to
                 samples from an under-represented class.
+            return_model_output: Optional boolean, indicates whether the raw output of
+                the model should be returned.
 
         # Returns
             Scalar training loss
@@ -1839,7 +1842,7 @@ class Model(Container):
             ins = x + y + sample_weights + [1.]
         else:
             ins = x + y + sample_weights
-        self._make_train_function()
+        self._make_train_function(return_model_output=return_model_output)
         outputs = self.train_function(ins)
         if len(outputs) == 1:
             return outputs[0]

--- a/keras/models.py
+++ b/keras/models.py
@@ -138,6 +138,7 @@ def save_model(model, filepath, overwrite=True, include_optimizer=True):
                     'metrics': model.metrics,
                     'sample_weight_mode': model.sample_weight_mode,
                     'loss_weights': model.loss_weights,
+                    'return_model_output': model.return_model_output,
                 }, default=get_json_type).encode('utf8')
 
                 # Save optimizer weights.
@@ -262,13 +263,15 @@ def load_model(filepath, custom_objects=None, compile=True):
         metrics = convert_custom_objects(training_config['metrics'])
         sample_weight_mode = training_config['sample_weight_mode']
         loss_weights = training_config['loss_weights']
+        return_model_output = training_config.get('return_model_output', False)
 
         # Compile model.
         model.compile(optimizer=optimizer,
                       loss=loss,
                       metrics=metrics,
                       loss_weights=loss_weights,
-                      sample_weight_mode=sample_weight_mode)
+                      sample_weight_mode=sample_weight_mode,
+                      return_model_output=return_model_output)
 
         # Set optimizer weights.
         if 'optimizer_weights' in f:


### PR DESCRIPTION
This pull request is an implementation of #8468.

**Design document:**  https://docs.google.com/a/mai-ai.org/document/d/1AIcofCD4jV6iQyoLKpoS7xWgI5ImFfDcar2S9Oz84bc/edit?usp=sharing
**Google groups post**: https://groups.google.com/forum/#!topic/keras-users/6wAE6ZTDApw

This pull request was created to show the feasibility of the feature request and as a proposed implementation. 

**Main changes:**

- Add a new flag `return_model_output` to compile() that signals whether the train and test function should return model output.
- Changed the functions that make the train and test functions to add the model output to the list of outputs.
- Added a parameter to the training_config used in save/load to set the correct value of  `return_model_output`  during compile().

As the API changes are small I'm not sure whether a new test case needs to be added for this feature. If so, please let me know. Suggestions on other ways of handling new the flag are also welcome.