### PR TITLE
Add ability to load Applications weights from arbitrary local filepath

### DIFF
--- a/keras/applications/inception_resnet_v2.py
+++ b/keras/applications/inception_resnet_v2.py
@@ -16,6 +16,7 @@ https://github.com/tensorflow/models/tree/master/research/slim#pre-trained-model
 from __future__ import print_function
 from __future__ import absolute_import
 
+import os
 import warnings
 
 from ..models import Model
@@ -177,7 +178,6 @@ def InceptionResNetV2(include_top=True,
                       input_tensor=None,
                       input_shape=None,
                       pooling=None,
-                      pretrained_weights_path=None,
                       classes=1000):
     """Instantiates the Inception-ResNet v2 architecture.
 
@@ -200,8 +200,7 @@ def InceptionResNetV2(include_top=True,
             layer at the top of the network.
         weights: one of `None` (random initialization),
               'imagenet' (pre-training on ImageNet),
-              or 'custom' (load pre-trained weights from file at
-              `pretrained_weights_path`).
+              or the path to the weights file to be loaded.
         input_tensor: optional Keras tensor (i.e. output of `layers.Input()`)
             to use as image input for the model.
         input_shape: optional shape tuple, only to be specified
@@ -220,8 +219,6 @@ def InceptionResNetV2(include_top=True,
                 last convolutional layer, and thus
                 the output of the model will be a 2D tensor.
             - `'max'` means that global max pooling will be applied.
-        pretrained_weights_path: optional path to h5 file containing
-            pretrained model weights
         classes: optional number of classes to classify images
             into, only to be specified if `include_top` is `True`, and
             if no `weights` argument is specified.
@@ -233,11 +230,11 @@ def InceptionResNetV2(include_top=True,
         ValueError: in case of invalid argument for `weights`,
             or invalid input shape.
     """
