### PR TITLE
Fix function serialization + deserialization where the function has values captured in its closure.

### DIFF
--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -182,6 +182,23 @@ def func_dump(func):
         closure = None
     return code, defaults, closure
 
+def ensure_value_to_cell(value):
+    """Ensures that a value is converted to a python cell object.
+
+    # Arguments
+        value: Any value that needs to be casted to the cell type
+
+    # Returns
+        A value wrapped as a cell object (see function "func_load")
+
+    """
+    def dummy_fn():
+        value  # just access it so it gets captured in .__closure__
+    cell_value = dummy_fn.__closure__[0]
+    if not isinstance(value, type(cell_value)):
+        return dummy_fn.__closure__[0]
+    else:
+        return value
 
 def func_load(code, defaults=None, closure=None, globs=None):
     """Deserializes a user defined function.
@@ -199,6 +216,8 @@ def func_load(code, defaults=None, closure=None, globs=None):
         code, defaults, closure = code
         if isinstance(defaults, list):
             defaults = tuple(defaults)
+    if not closure is None:
+        closure = tuple(ensure_value_to_cell(_) for _ in closure)
     raw_code = codecs.decode(code.encode('ascii'), 'base64')
     code = marshal.loads(raw_code)
     if globs is None:

--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -182,6 +182,7 @@ def func_dump(func):
         closure = None
     return code, defaults, closure
 
+
 def ensure_value_to_cell(value):
     """Ensures that a value is converted to a python cell object.
 
@@ -199,6 +200,7 @@ def ensure_value_to_cell(value):
         return cell_value
     else:
         return value
+
 
 def func_load(code, defaults=None, closure=None, globs=None):
     """Deserializes a user defined function.

--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -196,7 +196,7 @@ def ensure_value_to_cell(value):
         value  # just access it so it gets captured in .__closure__
     cell_value = dummy_fn.__closure__[0]
     if not isinstance(value, type(cell_value)):
-        return dummy_fn.__closure__[0]
+        return cell_value
     else:
         return value
 
@@ -216,7 +216,7 @@ def func_load(code, defaults=None, closure=None, globs=None):
         code, defaults, closure = code
         if isinstance(defaults, list):
             defaults = tuple(defaults)
-    if not closure is None:
+    if closure is not None:
         closure = tuple(ensure_value_to_cell(_) for _ in closure)
     raw_code = codecs.decode(code.encode('ascii'), 'base64')
     code = marshal.loads(raw_code)

--- a/keras/utils/generic_utils.py
+++ b/keras/utils/generic_utils.py
@@ -183,25 +183,6 @@ def func_dump(func):
     return code, defaults, closure
 
 
-def ensure_value_to_cell(value):
-    """Ensures that a value is converted to a python cell object.
-
-    # Arguments
-        value: Any value that needs to be casted to the cell type
-
-    # Returns
-        A value wrapped as a cell object (see function "func_load")
-
-    """
-    def dummy_fn():
-        value  # just access it so it gets captured in .__closure__
-    cell_value = dummy_fn.__closure__[0]
-    if not isinstance(value, type(cell_value)):
-        return cell_value
-    else:
-        return value
-
-
 def func_load(code, defaults=None, closure=None, globs=None):
     """Deserializes a user defined function.
 
@@ -218,6 +199,25 @@ def func_load(code, defaults=None, closure=None, globs=None):
         code, defaults, closure = code
         if isinstance(defaults, list):
             defaults = tuple(defaults)
+
+    def ensure_value_to_cell(value):
+        """Ensures that a value is converted to a python cell object.
+
+        # Arguments
+            value: Any value that needs to be casted to the cell type
+
+        # Returns
+            A value wrapped as a cell object (see function "func_load")
+
+        """
+        def dummy_fn():
+            value  # just access it so it gets captured in .__closure__
+        cell_value = dummy_fn.__closure__[0]
+        if not isinstance(value, type(cell_value)):
+            return cell_value
+        else:
+            return value
+
     if closure is not None:
         closure = tuple(ensure_value_to_cell(_) for _ in closure)
     raw_code = codecs.decode(code.encode('ascii'), 'base64')

--- a/tests/keras/utils/generic_utils_test.py
+++ b/tests/keras/utils/generic_utils_test.py
@@ -79,8 +79,12 @@ def test_has_arg_positional_only():
 
 
 def test_func_dump_and_load():
-    def test_func():
-        return r'\u'
+    def get_test_func():
+        x = r'\u'
+        def test_func():
+            return x
+        return test_func
+    test_func = get_test_func()
     serialized = func_dump(test_func)
     deserialized = func_load(serialized)
     assert deserialized.__code__ == test_func.__code__

--- a/tests/keras/utils/generic_utils_test.py
+++ b/tests/keras/utils/generic_utils_test.py
@@ -79,11 +79,14 @@ def test_has_arg_positional_only():
 
 
 def test_func_dump_and_load():
+
     def get_test_func():
         x = r'\u'
+
         def test_func():
             return x
         return test_func
+
     test_func = get_test_func()
     serialized = func_dump(test_func)
     deserialized = func_load(serialized)

--- a/tests/keras/utils/generic_utils_test.py
+++ b/tests/keras/utils/generic_utils_test.py
@@ -78,16 +78,25 @@ def test_has_arg_positional_only():
     assert has_arg(pow, 'x') is False
 
 
-def test_func_dump_and_load():
+@pytest.mark.parametrize(
+    'test_funcion_type',
+    ('simple function', 'closured function'))
+def test_func_dump_and_load(test_funcion_type):
 
-    def get_test_func():
-        x = r'\u'
-
+    if test_funcion_type == 'simple function':
         def test_func():
-            return x
-        return test_func
+            return r'\u'
+    elif test_funcion_type == 'closured function':
+        def get_test_func():
+            x = r'\u'
 
-    test_func = get_test_func()
+            def test_func():
+                return x
+            return test_func
+        test_func = get_test_func()
+    else:
+        raise Exception('Unknown test case for test_func_dump_and_load')
+
     serialized = func_dump(test_func)
     deserialized = func_load(serialized)
     assert deserialized.__code__ == test_func.__code__


### PR DESCRIPTION
I recently ran into a situation where I used a Lambda layer to do some splicing.

Long story short, the lambda function inside the Lambda layer had the splice index as a closure'd value and when saving/loading the model this value did not properly deserialize (it threw an error instead).

After investigating the code, I found that `func_load` in `keras/utils/generic_utils.py` called `python_types.FunctionType` with the closure parameter as a tuple of values instead of a tuple of **_cell_** values. (Read more about cell values here: [https://docs.python.org/3.6/c-api/cell.html](url))

I've made the required fixes, and updated the test.

Please let me know if this works for you :)
