### PR TITLE
Documentation fix for imdb.load_data

### DIFF
--- a/keras/datasets/imdb.py
+++ b/keras/datasets/imdb.py
@@ -18,7 +18,7 @@ def load_data(path='imdb.npz', num_words=None, skip_top=0,
             the most frequent words are kept
         skip_top: skip the top N most frequently occurring words
             (which may not be informative).
-        maxlen: truncate sequences after this length.
+        maxlen: sequences longer than this will be filtered out.
         seed: random seed for sample shuffling.
         start_char: The start of a sequence will be marked with this character.
             Set to 1 because 0 is usually the padding character.


### PR DESCRIPTION
maxlen is passed to _remove_long_seq which filters out sequences; the documentation stated sequences would be truncated.