### PR TITLE
add ConvGRU2D

### DIFF
--- a/keras/layers/convolutional_recurrent.py
+++ b/keras/layers/convolutional_recurrent.py
@@ -161,7 +161,380 @@ class ConvRecurrent2D(Recurrent):
         base_config = super(ConvRecurrent2D, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
 
+class ConvGRU2D(ConvRecurrent2D):
+    """Convolutional GRU.
 
+    It is similar to an GRU layer, but the input transformations
+    and recurrent transformations are both convolutional.
+
+    # Arguments
+        filters: Integer, the dimensionality of the output space
+            (i.e. the number output of filters in the convolution).
+        kernel_size: An integer or tuple/list of n integers, specifying the
+            dimensions of the convolution window.
+        strides: An integer or tuple/list of n integers,
+            specifying the strides of the convolution.
+            Specifying any stride value != 1 is incompatible with specifying
+            any `dilation_rate` value != 1.
+        padding: One of `"valid"` or `"same"` (case-insensitive).
+        data_format: A string,
+            one of `channels_last` (default) or `channels_first`.
+            The ordering of the dimensions in the inputs.
+            `channels_last` corresponds to inputs with shape
+            `(batch, time, ..., channels)`
+            while `channels_first` corresponds to
+            inputs with shape `(batch, time, channels, ...)`.
+            It defaults to the `image_data_format` value found in your
+            Keras config file at `~/.keras/keras.json`.
+            If you never set it, then it will be "channels_last".
+        dilation_rate: An integer or tuple/list of n integers, specifying
+            the dilation rate to use for dilated convolution.
+            Currently, specifying any `dilation_rate` value != 1 is
+            incompatible with specifying any `strides` value != 1.
+        activation: Activation function to use
+            (see [activations](../activations.md)).
+            If you don't specify anything, no activation is applied
+            (ie. "linear" activation: `a(x) = x`).
+        recurrent_activation: Activation function to use
+            for the recurrent step
+            (see [activations](../activations.md)).
+        use_bias: Boolean, whether the layer uses a bias vector.
+        kernel_initializer: Initializer for the `kernel` weights matrix,
+            used for the linear transformation of the inputs.
+            (see [initializers](../initializers.md)).
+        recurrent_initializer: Initializer for the `recurrent_kernel`
+            weights matrix,
+            used for the linear transformation of the recurrent state.
+            (see [initializers](../initializers.md)).
+        bias_initializer: Initializer for the bias vector
+            (see [initializers](../initializers.md)).
+        kernel_regularizer: Regularizer function applied to
+            the `kernel` weights matrix
+            (see [regularizer](../regularizers.md)).
+        recurrent_regularizer: Regularizer function applied to
+            the `recurrent_kernel` weights matrix
+            (see [regularizer](../regularizers.md)).
+        bias_regularizer: Regularizer function applied to the bias vector
+            (see [regularizer](../regularizers.md)).
+        activity_regularizer: Regularizer function applied to
+            the output of the layer (its "activation").
+            (see [regularizer](../regularizers.md)).
+        kernel_constraint: Constraint function applied to
+            the `kernel` weights matrix
+            (see [constraints](../constraints.md)).
+        recurrent_constraint: Constraint function applied to
+            the `recurrent_kernel` weights matrix
+            (see [constraints](../constraints.md)).
+        bias_constraint: Constraint function applied to the bias vector
+            (see [constraints](../constraints.md)).
+        return_sequences: Boolean. Whether to return the last output
+            in the output sequence, or the full sequence.
+        go_backwards: Boolean (default False).
+            If True, rocess the input sequence backwards.
+        stateful: Boolean (default False). If True, the last state
+            for each sample at index i in a batch will be used as initial
+            state for the sample of index i in the following batch.
+        dropout: Float between 0 and 1.
+            Fraction of the units to drop for
+            the linear transformation of the inputs.
+        recurrent_dropout: Float between 0 and 1.
+            Fraction of the units to drop for
+            the linear transformation of the recurrent state.
+
+    # Input shape
+        - if data_format='channels_first'
+            5D tensor with shape:
+            `(samples,time, channels, rows, cols)`
+        - if data_format='channels_last'
+            5D tensor with shape:
+            `(samples,time, rows, cols, channels)`
+
+     # Output shape
+        - if `return_sequences`
+             - if data_format='channels_first'
+                5D tensor with shape:
+                `(samples, time, filters, output_row, output_col)`
+             - if data_format='channels_last'
+                5D tensor with shape:
+                `(samples, time, output_row, output_col, filters)`
+        - else
+            - if data_format ='channels_first'
+                4D tensor with shape:
+                `(samples, filters, output_row, output_col)`
+            - if data_format='channels_last'
+                4D tensor with shape:
+                `(samples, output_row, output_col, filters)`
+            where o_row and o_col depend on the shape of the filter and
+            the padding
+
+    # Raises
+        ValueError: in case of invalid constructor arguments.
+
+    # References
+        - [Convolutional LSTM Network: A Machine Learning Approach for
+        Precipitation Nowcasting](http://arxiv.org/abs/1506.04214v1)
+        The current implementation does not include the feedback loop on the
+        cells output
+    """
+
+    @interfaces.legacy_convgru2d_support
+    def __init__(self, filters,
+                 kernel_size,
+                 strides=(1, 1),
+                 padding='valid',
+                 data_format=None,
+                 dilation_rate=(1, 1),
+                 activation='tanh',
+                 recurrent_activation='hard_sigmoid',
+                 use_bias=True,
+                 kernel_initializer='glorot_uniform',
+                 recurrent_initializer='orthogonal',
+                 bias_initializer='zeros',
+                 kernel_regularizer=None,
+                 recurrent_regularizer=None,
+                 bias_regularizer=None,
+                 activity_regularizer=None,
+                 kernel_constraint=None,
+                 recurrent_constraint=None,
+                 bias_constraint=None,
+                 return_sequences=False,
+                 go_backwards=False,
+                 stateful=False,
+                 dropout=0.,
+                 recurrent_dropout=0.,
+                 **kwargs):
+        super(ConvGRU2D, self).__init__(filters,
+                                         kernel_size,
+                                         strides=strides,
+                                         padding=padding,
+                                         data_format=data_format,
+                                         dilation_rate=dilation_rate,
+                                         return_sequences=return_sequences,
+                                         go_backwards=go_backwards,
+                                         stateful=stateful,
+                                         **kwargs)
+        self.activation = activations.get(activation)
+        self.recurrent_activation = activations.get(recurrent_activation)
+        self.use_bias = use_bias
+
+        self.kernel_initializer = initializers.get(kernel_initializer)
+        self.recurrent_initializer = initializers.get(recurrent_initializer)
+        self.bias_initializer = initializers.get(bias_initializer)
+
+        self.kernel_regularizer = regularizers.get(kernel_regularizer)
+        self.recurrent_regularizer = regularizers.get(recurrent_regularizer)
+        self.bias_regularizer = regularizers.get(bias_regularizer)
+        self.activity_regularizer = regularizers.get(activity_regularizer)
+
+        self.kernel_constraint = constraints.get(kernel_constraint)
+        self.recurrent_constraint = constraints.get(recurrent_constraint)
+        self.bias_constraint = constraints.get(bias_constraint)
+
+        self.dropout = min(1., max(0., dropout))
+        self.recurrent_dropout = min(1., max(0., recurrent_dropout))
+        self.state_spec = [InputSpec(ndim=4)]
+
+    def build(self, input_shape):
+        if isinstance(input_shape, list):
+            input_shape = input_shape[0]
+        batch_size = input_shape[0] if self.stateful else None
+        self.input_spec[0] = InputSpec(shape=(batch_size, None) + input_shape[2:])
+        if self.stateful:
+            self.reset_states()
+        else:
+            # initial states: 1 all-zero tensor of shape (filters)
+            self.states = [None]
+
+        if self.data_format == 'channels_first':
+            channel_axis = 2
+        else:
+            channel_axis = -1
+        if input_shape[channel_axis] is None:
+            raise ValueError('The channel dimension of the inputs '
+                             'should be defined. Found `None`.')
+        input_dim = input_shape[channel_axis]
+        state_shape = [None] * 3
+        state_shape[channel_axis] = input_dim
+        state_shape = tuple(state_shape)
+        self.state_spec = [InputSpec(shape=state_shape), InputSpec(shape=state_shape)]
+        kernel_shape = self.kernel_size + (input_dim, self.filters * 3)
+        self.kernel_shape = kernel_shape
+        recurrent_kernel_shape = self.kernel_size + (self.filters, self.filters * 3)
+
+        self.kernel = self.add_weight(shape=kernel_shape,
+                                      initializer=self.kernel_initializer,
+                                      name='kernel',
+                                      regularizer=self.kernel_regularizer,
+                                      constraint=self.kernel_constraint)
+        self.recurrent_kernel = self.add_weight(
+            shape=recurrent_kernel_shape,
+            initializer=self.recurrent_initializer,
+            name='recurrent_kernel',
+            regularizer=self.recurrent_regularizer,
+            constraint=self.recurrent_constraint)
+        if self.use_bias:
+            self.bias = self.add_weight(shape=(self.filters * 3,),
+                                        initializer=self.bias_initializer,
+                                        name='bias',
+                                        regularizer=self.bias_regularizer,
+                                        constraint=self.bias_constraint)
+        else:
+            self.bias = None
+
+        self.kernel_z = self.kernel[:, :, :, :self.filters]
+        self.recurrent_kernel_z = self.recurrent_kernel[:, :, :, :self.filters]
+        self.kernel_r = self.kernel[:, :, :, self.filters: self.filters * 2]
+        self.recurrent_kernel_r = self.recurrent_kernel[:, :, :, self.filters: self.filters * 2]
+        self.kernel_h = self.kernel[:, :, :, self.filters * 2:]
+        self.recurrent_kernel_h = self.recurrent_kernel[:, :, :, self.filters * 2:]
+
+        if self.use_bias:
+            self.bias_z = self.bias[:self.filters]
+            self.bias_r = self.bias[self.filters: self.filters * 2]
+            self.bias_h = self.bias[self.filters * 2:]
+
+        else:
+            self.bias_z = None
+            self.bias_r = None
+            self.bias_h = None
+        self.built = True
+
+    def get_initial_state(self, inputs):
+        # (samples, timesteps, rows, cols, filters)
+        initial_state = K.zeros_like(inputs)
+        # (samples, rows, cols, filters)
+        initial_state = K.sum(initial_state, axis=1)
+        shape = list(self.kernel_shape)
+        shape[-1] = self.filters
+        initial_state = self.input_conv(initial_state,
+                                        K.zeros(tuple(shape)),
+                                        padding=self.padding)
+
+        initial_states = [initial_state]
+        return initial_states
+
+    def reset_states(self):
+        if not self.stateful:
+            raise RuntimeError('Layer must be stateful.')
+        input_shape = self.input_spec[0].shape
+        output_shape = self.compute_output_shape(input_shape)
+        if not input_shape[0]:
+            raise ValueError('If a RNN is stateful, a complete '
+                             'input_shape must be provided '
+                             '(including batch size). '
+                             'Got input shape: ' + str(input_shape))
+        if self.return_sequences:
+            if self.return_state:
+                output_shape = output_shape[1]
+            else:
+                output_shape = (input_shape[0],) + output_shape[2:]
+        else:
+            if self.return_state:
+                output_shape = output_shape[1]
+            else:
+                output_shape = (input_shape[0],) + output_shape[1:]
+
+        if hasattr(self, 'states'):
+            K.set_value(self.states[0],
+                        np.zeros(output_shape))
+        else:
+            self.states = [K.zeros(output_shape)]
+
+    def get_constants(self, inputs, training=None):
+        constants = []
+        if self.implementation == 0 and 0 < self.dropout < 1:
+            ones = K.zeros_like(inputs)
+            ones = K.sum(ones, axis=1)
+            ones += 1
+
+            def dropped_inputs():
+                return K.dropout(ones, self.dropout)
+
+            dp_mask = [K.in_train_phase(dropped_inputs,
+                                        ones,
+                                        training=training) for _ in range(3)]
+            constants.append(dp_mask)
+        else:
+            constants.append([K.cast_to_floatx(1.) for _ in range(3)])
+
+        if 0 < self.recurrent_dropout < 1:
+            shape = list(self.kernel_shape)
+            shape[-1] = self.filters
+            ones = K.zeros_like(inputs)
+            ones = K.sum(ones, axis=1)
+            ones = self.input_conv(ones, K.zeros(shape),
+                                   padding=self.padding)
+            ones += 1.
+
+            def dropped_inputs():
+                return K.dropout(ones, self.recurrent_dropout)
+            rec_dp_mask = [K.in_train_phase(dropped_inputs,
+                                            ones,
+                                            training=training) for _ in range(3)]
+            constants.append(rec_dp_mask)
+        else:
+            constants.append([K.cast_to_floatx(1.) for _ in range(3)])
+        return constants
+
+    def input_conv(self, x, w, b=None, padding='valid'):
+        conv_out = K.conv2d(x, w, strides=self.strides,
+                            padding=padding,
+                            data_format=self.data_format,
+                            dilation_rate=self.dilation_rate)
+        if b is not None:
+            conv_out = K.bias_add(conv_out, b,
+                                  data_format=self.data_format)
+        return conv_out
+
+    def recurrent_conv(self, x, w):
+        conv_out = K.conv2d(x, w, strides=(1, 1),
+                            padding='same',
+                            data_format=self.data_format)
+        return conv_out
+
+    def step(self, inputs, states):
+        assert len(states) == 3
+        h_tm1 = states[0]
+        dp_mask = states[1]
+        rec_dp_mask = states[2]
+
+        x_z = self.input_conv(inputs * dp_mask[0], self.kernel_z, self.bias_z,
+                              padding=self.padding)
+        x_r = self.input_conv(inputs * dp_mask[1], self.kernel_r, self.bias_r,
+                              padding=self.padding)
+        h_z = self.recurrent_conv(h_tm1 * rec_dp_mask[0],
+                                  self.recurrent_kernel_z)
+        h_r = self.recurrent_conv(h_tm1 * rec_dp_mask[1],
+                                  self.recurrent_kernel_r)
+        z = self.recurrent_activation(x_z + h_z)
+        r = self.recurrent_activation(x_r + h_r)
+
+        x_h = self.input_conv(inputs * dp_mask[2], self.kernel_h, self.bias_h,
+                              padding=self.padding)      
+        h_h = self.recurrent_conv(h_tm1 * r * rec_dp_mask[2],
+                                  self.recurrent_kernel_h)
+        h = (1.0 - z) * h_tm1 + z * self.activation(x_h + h_h)
+        return h, [h]
+
+    def get_config(self):
+        config = {'activation': activations.serialize(self.activation),
+                  'recurrent_activation': activations.serialize(self.recurrent_activation),
+                  'use_bias': self.use_bias,
+                  'kernel_initializer': initializers.serialize(self.kernel_initializer),
+                  'recurrent_initializer': initializers.serialize(self.recurrent_initializer),
+                  'bias_initializer': initializers.serialize(self.bias_initializer),
+                  'kernel_regularizer': regularizers.serialize(self.kernel_regularizer),
+                  'recurrent_regularizer': regularizers.serialize(self.recurrent_regularizer),
+                  'bias_regularizer': regularizers.serialize(self.bias_regularizer),
+                  'activity_regularizer': regularizers.serialize(self.activity_regularizer),
+                  'kernel_constraint': constraints.serialize(self.kernel_constraint),
+                  'recurrent_constraint': constraints.serialize(self.recurrent_constraint),
+                  'bias_constraint': constraints.serialize(self.bias_constraint),
+                  'dropout': self.dropout,
+                  'recurrent_dropout': self.recurrent_dropout}
+        base_config = super(ConvGRU2D, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))
+        
 class ConvLSTM2D(ConvRecurrent2D):
     """Convolutional LSTM.
 

--- a/keras/layers/convolutional_recurrent.py
+++ b/keras/layers/convolutional_recurrent.py
@@ -161,6 +161,7 @@ class ConvRecurrent2D(Recurrent):
         base_config = super(ConvRecurrent2D, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
 
+
 class ConvGRU2D(ConvRecurrent2D):
     """Convolutional GRU.
 
