### PR TITLE
Fix function serialization

### DIFF
--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -174,7 +174,7 @@ def func_dump(func):
         A tuple `(code, defaults, closure)`.
     """
     raw_code = marshal.dumps(func.__code__)
-    code = str(codecs.encode(raw_code, 'base64'))
+    code = codecs.encode(raw_code, 'base64')
     defaults = func.__defaults__
     if func.__closure__:
         closure = tuple(c.cell_contents for c in func.__closure__)
@@ -199,7 +199,7 @@ def func_load(code, defaults=None, closure=None, globs=None):
         code, defaults, closure = code
         if isinstance(defaults, list):
             defaults = tuple(defaults)
-    raw_code = codecs.decode(six.b(code), 'base64')
+    raw_code = codecs.decode(code, 'base64')
     code = marshal.loads(raw_code)
     if globs is None:
         globs = globals()

--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -9,6 +9,7 @@ import six
 import marshal
 import types as python_types
 import inspect
+import codecs
 
 _GLOBAL_CUSTOM_OBJECTS = {}
 
@@ -172,7 +173,8 @@ def func_dump(func):
     # Returns
         A tuple `(code, defaults, closure)`.
     """
-    code = marshal.dumps(func.__code__).decode('raw_unicode_escape')
+    raw_code = marshal.dumps(func.__code__)
+    code = codecs.encode(raw_code, "base64")
     defaults = func.__defaults__
     if func.__closure__:
         closure = tuple(c.cell_contents for c in func.__closure__)
@@ -197,7 +199,7 @@ def func_load(code, defaults=None, closure=None, globs=None):
         code, defaults, closure = code
         if isinstance(defaults, list):
             defaults = tuple(defaults)
-    code = marshal.loads(code.encode('raw_unicode_escape'))
+    code = marshal.loads(codecs.decode(six.binary_type(code), "base64"))
     if globs is None:
         globs = globals()
     return python_types.FunctionType(code, globs,

--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -174,7 +174,7 @@ def func_dump(func):
         A tuple `(code, defaults, closure)`.
     """
     raw_code = marshal.dumps(func.__code__)
-    code = codecs.encode(raw_code, 'base64')
+    code = codecs.encode(raw_code, 'base64').decode('ascii')
     defaults = func.__defaults__
     if func.__closure__:
         closure = tuple(c.cell_contents for c in func.__closure__)
@@ -199,7 +199,7 @@ def func_load(code, defaults=None, closure=None, globs=None):
         code, defaults, closure = code
         if isinstance(defaults, list):
             defaults = tuple(defaults)
-    raw_code = codecs.decode(code, 'base64')
+    raw_code = codecs.decode(code.encode('ascii'), 'base64')
     code = marshal.loads(raw_code)
     if globs is None:
         globs = globals()

--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -199,7 +199,8 @@ def func_load(code, defaults=None, closure=None, globs=None):
         code, defaults, closure = code
         if isinstance(defaults, list):
             defaults = tuple(defaults)
-    code = marshal.loads(codecs.decode(six.binary_type(code), 'base64'))
+    raw_code = codecs.decode(six.b(code), 'base64')
+    code = marshal.loads(raw_code)
     if globs is None:
         globs = globals()
     return python_types.FunctionType(code, globs,

--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -174,7 +174,7 @@ def func_dump(func):
         A tuple `(code, defaults, closure)`.
     """
     raw_code = marshal.dumps(func.__code__)
-    code = codecs.encode(raw_code, "base64")
+    code = codecs.encode(raw_code, 'base64')
     defaults = func.__defaults__
     if func.__closure__:
         closure = tuple(c.cell_contents for c in func.__closure__)
@@ -199,7 +199,7 @@ def func_load(code, defaults=None, closure=None, globs=None):
         code, defaults, closure = code
         if isinstance(defaults, list):
             defaults = tuple(defaults)
-    code = marshal.loads(codecs.decode(six.binary_type(code), "base64"))
+    code = marshal.loads(codecs.decode(six.binary_type(code), 'base64'))
     if globs is None:
         globs = globals()
     return python_types.FunctionType(code, globs,

--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -174,7 +174,7 @@ def func_dump(func):
         A tuple `(code, defaults, closure)`.
     """
     raw_code = marshal.dumps(func.__code__)
-    code = codecs.encode(raw_code, 'base64')
+    code = str(codecs.encode(raw_code, 'base64'))
     defaults = func.__defaults__
     if func.__closure__:
         closure = tuple(c.cell_contents for c in func.__closure__)

--- a/tests/keras/utils/generic_utils_test.py
+++ b/tests/keras/utils/generic_utils_test.py
@@ -4,6 +4,8 @@ import numpy as np
 from keras.utils.generic_utils import custom_object_scope
 from keras.utils.generic_utils import has_arg
 from keras.utils.generic_utils import Progbar
+from keras.utils.generic_utils import func_dump
+from keras.utils.generic_utils import func_load
 from keras.utils.test_utils import keras_test
 from keras import activations
 from keras import regularizers
@@ -74,6 +76,16 @@ def test_has_arg(fn, name, accept_all, expected):
                    reason='inspect API does not reveal positional-only arguments')
 def test_has_arg_positional_only():
     assert has_arg(pow, 'x') is False
+
+
+def test_func_dump_and_load():
+    def test_func():
+        return r'\u'
+    serialized = func_dump(test_func)
+    deserialized = func_load(serialized)
+    assert deserialized.__code__ == test_func.__code__
+    assert deserialized.__defaults__ == test_func.__defaults__
+    assert deserialized.__closure__ == test_func.__closure__
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This fixes an error I'd been struggling with for a while. Previously, `func_dump` was trying to _decode_ the marshaling output using the `raw_unicode_escapes` codec for portability, then _encode_ it to get back to the original. This is the exact opposite of what you want to be doing: you want to _encode_ the bytes returned by marshal into some portable format, then _decode_ it back into the original bytes.

As a result of this confusion, instead of (as I presume was intended) encoding the bytes as Unicode escapes, the code was _searching the bytes for anything that looked like a Unicode escape and parsing it as such_. This is seriously problematic, as _marshaled output can contain invalid Unicode escapes,_ which was the problem I was having. Specifically, my marshaled output contained a path, which, since I'm on Windows, included `c:\users\`, which is an invalid Unicode escape and thus failed the decoding.

Presumably, the reason this mistake was made is that marshal returns bytes, which needed to be converted to a string, and decode is the method used to do that, despite the fact that semantically decoding is the opposite of the operation that needs to be performed. This is due to the fact that, for Python, encoding is the operation of encoding a string into bytes and decoding is the operation of decoding bytes into a string. Thus, since here you want to do the opposite, and encode bytes into a string and decode a string into bytes, the default methods fight back against you.

My fix is fairly simple. I explicitly use `codecs` to force the right type of encoding/decoding to be performed, and for portability, I'm using the `base64` codec. Thus, the code takes the marshaled output, converts it to base 64 for portability, then converts it back into bytes when it needs to be loaded. This does the semantically correct thing, and solves the issue I was experiencing above.