### PR TITLE
acgan: Add batch normalization to the Generator, etc

### DIFF
--- a/examples/mnist_acgan.py
+++ b/examples/mnist_acgan.py
@@ -33,6 +33,7 @@ from six.moves import range
 from keras.datasets import mnist
 from keras import layers
 from keras.layers import Input, Dense, Reshape, Flatten, Embedding, Dropout
+from keras.layers import BatchNormalization
 from keras.layers.advanced_activations import LeakyReLU
 from keras.layers.convolutional import Conv2DTranspose, Conv2D
 from keras.models import Sequential, Model
@@ -56,11 +57,13 @@ def build_generator(latent_size):
     cnn.add(Conv2DTranspose(192, 5, strides=1, padding='valid',
                             activation='relu',
                             kernel_initializer='glorot_normal'))
+    cnn.add(BatchNormalization())
 
     # upsample to (14, 14, ...)
     cnn.add(Conv2DTranspose(96, 5, strides=2, padding='same',
                             activation='relu',
                             kernel_initializer='glorot_normal'))
+    cnn.add(BatchNormalization())
 
     # upsample to (28, 28, ...)
     cnn.add(Conv2DTranspose(1, 5, strides=2, padding='same',
@@ -124,7 +127,7 @@ def build_discriminator():
 if __name__ == '__main__':
 
     # batch and latent size taken from the paper
-    epochs = 50
+    epochs = 100
     batch_size = 100
     latent_size = 100
 
@@ -215,8 +218,9 @@ if __name__ == '__main__':
 
             x = np.concatenate((image_batch, generated_images))
 
-            # use soft real/fake labels
-            soft_zero, soft_one = 0.1, 0.9
+            # use one-sided soft real/fake labels
+            # https://arxiv.org/pdf/1606.03498.pdf (Section 3.4)
+            soft_zero, soft_one = 0, 0.95
             y = np.array([soft_one] * batch_size + [soft_zero] * batch_size)
             aux_y = np.concatenate((label_batch, sampled_labels), axis=0)
 
@@ -286,7 +290,7 @@ if __name__ == '__main__':
             'component', *discriminator.metrics_names))
         print('-' * 65)
 
-        ROW_FMT = '{0:<22s} | {1:<4.2f} | {2:<15.2f} | {3:<5.2f}'
+        ROW_FMT = '{0:<22s} | {1:<4.2f} | {2:<15.4f} | {3:<5.4f}'
         print(ROW_FMT.format('generator (train)',
                              *train_history['generator'][-1]))
         print(ROW_FMT.format('generator (test)',


### PR DESCRIPTION
1. Add batch normalization to the Generator. This makes the example closer to the referenced paper and improves generated images. Adding batch normalization to the Discriminator breaks training so badly, that I suspect a bug (maybe https://github.com/fchollet/keras/pull/5647 is fixed incompletely or something). Not adding batch normalization to the Discriminator also side-steps the issue of correlation of samples within a batch (https://github.com/soumith/ganhacks#4-batchnorm)

2.  Use one-sided soft labels and a harder `soft_one=0.95` vs 0.9). The referenced paper says they don't need one-sided soft labels. This example also doesn't "need" them any more, but the generated images are better. Add reference to a paper.

3. Increase `epoch=100` from 50, as good images often appear between epochs 50 and 100. Note that the training time per epoch is half that of the original example, after https://github.com/fchollet/keras/pull/8482/commits/67cd3b09510643655998311d66f0e9b3475f32e5

4. Increase output precision of various losses from 2 decimal digits to 4. You can't really tell what is going on with just 2. 

@lukedeo , I see a lot of examples online which use embedding with Hadamard, but do you know of any paper(s) we can reference? I haven't seen it in any of the GAN papers. I really like embedding with Hadamard, as replacing them would require multiple (3-5?) additional layers, but to be thorough I did a half-hearted attempts to remove them (make closer to the acgan paper), just to see if I can, and failed (generated images are much worse).
