### PR TITLE
Update training_utils.py to make compatible with tensorflow r1.2 and lower version

### DIFF
--- a/keras/utils/training_utils.py
+++ b/keras/utils/training_utils.py
@@ -9,7 +9,7 @@ def _get_available_devices():
 
 
 def _normalize_device_name(name):
-    name = '/' + name.lower().split('device:')[1]
+    name = '/' + ':'.join(name.lower().replace('/', '').split(':')[-2:])
     return name
 
 


### PR DESCRIPTION
When the tensorflow version is r1.2 and lower, the name of list_devices() funtion's output will not have "device:" keyword, because of the PR #8567. This change will work just fine.