### PR TITLE
Add RedirectModel callback.

### DIFF
--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -45,8 +45,7 @@ class CallbackList(object):
 
     def set_model(self, model):
         for callback in self.callbacks:
-            if callback.model is None:
-                callback.set_model(model)
+            callback.set_model(model)
 
     def on_epoch_begin(self, epoch, logs=None):
         """Called at the start of an epoch.
@@ -992,7 +991,7 @@ class CSVLogger(Callback):
 
 
 class LambdaCallback(Callback):
-    r"""Callback for creating simple, custom callbacks on-the-fly.
+    """Callback for creating simple, custom callbacks on-the-fly.
 
     This callback is constructed with anonymous functions that will be called
     at the appropriate time. Note that the callbacks expects positional
@@ -1076,3 +1075,49 @@ class LambdaCallback(Callback):
             self.on_train_end = on_train_end
         else:
             self.on_train_end = lambda logs: None
+
+
+class RedirectModel(Callback):
+    """Callback which wraps another callback, but executed on a different model.
+
+    # Arguments
+        callback: callback to wrap.
+        model: model to use when executing callbacks.
+
+    # Example
+        ```python
+        model = keras.models.load_model('model.h5')
+        model_checkpoint = ModelCheckpoint(filepath='snapshot.h5')
+        parallel_model = multi_gpu_model(model, gpus=2)
+        parallel_model.fit(X_train, Y_train, callbacks=[RedirectModel(model_checkpoint, model)])
+        ```
+    """
+
+    def __init__(self,
+                 callback,
+                 model):
+        super(RedirectModel, self).__init__()
+
+        self.callback = callback
+        self.redirect_model = model
+
+    def on_epoch_begin(self, epoch, logs=None):
+        self.callback.on_epoch_begin(epoch, logs=logs)
+
+    def on_epoch_end(self, epoch, logs=None):
+        self.callback.on_epoch_end(epoch, logs=logs)
+
+    def on_batch_begin(self, batch, logs=None):
+        self.callback.on_batch_begin(batch, logs=logs)
+
+    def on_batch_end(self, batch, logs=None):
+        self.callback.on_batch_end(batch, logs=logs)
+
+    def on_train_begin(self, logs=None):
+        # overwrite the model with our custom model
+        self.callback.set_model(self.redirect_model)
+
+        self.callback.on_train_begin(logs=logs)
+
+    def on_train_end(self, logs=None):
+        self.callback.on_train_end(logs=logs)


### PR DESCRIPTION
https://github.com/fchollet/keras/pull/8598 conditionally sets a model if it is not already set. After discussing with a colleague, this is a bit strange that a `set` function conditionally does or doesn't set something. This PR corrects that by adding a `RedirectModel` callback instead. This callback can be used to wrap another callback, while setting a different model when the training begins.

Example usage:

```python
    model = keras.models.load_model('model.h5')
    model_checkpoint = ModelCheckpoint(filepath='snapshot.h5')
    parallel_model = multi_gpu_model(model, gpus=2)
    parallel_model.fit(X_train, Y_train, callbacks=[RedirectModel(model_checkpoint, model)])
```