@@ -304,15 +305,15 @@ class ConvGRU2D(ConvRecurrent2D):
                  recurrent_dropout=0.,
                  **kwargs):
         super(ConvGRU2D, self).__init__(filters,
-                                         kernel_size,
-                                         strides=strides,
-                                         padding=padding,
-                                         data_format=data_format,
-                                         dilation_rate=dilation_rate,
-                                         return_sequences=return_sequences,
-                                         go_backwards=go_backwards,
-                                         stateful=stateful,
-                                         **kwargs)
+                                        kernel_size,
+                                        strides=strides,
+                                        padding=padding,
+                                        data_format=data_format,
+                                        dilation_rate=dilation_rate,
+                                        return_sequences=return_sequences,
+                                        go_backwards=go_backwards,
+                                        stateful=stateful,
+                                        **kwargs)
         self.activation = activations.get(activation)
         self.recurrent_activation = activations.get(recurrent_activation)
         self.use_bias = use_bias
@@ -510,7 +511,7 @@ class ConvGRU2D(ConvRecurrent2D):
         r = self.recurrent_activation(x_r + h_r)
 
         x_h = self.input_conv(inputs * dp_mask[2], self.kernel_h, self.bias_h,
-                              padding=self.padding)      
+                              padding=self.padding)
         h_h = self.recurrent_conv(h_tm1 * r * rec_dp_mask[2],
                                   self.recurrent_kernel_h)
         h = (1.0 - z) * h_tm1 + z * self.activation(x_h + h_h)
