### PR TITLE
Allow callbacks to override their model.

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -45,7 +45,8 @@ class CallbackList(object):
 
     def set_model(self, model):
         for callback in self.callbacks:
-            callback.set_model(model)
+            if callback.model is None:
+                callback.set_model(model)
 
     def on_epoch_begin(self, epoch, logs=None):
         """Called at the start of an epoch.
@@ -168,6 +169,7 @@ class Callback(object):
 
     def __init__(self):
         self.validation_data = None
+        self.model = None
 
     def set_params(self, params):
         self.params = params


### PR DESCRIPTION
I'm trying to set up a multi-gpu training environment. I have 2 callbacks: `ModelCheckpoint` and `ReduceLROnPlateau`. The first should save the non-wrapped `model`, the second should reduce the LR on the `parallel_model`. In other words, they need to operate on different models. I saw there is an [undocumented attribute](https://github.com/fchollet/keras/blob/master/keras/engine/training.py#L1141) of `Model` to change the model the callbacks will receive, but this changes _all_ models to that model. In my case I only want to change some, not _all_.

This PR allows the user to create callbacks, set models and then pass them to a `fit` function or anything similar. In case there is a callback where a model has been set, the training procedure will not override it with the training model, preserving the model set by the user.

```
    # save the non-parallelized model
    checkpoint = keras.callbacks.ModelCheckpoint(os.path.join('snapshots', 'resnet50_coco_{epoch:02d}.h5'), verbose=1)
    checkpoint.set_model(model)

    # use training model for lr scheduling (default)
    lr_scheduler = keras.callbacks.ReduceLROnPlateau(monitor='loss', factor=0.1, patience=2, verbose=1, mode='auto', epsilon=0.0001, cooldown=0, min_lr=0)

    parallel_model.fit_generator(
        generator=train_generator,
        steps_per_epoch=10000,
        epochs=50,
        verbose=1,
        callbacks=[checkpoint, lr_scheduler]
    )
```