-    if weights not in {'imagenet', 'custom', None}:
+    if not (weights in {'imagenet', None} or os.path.exists(weights)):
         raise ValueError('The `weights` argument should be either '
                          '`None` (random initialization), `imagenet` '
                          '(pre-training on ImageNet), '
-                         'or `custom` (supplied at user-defined path).')
+                         'or the path to the weights file to be loaded.')
 
     if weights == 'imagenet' and include_top and classes != 1000:
         raise ValueError('If using `weights` as imagenet with `include_top`'
@@ -377,8 +374,7 @@ def InceptionResNetV2(include_top=True,
                                     cache_subdir='models',
                                     file_hash='d19885ff4a710c122648d3b5c3b684e4')
         model.load_weights(weights_path)
-
-    if weights == 'custom':
-        model.load_weights(pretrained_weights_path)
+    elif weights is not None:
+        model.load_weights(weights)
 
     return model

--- a/keras/applications/inception_resnet_v2.py
+++ b/keras/applications/inception_resnet_v2.py
@@ -177,6 +177,7 @@ def InceptionResNetV2(include_top=True,
                       input_tensor=None,
                       input_shape=None,
                       pooling=None,
+                      pretrained_weights_path=None,
                       classes=1000):
     """Instantiates the Inception-ResNet v2 architecture.
 
@@ -197,8 +198,10 @@ def InceptionResNetV2(include_top=True,
     # Arguments
         include_top: whether to include the fully-connected
             layer at the top of the network.
-        weights: one of `None` (random initialization)
-            or `'imagenet'` (pre-training on ImageNet).
+        weights: one of `None` (random initialization),
+              'imagenet' (pre-training on ImageNet),
+              or 'custom' (load pre-trained weights from file at
+              `pretrained_weights_path`).
         input_tensor: optional Keras tensor (i.e. output of `layers.Input()`)
             to use as image input for the model.
         input_shape: optional shape tuple, only to be specified
@@ -217,6 +220,8 @@ def InceptionResNetV2(include_top=True,
                 last convolutional layer, and thus
                 the output of the model will be a 2D tensor.
             - `'max'` means that global max pooling will be applied.
+        pretrained_weights_path: optional path to h5 file containing
+            pretrained model weights
         classes: optional number of classes to classify images
             into, only to be specified if `include_top` is `True`, and
             if no `weights` argument is specified.
@@ -228,10 +233,11 @@ def InceptionResNetV2(include_top=True,
         ValueError: in case of invalid argument for `weights`,
             or invalid input shape.
     """
-    if weights not in {'imagenet', None}:
+    if weights not in {'imagenet', 'custom', None}:
         raise ValueError('The `weights` argument should be either '
-                         '`None` (random initialization) or `imagenet` '
-                         '(pre-training on ImageNet).')
+                         '`None` (random initialization), `imagenet` '
+                         '(pre-training on ImageNet), '
+                         'or `custom` (supplied at user-defined path).')
 
     if weights == 'imagenet' and include_top and classes != 1000:
         raise ValueError('If using `weights` as imagenet with `include_top`'
@@ -371,5 +377,8 @@ def InceptionResNetV2(include_top=True,
                                     cache_subdir='models',
                                     file_hash='d19885ff4a710c122648d3b5c3b684e4')
         model.load_weights(weights_path)
+
+    if weights == 'custom':
+        model.load_weights(pretrained_weights_path)
 
     return model

--- a/keras/applications/inception_v3.py
+++ b/keras/applications/inception_v3.py
@@ -13,6 +13,7 @@ and that the input preprocessing function is also different (same as Xception).
 from __future__ import print_function
 from __future__ import absolute_import
 
+import os
 import warnings
 
 from ..models import Model
@@ -87,7 +88,6 @@ def InceptionV3(include_top=True,
                 input_tensor=None,
                 input_shape=None,
                 pooling=None,
-                pretrained_weights_path=None,
                 classes=1000):
     """Instantiates the Inception v3 architecture.
 
@@ -107,8 +107,7 @@ def InceptionV3(include_top=True,
             layer at the top of the network.
         weights: one of `None` (random initialization),
               'imagenet' (pre-training on ImageNet),
-              or 'custom' (load pre-trained weights from file at
-              `pretrained_weights_path`).
+              or the path to the weights file to be loaded.
         input_tensor: optional Keras tensor (i.e. output of `layers.Input()`)
             to use as image input for the model.
         input_shape: optional shape tuple, only to be specified
@@ -129,8 +128,6 @@ def InceptionV3(include_top=True,
                 the output of the model will be a 2D tensor.
             - `max` means that global max pooling will
                 be applied.
-        pretrained_weights_path: optional path to h5 file containing
-            pretrained model weights
         classes: optional number of classes to classify images
             into, only to be specified if `include_top` is True, and
             if no `weights` argument is specified.
@@ -142,11 +139,11 @@ def InceptionV3(include_top=True,
         ValueError: in case of invalid argument for `weights`,
             or invalid input shape.
     """
-    if weights not in {'imagenet', 'custom', None}:
+    if not (weights in {'imagenet', None} or os.path.exists(weights)):
         raise ValueError('The `weights` argument should be either '
                          '`None` (random initialization), `imagenet` '
                          '(pre-training on ImageNet), '
-                         'or `custom` (supplied at user-defined path).')
+                         'or the path to the weights file to be loaded.')
 
     if weights == 'imagenet' and include_top and classes != 1000:
         raise ValueError('If using `weights` as imagenet with `include_top`'
@@ -391,9 +388,8 @@ def InceptionV3(include_top=True,
                 cache_subdir='models',
                 file_hash='bcbd6486424b2319ff4ef7d526e38f63')
         model.load_weights(weights_path)
-
-    if weights == 'custom':
-        model.load_weights(pretrained_weights_path)
+    elif weights is not None:
+        model.load_weights(weights)
 
     return model
 

--- a/keras/applications/inception_v3.py
+++ b/keras/applications/inception_v3.py
@@ -87,6 +87,7 @@ def InceptionV3(include_top=True,
                 input_tensor=None,
                 input_shape=None,
                 pooling=None,
+                pretrained_weights_path=None,
                 classes=1000):
     """Instantiates the Inception v3 architecture.
 
@@ -104,8 +105,10 @@ def InceptionV3(include_top=True,
     # Arguments
         include_top: whether to include the fully-connected
             layer at the top of the network.
-        weights: one of `None` (random initialization)
-            or 'imagenet' (pre-training on ImageNet).
+        weights: one of `None` (random initialization),
+              'imagenet' (pre-training on ImageNet),
+              or 'custom' (load pre-trained weights from file at
+              `pretrained_weights_path`).
         input_tensor: optional Keras tensor (i.e. output of `layers.Input()`)
             to use as image input for the model.
         input_shape: optional shape tuple, only to be specified
@@ -126,6 +129,8 @@ def InceptionV3(include_top=True,
                 the output of the model will be a 2D tensor.
             - `max` means that global max pooling will
                 be applied.
+        pretrained_weights_path: optional path to h5 file containing
+            pretrained model weights
         classes: optional number of classes to classify images
             into, only to be specified if `include_top` is True, and
             if no `weights` argument is specified.
@@ -137,10 +142,11 @@ def InceptionV3(include_top=True,
         ValueError: in case of invalid argument for `weights`,
             or invalid input shape.
     """
-    if weights not in {'imagenet', None}:
+    if weights not in {'imagenet', 'custom', None}:
         raise ValueError('The `weights` argument should be either '
-                         '`None` (random initialization) or `imagenet` '
-                         '(pre-training on ImageNet).')
+                         '`None` (random initialization), `imagenet` '
+                         '(pre-training on ImageNet), '
+                         'or `custom` (supplied at user-defined path).')
 
     if weights == 'imagenet' and include_top and classes != 1000:
         raise ValueError('If using `weights` as imagenet with `include_top`'
@@ -385,6 +391,10 @@ def InceptionV3(include_top=True,
                 cache_subdir='models',
                 file_hash='bcbd6486424b2319ff4ef7d526e38f63')
         model.load_weights(weights_path)
+
+    if weights == 'custom':
+        model.load_weights(pretrained_weights_path)
+
     return model
 
 

--- a/keras/applications/mobilenet.py
+++ b/keras/applications/mobilenet.py
@@ -302,6 +302,7 @@ def MobileNet(input_shape=None,
               weights='imagenet',
               input_tensor=None,
               pooling=None,
+              pretrained_weights_path=None,
               classes=1000):
     """Instantiates the MobileNet architecture.
 
@@ -338,8 +339,10 @@ def MobileNet(input_shape=None,
         dropout: dropout rate
         include_top: whether to include the fully-connected
             layer at the top of the network.
-        weights: `None` (random initialization) or
-            `imagenet` (ImageNet weights)
+        weights: one of `None` (random initialization),
+              'imagenet' (pre-training on ImageNet),
+              or 'custom' (load pre-trained weights from file at
+              `pretrained_weights_path`).
         input_tensor: optional Keras tensor (i.e. output of
             `layers.Input()`)
             to use as image input for the model.
@@ -355,6 +358,8 @@ def MobileNet(input_shape=None,
                 2D tensor.
             - `max` means that global max pooling will
                 be applied.
+        pretrained_weights_path: optional path to h5 file containing
+            pretrained model weights
         classes: optional number of classes to classify images
             into, only to be specified if `include_top` is True, and
             if no `weights` argument is specified.
@@ -374,10 +379,11 @@ def MobileNet(input_shape=None,
                            'as other backends do not support '
                            'depthwise convolution.')
 
-    if weights not in {'imagenet', None}:
+    if weights not in {'imagenet', 'custom', None}:
         raise ValueError('The `weights` argument should be either '
-                         '`None` (random initialization) or `imagenet` '
-                         '(pre-training on ImageNet).')
+                         '`None` (random initialization), `imagenet` '
+                         '(pre-training on ImageNet), '
+                         'or `custom` (supplied at user-defined path).')
 
     if weights == 'imagenet' and include_top and classes != 1000:
         raise ValueError('If using `weights` as ImageNet with `include_top` '
@@ -531,6 +537,9 @@ def MobileNet(input_shape=None,
                                     weigh_path,
                                     cache_subdir='models')
         model.load_weights(weights_path)
+
+    if weights == 'custom':
+        model.load_weights(pretrained_weights_path)
 
     if old_data_format:
         K.set_image_data_format(old_data_format)

--- a/keras/applications/mobilenet.py
+++ b/keras/applications/mobilenet.py
@@ -53,6 +53,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
 
+import os
 import warnings
 
 from ..models import Model
@@ -302,7 +303,6 @@ def MobileNet(input_shape=None,
               weights='imagenet',
               input_tensor=None,
               pooling=None,
-              pretrained_weights_path=None,
               classes=1000):
     """Instantiates the MobileNet architecture.
 
@@ -341,8 +341,7 @@ def MobileNet(input_shape=None,
             layer at the top of the network.
         weights: one of `None` (random initialization),
               'imagenet' (pre-training on ImageNet),
-              or 'custom' (load pre-trained weights from file at
-              `pretrained_weights_path`).
+              or the path to the weights file to be loaded.
         input_tensor: optional Keras tensor (i.e. output of
             `layers.Input()`)
             to use as image input for the model.
@@ -358,8 +357,6 @@ def MobileNet(input_shape=None,
                 2D tensor.
             - `max` means that global max pooling will
                 be applied.
-        pretrained_weights_path: optional path to h5 file containing
-            pretrained model weights
         classes: optional number of classes to classify images
             into, only to be specified if `include_top` is True, and
             if no `weights` argument is specified.
@@ -379,11 +376,11 @@ def MobileNet(input_shape=None,
                            'as other backends do not support '
                            'depthwise convolution.')
 
-    if weights not in {'imagenet', 'custom', None}:
+    if not (weights in {'imagenet', None} or os.path.exists(weights)):
         raise ValueError('The `weights` argument should be either '
                          '`None` (random initialization), `imagenet` '
                          '(pre-training on ImageNet), '
-                         'or `custom` (supplied at user-defined path).')
+                         'or the path to the weights file to be loaded.')
 
     if weights == 'imagenet' and include_top and classes != 1000:
         raise ValueError('If using `weights` as ImageNet with `include_top` '
@@ -537,9 +534,8 @@ def MobileNet(input_shape=None,
                                     weigh_path,
                                     cache_subdir='models')
         model.load_weights(weights_path)
-
-    if weights == 'custom':
-        model.load_weights(pretrained_weights_path)
+    elif weights is not None:
+        model.load_weights(weights)
 
     if old_data_format:
         K.set_image_data_format(old_data_format)

--- a/keras/applications/resnet50.py
+++ b/keras/applications/resnet50.py
@@ -124,6 +124,7 @@ def conv_block(input_tensor, kernel_size, filters, stage, block, strides=(2, 2))
 def ResNet50(include_top=True, weights='imagenet',
              input_tensor=None, input_shape=None,
              pooling=None,
+             pretrained_weights_path=None,
              classes=1000):
     """Instantiates the ResNet50 architecture.
 
@@ -141,8 +142,10 @@ def ResNet50(include_top=True, weights='imagenet',
     # Arguments
         include_top: whether to include the fully-connected
             layer at the top of the network.
-        weights: one of `None` (random initialization)
-            or 'imagenet' (pre-training on ImageNet).
+        weights: one of `None` (random initialization),
+              'imagenet' (pre-training on ImageNet),
+              or 'custom' (load pre-trained weights from file at
+              `pretrained_weights_path`).
         input_tensor: optional Keras tensor (i.e. output of `layers.Input()`)
             to use as image input for the model.
         input_shape: optional shape tuple, only to be specified
@@ -163,6 +166,8 @@ def ResNet50(include_top=True, weights='imagenet',
                 the output of the model will be a 2D tensor.
             - `max` means that global max pooling will
                 be applied.
+        pretrained_weights_path: optional path to h5 file containing
+            pretrained model weights
         classes: optional number of classes to classify images
             into, only to be specified if `include_top` is True, and
             if no `weights` argument is specified.
@@ -174,10 +179,11 @@ def ResNet50(include_top=True, weights='imagenet',
         ValueError: in case of invalid argument for `weights`,
             or invalid input shape.
     """
-    if weights not in {'imagenet', None}:
+    if weights not in {'imagenet', 'custom', None}:
         raise ValueError('The `weights` argument should be either '
-                         '`None` (random initialization) or `imagenet` '
-                         '(pre-training on ImageNet).')
+                         '`None` (random initialization), `imagenet` '
+                         '(pre-training on ImageNet), '
+                         'or `custom` (supplied at user-defined path).')
 
     if weights == 'imagenet' and include_top and classes != 1000:
         raise ValueError('If using `weights` as imagenet with `include_top`'
@@ -279,4 +285,8 @@ def ResNet50(include_top=True, weights='imagenet',
                           '`image_data_format="channels_last"` in '
                           'your Keras config '
                           'at ~/.keras/keras.json.')
+
+    if weights == 'custom':
+        model.load_weights(pretrained_weights_path)
+
     return model

--- a/keras/applications/resnet50.py
+++ b/keras/applications/resnet50.py
@@ -10,6 +10,7 @@ Adapted from code contributed by BigMoyan.
 from __future__ import print_function
 from __future__ import absolute_import
 
+import os
 import warnings
 
 from ..layers import Input
@@ -124,7 +125,6 @@ def conv_block(input_tensor, kernel_size, filters, stage, block, strides=(2, 2))
 def ResNet50(include_top=True, weights='imagenet',
              input_tensor=None, input_shape=None,
              pooling=None,
-             pretrained_weights_path=None,
              classes=1000):
     """Instantiates the ResNet50 architecture.
 
@@ -144,8 +144,7 @@ def ResNet50(include_top=True, weights='imagenet',
             layer at the top of the network.
         weights: one of `None` (random initialization),
               'imagenet' (pre-training on ImageNet),
-              or 'custom' (load pre-trained weights from file at
-              `pretrained_weights_path`).
+              or the path to the weights file to be loaded.
         input_tensor: optional Keras tensor (i.e. output of `layers.Input()`)
             to use as image input for the model.
         input_shape: optional shape tuple, only to be specified
@@ -166,8 +165,6 @@ def ResNet50(include_top=True, weights='imagenet',
                 the output of the model will be a 2D tensor.
             - `max` means that global max pooling will
                 be applied.
-        pretrained_weights_path: optional path to h5 file containing
-            pretrained model weights
         classes: optional number of classes to classify images
             into, only to be specified if `include_top` is True, and
             if no `weights` argument is specified.
@@ -179,11 +176,11 @@ def ResNet50(include_top=True, weights='imagenet',
         ValueError: in case of invalid argument for `weights`,
             or invalid input shape.
     """
-    if weights not in {'imagenet', 'custom', None}:
+    if not (weights in {'imagenet', None} or os.path.exists(weights)):
         raise ValueError('The `weights` argument should be either '
                          '`None` (random initialization), `imagenet` '
                          '(pre-training on ImageNet), '
-                         'or `custom` (supplied at user-defined path).')
+                         'or the path to the weights file to be loaded.')
 
     if weights == 'imagenet' and include_top and classes != 1000:
         raise ValueError('If using `weights` as imagenet with `include_top`'
@@ -285,8 +282,7 @@ def ResNet50(include_top=True, weights='imagenet',
                           '`image_data_format="channels_last"` in '
                           'your Keras config '
                           'at ~/.keras/keras.json.')
-
-    if weights == 'custom':
-        model.load_weights(pretrained_weights_path)
+    elif weights is not None:
+        model.load_weights(weights)
 
     return model

--- a/keras/applications/vgg16.py
+++ b/keras/applications/vgg16.py
@@ -35,6 +35,7 @@ WEIGHTS_PATH_NO_TOP = 'https://github.com/fchollet/deep-learning-models/releases
 def VGG16(include_top=True, weights='imagenet',
           input_tensor=None, input_shape=None,
           pooling=None,
+          pretrained_weights_path=None,
           classes=1000):
     """Instantiates the VGG16 architecture.
 
@@ -52,8 +53,10 @@ def VGG16(include_top=True, weights='imagenet',
     # Arguments
         include_top: whether to include the 3 fully-connected
             layers at the top of the network.
-        weights: one of `None` (random initialization)
-            or 'imagenet' (pre-training on ImageNet).
+        weights: one of `None` (random initialization),
+              'imagenet' (pre-training on ImageNet),
+              or 'custom' (load pre-trained weights from file at
+              `pretrained_weights_path`).
         input_tensor: optional Keras tensor (i.e. output of `layers.Input()`)
             to use as image input for the model.
         input_shape: optional shape tuple, only to be specified
@@ -74,6 +77,8 @@ def VGG16(include_top=True, weights='imagenet',
                 the output of the model will be a 2D tensor.
             - `max` means that global max pooling will
                 be applied.
+        pretrained_weights_path: optional path to h5 file containing
+            pretrained model weights
         classes: optional number of classes to classify images
             into, only to be specified if `include_top` is True, and
             if no `weights` argument is specified.
@@ -85,10 +90,11 @@ def VGG16(include_top=True, weights='imagenet',
         ValueError: in case of invalid argument for `weights`,
             or invalid input shape.
     """
-    if weights not in {'imagenet', None}:
+    if weights not in {'imagenet', 'custom', None}:
         raise ValueError('The `weights` argument should be either '
-                         '`None` (random initialization) or `imagenet` '
-                         '(pre-training on ImageNet).')
+                         '`None` (random initialization), `imagenet` '
+                         '(pre-training on ImageNet), '
+                         'or `custom` (supplied at user-defined path).')
 
     if weights == 'imagenet' and include_top and classes != 1000:
         raise ValueError('If using `weights` as imagenet with `include_top`'
@@ -189,4 +195,8 @@ def VGG16(include_top=True, weights='imagenet',
                               '`image_data_format="channels_last"` in '
                               'your Keras config '
                               'at ~/.keras/keras.json.')
+
+    if weights == 'custom':
+        model.load_weights(pretrained_weights_path)
+
     return model

--- a/keras/applications/vgg16.py
+++ b/keras/applications/vgg16.py
@@ -9,6 +9,7 @@
 from __future__ import print_function
 from __future__ import absolute_import
 
+import os
 import warnings
 
 from ..models import Model
@@ -35,7 +36,6 @@ WEIGHTS_PATH_NO_TOP = 'https://github.com/fchollet/deep-learning-models/releases
 def VGG16(include_top=True, weights='imagenet',
           input_tensor=None, input_shape=None,
           pooling=None,
-          pretrained_weights_path=None,
           classes=1000):
     """Instantiates the VGG16 architecture.
 
@@ -55,8 +55,7 @@ def VGG16(include_top=True, weights='imagenet',
             layers at the top of the network.
         weights: one of `None` (random initialization),
               'imagenet' (pre-training on ImageNet),
-              or 'custom' (load pre-trained weights from file at
-              `pretrained_weights_path`).
+              or the path to the weights file to be loaded.
         input_tensor: optional Keras tensor (i.e. output of `layers.Input()`)
             to use as image input for the model.
         input_shape: optional shape tuple, only to be specified
@@ -77,8 +76,6 @@ def VGG16(include_top=True, weights='imagenet',
                 the output of the model will be a 2D tensor.
             - `max` means that global max pooling will
                 be applied.
-        pretrained_weights_path: optional path to h5 file containing
-            pretrained model weights
         classes: optional number of classes to classify images
             into, only to be specified if `include_top` is True, and
             if no `weights` argument is specified.
@@ -90,11 +87,11 @@ def VGG16(include_top=True, weights='imagenet',
         ValueError: in case of invalid argument for `weights`,
             or invalid input shape.
     """
-    if weights not in {'imagenet', 'custom', None}:
+    if not (weights in {'imagenet', None} or os.path.exists(weights)):
         raise ValueError('The `weights` argument should be either '
                          '`None` (random initialization), `imagenet` '
                          '(pre-training on ImageNet), '
-                         'or `custom` (supplied at user-defined path).')
+                         'or the path to the weights file to be loaded.')
 
     if weights == 'imagenet' and include_top and classes != 1000:
         raise ValueError('If using `weights` as imagenet with `include_top`'
@@ -195,8 +192,7 @@ def VGG16(include_top=True, weights='imagenet',
                               '`image_data_format="channels_last"` in '
                               'your Keras config '
                               'at ~/.keras/keras.json.')
-
-    if weights == 'custom':
-        model.load_weights(pretrained_weights_path)
+    elif weights is not None:
+        model.load_weights(weights)
 
     return model

--- a/keras/applications/vgg19.py
+++ b/keras/applications/vgg19.py
@@ -35,6 +35,7 @@ WEIGHTS_PATH_NO_TOP = 'https://github.com/fchollet/deep-learning-models/releases
 def VGG19(include_top=True, weights='imagenet',
           input_tensor=None, input_shape=None,
           pooling=None,
+          pretrained_weights_path=None,
           classes=1000):
     """Instantiates the VGG19 architecture.
 
@@ -52,8 +53,10 @@ def VGG19(include_top=True, weights='imagenet',
     # Arguments
         include_top: whether to include the 3 fully-connected
             layers at the top of the network.
-        weights: one of `None` (random initialization)
-            or 'imagenet' (pre-training on ImageNet).
+        weights: one of `None` (random initialization),
+              'imagenet' (pre-training on ImageNet),
+              or 'custom' (load pre-trained weights from file at
+              `pretrained_weights_path`).
         input_tensor: optional Keras tensor (i.e. output of `layers.Input()`)
             to use as image input for the model.
         input_shape: optional shape tuple, only to be specified
@@ -74,6 +77,8 @@ def VGG19(include_top=True, weights='imagenet',
                 the output of the model will be a 2D tensor.
             - `max` means that global max pooling will
                 be applied.
+        pretrained_weights_path: optional path to h5 file containing
+            pretrained model weights
         classes: optional number of classes to classify images
             into, only to be specified if `include_top` is True, and
             if no `weights` argument is specified.
@@ -85,10 +90,11 @@ def VGG19(include_top=True, weights='imagenet',
         ValueError: in case of invalid argument for `weights`,
             or invalid input shape.
     """
-    if weights not in {'imagenet', None}:
+    if weights not in {'imagenet', 'custom', None}:
         raise ValueError('The `weights` argument should be either '
-                         '`None` (random initialization) or `imagenet` '
-                         '(pre-training on ImageNet).')
+                         '`None` (random initialization), `imagenet` '
+                         '(pre-training on ImageNet), '
+                         'or `custom` (supplied at user-defined path).')
 
     if weights == 'imagenet' and include_top and classes != 1000:
         raise ValueError('If using `weights` as imagenet with `include_top`'
@@ -192,4 +198,8 @@ def VGG19(include_top=True, weights='imagenet',
                               '`image_data_format="channels_last"` in '
                               'your Keras config '
                               'at ~/.keras/keras.json.')
+
+    if weights == 'custom':
+        model.load_weights(pretrained_weights_path)
+
     return model

--- a/keras/applications/vgg19.py
+++ b/keras/applications/vgg19.py
@@ -9,6 +9,7 @@
 from __future__ import print_function
 from __future__ import absolute_import
 
+import os
 import warnings
 
 from ..models import Model
@@ -35,7 +36,6 @@ WEIGHTS_PATH_NO_TOP = 'https://github.com/fchollet/deep-learning-models/releases
 def VGG19(include_top=True, weights='imagenet',
           input_tensor=None, input_shape=None,
           pooling=None,
-          pretrained_weights_path=None,
           classes=1000):
     """Instantiates the VGG19 architecture.
 
@@ -55,8 +55,7 @@ def VGG19(include_top=True, weights='imagenet',
             layers at the top of the network.
         weights: one of `None` (random initialization),
               'imagenet' (pre-training on ImageNet),
-              or 'custom' (load pre-trained weights from file at
-              `pretrained_weights_path`).
+              or the path to the weights file to be loaded.
         input_tensor: optional Keras tensor (i.e. output of `layers.Input()`)
             to use as image input for the model.
         input_shape: optional shape tuple, only to be specified
@@ -77,8 +76,6 @@ def VGG19(include_top=True, weights='imagenet',
                 the output of the model will be a 2D tensor.
             - `max` means that global max pooling will
                 be applied.
-        pretrained_weights_path: optional path to h5 file containing
-            pretrained model weights
         classes: optional number of classes to classify images
             into, only to be specified if `include_top` is True, and
             if no `weights` argument is specified.
@@ -90,11 +87,11 @@ def VGG19(include_top=True, weights='imagenet',
         ValueError: in case of invalid argument for `weights`,
             or invalid input shape.
     """
-    if weights not in {'imagenet', 'custom', None}:
+    if not (weights in {'imagenet', None} or os.path.exists(weights)):
         raise ValueError('The `weights` argument should be either '
                          '`None` (random initialization), `imagenet` '
                          '(pre-training on ImageNet), '
-                         'or `custom` (supplied at user-defined path).')
+                         'or the path to the weights file to be loaded.')
 
     if weights == 'imagenet' and include_top and classes != 1000:
         raise ValueError('If using `weights` as imagenet with `include_top`'
@@ -198,8 +195,7 @@ def VGG19(include_top=True, weights='imagenet',
                               '`image_data_format="channels_last"` in '
                               'your Keras config '
                               'at ~/.keras/keras.json.')
-
-    if weights == 'custom':
-        model.load_weights(pretrained_weights_path)
+    elif weights is not None:
+        model.load_weights(weights)
 
     return model

--- a/keras/applications/xception.py
+++ b/keras/applications/xception.py
@@ -20,6 +20,7 @@ due to its reliance on `SeparableConvolution` layers.
 from __future__ import print_function
 from __future__ import absolute_import
 
+import os
 import warnings
 
 from ..models import Model
@@ -48,7 +49,6 @@ TF_WEIGHTS_PATH_NO_TOP = 'https://github.com/fchollet/deep-learning-models/relea
 def Xception(include_top=True, weights='imagenet',
              input_tensor=None, input_shape=None,
              pooling=None,
-             pretrained_weights_path=None,
              classes=1000):
     """Instantiates the Xception architecture.
 
@@ -66,8 +66,7 @@ def Xception(include_top=True, weights='imagenet',
             layer at the top of the network.
         weights: one of `None` (random initialization),
               'imagenet' (pre-training on ImageNet),
-              or 'custom' (load pre-trained weights from file at
-              `pretrained_weights_path`).
+              or the path to the weights file to be loaded.
         input_tensor: optional Keras tensor (i.e. output of `layers.Input()`)
             to use as image input for the model.
         input_shape: optional shape tuple, only to be specified
@@ -87,8 +86,6 @@ def Xception(include_top=True, weights='imagenet',
                 the output of the model will be a 2D tensor.
             - `max` means that global max pooling will
                 be applied.
-        pretrained_weights_path: optional path to h5 file containing
-            pretrained model weights
         classes: optional number of classes to classify images
             into, only to be specified if `include_top` is True, and
             if no `weights` argument is specified.
@@ -102,11 +99,11 @@ def Xception(include_top=True, weights='imagenet',
         RuntimeError: If attempting to run this model with a
             backend that does not support separable convolutions.
     """
-    if weights not in {'imagenet', 'custom', None}:
+    if not (weights in {'imagenet', None} or os.path.exists(weights)):
         raise ValueError('The `weights` argument should be either '
                          '`None` (random initialization), `imagenet` '
                          '(pre-training on ImageNet), '
-                         'or `custom` (supplied at user-defined path).')
+                         'or the path to the weights file to be loaded.')
 
     if weights == 'imagenet' and include_top and classes != 1000:
         raise ValueError('If using `weights` as imagenet with `include_top`'
@@ -263,9 +260,8 @@ def Xception(include_top=True, weights='imagenet',
                                     cache_subdir='models',
                                     file_hash='b0042744bf5b25fce3cb969f33bebb97')
         model.load_weights(weights_path)
-
-    if weights == 'custom':
-        model.load_weights(pretrained_weights_path)
+    elif weights is not None:
+        model.load_weights(weights)
 
     if old_data_format:
         K.set_image_data_format(old_data_format)

--- a/keras/applications/xception.py
+++ b/keras/applications/xception.py
@@ -48,6 +48,7 @@ TF_WEIGHTS_PATH_NO_TOP = 'https://github.com/fchollet/deep-learning-models/relea
 def Xception(include_top=True, weights='imagenet',
              input_tensor=None, input_shape=None,
              pooling=None,
+             pretrained_weights_path=None,
              classes=1000):
     """Instantiates the Xception architecture.
 
@@ -63,8 +64,10 @@ def Xception(include_top=True, weights='imagenet',
     # Arguments
         include_top: whether to include the fully-connected
             layer at the top of the network.
-        weights: one of `None` (random initialization)
-            or 'imagenet' (pre-training on ImageNet).
+        weights: one of `None` (random initialization),
+              'imagenet' (pre-training on ImageNet),
+              or 'custom' (load pre-trained weights from file at
+              `pretrained_weights_path`).
         input_tensor: optional Keras tensor (i.e. output of `layers.Input()`)
             to use as image input for the model.
         input_shape: optional shape tuple, only to be specified
@@ -84,6 +87,8 @@ def Xception(include_top=True, weights='imagenet',
                 the output of the model will be a 2D tensor.
             - `max` means that global max pooling will
                 be applied.
+        pretrained_weights_path: optional path to h5 file containing
+            pretrained model weights
         classes: optional number of classes to classify images
             into, only to be specified if `include_top` is True, and
             if no `weights` argument is specified.
@@ -97,10 +102,11 @@ def Xception(include_top=True, weights='imagenet',
         RuntimeError: If attempting to run this model with a
             backend that does not support separable convolutions.
     """
-    if weights not in {'imagenet', None}:
+    if weights not in {'imagenet', 'custom', None}:
         raise ValueError('The `weights` argument should be either '
-                         '`None` (random initialization) or `imagenet` '
-                         '(pre-training on ImageNet).')
+                         '`None` (random initialization), `imagenet` '
+                         '(pre-training on ImageNet), '
+                         'or `custom` (supplied at user-defined path).')
 
     if weights == 'imagenet' and include_top and classes != 1000:
         raise ValueError('If using `weights` as imagenet with `include_top`'
@@ -257,6 +263,9 @@ def Xception(include_top=True, weights='imagenet',
                                     cache_subdir='models',
                                     file_hash='b0042744bf5b25fce3cb969f33bebb97')
         model.load_weights(weights_path)
+
+    if weights == 'custom':
+        model.load_weights(pretrained_weights_path)
 
     if old_data_format:
         K.set_image_data_format(old_data_format)


### PR DESCRIPTION
This PR allows a pretrained model from keras.applications to load weights from an arbitrary path (rather than only the path currently hardcoded for pretrained imagenet models).  Use cases for this include:
- Using applications architectures with pre-trained weights other than keras' canonical imagenet weights
- Loading models in environment with limitations that prohibit accessing `~/.keras/models` (kaggle kernels happens to be such an environment)

I found it difficult to write appropriate automated tests.  Before issuing the PR, I locally tested that each architecture returns the same values when predicting on an image with the `weights='imagenet'` and with the same weights files loaded through an alternative path defined in the `pretrained_weights_path` argument.

If this is accepted, I plan to submit a parallel PR to tensorflow.python.keras