@@ -534,7 +535,8 @@ class ConvGRU2D(ConvRecurrent2D):
                   'recurrent_dropout': self.recurrent_dropout}
         base_config = super(ConvGRU2D, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
-        
+
+
 class ConvLSTM2D(ConvRecurrent2D):
     """Convolutional LSTM.
 

--- a/keras/legacy/interfaces.py
+++ b/keras/legacy/interfaces.py
@@ -490,7 +490,32 @@ legacy_batchnorm_support = generate_legacy_interface(
                  ('gamma_init', 'gamma_initializer')],
     preprocessor=batchnorm_args_preprocessor)
 
+def convgru2d_args_preprocessor(args, kwargs):
+    converted = []
 
+    args, kwargs, _converted = conv2d_args_preprocessor(args, kwargs)
+    return args, kwargs, converted + _converted
+
+legacy_convgru2d_support = generate_legacy_interface(
+    allowed_positional_args=['filters', 'kernel_size'],
+    conversions=[('nb_filter', 'filters'),
+                 ('subsample', 'strides'),
+                 ('border_mode', 'padding'),
+                 ('dim_ordering', 'data_format'),
+                 ('init', 'kernel_initializer'),
+                 ('inner_init', 'recurrent_initializer'),
+                 ('W_regularizer', 'kernel_regularizer'),
+                 ('U_regularizer', 'recurrent_regularizer'),
+                 ('b_regularizer', 'bias_regularizer'),
+                 ('inner_activation', 'recurrent_activation'),
+                 ('dropout_W', 'dropout'),
+                 ('dropout_U', 'recurrent_dropout'),
+                 ('bias', 'use_bias')],
+    value_conversions={'dim_ordering': {'tf': 'channels_last',
+                                        'th': 'channels_first',
+                                        'default': None}},
+    preprocessor=convgru2d_args_preprocessor)
+    
 def zeropadding2d_args_preprocessor(args, kwargs):
     converted = []
     if 'padding' in kwargs and isinstance(kwargs['padding'], dict):

--- a/keras/legacy/interfaces.py
+++ b/keras/legacy/interfaces.py
@@ -464,6 +464,7 @@ def convlstm2d_args_preprocessor(args, kwargs):
     args, kwargs, _converted = conv2d_args_preprocessor(args, kwargs)
     return args, kwargs, converted + _converted
 
+
 legacy_convlstm2d_support = generate_legacy_interface(
     allowed_positional_args=['filters', 'kernel_size'],
     conversions=[('nb_filter', 'filters'),
@@ -490,11 +491,13 @@ legacy_batchnorm_support = generate_legacy_interface(
                  ('gamma_init', 'gamma_initializer')],
     preprocessor=batchnorm_args_preprocessor)
 
+
 def convgru2d_args_preprocessor(args, kwargs):
     converted = []
 
     args, kwargs, _converted = conv2d_args_preprocessor(args, kwargs)
     return args, kwargs, converted + _converted
+
 
 legacy_convgru2d_support = generate_legacy_interface(
     allowed_positional_args=['filters', 'kernel_size'],
@@ -515,7 +518,8 @@ legacy_convgru2d_support = generate_legacy_interface(
                                         'th': 'channels_first',
                                         'default': None}},
     preprocessor=convgru2d_args_preprocessor)
-    
+
+
 def zeropadding2d_args_preprocessor(args, kwargs):
     converted = []
     if 'padding' in kwargs and isinstance(kwargs['padding'], dict):

--- a/tests/keras/layers/convolutional_recurrent_test.py
+++ b/tests/keras/layers/convolutional_recurrent_test.py
@@ -9,7 +9,7 @@ from keras.utils.test_utils import layer_test
 from keras import regularizers
 
 
-def test_convolutional_recurrent():
+def test_ConvLSTM2D():
     num_row = 3
     num_col = 3
     filters = 2
@@ -151,6 +151,147 @@ def test_convolutional_recurrent():
             model = Model(x, y)
             assert model.predict(inputs).shape == layer.compute_output_shape(inputs.shape)
 
+def test_ConvGRU2D():
+    num_row = 3
+    num_col = 3
+    filters = 2
+    num_samples = 1
+    input_channel = 2
+    input_num_row = 5
+    input_num_col = 5
+    sequence_len = 2
+    for data_format in ['channels_first', 'channels_last']:
+
+        if data_format == 'channels_first':
+            inputs = np.random.rand(num_samples, sequence_len,
+                                    input_channel,
+                                    input_num_row, input_num_col)
+        else:
+            inputs = np.random.rand(num_samples, sequence_len,
+                                    input_num_row, input_num_col,
+                                    input_channel)
+
+        for return_sequences in [True, False]:
+
+            # test for return state:
+            x = Input(batch_shape=inputs.shape)
+            kwargs = {'data_format': data_format,
+                      'return_sequences': return_sequences,
+                      'return_state': True,
+                      'stateful': True,
+                      'filters': filters,
+                      'kernel_size': (num_row, num_col),
+                      'padding': 'valid'}
+            layer = convolutional_recurrent.ConvGRU2D(**kwargs)
+            layer.build(inputs.shape)
+            outputs = layer(x)
+            output, states = outputs[0], outputs[1:]
+            assert len(states) == 1
+            model = Model(x, states[0])
+            state = model.predict(inputs)
+            np.testing.assert_allclose(
+                K.eval(layer.states[0]), state, atol=1e-4)
+
+            # test for output shape:
+            output = layer_test(convolutional_recurrent.ConvGRU2D,
+                                kwargs={'data_format': data_format,
+                                        'return_sequences': return_sequences,
+                                        'filters': filters,
+                                        'kernel_size': (num_row, num_col),
+                                        'padding': 'valid'},
+                                input_shape=inputs.shape)
+
+            # No need to check following tests for both data formats
+            if data_format == 'channels_first' or return_sequences:
+                continue
+
+            # Tests for statefulness
+            model = Sequential()
+            kwargs = {'data_format': data_format,
+                      'return_sequences': return_sequences,
+                      'filters': filters,
+                      'kernel_size': (num_row, num_col),
+                      'stateful': True,
+                      'batch_input_shape': inputs.shape,
+                      'padding': 'same'}
+            layer = convolutional_recurrent.ConvGRU2D(**kwargs)
+
+            model.add(layer)
+            model.compile(optimizer='sgd', loss='mse')
+            out1 = model.predict(np.ones_like(inputs))
+
+            # train once so that the states change
+            model.train_on_batch(np.ones_like(inputs),
+                                 np.random.random(out1.shape))
+            out2 = model.predict(np.ones_like(inputs))
+
+            # if the state is not reset, output should be different
+            assert(out1.max() != out2.max())
+
+            # check that output changes after states are reset
+            # (even though the model itself didn't change)
+            layer.reset_states()
+            out3 = model.predict(np.ones_like(inputs))
+            assert(out2.max() != out3.max())
+
+            # check that container-level reset_states() works
+            model.reset_states()
+            out4 = model.predict(np.ones_like(inputs))
+            assert_allclose(out3, out4, atol=1e-5)
+
+            # check that the call to `predict` updated the states
+            out5 = model.predict(np.ones_like(inputs))
+            assert(out4.max() != out5.max())
+
+            # cntk doesn't support eval convolution with static
+            # variable, will enable it later
+            if K.backend() != 'cntk':
+                # check regularizers
+                kwargs = {'data_format': data_format,
+                          'return_sequences': return_sequences,
+                          'kernel_size': (num_row, num_col),
+                          'stateful': True,
+                          'filters': filters,
+                          'batch_input_shape': inputs.shape,
+                          'kernel_regularizer': regularizers.L1L2(l1=0.01),
+                          'recurrent_regularizer': regularizers.L1L2(l1=0.01),
+                          'bias_regularizer': 'l2',
+                          'activity_regularizer': 'l2',
+                          'kernel_constraint': 'max_norm',
+                          'recurrent_constraint': 'max_norm',
+                          'bias_constraint': 'max_norm',
+                          'padding': 'same'}
+
+                layer = convolutional_recurrent.ConvGRU2D(**kwargs)
+                layer.build(inputs.shape)
+                assert len(layer.losses) == 3
+                assert layer.activity_regularizer
+                output = layer(K.variable(np.ones(inputs.shape)))
+                assert len(layer.losses) == 4
+                K.eval(output)
+
+            # check dropout
+            layer_test(convolutional_recurrent.ConvGRU2D,
+                       kwargs={'data_format': data_format,
+                               'return_sequences': return_sequences,
+                               'filters': filters,
+                               'kernel_size': (num_row, num_col),
+                               'padding': 'same',
+                               'dropout': 0.1,
+                               'recurrent_dropout': 0.1},
+                       input_shape=inputs.shape)
+
+            # check state initialization
+            layer = convolutional_recurrent.ConvGRU2D(filters=filters,
+                                                       kernel_size=(num_row, num_col),
+                                                       data_format=data_format,
+                                                       return_sequences=return_sequences)
+            layer.build(inputs.shape)
+            x = Input(batch_shape=inputs.shape)
+            initial_state = layer.get_initial_state(x)
+            y = layer(x, initial_state=initial_state)
+            model = Model(x, y)
+            assert model.predict(inputs).shape == layer.compute_output_shape(inputs.shape)
 
 if __name__ == '__main__':
     pytest.main([__file__])

--- a/tests/keras/layers/convolutional_recurrent_test.py
+++ b/tests/keras/layers/convolutional_recurrent_test.py
@@ -151,6 +151,7 @@ def test_ConvLSTM2D():
             model = Model(x, y)
             assert model.predict(inputs).shape == layer.compute_output_shape(inputs.shape)
 
+
 def test_ConvGRU2D():
     num_row = 3
     num_col = 3
@@ -283,15 +284,16 @@ def test_ConvGRU2D():
 
             # check state initialization
             layer = convolutional_recurrent.ConvGRU2D(filters=filters,
-                                                       kernel_size=(num_row, num_col),
-                                                       data_format=data_format,
-                                                       return_sequences=return_sequences)
+                                                      kernel_size=(num_row, num_col),
+                                                      data_format=data_format,
+                                                      return_sequences=return_sequences)
             layer.build(inputs.shape)
             x = Input(batch_shape=inputs.shape)
             initial_state = layer.get_initial_state(x)
             y = layer(x, initial_state=initial_state)
             model = Model(x, y)
             assert model.predict(inputs).shape == layer.compute_output_shape(inputs.shape)
+
 
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
adds ConvGRU2D, similar to ConvLSTM2D but uses GRU. When used as a drop-in replacement in examples/conv_lstm.py, it perform's little bit better than ConvLSTM2D @ epoch 30. Not sure if it's place is here or keras-contrib. If latter, let me know and I'll send it there. 