### PR TITLE
Refactor RNN dropout to be self-contained in RNN cells

### DIFF
--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -663,6 +663,8 @@ def zeros(shape, dtype=None, name=None):
 
     # Returns
         A variable (including Keras metadata), filled with `0.0`.
+        Note that if `shape` was symbolic, we cannot return a variable,
+        and will return a dynamically-shaped tensor instead.
 
     # Example
     ```python
@@ -677,12 +679,14 @@ def zeros(shape, dtype=None, name=None):
     if dtype is None:
         dtype = floatx()
     tf_dtype = tf.as_dtype(dtype)
-    return variable(tf.constant_initializer(0., dtype=tf_dtype)(shape),
-                    dtype, name)
+    v = tf.zeros(shape=shape, dtype=tf_dtype, name=name)
+    if py_all(v.get_shape().as_list()):
+        return variable(v, dtype=dtype, name=name)
+    return v
 
 
 def ones(shape, dtype=None, name=None):
-    """Instantiates an all-ones tensor variable and returns it.
+    """Instantiates an all-ones variable and returns it.
 
     # Arguments
         shape: Tuple of integers, shape of returned Keras variable.
@@ -691,6 +695,8 @@ def ones(shape, dtype=None, name=None):
 
     # Returns
         A Keras variable, filled with `1.0`.
+        Note that if `shape` was symbolic, we cannot return a variable,
+        and will return a dynamically-shaped tensor instead.
 
     # Example
     ```python
@@ -705,8 +711,10 @@ def ones(shape, dtype=None, name=None):
     if dtype is None:
         dtype = floatx()
     tf_dtype = tf.as_dtype(dtype)
-    return variable(tf.constant_initializer(1., dtype=tf_dtype)(shape),
-                    dtype, name)
+    v = tf.ones(shape=shape, dtype=tf_dtype, name=name)
+    if py_all(v.get_shape().as_list()):
+        return variable(v, dtype=dtype, name=name)
+    return v
 
 
 def eye(size, dtype=None, name=None):

--- a/tests/keras/layers/recurrent_test.py
+++ b/tests/keras/layers/recurrent_test.py
@@ -70,8 +70,8 @@ def test_stateful_invalid_use(layer_class):
 
 
 @rnn_test
-@pytest.mark.skipif((K.backend() == 'cntk'),
-                    reason='Not yet supported.')
+@pytest.mark.skipif((K.backend() in ['cntk', 'theano']),
+                    reason='Not supported.')
 def test_dropout(layer_class):
     for unroll in [True, False]:
         layer_test(layer_class,
@@ -554,6 +554,23 @@ def test_minimal_rnn_cell_layer():
     model.set_weights(weights)
     y_np_2 = model.predict(x_np)
     assert_allclose(y_np, y_np_2, atol=1e-4)
+
+
+@keras_test
+@pytest.mark.skipif((K.backend() in ['cntk', 'theano']),
+                    reason='Not supported.')
+def test_stacked_rnn_dropout():
+    cells = [recurrent.LSTMCell(3, dropout=0.1, recurrent_dropout=0.1),
+             recurrent.LSTMCell(3, dropout=0.1, recurrent_dropout=0.1)]
+    layer = recurrent.RNN(cells)
+
+    x = keras.Input((None, 5))
+    y = layer(x)
+    model = keras.models.Model(x, y)
+    model.compile('sgd', 'mse')
+    x_np = np.random.random((6, 5, 5))
+    y_np = np.random.random((6, 3))
+    model.train_on_batch(x_np, y_np)
 
 
 @keras_test

--- a/tests/keras/layers/wrappers_test.py
+++ b/tests/keras/layers/wrappers_test.py
@@ -199,8 +199,8 @@ def test_Bidirectional():
         outputs = wrappers.Bidirectional(rnn(output_dim, dropout=dropout_rate,
                                              recurrent_dropout=dropout_rate),
                                          merge_mode=mode)(inputs)
-        if dropout_rate and K.backend() != 'cntk':
-            # Dropout is disabled with CNTK for now.
+        if dropout_rate and K.backend() == 'tensorflow':
+            # Dropout is disabled with CNTK/Theano.
             assert outputs._uses_learning_phase
         model = Model(inputs, outputs)
         model.compile(loss='mse', optimizer='sgd')


### PR DESCRIPTION
Which is cleaner, and fixes a couple of outstanding bugs. Side effect: disables RNN dropout for Theano. Indeed, Theano does not allow new variables to be created inside a recurrent loop. Creating the dropout masks in advance would break the containerization. 