### PR TITLE
Fix GeneratorEnqueuer Multithreading on Windows (and Linux...)

### DIFF
--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -617,9 +617,9 @@ class GeneratorEnqueuer(SequenceEnqueuer):
             # `TypeError: can't pickle generator objects`
             # => Suggest multithreading instead of multiprocessing on Windows
             raise ValueError('Using a generator with `use_multiprocessing=True`'
-                            ' is not supported on Windows (no marshalling of'
-                            ' generators across process boundaries). Instead,'
-                            ' use single thread/process or multithreading.')
+                             ' is not supported on Windows (no marshalling of'
+                             ' generators across process boundaries). Instead,'
+                             ' use single thread/process or multithreading.')
         else:
             self._use_multiprocessing = use_multiprocessing
         self._threads = []
@@ -650,7 +650,7 @@ class GeneratorEnqueuer(SequenceEnqueuer):
                             setattr(e, '__traceback__', sys.exc_info()[2])
                         self.queue.put((False, e))
                         self._stop_event.set()
-                        break            
+                        break
         else:
             while not self._stop_event.is_set():
                 try:
@@ -697,12 +697,12 @@ class GeneratorEnqueuer(SequenceEnqueuer):
                     # Reset random seed else all children processes
                     # share the same seed
                     np.random.seed(self.seed)
-                    thread = multiprocessing.Process(target=self.data_generator_task, args=()) 
+                    thread = multiprocessing.Process(target=self.data_generator_task)
                     thread.daemon = True
                     if self.seed is not None:
                         self.seed += 1
                 else:
-                    thread = threading.Thread(target=self.data_generator_task, args=())
+                    thread = threading.Thread(target=self.data_generator_task)
                 self._threads.append(thread)
                 thread.start()
         except:

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -628,7 +628,7 @@ class GeneratorEnqueuer(SequenceEnqueuer):
         self.queue = None
         self.seed = seed
 
-    def __data_generator_task(self):
+    def _data_generator_task(self):
         if self._use_multiprocessing is False:
             while not self._stop_event.is_set():
                 with self.genlock:
@@ -697,12 +697,12 @@ class GeneratorEnqueuer(SequenceEnqueuer):
                     # Reset random seed else all children processes
                     # share the same seed
                     np.random.seed(self.seed)
-                    thread = multiprocessing.Process(target=self.__data_generator_task)
+                    thread = multiprocessing.Process(target=self._data_generator_task)
                     thread.daemon = True
                     if self.seed is not None:
                         self.seed += 1
                 else:
-                    thread = threading.Thread(target=self.__data_generator_task)
+                    thread = threading.Thread(target=self._data_generator_task)
                 self._threads.append(thread)
                 thread.start()
         except:

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -628,7 +628,7 @@ class GeneratorEnqueuer(SequenceEnqueuer):
         self.queue = None
         self.seed = seed
 
-    def data_generator_task(self):
+    def __data_generator_task(self):
         if self._use_multiprocessing is False:
             while not self._stop_event.is_set():
                 with self.genlock:
@@ -644,7 +644,7 @@ class GeneratorEnqueuer(SequenceEnqueuer):
                     except StopIteration:
                         break
                     except Exception as e:
-                        # Can't pick tracebacks.
+                        # Can't pickle tracebacks.
                         # As a compromise, print the traceback and pickle None instead.
                         if not hasattr(e, '__traceback__'):
                             setattr(e, '__traceback__', sys.exc_info()[2])
@@ -662,7 +662,7 @@ class GeneratorEnqueuer(SequenceEnqueuer):
                 except StopIteration:
                     break
                 except Exception as e:
-                    # Can't pick tracebacks.
+                    # Can't pickle tracebacks.
                     # As a compromise, print the traceback and pickle None instead.
                     traceback.print_exc()
                     setattr(e, '__traceback__', None)
@@ -697,12 +697,12 @@ class GeneratorEnqueuer(SequenceEnqueuer):
                     # Reset random seed else all children processes
                     # share the same seed
                     np.random.seed(self.seed)
-                    thread = multiprocessing.Process(target=self.data_generator_task)
+                    thread = multiprocessing.Process(target=self.__data_generator_task)
                     thread.daemon = True
                     if self.seed is not None:
                         self.seed += 1
                 else:
-                    thread = threading.Thread(target=self.data_generator_task)
+                    thread = threading.Thread(target=self.__data_generator_task)
                 self._threads.append(thread)
                 thread.start()
         except:

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -612,26 +612,49 @@ class GeneratorEnqueuer(SequenceEnqueuer):
                  seed=None):
         self.wait_time = wait_time
         self._generator = generator
-        self._use_multiprocessing = use_multiprocessing
+        if os.name is 'nt' and use_multiprocessing is True:
+            # On Windows, avoid **SYSTEMATIC** error in `multiprocessing`:
+            # `TypeError: can't pickle generator objects`
+            # => Suggest multithreading instead of multiprocessing on Windows
+            raise ValueError('Using a generator with `use_multiprocessing=True`'
+                            ' is not supported on Windows (no marshalling of'
+                            ' generators across process boundaries). Instead,'
+                            ' use single thread/process or multithreading.')
+        else:
+            self._use_multiprocessing = use_multiprocessing
         self._threads = []
         self._stop_event = None
         self._manager = None
         self.queue = None
         self.seed = seed
 
-    def start(self, workers=1, max_queue_size=10):
-        """Kicks off threads which add data from the generator into the queue.
-
-        # Arguments
-            workers: number of worker threads
-            max_queue_size: queue size
-                (when full, threads could block on `put()`)
-        """
-
-        def data_generator_task():
+    def data_generator_task(self):
+        if self._use_multiprocessing is False:
+            while not self._stop_event.is_set():
+                with self.genlock:
+                    try:
+                        if self.queue is not None and self.queue.qsize() < self.max_queue_size:
+                            # On all OSes, avoid **SYSTEMATIC** error in multithreading mode:
+                            # `ValueError: generator already executing`
+                            # => Serialize calls to infinite iterator/generator's next() function
+                            generator_output = next(self._generator)
+                            self.queue.put((True, generator_output))
+                        else:
+                            time.sleep(self.wait_time)
+                    except StopIteration:
+                        break
+                    except Exception as e:
+                        # Can't pick tracebacks.
+                        # As a compromise, print the traceback and pickle None instead.
+                        if not hasattr(e, '__traceback__'):
+                            setattr(e, '__traceback__', sys.exc_info()[2])
+                        self.queue.put((False, e))
+                        self._stop_event.set()
+                        break            
+        else:
             while not self._stop_event.is_set():
                 try:
-                    if self._use_multiprocessing or self.queue.qsize() < max_queue_size:
+                    if self.queue is not None and self.queue.qsize() < self.max_queue_size:
                         generator_output = next(self._generator)
                         self.queue.put((True, generator_output))
                     else:
@@ -641,22 +664,32 @@ class GeneratorEnqueuer(SequenceEnqueuer):
                 except Exception as e:
                     # Can't pick tracebacks.
                     # As a compromise, print the traceback and pickle None instead.
-                    if self._use_multiprocessing:
-                        traceback.print_exc()
-                        setattr(e, '__traceback__', None)
-                    elif not hasattr(e, '__traceback__'):
-                        setattr(e, '__traceback__', sys.exc_info()[2])
+                    traceback.print_exc()
+                    setattr(e, '__traceback__', None)
                     self.queue.put((False, e))
                     self._stop_event.set()
                     break
 
+    def start(self, workers=1, max_queue_size=10):
+        """Kicks off threads which add data from the generator into the queue.
+
+        # Arguments
+            workers: number of worker threads
+            max_queue_size: queue size
+                (when full, threads could block on `put()`)
+        """
         try:
+            self.max_queue_size = max_queue_size
             if self._use_multiprocessing:
                 self._manager = multiprocessing.Manager()
                 self.queue = self._manager.Queue(maxsize=max_queue_size)
                 self._stop_event = multiprocessing.Event()
             else:
-                self.queue = queue.Queue()
+                # On all OSes, avoid **SYSTEMATIC** error in multithreading mode:
+                # `ValueError: generator already executing`
+                # => Serialize calls to infinite iterator/generator's next() function
+                self.genlock = threading.Lock()
+                self.queue = queue.Queue(maxsize=max_queue_size)
                 self._stop_event = threading.Event()
 
             for _ in range(workers):
@@ -664,12 +697,12 @@ class GeneratorEnqueuer(SequenceEnqueuer):
                     # Reset random seed else all children processes
                     # share the same seed
                     np.random.seed(self.seed)
-                    thread = multiprocessing.Process(target=data_generator_task)
+                    thread = multiprocessing.Process(target=self.data_generator_task, args=()) 
                     thread.daemon = True
                     if self.seed is not None:
                         self.seed += 1
                 else:
-                    thread = threading.Thread(target=data_generator_task)
+                    thread = threading.Thread(target=self.data_generator_task, args=())
                 self._threads.append(thread)
                 thread.start()
         except:
@@ -691,11 +724,15 @@ class GeneratorEnqueuer(SequenceEnqueuer):
             self._stop_event.set()
 
         for thread in self._threads:
-            if thread.is_alive():
-                if self._use_multiprocessing:
+            if self._use_multiprocessing:
+                if thread.is_alive():
                     thread.terminate()
-                else:
-                    thread.join(timeout)
+            else:
+                # The thread.is_alive() test is subject to a race condition:
+                # the thread could terminate right after the test and before the
+                # join, rendering this test meaningless -> Call thread.join()
+                # always, which is ok no matter what the status of the thread.
+                thread.join(timeout)
 
         if self._manager:
             self._manager.shutdown()

--- a/tests/test_multiprocessing.py
+++ b/tests/test_multiprocessing.py
@@ -1,11 +1,15 @@
 from __future__ import print_function
 import os
+import threading
 import pytest
 import numpy as np
 from keras.models import Sequential
 from keras.layers.core import Dense
 from keras.utils.test_utils import keras_test
 
+gsteps_per_epoch = 100
+gsteps = 100
+gworkers = 4
 
 @pytest.fixture
 def in_tmpdir(tmpdir):
@@ -16,7 +20,6 @@ def in_tmpdir(tmpdir):
     with tmpdir.as_cwd():
         yield None
     assert not tmpdir.listdir()
-
 
 @keras_test
 def test_multiprocessing_training():
@@ -45,38 +48,130 @@ def test_multiprocessing_training():
     model.add(Dense(1, input_shape=(2, )))
     model.compile(loss='mse', optimizer='adadelta')
 
+    # - Produce data on 4 worker processes, consume on main process:
+    #   - Each worker process runs OWN copy of generator 
+    #   - BUT on Windows, `multiprocessing` won't marshall generators across
+    #     process boundaries -> make sure `fit_generator()` raises ValueError
+    #     exception and does not attempt to run the generator.
+    if os.name is 'nt':
+        with pytest.raises(ValueError):
+            model.fit_generator(custom_generator(),
+                    steps_per_epoch=gsteps_per_epoch,
+                    epochs=1,
+                    verbose=1,
+                    validation_steps=None,
+                    max_queue_size=10,
+                    workers=gworkers,
+                    use_multiprocessing=True)
+    else:
+        model.fit_generator(custom_generator(),
+                    steps_per_epoch=gsteps_per_epoch,
+                    epochs=1,
+                    verbose=1,
+                    validation_steps=None,
+                    max_queue_size=10,
+                    workers=gworkers,
+                    use_multiprocessing=True)
+
+    # - Produce data on 4 worker threads, consume on main thread:
+    #   - All worker threads share the SAME generator
     model.fit_generator(custom_generator(),
-                        steps_per_epoch=5,
-                        epochs=1,
-                        verbose=1,
-                        max_queue_size=10,
-                        workers=4,
-                        use_multiprocessing=True)
+                    steps_per_epoch=gsteps_per_epoch,
+                    epochs=1,
+                    verbose=1,
+                    validation_steps=None,
+                    max_queue_size=10,
+                    workers=gworkers,
+                    use_multiprocessing=False)
 
-    model.fit_generator(custom_generator(),
-                        steps_per_epoch=5,
-                        epochs=1,
-                        verbose=1,
-                        max_queue_size=10,
-                        use_multiprocessing=False)
+    # - Produce data on 1 worker process, consume on main process:
+    #   - Worker process runs generator 
+    #   - BUT on Windows, `multiprocessing` won't marshall generators across
+    #     process boundaries -> make sure `fit_generator()` raises ValueError
+    #     exception and does not attempt to run the generator.
+    if os.name is 'nt':
+        with pytest.raises(ValueError):
+            model.fit_generator(custom_generator(True),
+                    steps_per_epoch=gsteps_per_epoch,
+                    validation_data=(arr_data[:10],
+                                     arr_labels[:10],
+                                     arr_weights[:10]),
+                    validation_steps=1,
+                    max_queue_size=10,
+                    workers=1,
+                    use_multiprocessing=True)
+    else:
+        model.fit_generator(custom_generator(True),
+                    steps_per_epoch=gsteps_per_epoch,
+                    validation_data=(arr_data[:10],
+                                     arr_labels[:10],
+                                     arr_weights[:10]),
+                    validation_steps=1,
+                    max_queue_size=10,
+                    workers=1,
+                    use_multiprocessing=True)
 
+    # - Produce data on 1 worker thread, consume on main thread:
+    #   - Worker thread is the only thread running the generator
     model.fit_generator(custom_generator(True),
-                        steps_per_epoch=5,
-                        validation_data=(arr_data[:10],
-                                         arr_labels[:10],
-                                         arr_weights[:10]),
-                        validation_steps=1)
+                    steps_per_epoch=gsteps_per_epoch,
+                    validation_data=(arr_data[:10],
+                                     arr_labels[:10],
+                                     arr_weights[:10]),
+                    validation_steps=1,
+                    max_queue_size=10,
+                    workers=1,
+                    use_multiprocessing=False)
 
-    model.fit_generator(custom_generator(True),
-                        steps_per_epoch=5,
-                        validation_data=custom_generator(True),
-                        validation_steps=1)
+    # - Produce data on 1 worker process, consume on main process:
+    #   - Worker process runs generator 
+    #   - BUT on Windows, `multiprocessing` won't marshall generators across
+    #     process boundaries -> make sure `fit_generator()` raises ValueError
+    #     exception and does not attempt to run the generator.
+    if os.name is 'nt':
+        with pytest.raises(ValueError):
+            model.fit_generator(custom_generator(True),
+                    steps_per_epoch=gsteps_per_epoch,
+                    validation_data=custom_generator(True),
+                    validation_steps=1,
+                    max_queue_size=10,
+                    workers=1,
+                    use_multiprocessing=True)
+    else:
+        model.fit_generator(custom_generator(True),
+                    steps_per_epoch=gsteps_per_epoch,
+                    validation_data=custom_generator(True),
+                    validation_steps=1,
+                    max_queue_size=10,
+                    workers=1,
+                    use_multiprocessing=True)
 
+    # - Produce data on 1 worker thread AT A TIME, consume on main thread:
+    #   - Worker threads for training and validation run generator SEQUENTIALLY
     model.fit_generator(custom_generator(True),
-                        steps_per_epoch=5,
-                        validation_data=custom_generator(True),
-                        validation_steps=1,
-                        workers=0)
+                    steps_per_epoch=gsteps_per_epoch,
+                    validation_data=custom_generator(True),
+                    validation_steps=1,
+                    max_queue_size=10,
+                    workers=1,
+                    use_multiprocessing=False)
+
+    # - Produce and consume data without a queue on main thread
+    #   - Make sure the value of `use_multiprocessing` is ignored
+    model.fit_generator(custom_generator(True),
+                    steps_per_epoch=gsteps_per_epoch,
+                    validation_data=custom_generator(True),
+                    validation_steps=1,
+                    max_queue_size=10,
+                    workers=0,
+                    use_multiprocessing=True)
+    model.fit_generator(custom_generator(True),
+                    steps_per_epoch=gsteps_per_epoch,
+                    validation_data=custom_generator(True),
+                    validation_steps=1,
+                    max_queue_size=10,
+                    workers=0,
+                    use_multiprocessing=False)
 
     # Test invalid use cases
     def invalid_generator():
@@ -86,29 +181,38 @@ def test_multiprocessing_training():
     # not specified `validation_steps`
     with pytest.raises(ValueError):
         model.fit_generator(custom_generator(),
-                            steps_per_epoch=5,
-                            validation_data=custom_generator())
+                    steps_per_epoch=gsteps_per_epoch,
+                    validation_data=custom_generator(),
+                    validation_steps=None,
+                    max_queue_size=10,
+                    workers=1,
+                    use_multiprocessing=False)
 
     # validation data is neither a tuple nor a triple.
     with pytest.raises(ValueError):
         model.fit_generator(custom_generator(),
-                            steps_per_epoch=5,
-                            validation_data=(arr_data[:10],
-                                             arr_data[:10],
-                                             arr_labels[:10],
-                                             arr_weights[:10]),
-                            validation_steps=1)
+                    steps_per_epoch=gsteps_per_epoch,
+                    validation_data=(arr_data[:10],
+                                     arr_data[:10],
+                                     arr_labels[:10],
+                                     arr_weights[:10]),
+                    validation_steps=1,
+                    max_queue_size=10,
+                    workers=1,
+                    use_multiprocessing=False)
 
     # validation generator is neither a tuple nor a triple.
     with pytest.raises(ValueError):
         model.fit_generator(custom_generator(),
-                            steps_per_epoch=5,
-                            validation_data=invalid_generator(),
-                            validation_steps=1)
-
+                    steps_per_epoch=gsteps_per_epoch,
+                    validation_data=invalid_generator(),
+                    validation_steps=1,
+                    max_queue_size=10,
+                    workers=1,
+                    use_multiprocessing=False)
 
 @keras_test
-def test_multiprocessing_training_fromfile(in_tmpdir):
+def test_multiprocessing_training_from_file(in_tmpdir):
     arr_data = np.random.randint(0, 256, (50, 2))
     arr_labels = np.random.randint(0, 2, 50)
     np.savez('data.npz', **{'data': arr_data, 'labels': arr_labels})
@@ -133,23 +237,98 @@ def test_multiprocessing_training_fromfile(in_tmpdir):
     model.add(Dense(1, input_shape=(2, )))
     model.compile(loss='mse', optimizer='adadelta')
 
-    model.fit_generator(custom_generator(),
-                        steps_per_epoch=5,
-                        epochs=1,
-                        verbose=1,
-                        max_queue_size=10,
-                        workers=2,
-                        use_multiprocessing=True)
+    # - Produce data on 4 worker processes, consume on main process:
+    #   - Each worker process runs OWN copy of generator 
+    #   - BUT on Windows, `multiprocessing` won't marshall generators across
+    #     process boundaries -> make sure `fit_generator()` raises ValueError
+    #     exception and does not attempt to run the generator.
+    if os.name is 'nt':
+        with pytest.raises(ValueError):
+            model.fit_generator(custom_generator(),
+                    steps_per_epoch=gsteps_per_epoch,
+                    epochs=1,
+                    verbose=1,
+                    validation_steps=None,
+                    max_queue_size=10,
+                    workers=gworkers,
+                    use_multiprocessing=True)
+    else:
+        model.fit_generator(custom_generator(),
+                    steps_per_epoch=gsteps_per_epoch,
+                    epochs=1,
+                    verbose=1,
+                    validation_steps=None,
+                    max_queue_size=10,
+                    workers=gworkers,
+                    use_multiprocessing=True)
 
+    # - Produce data on 4 worker threads, consume on main thread:
+    #   - All worker threads share the SAME generator
     model.fit_generator(custom_generator(),
-                        steps_per_epoch=5,
-                        epochs=1,
-                        verbose=1,
-                        max_queue_size=10,
-                        use_multiprocessing=False)
+                    steps_per_epoch=gsteps_per_epoch,
+                    epochs=1,
+                    verbose=1,
+                    validation_steps=None,
+                    max_queue_size=10,
+                    workers=gworkers,
+                    use_multiprocessing=False)
+
+    # - Produce data on 1 worker process, consume on main process:
+    #   - Worker process runs generator 
+    #   - BUT on Windows, `multiprocessing` won't marshall generators across
+    #     process boundaries -> make sure `fit_generator()` raises ValueError
+    #     exception and does not attempt to run the generator.
+    if os.name is 'nt':
+        with pytest.raises(ValueError):
+            model.fit_generator(custom_generator(),
+                    steps_per_epoch=gsteps_per_epoch,
+                    epochs=1,
+                    verbose=1,
+                    validation_steps=None,
+                    max_queue_size=10,
+                    workers=1,
+                    use_multiprocessing=True)
+    else:
+        model.fit_generator(custom_generator(),
+                    steps_per_epoch=gsteps_per_epoch,
+                    epochs=1,
+                    verbose=1,
+                    validation_steps=None,
+                    max_queue_size=10,
+                    workers=1,
+                    use_multiprocessing=True)
+
+    # - Produce data on 1 worker thread, consume on main thread:
+    #   - Worker thread is the only thread running the generator
+    model.fit_generator(custom_generator(),
+                    steps_per_epoch=gsteps_per_epoch,
+                    epochs=1,
+                    verbose=1,
+                    validation_steps=None,
+                    max_queue_size=10,
+                    workers=1,
+                    use_multiprocessing=False)
+
+    # - Produce and consume data without a queue on main thread
+    #   - Make sure the value of `use_multiprocessing` is ignored
+    model.fit_generator(custom_generator(),
+                    steps_per_epoch=gsteps_per_epoch,
+                    epochs=1,
+                    verbose=1,
+                    validation_steps=None,
+                    max_queue_size=10,
+                    workers=0,
+                    use_multiprocessing=True)
+    model.fit_generator(custom_generator(),
+                    steps_per_epoch=gsteps_per_epoch,
+                    epochs=1,
+                    verbose=1,
+                    validation_steps=None,
+                    max_queue_size=10,
+                    workers=0,
+                    use_multiprocessing=False)
 
     os.remove('data.npz')
-
 
 @keras_test
 def test_multiprocessing_predicting():
@@ -170,20 +349,73 @@ def test_multiprocessing_predicting():
     model = Sequential()
     model.add(Dense(1, input_shape=(2, )))
     model.compile(loss='mse', optimizer='adadelta')
-    model.predict_generator(custom_generator(),
-                            steps=5,
-                            max_queue_size=10,
-                            workers=2,
-                            use_multiprocessing=True)
-    model.predict_generator(custom_generator(),
-                            steps=5,
-                            max_queue_size=10,
-                            use_multiprocessing=False)
-    model.predict_generator(custom_generator(),
-                            steps=5,
-                            max_queue_size=10,
-                            workers=0)
 
+    # - Produce data on 4 worker processes, consume on main process:
+    #   - Each worker process runs OWN copy of generator 
+    #   - BUT on Windows, `multiprocessing` won't marshall generators across
+    #     process boundaries -> make sure `predict_generator()` raises ValueError
+    #     exception and does not attempt to run the generator.
+    if os.name is 'nt':
+        with pytest.raises(ValueError):
+            model.predict_generator(custom_generator(),
+                    steps=gsteps,
+                    max_queue_size=10,
+                    workers=gworkers,
+                    use_multiprocessing=True)
+    else:
+        model.predict_generator(custom_generator(),
+                    steps=gsteps,
+                    max_queue_size=10,
+                    workers=gworkers,
+                    use_multiprocessing=True)
+
+    # - Produce data on 4 worker threads, consume on main thread:
+    #   - All worker threads share the SAME generator
+    model.predict_generator(custom_generator(),
+                    steps=gsteps,
+                    max_queue_size=10,
+                    workers=gworkers,
+                    use_multiprocessing=False)
+
+    # - Produce data on 1 worker process, consume on main process:
+    #   - Worker process runs generator 
+    #   - BUT on Windows, `multiprocessing` won't marshall generators across
+    #     process boundaries -> make sure `predict_generator()` raises ValueError
+    #     exception and does not attempt to run the generator.
+    if os.name is 'nt':
+        with pytest.raises(ValueError):
+            model.predict_generator(custom_generator(),
+                    steps=gsteps,
+                    max_queue_size=10,
+                    workers=1,
+                    use_multiprocessing=True)
+    else:
+        model.predict_generator(custom_generator(),
+                    steps=gsteps,
+                    max_queue_size=10,
+                    workers=1,
+                    use_multiprocessing=True)
+
+    # - Produce data on 1 worker thread, consume on main thread:
+    #   - Worker thread is the only thread running the generator
+    model.predict_generator(custom_generator(),
+                    steps=gsteps,
+                    max_queue_size=10,
+                    workers=1,
+                    use_multiprocessing=False)
+
+    # - Main thread runs the generator without a queue
+    #   - Make sure the value of `use_multiprocessing` is ignored
+    model.predict_generator(custom_generator(),
+                    steps=gsteps,
+                    max_queue_size=10,
+                    workers=0,
+                    use_multiprocessing=True)
+    model.predict_generator(custom_generator(),
+                    steps=gsteps,
+                    max_queue_size=10,
+                    workers=0,
+                    use_multiprocessing=False)
 
 @keras_test
 def test_multiprocessing_evaluating():
@@ -207,32 +439,91 @@ def test_multiprocessing_evaluating():
     model.add(Dense(1, input_shape=(2, )))
     model.compile(loss='mse', optimizer='adadelta')
 
-    model.evaluate_generator(custom_generator(),
-                             steps=5,
-                             max_queue_size=10,
-                             workers=2,
-                             use_multiprocessing=True)
-    model.evaluate_generator(custom_generator(),
-                             steps=5,
-                             max_queue_size=10,
-                             use_multiprocessing=False)
-    model.evaluate_generator(custom_generator(),
-                             steps=5,
-                             max_queue_size=10,
-                             use_multiprocessing=False,
-                             workers=0)
+    # - Produce data on 4 worker processes, consume on main process:
+    #   - Each worker process runs OWN copy of generator 
+    #   - BUT on Windows, `multiprocessing` won't marshall generators across
+    #     process boundaries 
+    #       -> make sure `evaluate_generator()` raises raises ValueError
+    #          exception and does not attempt to run the generator.
+    if os.name is 'nt':
+        with pytest.raises(ValueError):
+            model.evaluate_generator(custom_generator(),
+                    steps=gsteps,
+                    max_queue_size=10,
+                    workers=gworkers,
+                    use_multiprocessing=True)
+    else:
+        model.evaluate_generator(custom_generator(),
+                    steps=gsteps,
+                    max_queue_size=10,
+                    workers=gworkers,
+                    use_multiprocessing=True)
 
+    # - Produce data on 4 worker threads, consume on main thread:
+    #   - All worker threads share the SAME generator
+    model.evaluate_generator(custom_generator(),
+                    steps=gsteps,
+                    max_queue_size=10,
+                    workers=gworkers,
+                    use_multiprocessing=False)
+
+    # - Produce data on 1 worker process, consume on main process:
+    #   - Worker process runs generator 
+    #   - BUT on Windows, `multiprocessing` won't marshall generators across
+    #     process boundaries -> make sure `evaluate_generator()` raises ValueError
+    #     exception and does not attempt to run the generator.
+    if os.name is 'nt':
+        with pytest.raises(ValueError):
+            model.evaluate_generator(custom_generator(),
+                    steps=gsteps,
+                    max_queue_size=10,
+                    workers=1,
+                    use_multiprocessing=True)
+    else:
+        model.evaluate_generator(custom_generator(),
+                    steps=gsteps,
+                    max_queue_size=10,
+                    workers=1,
+                    use_multiprocessing=True)
+
+    # - Produce data on 1 worker thread, consume on main thread:
+    #   - Worker thread is the only thread running the generator
+    model.evaluate_generator(custom_generator(),
+                    steps=gsteps,
+                    max_queue_size=10,
+                    workers=1,
+                    use_multiprocessing=False)
+
+    # - Produce and consume data without a queue on main thread
+    #   - Make sure the value of `use_multiprocessing` is ignored
+    model.evaluate_generator(custom_generator(),
+                    steps=gsteps,
+                    max_queue_size=10,
+                    workers=0,
+                    use_multiprocessing=True)
+    model.evaluate_generator(custom_generator(),
+                    steps=gsteps,
+                    max_queue_size=10,
+                    workers=0,
+                    use_multiprocessing=False)
 
 @keras_test
 def test_multiprocessing_fit_error():
+    arr_data = np.random.randint(0, 256, (50, 2))
+    arr_labels = np.random.randint(0, 2, 50)
     batch_size = 10
+    n_samples = 50
     good_batches = 3
 
-    def custom_generator():
+    def custom_generator(use_weights=False):
         """Raises an exception after a few good batches"""
         for i in range(good_batches):
-            yield (np.random.randint(batch_size, 256, (50, 2)),
-                   np.random.randint(batch_size, 12, 50))
+            batch_index = np.random.randint(0, n_samples - batch_size)
+            start = batch_index
+            end = start + batch_size
+            X = arr_data[start: end]
+            y = arr_labels[start: end]
+            yield X, y
         raise RuntimeError
 
     model = Sequential()
@@ -241,77 +532,292 @@ def test_multiprocessing_fit_error():
 
     samples = batch_size * (good_batches + 1)
 
-    with pytest.raises(RuntimeError):
-        model.fit_generator(
-            custom_generator(), samples, 1,
-            workers=4, use_multiprocessing=True,
-        )
+    # - Produce data on 4 worker processes, consume on main process:
+    #   - Each worker process runs OWN copy of generator 
+    #   - BUT on Windows, `multiprocessing` won't marshall generators across
+    #     process boundaries -> make sure `fit_generator()` raises ValueError
+    #     exception and does not attempt to run the generator.
+    #   - On other platforms, make sure `RuntimeError` exception bubbles up
+    if os.name is 'nt':
+        with pytest.raises(ValueError):
+            model.fit_generator(custom_generator(),
+                    steps_per_epoch=samples,
+                    validation_steps=None,
+                    max_queue_size=10,
+                    workers=gworkers,
+                    use_multiprocessing=True)
+    else:
+        with pytest.raises(RuntimeError):
+            model.fit_generator(custom_generator(),
+                    steps_per_epoch=samples,
+                    validation_steps=None,
+                    max_queue_size=10,
+                    workers=gworkers,
+                    use_multiprocessing=True)
 
+    # - Produce data on 4 worker threads, consume on main thread:
+    #   - All worker threads share the SAME generator
+    #   - Make sure `RuntimeError` exception bubbles up
     with pytest.raises(RuntimeError):
-        model.fit_generator(
-            custom_generator(), samples, 1,
-            use_multiprocessing=False,
-        )
+        model.fit_generator(custom_generator(),
+                    steps_per_epoch=samples,
+                    validation_steps=None,
+                    max_queue_size=10,
+                    workers=gworkers,
+                    use_multiprocessing=False)
 
+    # - Produce data on 1 worker process, consume on main process:
+    #   - Worker process runs generator 
+    #   - BUT on Windows, `multiprocessing` won't marshall generators across
+    #     process boundaries -> make sure `fit_generator()` raises ValueError
+    #     exception and does not attempt to run the generator.
+    #   - On other platforms, make sure `RuntimeError` exception bubbles up
+    if os.name is 'nt':
+        with pytest.raises(ValueError):
+            model.fit_generator(custom_generator(),
+                    steps_per_epoch=samples,
+                    validation_steps=None,
+                    max_queue_size=10,
+                    workers=1,
+                    use_multiprocessing=True)
+    else:
+        with pytest.raises(RuntimeError):
+            model.fit_generator(custom_generator(),
+                    steps_per_epoch=samples,
+                    validation_steps=None,
+                    max_queue_size=10,
+                    workers=1,
+                    use_multiprocessing=True)
+
+    # - Produce data on 1 worker thread, consume on main thread:
+    #   - Worker thread is the only thread running the generator
+    #   - Make sure `RuntimeError` exception bubbles up
+    with pytest.raises(RuntimeError):
+        model.fit_generator(custom_generator(),
+                    steps_per_epoch=samples,
+                    validation_steps=None,
+                    max_queue_size=10,
+                    workers=1,
+                    use_multiprocessing=False)
+
+    # - Produce and consume data without a queue on main thread
+    #   - Make sure the value of `use_multiprocessing` is ignored
+    #   - Make sure `RuntimeError` exception bubbles up
+    with pytest.raises(RuntimeError):
+        model.fit_generator(custom_generator(),
+                    steps_per_epoch=samples,
+                    validation_steps=None,
+                    max_queue_size=10,
+                    workers=0,
+                    use_multiprocessing=True)
+    with pytest.raises(RuntimeError):
+        model.fit_generator(custom_generator(),
+                    steps_per_epoch=samples,
+                    validation_steps=None,
+                    max_queue_size=10,
+                    workers=0,
+                    use_multiprocessing=False)
 
 @keras_test
 def test_multiprocessing_evaluate_error():
+    arr_data = np.random.randint(0, 256, (50, 2))
+    arr_labels = np.random.randint(0, 2, 50)
     batch_size = 10
+    n_samples = 50
     good_batches = 3
-    workers = 4
 
     def custom_generator():
         """Raises an exception after a few good batches"""
         for i in range(good_batches):
-            yield (np.random.randint(batch_size, 256, (50, 2)),
-                   np.random.randint(batch_size, 12, 50))
+            batch_index = np.random.randint(0, n_samples - batch_size)
+            start = batch_index
+            end = start + batch_size
+            X = arr_data[start: end]
+            y = arr_labels[start: end]
+            yield X, y
         raise RuntimeError
 
     model = Sequential()
     model.add(Dense(1, input_shape=(2, )))
     model.compile(loss='mse', optimizer='adadelta')
 
-    with pytest.raises(RuntimeError):
-        model.evaluate_generator(
-            custom_generator(), good_batches * workers + 1, 1,
-            workers=workers, use_multiprocessing=True,
-        )
+    # - Produce data on 4 worker processes, consume on main process:
+    #   - Each worker process runs OWN copy of generator 
+    #   - BUT on Windows, `multiprocessing` won't marshall generators across
+    #     process boundaries -> make sure `evaluate_generator()` raises ValueError
+    #     exception and does not attempt to run the generator.
+    #   - On other platforms, make sure `RuntimeError` exception bubbles up
+    if os.name is 'nt':
+        with pytest.raises(ValueError):
+            model.evaluate_generator(custom_generator(),
+                    steps=good_batches * gworkers + 1,
+                    max_queue_size=10,
+                    workers=gworkers,
+                    use_multiprocessing=True)
+    else:
+        with pytest.raises(RuntimeError):
+            model.evaluate_generator(custom_generator(),
+                    steps=good_batches * gworkers + 1,
+                    max_queue_size=10,
+                    workers=gworkers,
+                    use_multiprocessing=True)
 
+    # - Produce data on 4 worker threads, consume on main thread:
+    #   - All worker threads share the SAME generator
+    #   - Make sure `RuntimeError` exception bubbles up
     with pytest.raises(RuntimeError):
-        model.evaluate_generator(
-            custom_generator(), good_batches + 1, 1,
-            use_multiprocessing=False,
-        )
+        model.evaluate_generator(custom_generator(),
+                    steps=good_batches * gworkers + 1,
+                    max_queue_size=10,
+                    workers=gworkers,
+                    use_multiprocessing=False)
 
+    # - Produce data on 1 worker process, consume on main process:
+    #   - Worker process runs generator 
+    #   - BUT on Windows, `multiprocessing` won't marshall generators across
+    #     process boundaries -> make sure `evaluate_generator()` raises ValueError
+    #     exception and does not attempt to run the generator.
+    #   - On other platforms, make sure `RuntimeError` exception bubbles up
+    if os.name is 'nt':
+        with pytest.raises(ValueError):
+            model.evaluate_generator(custom_generator(),
+                    steps=good_batches + 1,
+                    max_queue_size=10,
+                    workers=1,
+                    use_multiprocessing=True)
+    else:
+        with pytest.raises(RuntimeError):
+            model.evaluate_generator(custom_generator(),
+                    steps=good_batches + 1,
+                    max_queue_size=10,
+                    workers=1,
+                    use_multiprocessing=True)
+
+    # - Produce data on 1 worker thread, consume on main thread:
+    #   - Worker thread is the only thread running the generator
+    #   - Make sure `RuntimeError` exception bubbles up
+    with pytest.raises(RuntimeError):
+        model.evaluate_generator(custom_generator(),
+                    steps=good_batches + 1,
+                    max_queue_size=10,
+                    workers=1,
+                    use_multiprocessing=False)
+
+    # - Produce and consume data without a queue on main thread
+    #   - Make sure the value of `use_multiprocessing` is ignored
+    #   - Make sure `RuntimeError` exception bubbles up
+    with pytest.raises(RuntimeError):
+        model.evaluate_generator(custom_generator(),
+                    steps=good_batches + 1,
+                    max_queue_size=10,
+                    workers=0,
+                    use_multiprocessing=True)
+    with pytest.raises(RuntimeError):
+        model.evaluate_generator(custom_generator(),
+                    steps=good_batches + 1,
+                    max_queue_size=10,
+                    workers=0,
+                    use_multiprocessing=False)
 
 @keras_test
 def test_multiprocessing_predict_error():
+    arr_data = np.random.randint(0, 256, (50, 2))
     good_batches = 3
-    workers = 4
 
     def custom_generator():
         """Raises an exception after a few good batches"""
+        batch_size = 10
+        n_samples = 50
+
         for i in range(good_batches):
-            yield (np.random.randint(1, 256, size=(2, 5)),
-                   np.random.randint(1, 256, size=(2, 5)))
+            batch_index = np.random.randint(0, n_samples - batch_size)
+            start = batch_index
+            end = start + batch_size
+            X = arr_data[start: end]
+            yield X
         raise RuntimeError
 
     model = Sequential()
-    model.add(Dense(1, input_shape=(5,)))
+    model.add(Dense(1, input_shape=(2, )))
     model.compile(loss='mse', optimizer='adadelta')
 
-    with pytest.raises(RuntimeError):
-        model.predict_generator(
-            custom_generator(), good_batches * workers + 1, 1,
-            workers=workers, use_multiprocessing=True,
-        )
+    # - Produce data on 4 worker processes, consume on main process:
+    #   - Each worker process runs OWN copy of generator 
+    #   - BUT on Windows, `multiprocessing` won't marshall generators across
+    #     process boundaries -> make sure `predict_generator()` raises ValueError
+    #     exception and does not attempt to run the generator.
+    #   - On other platforms, make sure `RuntimeError` exception bubbles up
+    if os.name is 'nt':
+        with pytest.raises(ValueError):
+            model.predict_generator(custom_generator(),
+                    steps=good_batches * gworkers + 1,
+                    max_queue_size=10,
+                    workers=gworkers,
+                    use_multiprocessing=True)
+    else:
+        with pytest.raises(RuntimeError):
+            model.predict_generator(custom_generator(),
+                    steps=good_batches * gworkers + 1,
+                    max_queue_size=10,
+                    workers=gworkers,
+                    use_multiprocessing=True)
 
+    # - Produce data on 4 worker threads, consume on main thread:
+    #   - All worker threads share the SAME generator
+    #   - Make sure `RuntimeError` exception bubbles up
     with pytest.raises(RuntimeError):
-        model.predict_generator(
-            custom_generator(), good_batches + 1, 1,
-            use_multiprocessing=False,
-        )
+        model.predict_generator(custom_generator(),
+                    steps=good_batches * gworkers + 1,
+                    max_queue_size=10,
+                    workers=gworkers,
+                    use_multiprocessing=False)
 
+    # - Produce data on 1 worker process, consume on main process:
+    #   - Worker process runs generator 
+    #   - BUT on Windows, `multiprocessing` won't marshall generators across
+    #     process boundaries -> make sure `predict_generator()` raises ValueError
+    #     exception and does not attempt to run the generator.
+    #   - On other platforms, make sure `RuntimeError` exception bubbles up
+    if os.name is 'nt':
+        with pytest.raises(ValueError):
+            model.predict_generator(custom_generator(),
+                    steps=good_batches + 1,
+                    max_queue_size=10,
+                    workers=1,
+                    use_multiprocessing=True)
+    else:
+        with pytest.raises(RuntimeError):
+            model.predict_generator(custom_generator(),
+                    steps=good_batches + 1,
+                    max_queue_size=10,
+                    workers=1,
+                    use_multiprocessing=True)
+
+    # - Produce data on 1 worker thread, consume on main thread:
+    #   - Worker thread is the only thread running the generator
+    #   - Make sure `RuntimeError` exception bubbles up
+    with pytest.raises(RuntimeError):
+        model.predict_generator(custom_generator(),
+                    steps=good_batches + 1,
+                    max_queue_size=10,
+                    workers=1,
+                    use_multiprocessing=False)
+
+    # - Produce and consume data without a queue on main thread
+    #   - Make sure the value of `use_multiprocessing` is ignored
+    #   - Make sure `RuntimeError` exception bubbles up
+    with pytest.raises(RuntimeError):
+        model.predict_generator(custom_generator(),
+                    steps=good_batches + 1,
+                    max_queue_size=10,
+                    workers=0,
+                    use_multiprocessing=True)
+    with pytest.raises(RuntimeError):
+        model.predict_generator(custom_generator(),
+                    steps=good_batches + 1,
+                    max_queue_size=10,
+                    workers=0,
+                    use_multiprocessing=False)
 
 if __name__ == '__main__':
     pytest.main([__file__])

--- a/tests/test_multiprocessing.py
+++ b/tests/test_multiprocessing.py
@@ -7,9 +7,10 @@ from keras.models import Sequential
 from keras.layers.core import Dense
 from keras.utils.test_utils import keras_test
 
-gsteps_per_epoch = 100
-gsteps = 100
-gworkers = 4
+STEPS_PER_EPOCH = 100
+STEPS = 100
+WORKERS = 4
+
 
 @pytest.fixture
 def in_tmpdir(tmpdir):
@@ -20,6 +21,7 @@ def in_tmpdir(tmpdir):
     with tmpdir.as_cwd():
         yield None
     assert not tmpdir.listdir()
+
 
 @keras_test
 def test_multiprocessing_training():
@@ -49,129 +51,129 @@ def test_multiprocessing_training():
     model.compile(loss='mse', optimizer='adadelta')
 
     # - Produce data on 4 worker processes, consume on main process:
-    #   - Each worker process runs OWN copy of generator 
+    #   - Each worker process runs OWN copy of generator
     #   - BUT on Windows, `multiprocessing` won't marshall generators across
     #     process boundaries -> make sure `fit_generator()` raises ValueError
     #     exception and does not attempt to run the generator.
     if os.name is 'nt':
         with pytest.raises(ValueError):
             model.fit_generator(custom_generator(),
-                    steps_per_epoch=gsteps_per_epoch,
-                    epochs=1,
-                    verbose=1,
-                    validation_steps=None,
-                    max_queue_size=10,
-                    workers=gworkers,
-                    use_multiprocessing=True)
+                                steps_per_epoch=STEPS_PER_EPOCH,
+                                epochs=1,
+                                verbose=1,
+                                validation_steps=None,
+                                max_queue_size=10,
+                                workers=WORKERS,
+                                use_multiprocessing=True)
     else:
         model.fit_generator(custom_generator(),
-                    steps_per_epoch=gsteps_per_epoch,
-                    epochs=1,
-                    verbose=1,
-                    validation_steps=None,
-                    max_queue_size=10,
-                    workers=gworkers,
-                    use_multiprocessing=True)
+                            steps_per_epoch=STEPS_PER_EPOCH,
+                            epochs=1,
+                            verbose=1,
+                            validation_steps=None,
+                            max_queue_size=10,
+                            workers=WORKERS,
+                            use_multiprocessing=True)
 
     # - Produce data on 4 worker threads, consume on main thread:
     #   - All worker threads share the SAME generator
     model.fit_generator(custom_generator(),
-                    steps_per_epoch=gsteps_per_epoch,
-                    epochs=1,
-                    verbose=1,
-                    validation_steps=None,
-                    max_queue_size=10,
-                    workers=gworkers,
-                    use_multiprocessing=False)
+                        steps_per_epoch=STEPS_PER_EPOCH,
+                        epochs=1,
+                        verbose=1,
+                        validation_steps=None,
+                        max_queue_size=10,
+                        workers=WORKERS,
+                        use_multiprocessing=False)
 
     # - Produce data on 1 worker process, consume on main process:
-    #   - Worker process runs generator 
+    #   - Worker process runs generator
     #   - BUT on Windows, `multiprocessing` won't marshall generators across
     #     process boundaries -> make sure `fit_generator()` raises ValueError
     #     exception and does not attempt to run the generator.
     if os.name is 'nt':
         with pytest.raises(ValueError):
             model.fit_generator(custom_generator(True),
-                    steps_per_epoch=gsteps_per_epoch,
-                    validation_data=(arr_data[:10],
-                                     arr_labels[:10],
-                                     arr_weights[:10]),
-                    validation_steps=1,
-                    max_queue_size=10,
-                    workers=1,
-                    use_multiprocessing=True)
+                                steps_per_epoch=STEPS_PER_EPOCH,
+                                validation_data=(arr_data[:10],
+                                                 arr_labels[:10],
+                                                 arr_weights[:10]),
+                                validation_steps=1,
+                                max_queue_size=10,
+                                workers=1,
+                                use_multiprocessing=True)
     else:
         model.fit_generator(custom_generator(True),
-                    steps_per_epoch=gsteps_per_epoch,
-                    validation_data=(arr_data[:10],
-                                     arr_labels[:10],
-                                     arr_weights[:10]),
-                    validation_steps=1,
-                    max_queue_size=10,
-                    workers=1,
-                    use_multiprocessing=True)
+                            steps_per_epoch=STEPS_PER_EPOCH,
+                            validation_data=(arr_data[:10],
+                                             arr_labels[:10],
+                                             arr_weights[:10]),
+                            validation_steps=1,
+                            max_queue_size=10,
+                            workers=1,
+                            use_multiprocessing=True)
 
     # - Produce data on 1 worker thread, consume on main thread:
     #   - Worker thread is the only thread running the generator
     model.fit_generator(custom_generator(True),
-                    steps_per_epoch=gsteps_per_epoch,
-                    validation_data=(arr_data[:10],
-                                     arr_labels[:10],
-                                     arr_weights[:10]),
-                    validation_steps=1,
-                    max_queue_size=10,
-                    workers=1,
-                    use_multiprocessing=False)
+                        steps_per_epoch=STEPS_PER_EPOCH,
+                        validation_data=(arr_data[:10],
+                                         arr_labels[:10],
+                                         arr_weights[:10]),
+                        validation_steps=1,
+                        max_queue_size=10,
+                        workers=1,
+                        use_multiprocessing=False)
 
     # - Produce data on 1 worker process, consume on main process:
-    #   - Worker process runs generator 
+    #   - Worker process runs generator
     #   - BUT on Windows, `multiprocessing` won't marshall generators across
     #     process boundaries -> make sure `fit_generator()` raises ValueError
     #     exception and does not attempt to run the generator.
     if os.name is 'nt':
         with pytest.raises(ValueError):
             model.fit_generator(custom_generator(True),
-                    steps_per_epoch=gsteps_per_epoch,
-                    validation_data=custom_generator(True),
-                    validation_steps=1,
-                    max_queue_size=10,
-                    workers=1,
-                    use_multiprocessing=True)
+                                steps_per_epoch=STEPS_PER_EPOCH,
+                                validation_data=custom_generator(True),
+                                validation_steps=1,
+                                max_queue_size=10,
+                                workers=1,
+                                use_multiprocessing=True)
     else:
         model.fit_generator(custom_generator(True),
-                    steps_per_epoch=gsteps_per_epoch,
-                    validation_data=custom_generator(True),
-                    validation_steps=1,
-                    max_queue_size=10,
-                    workers=1,
-                    use_multiprocessing=True)
+                            steps_per_epoch=STEPS_PER_EPOCH,
+                            validation_data=custom_generator(True),
+                            validation_steps=1,
+                            max_queue_size=10,
+                            workers=1,
+                            use_multiprocessing=True)
 
     # - Produce data on 1 worker thread AT A TIME, consume on main thread:
     #   - Worker threads for training and validation run generator SEQUENTIALLY
     model.fit_generator(custom_generator(True),
-                    steps_per_epoch=gsteps_per_epoch,
-                    validation_data=custom_generator(True),
-                    validation_steps=1,
-                    max_queue_size=10,
-                    workers=1,
-                    use_multiprocessing=False)
+                        steps_per_epoch=STEPS_PER_EPOCH,
+                        validation_data=custom_generator(True),
+                        validation_steps=1,
+                        max_queue_size=10,
+                        workers=1,
+                        use_multiprocessing=False)
 
     # - Produce and consume data without a queue on main thread
     #   - Make sure the value of `use_multiprocessing` is ignored
     model.fit_generator(custom_generator(True),
-                    steps_per_epoch=gsteps_per_epoch,
-                    validation_data=custom_generator(True),
-                    validation_steps=1,
-                    max_queue_size=10,
-                    workers=0,
-                    use_multiprocessing=True)
+                        steps_per_epoch=STEPS_PER_EPOCH,
+                        validation_data=custom_generator(True),
+                        validation_steps=1,
+                        max_queue_size=10,
+                        workers=0,
+                        use_multiprocessing=True)
     model.fit_generator(custom_generator(True),
-                    steps_per_epoch=gsteps_per_epoch,
-                    validation_data=custom_generator(True),
-                    validation_steps=1,
-                    max_queue_size=10,
-                    workers=0,
-                    use_multiprocessing=False)
+                        steps_per_epoch=STEPS_PER_EPOCH,
+                        validation_data=custom_generator(True),
+                        validation_steps=1,
+                        max_queue_size=10,
+                        workers=0,
+                        use_multiprocessing=False)
 
     # Test invalid use cases
     def invalid_generator():
@@ -181,35 +183,36 @@ def test_multiprocessing_training():
     # not specified `validation_steps`
     with pytest.raises(ValueError):
         model.fit_generator(custom_generator(),
-                    steps_per_epoch=gsteps_per_epoch,
-                    validation_data=custom_generator(),
-                    validation_steps=None,
-                    max_queue_size=10,
-                    workers=1,
-                    use_multiprocessing=False)
+                            steps_per_epoch=STEPS_PER_EPOCH,
+                            validation_data=custom_generator(),
+                            validation_steps=None,
+                            max_queue_size=10,
+                            workers=1,
+                            use_multiprocessing=False)
 
     # validation data is neither a tuple nor a triple.
     with pytest.raises(ValueError):
         model.fit_generator(custom_generator(),
-                    steps_per_epoch=gsteps_per_epoch,
-                    validation_data=(arr_data[:10],
-                                     arr_data[:10],
-                                     arr_labels[:10],
-                                     arr_weights[:10]),
-                    validation_steps=1,
-                    max_queue_size=10,
-                    workers=1,
-                    use_multiprocessing=False)
+                            steps_per_epoch=STEPS_PER_EPOCH,
+                            validation_data=(arr_data[:10],
+                                             arr_data[:10],
+                                             arr_labels[:10],
+                                             arr_weights[:10]),
+                            validation_steps=1,
+                            max_queue_size=10,
+                            workers=1,
+                            use_multiprocessing=False)
 
     # validation generator is neither a tuple nor a triple.
     with pytest.raises(ValueError):
         model.fit_generator(custom_generator(),
-                    steps_per_epoch=gsteps_per_epoch,
-                    validation_data=invalid_generator(),
-                    validation_steps=1,
-                    max_queue_size=10,
-                    workers=1,
-                    use_multiprocessing=False)
+                            steps_per_epoch=STEPS_PER_EPOCH,
+                            validation_data=invalid_generator(),
+                            validation_steps=1,
+                            max_queue_size=10,
+                            workers=1,
+                            use_multiprocessing=False)
+
 
 @keras_test
 def test_multiprocessing_training_from_file(in_tmpdir):
@@ -238,97 +241,98 @@ def test_multiprocessing_training_from_file(in_tmpdir):
     model.compile(loss='mse', optimizer='adadelta')
 
     # - Produce data on 4 worker processes, consume on main process:
-    #   - Each worker process runs OWN copy of generator 
+    #   - Each worker process runs OWN copy of generator
     #   - BUT on Windows, `multiprocessing` won't marshall generators across
     #     process boundaries -> make sure `fit_generator()` raises ValueError
     #     exception and does not attempt to run the generator.
     if os.name is 'nt':
         with pytest.raises(ValueError):
             model.fit_generator(custom_generator(),
-                    steps_per_epoch=gsteps_per_epoch,
-                    epochs=1,
-                    verbose=1,
-                    validation_steps=None,
-                    max_queue_size=10,
-                    workers=gworkers,
-                    use_multiprocessing=True)
+                                steps_per_epoch=STEPS_PER_EPOCH,
+                                epochs=1,
+                                verbose=1,
+                                validation_steps=None,
+                                max_queue_size=10,
+                                workers=WORKERS,
+                                use_multiprocessing=True)
     else:
         model.fit_generator(custom_generator(),
-                    steps_per_epoch=gsteps_per_epoch,
-                    epochs=1,
-                    verbose=1,
-                    validation_steps=None,
-                    max_queue_size=10,
-                    workers=gworkers,
-                    use_multiprocessing=True)
+                            steps_per_epoch=STEPS_PER_EPOCH,
+                            epochs=1,
+                            verbose=1,
+                            validation_steps=None,
+                            max_queue_size=10,
+                            workers=WORKERS,
+                            use_multiprocessing=True)
 
     # - Produce data on 4 worker threads, consume on main thread:
     #   - All worker threads share the SAME generator
     model.fit_generator(custom_generator(),
-                    steps_per_epoch=gsteps_per_epoch,
-                    epochs=1,
-                    verbose=1,
-                    validation_steps=None,
-                    max_queue_size=10,
-                    workers=gworkers,
-                    use_multiprocessing=False)
+                        steps_per_epoch=STEPS_PER_EPOCH,
+                        epochs=1,
+                        verbose=1,
+                        validation_steps=None,
+                        max_queue_size=10,
+                        workers=WORKERS,
+                        use_multiprocessing=False)
 
     # - Produce data on 1 worker process, consume on main process:
-    #   - Worker process runs generator 
+    #   - Worker process runs generator
     #   - BUT on Windows, `multiprocessing` won't marshall generators across
     #     process boundaries -> make sure `fit_generator()` raises ValueError
     #     exception and does not attempt to run the generator.
     if os.name is 'nt':
         with pytest.raises(ValueError):
             model.fit_generator(custom_generator(),
-                    steps_per_epoch=gsteps_per_epoch,
-                    epochs=1,
-                    verbose=1,
-                    validation_steps=None,
-                    max_queue_size=10,
-                    workers=1,
-                    use_multiprocessing=True)
+                                steps_per_epoch=STEPS_PER_EPOCH,
+                                epochs=1,
+                                verbose=1,
+                                validation_steps=None,
+                                max_queue_size=10,
+                                workers=1,
+                                use_multiprocessing=True)
     else:
         model.fit_generator(custom_generator(),
-                    steps_per_epoch=gsteps_per_epoch,
-                    epochs=1,
-                    verbose=1,
-                    validation_steps=None,
-                    max_queue_size=10,
-                    workers=1,
-                    use_multiprocessing=True)
+                            steps_per_epoch=STEPS_PER_EPOCH,
+                            epochs=1,
+                            verbose=1,
+                            validation_steps=None,
+                            max_queue_size=10,
+                            workers=1,
+                            use_multiprocessing=True)
 
     # - Produce data on 1 worker thread, consume on main thread:
     #   - Worker thread is the only thread running the generator
     model.fit_generator(custom_generator(),
-                    steps_per_epoch=gsteps_per_epoch,
-                    epochs=1,
-                    verbose=1,
-                    validation_steps=None,
-                    max_queue_size=10,
-                    workers=1,
-                    use_multiprocessing=False)
+                        steps_per_epoch=STEPS_PER_EPOCH,
+                        epochs=1,
+                        verbose=1,
+                        validation_steps=None,
+                        max_queue_size=10,
+                        workers=1,
+                        use_multiprocessing=False)
 
     # - Produce and consume data without a queue on main thread
     #   - Make sure the value of `use_multiprocessing` is ignored
     model.fit_generator(custom_generator(),
-                    steps_per_epoch=gsteps_per_epoch,
-                    epochs=1,
-                    verbose=1,
-                    validation_steps=None,
-                    max_queue_size=10,
-                    workers=0,
-                    use_multiprocessing=True)
+                        steps_per_epoch=STEPS_PER_EPOCH,
+                        epochs=1,
+                        verbose=1,
+                        validation_steps=None,
+                        max_queue_size=10,
+                        workers=0,
+                        use_multiprocessing=True)
     model.fit_generator(custom_generator(),
-                    steps_per_epoch=gsteps_per_epoch,
-                    epochs=1,
-                    verbose=1,
-                    validation_steps=None,
-                    max_queue_size=10,
-                    workers=0,
-                    use_multiprocessing=False)
+                        steps_per_epoch=STEPS_PER_EPOCH,
+                        epochs=1,
+                        verbose=1,
+                        validation_steps=None,
+                        max_queue_size=10,
+                        workers=0,
+                        use_multiprocessing=False)
 
     os.remove('data.npz')
+
 
 @keras_test
 def test_multiprocessing_predicting():
@@ -351,71 +355,72 @@ def test_multiprocessing_predicting():
     model.compile(loss='mse', optimizer='adadelta')
 
     # - Produce data on 4 worker processes, consume on main process:
-    #   - Each worker process runs OWN copy of generator 
+    #   - Each worker process runs OWN copy of generator
     #   - BUT on Windows, `multiprocessing` won't marshall generators across
     #     process boundaries -> make sure `predict_generator()` raises ValueError
     #     exception and does not attempt to run the generator.
     if os.name is 'nt':
         with pytest.raises(ValueError):
             model.predict_generator(custom_generator(),
-                    steps=gsteps,
-                    max_queue_size=10,
-                    workers=gworkers,
-                    use_multiprocessing=True)
+                                    steps=STEPS,
+                                    max_queue_size=10,
+                                    workers=WORKERS,
+                                    use_multiprocessing=True)
     else:
         model.predict_generator(custom_generator(),
-                    steps=gsteps,
-                    max_queue_size=10,
-                    workers=gworkers,
-                    use_multiprocessing=True)
+                                steps=STEPS,
+                                max_queue_size=10,
+                                workers=WORKERS,
+                                use_multiprocessing=True)
 
     # - Produce data on 4 worker threads, consume on main thread:
     #   - All worker threads share the SAME generator
     model.predict_generator(custom_generator(),
-                    steps=gsteps,
-                    max_queue_size=10,
-                    workers=gworkers,
-                    use_multiprocessing=False)
+                            steps=STEPS,
+                            max_queue_size=10,
+                            workers=WORKERS,
+                            use_multiprocessing=False)
 
     # - Produce data on 1 worker process, consume on main process:
-    #   - Worker process runs generator 
+    #   - Worker process runs generator
     #   - BUT on Windows, `multiprocessing` won't marshall generators across
     #     process boundaries -> make sure `predict_generator()` raises ValueError
     #     exception and does not attempt to run the generator.
     if os.name is 'nt':
         with pytest.raises(ValueError):
             model.predict_generator(custom_generator(),
-                    steps=gsteps,
-                    max_queue_size=10,
-                    workers=1,
-                    use_multiprocessing=True)
+                                    steps=STEPS,
+                                    max_queue_size=10,
+                                    workers=1,
+                                    use_multiprocessing=True)
     else:
         model.predict_generator(custom_generator(),
-                    steps=gsteps,
-                    max_queue_size=10,
-                    workers=1,
-                    use_multiprocessing=True)
+                                steps=STEPS,
+                                max_queue_size=10,
+                                workers=1,
+                                use_multiprocessing=True)
 
     # - Produce data on 1 worker thread, consume on main thread:
     #   - Worker thread is the only thread running the generator
     model.predict_generator(custom_generator(),
-                    steps=gsteps,
-                    max_queue_size=10,
-                    workers=1,
-                    use_multiprocessing=False)
+                            steps=STEPS,
+                            max_queue_size=10,
+                            workers=1,
+                            use_multiprocessing=False)
 
     # - Main thread runs the generator without a queue
     #   - Make sure the value of `use_multiprocessing` is ignored
     model.predict_generator(custom_generator(),
-                    steps=gsteps,
-                    max_queue_size=10,
-                    workers=0,
-                    use_multiprocessing=True)
+                            steps=STEPS,
+                            max_queue_size=10,
+                            workers=0,
+                            use_multiprocessing=True)
     model.predict_generator(custom_generator(),
-                    steps=gsteps,
-                    max_queue_size=10,
-                    workers=0,
-                    use_multiprocessing=False)
+                            steps=STEPS,
+                            max_queue_size=10,
+                            workers=0,
+                            use_multiprocessing=False)
+
 
 @keras_test
 def test_multiprocessing_evaluating():
@@ -440,72 +445,73 @@ def test_multiprocessing_evaluating():
     model.compile(loss='mse', optimizer='adadelta')
 
     # - Produce data on 4 worker processes, consume on main process:
-    #   - Each worker process runs OWN copy of generator 
+    #   - Each worker process runs OWN copy of generator
     #   - BUT on Windows, `multiprocessing` won't marshall generators across
-    #     process boundaries 
+    #     process boundaries
     #       -> make sure `evaluate_generator()` raises raises ValueError
     #          exception and does not attempt to run the generator.
     if os.name is 'nt':
         with pytest.raises(ValueError):
             model.evaluate_generator(custom_generator(),
-                    steps=gsteps,
-                    max_queue_size=10,
-                    workers=gworkers,
-                    use_multiprocessing=True)
+                                     steps=STEPS,
+                                     max_queue_size=10,
+                                     workers=WORKERS,
+                                     use_multiprocessing=True)
     else:
         model.evaluate_generator(custom_generator(),
-                    steps=gsteps,
-                    max_queue_size=10,
-                    workers=gworkers,
-                    use_multiprocessing=True)
+                                 steps=STEPS,
+                                 max_queue_size=10,
+                                 workers=WORKERS,
+                                 use_multiprocessing=True)
 
     # - Produce data on 4 worker threads, consume on main thread:
     #   - All worker threads share the SAME generator
     model.evaluate_generator(custom_generator(),
-                    steps=gsteps,
-                    max_queue_size=10,
-                    workers=gworkers,
-                    use_multiprocessing=False)
+                             steps=STEPS,
+                             max_queue_size=10,
+                             workers=WORKERS,
+                             use_multiprocessing=False)
 
     # - Produce data on 1 worker process, consume on main process:
-    #   - Worker process runs generator 
+    #   - Worker process runs generator
     #   - BUT on Windows, `multiprocessing` won't marshall generators across
     #     process boundaries -> make sure `evaluate_generator()` raises ValueError
     #     exception and does not attempt to run the generator.
     if os.name is 'nt':
         with pytest.raises(ValueError):
             model.evaluate_generator(custom_generator(),
-                    steps=gsteps,
-                    max_queue_size=10,
-                    workers=1,
-                    use_multiprocessing=True)
+                                     steps=STEPS,
+                                     max_queue_size=10,
+                                     workers=1,
+                                     use_multiprocessing=True)
     else:
         model.evaluate_generator(custom_generator(),
-                    steps=gsteps,
-                    max_queue_size=10,
-                    workers=1,
-                    use_multiprocessing=True)
+                                 steps=STEPS,
+                                 max_queue_size=10,
+                                 workers=1,
+                                 use_multiprocessing=True)
 
     # - Produce data on 1 worker thread, consume on main thread:
     #   - Worker thread is the only thread running the generator
     model.evaluate_generator(custom_generator(),
-                    steps=gsteps,
-                    max_queue_size=10,
-                    workers=1,
-                    use_multiprocessing=False)
+                             steps=STEPS,
+                             max_queue_size=10,
+                             workers=1,
+                             use_multiprocessing=False)
 
     # - Produce and consume data without a queue on main thread
     #   - Make sure the value of `use_multiprocessing` is ignored
     model.evaluate_generator(custom_generator(),
-                    steps=gsteps,
-                    max_queue_size=10,
-                    workers=0,
-                    use_multiprocessing=True)
+                             steps=STEPS,
+                             max_queue_size=10,
+                             workers=0,
+                             use_multiprocessing=True)
     model.evaluate_generator(custom_generator(),
-                    steps=gsteps,
-                    max_queue_size=10,
-                    workers=0,
-                    use_multiprocessing=False)
+                             steps=STEPS,
+                             max_queue_size=10,
+                             workers=0,
+                             use_multiprocessing=False)
+
 
 @keras_test
 def test_multiprocessing_fit_error():
@@ -533,7 +539,7 @@ def test_multiprocessing_fit_error():
     samples = batch_size * (good_batches + 1)
 
     # - Produce data on 4 worker processes, consume on main process:
-    #   - Each worker process runs OWN copy of generator 
+    #   - Each worker process runs OWN copy of generator
     #   - BUT on Windows, `multiprocessing` won't marshall generators across
     #     process boundaries -> make sure `fit_generator()` raises ValueError
     #     exception and does not attempt to run the generator.
@@ -541,33 +547,33 @@ def test_multiprocessing_fit_error():
     if os.name is 'nt':
         with pytest.raises(ValueError):
             model.fit_generator(custom_generator(),
-                    steps_per_epoch=samples,
-                    validation_steps=None,
-                    max_queue_size=10,
-                    workers=gworkers,
-                    use_multiprocessing=True)
+                                steps_per_epoch=samples,
+                                validation_steps=None,
+                                max_queue_size=10,
+                                workers=WORKERS,
+                                use_multiprocessing=True)
     else:
         with pytest.raises(RuntimeError):
             model.fit_generator(custom_generator(),
-                    steps_per_epoch=samples,
-                    validation_steps=None,
-                    max_queue_size=10,
-                    workers=gworkers,
-                    use_multiprocessing=True)
+                                steps_per_epoch=samples,
+                                validation_steps=None,
+                                max_queue_size=10,
+                                workers=WORKERS,
+                                use_multiprocessing=True)
 
     # - Produce data on 4 worker threads, consume on main thread:
     #   - All worker threads share the SAME generator
     #   - Make sure `RuntimeError` exception bubbles up
     with pytest.raises(RuntimeError):
         model.fit_generator(custom_generator(),
-                    steps_per_epoch=samples,
-                    validation_steps=None,
-                    max_queue_size=10,
-                    workers=gworkers,
-                    use_multiprocessing=False)
+                            steps_per_epoch=samples,
+                            validation_steps=None,
+                            max_queue_size=10,
+                            workers=WORKERS,
+                            use_multiprocessing=False)
 
     # - Produce data on 1 worker process, consume on main process:
-    #   - Worker process runs generator 
+    #   - Worker process runs generator
     #   - BUT on Windows, `multiprocessing` won't marshall generators across
     #     process boundaries -> make sure `fit_generator()` raises ValueError
     #     exception and does not attempt to run the generator.
@@ -575,48 +581,49 @@ def test_multiprocessing_fit_error():
     if os.name is 'nt':
         with pytest.raises(ValueError):
             model.fit_generator(custom_generator(),
-                    steps_per_epoch=samples,
-                    validation_steps=None,
-                    max_queue_size=10,
-                    workers=1,
-                    use_multiprocessing=True)
+                                steps_per_epoch=samples,
+                                validation_steps=None,
+                                max_queue_size=10,
+                                workers=1,
+                                use_multiprocessing=True)
     else:
         with pytest.raises(RuntimeError):
             model.fit_generator(custom_generator(),
-                    steps_per_epoch=samples,
-                    validation_steps=None,
-                    max_queue_size=10,
-                    workers=1,
-                    use_multiprocessing=True)
+                                steps_per_epoch=samples,
+                                validation_steps=None,
+                                max_queue_size=10,
+                                workers=1,
+                                use_multiprocessing=True)
 
     # - Produce data on 1 worker thread, consume on main thread:
     #   - Worker thread is the only thread running the generator
     #   - Make sure `RuntimeError` exception bubbles up
     with pytest.raises(RuntimeError):
         model.fit_generator(custom_generator(),
-                    steps_per_epoch=samples,
-                    validation_steps=None,
-                    max_queue_size=10,
-                    workers=1,
-                    use_multiprocessing=False)
+                            steps_per_epoch=samples,
+                            validation_steps=None,
+                            max_queue_size=10,
+                            workers=1,
+                            use_multiprocessing=False)
 
     # - Produce and consume data without a queue on main thread
     #   - Make sure the value of `use_multiprocessing` is ignored
     #   - Make sure `RuntimeError` exception bubbles up
     with pytest.raises(RuntimeError):
         model.fit_generator(custom_generator(),
-                    steps_per_epoch=samples,
-                    validation_steps=None,
-                    max_queue_size=10,
-                    workers=0,
-                    use_multiprocessing=True)
+                            steps_per_epoch=samples,
+                            validation_steps=None,
+                            max_queue_size=10,
+                            workers=0,
+                            use_multiprocessing=True)
     with pytest.raises(RuntimeError):
         model.fit_generator(custom_generator(),
-                    steps_per_epoch=samples,
-                    validation_steps=None,
-                    max_queue_size=10,
-                    workers=0,
-                    use_multiprocessing=False)
+                            steps_per_epoch=samples,
+                            validation_steps=None,
+                            max_queue_size=10,
+                            workers=0,
+                            use_multiprocessing=False)
+
 
 @keras_test
 def test_multiprocessing_evaluate_error():
@@ -642,7 +649,7 @@ def test_multiprocessing_evaluate_error():
     model.compile(loss='mse', optimizer='adadelta')
 
     # - Produce data on 4 worker processes, consume on main process:
-    #   - Each worker process runs OWN copy of generator 
+    #   - Each worker process runs OWN copy of generator
     #   - BUT on Windows, `multiprocessing` won't marshall generators across
     #     process boundaries -> make sure `evaluate_generator()` raises ValueError
     #     exception and does not attempt to run the generator.
@@ -650,30 +657,30 @@ def test_multiprocessing_evaluate_error():
     if os.name is 'nt':
         with pytest.raises(ValueError):
             model.evaluate_generator(custom_generator(),
-                    steps=good_batches * gworkers + 1,
-                    max_queue_size=10,
-                    workers=gworkers,
-                    use_multiprocessing=True)
+                                     steps=good_batches * WORKERS + 1,
+                                     max_queue_size=10,
+                                     workers=WORKERS,
+                                     use_multiprocessing=True)
     else:
         with pytest.raises(RuntimeError):
             model.evaluate_generator(custom_generator(),
-                    steps=good_batches * gworkers + 1,
-                    max_queue_size=10,
-                    workers=gworkers,
-                    use_multiprocessing=True)
+                                     steps=good_batches * WORKERS + 1,
+                                     max_queue_size=10,
+                                     workers=WORKERS,
+                                     use_multiprocessing=True)
 
     # - Produce data on 4 worker threads, consume on main thread:
     #   - All worker threads share the SAME generator
     #   - Make sure `RuntimeError` exception bubbles up
     with pytest.raises(RuntimeError):
         model.evaluate_generator(custom_generator(),
-                    steps=good_batches * gworkers + 1,
-                    max_queue_size=10,
-                    workers=gworkers,
-                    use_multiprocessing=False)
+                                 steps=good_batches * WORKERS + 1,
+                                 max_queue_size=10,
+                                 workers=WORKERS,
+                                 use_multiprocessing=False)
 
     # - Produce data on 1 worker process, consume on main process:
-    #   - Worker process runs generator 
+    #   - Worker process runs generator
     #   - BUT on Windows, `multiprocessing` won't marshall generators across
     #     process boundaries -> make sure `evaluate_generator()` raises ValueError
     #     exception and does not attempt to run the generator.
@@ -681,43 +688,44 @@ def test_multiprocessing_evaluate_error():
     if os.name is 'nt':
         with pytest.raises(ValueError):
             model.evaluate_generator(custom_generator(),
-                    steps=good_batches + 1,
-                    max_queue_size=10,
-                    workers=1,
-                    use_multiprocessing=True)
+                                     steps=good_batches + 1,
+                                     max_queue_size=10,
+                                     workers=1,
+                                     use_multiprocessing=True)
     else:
         with pytest.raises(RuntimeError):
             model.evaluate_generator(custom_generator(),
-                    steps=good_batches + 1,
-                    max_queue_size=10,
-                    workers=1,
-                    use_multiprocessing=True)
+                                     steps=good_batches + 1,
+                                     max_queue_size=10,
+                                     workers=1,
+                                     use_multiprocessing=True)
 
     # - Produce data on 1 worker thread, consume on main thread:
     #   - Worker thread is the only thread running the generator
     #   - Make sure `RuntimeError` exception bubbles up
     with pytest.raises(RuntimeError):
         model.evaluate_generator(custom_generator(),
-                    steps=good_batches + 1,
-                    max_queue_size=10,
-                    workers=1,
-                    use_multiprocessing=False)
+                                 steps=good_batches + 1,
+                                 max_queue_size=10,
+                                 workers=1,
+                                 use_multiprocessing=False)
 
     # - Produce and consume data without a queue on main thread
     #   - Make sure the value of `use_multiprocessing` is ignored
     #   - Make sure `RuntimeError` exception bubbles up
     with pytest.raises(RuntimeError):
         model.evaluate_generator(custom_generator(),
-                    steps=good_batches + 1,
-                    max_queue_size=10,
-                    workers=0,
-                    use_multiprocessing=True)
+                                 steps=good_batches + 1,
+                                 max_queue_size=10,
+                                 workers=0,
+                                 use_multiprocessing=True)
     with pytest.raises(RuntimeError):
         model.evaluate_generator(custom_generator(),
-                    steps=good_batches + 1,
-                    max_queue_size=10,
-                    workers=0,
-                    use_multiprocessing=False)
+                                 steps=good_batches + 1,
+                                 max_queue_size=10,
+                                 workers=0,
+                                 use_multiprocessing=False)
+
 
 @keras_test
 def test_multiprocessing_predict_error():
@@ -742,7 +750,7 @@ def test_multiprocessing_predict_error():
     model.compile(loss='mse', optimizer='adadelta')
 
     # - Produce data on 4 worker processes, consume on main process:
-    #   - Each worker process runs OWN copy of generator 
+    #   - Each worker process runs OWN copy of generator
     #   - BUT on Windows, `multiprocessing` won't marshall generators across
     #     process boundaries -> make sure `predict_generator()` raises ValueError
     #     exception and does not attempt to run the generator.
@@ -750,30 +758,30 @@ def test_multiprocessing_predict_error():
     if os.name is 'nt':
         with pytest.raises(ValueError):
             model.predict_generator(custom_generator(),
-                    steps=good_batches * gworkers + 1,
-                    max_queue_size=10,
-                    workers=gworkers,
-                    use_multiprocessing=True)
+                                    steps=good_batches * WORKERS + 1,
+                                    max_queue_size=10,
+                                    workers=WORKERS,
+                                    use_multiprocessing=True)
     else:
         with pytest.raises(RuntimeError):
             model.predict_generator(custom_generator(),
-                    steps=good_batches * gworkers + 1,
-                    max_queue_size=10,
-                    workers=gworkers,
-                    use_multiprocessing=True)
+                                    steps=good_batches * WORKERS + 1,
+                                    max_queue_size=10,
+                                    workers=WORKERS,
+                                    use_multiprocessing=True)
 
     # - Produce data on 4 worker threads, consume on main thread:
     #   - All worker threads share the SAME generator
     #   - Make sure `RuntimeError` exception bubbles up
     with pytest.raises(RuntimeError):
         model.predict_generator(custom_generator(),
-                    steps=good_batches * gworkers + 1,
-                    max_queue_size=10,
-                    workers=gworkers,
-                    use_multiprocessing=False)
+                                steps=good_batches * WORKERS + 1,
+                                max_queue_size=10,
+                                workers=WORKERS,
+                                use_multiprocessing=False)
 
     # - Produce data on 1 worker process, consume on main process:
-    #   - Worker process runs generator 
+    #   - Worker process runs generator
     #   - BUT on Windows, `multiprocessing` won't marshall generators across
     #     process boundaries -> make sure `predict_generator()` raises ValueError
     #     exception and does not attempt to run the generator.
@@ -781,43 +789,43 @@ def test_multiprocessing_predict_error():
     if os.name is 'nt':
         with pytest.raises(ValueError):
             model.predict_generator(custom_generator(),
-                    steps=good_batches + 1,
-                    max_queue_size=10,
-                    workers=1,
-                    use_multiprocessing=True)
+                                    steps=good_batches + 1,
+                                    max_queue_size=10,
+                                    workers=1,
+                                    use_multiprocessing=True)
     else:
         with pytest.raises(RuntimeError):
             model.predict_generator(custom_generator(),
-                    steps=good_batches + 1,
-                    max_queue_size=10,
-                    workers=1,
-                    use_multiprocessing=True)
+                                    steps=good_batches + 1,
+                                    max_queue_size=10,
+                                    workers=1,
+                                    use_multiprocessing=True)
 
     # - Produce data on 1 worker thread, consume on main thread:
     #   - Worker thread is the only thread running the generator
     #   - Make sure `RuntimeError` exception bubbles up
     with pytest.raises(RuntimeError):
         model.predict_generator(custom_generator(),
-                    steps=good_batches + 1,
-                    max_queue_size=10,
-                    workers=1,
-                    use_multiprocessing=False)
+                                steps=good_batches + 1,
+                                max_queue_size=10,
+                                workers=1,
+                                use_multiprocessing=False)
 
     # - Produce and consume data without a queue on main thread
     #   - Make sure the value of `use_multiprocessing` is ignored
     #   - Make sure `RuntimeError` exception bubbles up
     with pytest.raises(RuntimeError):
         model.predict_generator(custom_generator(),
-                    steps=good_batches + 1,
-                    max_queue_size=10,
-                    workers=0,
-                    use_multiprocessing=True)
+                                steps=good_batches + 1,
+                                max_queue_size=10,
+                                workers=0,
+                                use_multiprocessing=True)
     with pytest.raises(RuntimeError):
         model.predict_generator(custom_generator(),
-                    steps=good_batches + 1,
-                    max_queue_size=10,
-                    workers=0,
-                    use_multiprocessing=False)
+                                steps=good_batches + 1,
+                                max_queue_size=10,
+                                workers=0,
+                                use_multiprocessing=False)
 
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
# Modified Files

- `keras\utils\data_utils.py`
- `tests\test_multiprocessing.py`

# Issues with GeneratorEnqueuer Multithreading on Windows (and Linux...)

Open bugs:

https://github.com/fchollet/keras/issues/6582
https://github.com/fchollet/keras/issues/5071

Stale but legit bugs:

https://github.com/fchollet/keras/issues/3962
https://github.com/fchollet/keras/issues/5510

Any attempt to use multithreading or multiprocessing on Windows will result in a `AttributeError: Can't pickle local object 'GeneratorEnqueuer.start.<locals>.data_generator_task'` error in the `multiprocessing` package, as shwon below:

```
(dlwin36tf140kerasmaster) Phil@SERVERP e:\toolkits.win\anaconda3-4.4.0\envs\dlwin36tf140kerasmaster\Lib\site-packages\keras\tests
$ py.test test_multiprocessing.py
============================= test session starts =============================
platform win32 -- Python 3.6.2, pytest-3.2.1, py-1.4.34, pluggy-0.4.0 -- e:\toolkits.win\anaconda3-4.4.0\envs\dlwin36tf140kerasmaster\python.exe
cachedir: ..\.cache
rootdir: e:\toolkits.win\anaconda3-4.4.0\envs\dlwin36tf140kerasmaster\Lib\site-packages\keras, inifile: pytest.ini
collected 7 items

test_multiprocessing.py::test_multiprocessing_training FAILED
test_multiprocessing.py::test_multiprocessing_training_fromfile FAILED
test_multiprocessing.py::test_multiprocessing_training_fromfile ERROR
test_multiprocessing.py::test_multiprocessing_predicting FAILED
test_multiprocessing.py::test_multiprocessing_evaluating FAILED
test_multiprocessing.py::test_multiprocessing_fit_error FAILED
test_multiprocessing.py::test_multiprocessing_evaluate_error FAILED
test_multiprocessing.py::test_multiprocessing_predict_error FAILED

[...]

================================== FAILURES ===================================
________________________ test_multiprocessing_training ________________________

    @keras_test
    def test_multiprocessing_training():
        arr_data = np.random.randint(0, 256, (50, 2))
        arr_labels = np.random.randint(0, 2, 50)
        arr_weights = np.random.random(50)

        def custom_generator(use_weights=False):
            batch_size = 10
            n_samples = 50

            while True:
                batch_index = np.random.randint(0, n_samples - batch_size)
                start = batch_index
                end = start + batch_size
                X = arr_data[start: end]
                y = arr_labels[start: end]
                if use_weights:
                    w = arr_weights[start: end]
                    yield X, y, w
                else:
                    yield X, y

        # Build a NN
        model = Sequential()
        model.add(Dense(1, input_shape=(2, )))
        model.compile(loss='mse', optimizer='adadelta')

        model.fit_generator(custom_generator(),
                            steps_per_epoch=5,
                            epochs=1,
                            verbose=1,
                            max_queue_size=10,
                            workers=4,
>                           use_multiprocessing=True)

test_multiprocessing.py:54:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
e:\toolkits.win\anaconda3-4.4.0\envs\dlwin36tf140kerasmaster\lib\site-packages\keras-2.1.2-py3.6.egg\keras\legacy\interfaces.py:87: in wrapper
    return func(*args, **kwargs)
e:\toolkits.win\anaconda3-4.4.0\envs\dlwin36tf140kerasmaster\lib\site-packages\keras-2.1.2-py3.6.egg\keras\models.py:1227: in fit_generator
    initial_epoch=initial_epoch)
e:\toolkits.win\anaconda3-4.4.0\envs\dlwin36tf140kerasmaster\lib\site-packages\keras-2.1.2-py3.6.egg\keras\legacy\interfaces.py:87: in wrapper
    return func(*args, **kwargs)
e:\toolkits.win\anaconda3-4.4.0\envs\dlwin36tf140kerasmaster\lib\site-packages\keras-2.1.2-py3.6.egg\keras\engine\training.py:2104: in fit_generator
    enqueuer.start(workers=workers, max_queue_size=max_queue_size)
e:\toolkits.win\anaconda3-4.4.0\envs\dlwin36tf140kerasmaster\lib\site-packages\keras-2.1.2-py3.6.egg\keras\utils\data_utils.py:674: in start
    thread.start()
..\..\..\multiprocessing\process.py:105: in start
    self._popen = self._Popen(self)
..\..\..\multiprocessing\context.py:223: in _Popen
    return _default_context.get_context().Process._Popen(process_obj)
..\..\..\multiprocessing\context.py:322: in _Popen
    return Popen(process_obj)
..\..\..\multiprocessing\popen_spawn_win32.py:65: in __init__
    reduction.dump(process_obj, to_child)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

obj = <Process(Process-2, initial daemon)>, file = <_io.BufferedWriter name=11>
protocol = None

    def dump(obj, file, protocol=None):
        '''Replacement for pickle.dump() using ForkingPickler.'''
>       ForkingPickler(file, protocol).dump(obj)
E       AttributeError: Can't pickle local object 'GeneratorEnqueuer.start.<locals>.data_generator_task'

..\..\..\multiprocessing\reduction.py:60: AttributeError

[...]
```

Converting the `data_generator_task()` local function to a `GeneratorEnqueuer` class method fixes the issue. Fixing the error above, however, doesn't fix a more general problem with `multiprocessing` on Windows. Indeed, on Windows, `multiprocessing` **cannot marshall objects that contain generators** across process boundaries. Attempting to do so will systematically generate a `TypeError: can't pickle generator objects` error, as shown here:

```
[...]

Traceback (most recent call last):
  File "E:\repos\toolkits\keras_mpc_bug\tests\test_multiprocessing.py", line 77, in <module>
    test_multiprocessing_training()
  File "E:\repos\toolkits\keras_mpc_bug\tests\test_multiprocessing.py", line 41, in test_multiprocessing_training
    use_multiprocessing=True)
  File "e:\toolkits.win\anaconda3-4.4.0\envs\dlwin36tf140kerasmaster\lib\site-packages\keras-2.1.2-py3.6.egg\keras\legacy\interfaces.py", line 87, in wrapper
  File "e:\toolkits.win\anaconda3-4.4.0\envs\dlwin36tf140kerasmaster\lib\site-packages\keras-2.1.2-py3.6.egg\keras\models.py", line 1227, in fit_generator
  File "e:\toolkits.win\anaconda3-4.4.0\envs\dlwin36tf140kerasmaster\lib\site-packages\keras-2.1.2-py3.6.egg\keras\legacy\interfaces.py", line 87, in wrapper
  File "e:\toolkits.win\anaconda3-4.4.0\envs\dlwin36tf140kerasmaster\lib\site-packages\keras-2.1.2-py3.6.egg\keras\engine\training.py", line 2104, in fit_generator
  File "e:\toolkits.win\anaconda3-4.4.0\envs\dlwin36tf140kerasmaster\lib\site-packages\keras-2.1.2-py3.6.egg\keras\utils\data_utils.py", line 663, in start
  File "e:\toolkits.win\anaconda3-4.4.0\envs\dlwin36tf140kerasmaster\lib\multiprocessing\process.py", line 105, in start
    self._popen = self._Popen(self)
  File "e:\toolkits.win\anaconda3-4.4.0\envs\dlwin36tf140kerasmaster\lib\multiprocessing\context.py", line 223, in _Popen
    return _default_context.get_context().Process._Popen(process_obj)
  File "e:\toolkits.win\anaconda3-4.4.0\envs\dlwin36tf140kerasmaster\lib\multiprocessing\context.py", line 322, in _Popen
    return Popen(process_obj)
  File "e:\toolkits.win\anaconda3-4.4.0\envs\dlwin36tf140kerasmaster\lib\multiprocessing\popen_spawn_win32.py", line 65, in __init__
    reduction.dump(process_obj, to_child)
  File "e:\toolkits.win\anaconda3-4.4.0\envs\dlwin36tf140kerasmaster\lib\multiprocessing\reduction.py", line 60, in dump
    ForkingPickler(file, protocol).dump(obj)
TypeError: can't pickle generator objects

[...]
```

Our two-pronged `data_utils.py` fix for these issues is the following:
- On all platforms, convert the `data_generator_task()` local function to a `GeneratorEnqueuer` class method.
- On Windows, raise a `ValueError` exception instead if `use_multiprocessing` is set to True and suggest alternative in error message, such as using multithreading, BUT --

-- BUT the current code in `data_utils.py` does not work properly in multithreading mode. Since calls to the generator's `next()` function are not serialized, execution sytematically results in a `ValueError: generator already executing` (both on Windows and Linux!). See notes below on `test_multiprocessing.py` to see why this seldom shows up on Linux.

Our `data_utils.py` fix for this additional issue is the following:
- On all platforms, serialize calls to `generator_output = next(generator)` using a threading lock.
- Initialize the internal queue max size to `max_queue_size`. Right now, it is not properly initialized and grows indefinitely on all platforms!

Yes, we are aware of Python's **limited multithreaded abailities when it comes to the global interpreter lock (gil)**, as discussed [here](https://wiki.python.org/moin/GlobalInterpreterLock). We are also of the opinion that degraded performance is a better alternative to catastrophic failure in execution (as is the case right now). Without a fix, `GeneratorEnqueuer` is unusable on Windows.

If the PR for `data_utils.py` is rejected, please consider using our modified version of `test_multiprocessing.py`. The current version is woefully inadequate at catching multithreading and multiprocessing bugs or stressing the `GeneratorEnqueuer` queueing mechanism. Using our updated version, you will see that the same multithreading issues pop up immediately on Linux as well.

Our fix for `test_multiprocessing.py` to bring out threading issues and stressing the queue are the following:
- Use at least the same number of tests for each of the seven test scenarios:
  - 4 workers + one main thread (`use_multiprocessing` set to True, then False)
  - 1 worker + one main thread (`use_multiprocessing` set to True, then False)
  - No worker + one main thread (`use_multiprocessing` set to True, then False)
- Bump up the number of steps per epoch from 5 to 100:
  - Currently, the number of steps is 5. Since the maximum size of the queue is 10, this is clearly inadequate to really stress the queue in both multiprocessing and multithreading scenarios.

# Code to Repro Multiprocessing Bugs and Test Fix

Simply run `test_multiprocessing.py`. Below, we show execution of this code (with and without the fix) in four different configurations:

- Python 3.6 on Windows 10 with Tensorflow 1.4
- Python 2.7 on Windows 10 with CNTK 2.3
- Python 3.6 on Ubuntu 16.04 with Tensorflow 1.4
- Python 2.7 on Ubuntu 16.04 with CNTK 2.3

## `dlwin36tf140kerasmaster` (Python 3.6 on Windows 10 with Tensorflow 1.4) 

*Execution without the fix*

```
(dlwin36tf140kerasmaster) Phil@SERVERP e:\toolkits.win\anaconda3-4.4.0\envs\dlwin36tf140kerasmaster\Lib\site-packages\keras\tests
$ py.test test_multiprocessing.py
============================= test session starts =============================
platform win32 -- Python 3.6.2, pytest-3.2.1, py-1.4.34, pluggy-0.4.0 -- e:\toolkits.win\anaconda3-4.4.0\envs\dlwin36tf140kerasmaster\python.exe
cachedir: ..\.cache
rootdir: e:\toolkits.win\anaconda3-4.4.0\envs\dlwin36tf140kerasmaster\Lib\site-packages\keras, inifile: pytest.ini
collected 7 items

test_multiprocessing.py::test_multiprocessing_training FAILED
test_multiprocessing.py::test_multiprocessing_training_fromfile FAILED
test_multiprocessing.py::test_multiprocessing_training_fromfile ERROR
test_multiprocessing.py::test_multiprocessing_predicting FAILED
test_multiprocessing.py::test_multiprocessing_evaluating FAILED
test_multiprocessing.py::test_multiprocessing_fit_error FAILED
test_multiprocessing.py::test_multiprocessing_evaluate_error FAILED
test_multiprocessing.py::test_multiprocessing_predict_error FAILED

========================== slowest 10 test durations ==========================
0.51s call     tests/test_multiprocessing.py::test_multiprocessing_training
0.48s call     tests/test_multiprocessing.py::test_multiprocessing_training_fromfile
0.47s call     tests/test_multiprocessing.py::test_multiprocessing_fit_error
0.25s call     tests/test_multiprocessing.py::test_multiprocessing_evaluating
0.25s call     tests/test_multiprocessing.py::test_multiprocessing_evaluate_error
0.24s call     tests/test_multiprocessing.py::test_multiprocessing_predict_error
0.24s call     tests/test_multiprocessing.py::test_multiprocessing_predicting
0.01s setup    tests/test_multiprocessing.py::test_multiprocessing_training_fromfile
0.00s teardown tests/test_multiprocessing.py::test_multiprocessing_training
0.00s teardown tests/test_multiprocessing.py::test_multiprocessing_fit_error
=================================== ERRORS ====================================
_________ ERROR at teardown of test_multiprocessing_training_fromfile _________

tmpdir = local('C:\\Users\\Phil\\AppData\\Local\\Temp\\pytest-of-Phil\\pytest-109\\test_multiprocessing_training_0')

    @pytest.fixture
    def in_tmpdir(tmpdir):
        """Runs a function in a temporary directory.

        Checks that the directory is empty afterwards.
        """
        with tmpdir.as_cwd():
            yield None
>       assert not tmpdir.listdir()
E       AssertionError: assert not [local('C:\\Users\\Phil\\AppData\\Local\\Temp\\pytest-of-Phil\\pytest-109\\test_multiprocessing_training_0\\data.npz')]
E        +  where [local('C:\\Users\\Phil\\AppData\\Local\\Temp\\pytest-of-Phil\\pytest-109\\test_multiprocessing_training_0\\data.npz')] = <bound method LocalPath.listdir of local('C:\\Users\\Phil\\AppData\\Local\\Temp\\pytest-of-Phil\\pytest-109\\test_multiprocessing_training_0')>()
E        +    where <bound method LocalPath.listdir of local('C:\\Users\\Phil\\AppData\\Local\\Temp\\pytest-of-Phil\\pytest-109\\test_multiprocessing_training_0')> = local('C:\\Users\\Phil\\AppData\\Local\\Temp\\pytest-of-Phil\\pytest-109\\test_multiprocessing_training_0').listdir

test_multiprocessing.py:18: AssertionError
-------------------------- Captured stderr teardown ---------------------------
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "e:\toolkits.win\anaconda3-4.4.0\envs\dlwin36tf140kerasmaster\lib\multiprocessing\spawn.py", line 105, in spawn_main
    exitcode = _main(fd)
  File "e:\toolkits.win\anaconda3-4.4.0\envs\dlwin36tf140kerasmaster\lib\multiprocessing\spawn.py", line 115, in _main
    self = reduction.pickle.load(from_parent)
EOFError: Ran out of input
================================== FAILURES ===================================
________________________ test_multiprocessing_training ________________________

    @keras_test
    def test_multiprocessing_training():
        arr_data = np.random.randint(0, 256, (50, 2))
        arr_labels = np.random.randint(0, 2, 50)
        arr_weights = np.random.random(50)

        def custom_generator(use_weights=False):
            batch_size = 10
            n_samples = 50

            while True:
                batch_index = np.random.randint(0, n_samples - batch_size)
                start = batch_index
                end = start + batch_size
                X = arr_data[start: end]
                y = arr_labels[start: end]
                if use_weights:
                    w = arr_weights[start: end]
                    yield X, y, w
                else:
                    yield X, y

        # Build a NN
        model = Sequential()
        model.add(Dense(1, input_shape=(2, )))
        model.compile(loss='mse', optimizer='adadelta')

        model.fit_generator(custom_generator(),
                            steps_per_epoch=5,
                            epochs=1,
                            verbose=1,
                            max_queue_size=10,
                            workers=4,
>                           use_multiprocessing=True)

test_multiprocessing.py:54:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
e:\toolkits.win\anaconda3-4.4.0\envs\dlwin36tf140kerasmaster\lib\site-packages\keras-2.1.2-py3.6.egg\keras\legacy\interfaces.py:87: in wrapper
    return func(*args, **kwargs)
e:\toolkits.win\anaconda3-4.4.0\envs\dlwin36tf140kerasmaster\lib\site-packages\keras-2.1.2-py3.6.egg\keras\models.py:1227: in fit_generator
    initial_epoch=initial_epoch)
e:\toolkits.win\anaconda3-4.4.0\envs\dlwin36tf140kerasmaster\lib\site-packages\keras-2.1.2-py3.6.egg\keras\legacy\interfaces.py:87: in wrapper
    return func(*args, **kwargs)
e:\toolkits.win\anaconda3-4.4.0\envs\dlwin36tf140kerasmaster\lib\site-packages\keras-2.1.2-py3.6.egg\keras\engine\training.py:2104: in fit_generator
    enqueuer.start(workers=workers, max_queue_size=max_queue_size)
e:\toolkits.win\anaconda3-4.4.0\envs\dlwin36tf140kerasmaster\lib\site-packages\keras-2.1.2-py3.6.egg\keras\utils\data_utils.py:674: in start
    thread.start()
..\..\..\multiprocessing\process.py:105: in start
    self._popen = self._Popen(self)
..\..\..\multiprocessing\context.py:223: in _Popen
    return _default_context.get_context().Process._Popen(process_obj)
..\..\..\multiprocessing\context.py:322: in _Popen
    return Popen(process_obj)
..\..\..\multiprocessing\popen_spawn_win32.py:65: in __init__
    reduction.dump(process_obj, to_child)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

obj = <Process(Process-2, initial daemon)>, file = <_io.BufferedWriter name=11>
protocol = None

    def dump(obj, file, protocol=None):
        '''Replacement for pickle.dump() using ForkingPickler.'''
>       ForkingPickler(file, protocol).dump(obj)
E       AttributeError: Can't pickle local object 'GeneratorEnqueuer.start.<locals>.data_generator_task'

..\..\..\multiprocessing\reduction.py:60: AttributeError
...
```

*Execution with the fix*

```
(dlwin36tf140kerasmaster) Phil@SERVERP e:\toolkits.win\anaconda3-4.4.0\envs\dlwin36tf140kerasmaster\Lib\site-packages\keras\tests
$ py.test test_multiprocessing.py
============================= test session starts =============================
platform win32 -- Python 3.6.2, pytest-3.2.1, py-1.4.34, pluggy-0.4.0 -- e:\toolkits.win\anaconda3-4.4.0\envs\dlwin36tf140kerasmaster\python.exe
cachedir: ..\.cache
rootdir: e:\toolkits.win\anaconda3-4.4.0\envs\dlwin36tf140kerasmaster\Lib\site-packages\keras, inifile: pytest.ini
collected 7 items

test_multiprocessing.py::test_multiprocessing_training PASSED
test_multiprocessing.py::test_multiprocessing_training_from_file PASSED
test_multiprocessing.py::test_multiprocessing_predicting PASSED
test_multiprocessing.py::test_multiprocessing_evaluating PASSED
test_multiprocessing.py::test_multiprocessing_fit_error PASSED
test_multiprocessing.py::test_multiprocessing_evaluate_error PASSED
test_multiprocessing.py::test_multiprocessing_predict_error PASSED

========================== slowest 10 test durations ==========================
4.19s call     tests/test_multiprocessing.py::test_multiprocessing_training
2.04s call     tests/test_multiprocessing.py::test_multiprocessing_training_from_file
0.61s call     tests/test_multiprocessing.py::test_multiprocessing_evaluating
0.57s call     tests/test_multiprocessing.py::test_multiprocessing_fit_error
0.54s call     tests/test_multiprocessing.py::test_multiprocessing_predicting
0.12s call     tests/test_multiprocessing.py::test_multiprocessing_evaluate_error
0.11s call     tests/test_multiprocessing.py::test_multiprocessing_predict_error
0.02s setup    tests/test_multiprocessing.py::test_multiprocessing_training_from_file
0.00s teardown tests/test_multiprocessing.py::test_multiprocessing_evaluate_error
0.00s teardown tests/test_multiprocessing.py::test_multiprocessing_training_from_file
============================== warnings summary ===============================
tests/test_multiprocessing.py::test_multiprocessing_training
  e:\toolkits.win\anaconda3-4.4.0\envs\dlwin36tf140kerasmaster\lib\site-packages\keras-2.1.2-py3.6.egg\keras\engine\training.py:2023: UserWarning: Using a generator with `use_multiprocessing=True` and multiple workers may duplicate your data. Please consider using the`keras.utils.Sequence class.

tests/test_multiprocessing.py::test_multiprocessing_training_from_file
  e:\toolkits.win\anaconda3-4.4.0\envs\dlwin36tf140kerasmaster\lib\site-packages\keras-2.1.2-py3.6.egg\keras\engine\training.py:2023: UserWarning: Using a generator with `use_multiprocessing=True` and multiple workers may duplicate your data. Please consider using the`keras.utils.Sequence class.

tests/test_multiprocessing.py::test_multiprocessing_predicting
  e:\toolkits.win\anaconda3-4.4.0\envs\dlwin36tf140kerasmaster\lib\site-packages\keras-2.1.2-py3.6.egg\keras\engine\training.py:2375: UserWarning: Using a generator with `use_multiprocessing=True` and multiple workers may duplicate your data. Please consider using the`keras.utils.Sequence class.

tests/test_multiprocessing.py::test_multiprocessing_evaluating
  e:\toolkits.win\anaconda3-4.4.0\envs\dlwin36tf140kerasmaster\lib\site-packages\keras-2.1.2-py3.6.egg\keras\engine\training.py:2251: UserWarning: Using a generator with `use_multiprocessing=True` and multiple workers may duplicate your data. Please consider using the`keras.utils.Sequence class.

tests/test_multiprocessing.py::test_multiprocessing_fit_error
  e:\toolkits.win\anaconda3-4.4.0\envs\dlwin36tf140kerasmaster\lib\site-packages\keras-2.1.2-py3.6.egg\keras\engine\training.py:2023: UserWarning: Using a generator with `use_multiprocessing=True` and multiple workers may duplicate your data. Please consider using the`keras.utils.Sequence class.

tests/test_multiprocessing.py::test_multiprocessing_evaluate_error
  e:\toolkits.win\anaconda3-4.4.0\envs\dlwin36tf140kerasmaster\lib\site-packages\keras-2.1.2-py3.6.egg\keras\engine\training.py:2251: UserWarning: Using a generator with `use_multiprocessing=True` and multiple workers may duplicate your data. Please consider using the`keras.utils.Sequence class.

tests/test_multiprocessing.py::test_multiprocessing_predict_error
  e:\toolkits.win\anaconda3-4.4.0\envs\dlwin36tf140kerasmaster\lib\site-packages\keras-2.1.2-py3.6.egg\keras\engine\training.py:2375: UserWarning: Using a generator with `use_multiprocessing=True` and multiple workers may duplicate your data. Please consider using the`keras.utils.Sequence class.

-- Docs: http://doc.pytest.org/en/latest/warnings.html
==================== 7 passed, 7 warnings in 11.44 seconds ====================
2017-12-02 08:50:53.632443: I C:\tf_jenkins\home\workspace\rel-win\M\windows-gpu\PY\36\tensorflow\core\platform\cpu_feature_guard.cc:137] Your CPU supports instructions that this TensorFlow binary was not compiled to use: AVX AVX2
2017-12-02 08:50:54.016767: I C:\tf_jenkins\home\workspace\rel-win\M\windows-gpu\PY\36\tensorflow\core\common_runtime\gpu\gpu_device.cc:1030] Found device 0 with properties:
name: GeForce GTX TITAN X major: 5 minor: 2 memoryClockRate(GHz): 1.076
pciBusID: 0000:03:00.0
totalMemory: 12.00GiB freeMemory: 10.06GiB
2017-12-02 08:50:54.016804: I C:\tf_jenkins\home\workspace\rel-win\M\windows-gpu\PY\36\tensorflow\core\common_runtime\gpu\gpu_device.cc:1120] Creating TensorFlow device (/device:GPU:0) -> (device: 0, name: GeForce GTX TITAN X, pci bus id: 0000:03:00.0, compute capability: 5.2)
2017-12-02 08:50:57.848682: I C:\tf_jenkins\home\workspace\rel-win\M\windows-gpu\PY\36\tensorflow\core\common_runtime\gpu\gpu_device.cc:1120] Creating TensorFlow device (/device:GPU:0) -> (device: 0, name: GeForce GTX TITAN X, pci bus id: 0000:03:00.0, compute capability: 5.2)
2017-12-02 08:50:59.634973: I C:\tf_jenkins\home\workspace\rel-win\M\windows-gpu\PY\36\tensorflow\core\common_runtime\gpu\gpu_device.cc:1120] Creating TensorFlow device (/device:GPU:0) -> (device: 0, name: GeForce GTX TITAN X, pci bus id: 0000:03:00.0, compute capability: 5.2)
2017-12-02 08:51:00.172749: I C:\tf_jenkins\home\workspace\rel-win\M\windows-gpu\PY\36\tensorflow\core\common_runtime\gpu\gpu_device.cc:1120] Creating TensorFlow device (/device:GPU:0) -> (device: 0, name: GeForce GTX TITAN X, pci bus id: 0000:03:00.0, compute capability: 5.2)
2017-12-02 08:51:01.090078: I C:\tf_jenkins\home\workspace\rel-win\M\windows-gpu\PY\36\tensorflow\core\common_runtime\gpu\gpu_device.cc:1120] Creating TensorFlow device (/device:GPU:0) -> (device: 0, name: GeForce GTX TITAN X, pci bus id: 0000:03:00.0, compute capability: 5.2)
2017-12-02 08:51:01.358376: I C:\tf_jenkins\home\workspace\rel-win\M\windows-gpu\PY\36\tensorflow\core\common_runtime\gpu\gpu_device.cc:1120] Creating TensorFlow device (/device:GPU:0) -> (device: 0, name: GeForce GTX TITAN X, pci bus id: 0000:03:00.0, compute capability: 5.2)
2017-12-02 08:51:01.480222: I C:\tf_jenkins\home\workspace\rel-win\M\windows-gpu\PY\36\tensorflow\core\common_runtime\gpu\gpu_device.cc:1120] Creating TensorFlow device (/device:GPU:0) -> (device: 0, name: GeForce GTX TITAN X, pci bus id: 0000:03:00.0, compute capability: 5.2)
```

*Steps to recreate test environment*

```
$ conda create --yes -n dlwin36 numpy scipy mkl-service matplotlib pandas pillow scikit-learn jupyter pytest
$ conda create --name dlwin36tf140kerasmaster --clone dlwin36
$ activate dlwin36tf140kerasmaster 
$ pip install tensorflow-gpu==1.4.0 
$ cd "%CONDA_PREFIX%\Lib\site-packages"
$ git clone git://github.com/fchollet/keras.git
$ cd keras
$ python setup.py install
```

## `dlwin27cntk23kerasmaster` (Python 2.7 on Windows 10 with CNTK 2.3)

*Execution without the fix*

```
(dlwin27cntk23kerasmaster) Phil@SERVERP e:\toolkits.win\anaconda3-4.4.0\envs\dlwin27cntk23kerasmaster\Lib\site-packages\keras\tests
$ py.test test_multiprocessing.py
============================= test session starts =============================
platform win32 -- Python 2.7.13, pytest-3.2.1, py-1.4.34, pluggy-0.4.0 -- e:\toolkits.win\anaconda3-4.4.0\envs\dlwin27cntk23kerasmaster\python.exe
cachedir: ..\.cache
rootdir: e:\toolkits.win\anaconda3-4.4.0\envs\dlwin27cntk23kerasmaster\Lib\site-packages\keras, inifile: pytest.ini
collected 7 items

test_multiprocessing.py::test_multiprocessing_training FAILED
test_multiprocessing.py::test_multiprocessing_training_fromfile FAILED
test_multiprocessing.py::test_multiprocessing_training_fromfile ERROR
test_multiprocessing.py::test_multiprocessing_predicting FAILED
test_multiprocessing.py::test_multiprocessing_evaluating FAILED
test_multiprocessing.py::test_multiprocessing_fit_error FAILED
test_multiprocessing.py::test_multiprocessing_evaluate_error FAILED
test_multiprocessing.py::test_multiprocessing_predict_error FAILED

========================== slowest 10 test durations ==========================
0.63s call     tests/test_multiprocessing.py::test_multiprocessing_training
0.18s call     tests/test_multiprocessing.py::test_multiprocessing_training_fromfile
0.15s call     tests/test_multiprocessing.py::test_multiprocessing_fit_error
0.14s call     tests/test_multiprocessing.py::test_multiprocessing_predicting
0.14s call     tests/test_multiprocessing.py::test_multiprocessing_predict_error
0.14s call     tests/test_multiprocessing.py::test_multiprocessing_evaluating
0.14s call     tests/test_multiprocessing.py::test_multiprocessing_evaluate_error
0.01s setup    tests/test_multiprocessing.py::test_multiprocessing_training_fromfile
0.00s teardown tests/test_multiprocessing.py::test_multiprocessing_training_fromfile
0.00s teardown tests/test_multiprocessing.py::test_multiprocessing_predicting
=================================== ERRORS ====================================
_________ ERROR at teardown of test_multiprocessing_training_fromfile _________

tmpdir = local('c:\\users\\phil\\appdata\\local\\temp\\pytest-of-Phil\\pytest-103\\test_multiprocessing_training_0')

    @pytest.fixture
    def in_tmpdir(tmpdir):
        """Runs a function in a temporary directory.

        Checks that the directory is empty afterwards.
        """
        with tmpdir.as_cwd():
            yield None
>       assert not tmpdir.listdir()
E       AssertionError: assert not [local('c:\\users\\phil\\appdata\\local\\temp\\pytest-of-Phil\\pytest-103\\test_multiprocessing_training_0\\data.npz')]
E        +  where [local('c:\\users\\phil\\appdata\\local\\temp\\pytest-of-Phil\\pytest-103\\test_multiprocessing_training_0\\data.npz')] = <bound method LocalPath.listdir of local('c:\\users\\phil\\appdata\\local\\temp\\pytest-of-Phil\\pytest-103\\test_multiprocessing_training_0')>()
E        +    where <bound method LocalPath.listdir of local('c:\\users\\phil\\appdata\\local\\temp\\pytest-of-Phil\\pytest-103\\test_multiprocessing_training_0')> = local('c:\\users\\phil\\appdata\\local\\temp\\pytest-of-Phil\\pytest-103\\test_multiprocessing_training_0').listdir

test_multiprocessing.py:18: AssertionError
-------------------------- Captured stderr teardown ---------------------------
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "e:\toolkits.win\anaconda3-4.4.0\envs\dlwin27cntk23kerasmaster\lib\multiprocessing\forking.py", line 381, in main
    self = load(from_parent)
  File "e:\toolkits.win\anaconda3-4.4.0\envs\dlwin27cntk23kerasmaster\lib\pickle.py", line 1384, in load
    return Unpickler(file).load()
  File "e:\toolkits.win\anaconda3-4.4.0\envs\dlwin27cntk23kerasmaster\lib\pickle.py", line 864, in load
    dispatch[key](self)
  File "e:\toolkits.win\anaconda3-4.4.0\envs\dlwin27cntk23kerasmaster\lib\pickle.py", line 886, in load_eof
    raise EOFError
EOFError
================================== FAILURES ===================================
________________________ test_multiprocessing_training ________________________

    @keras_test
    def test_multiprocessing_training():
        arr_data = np.random.randint(0, 256, (50, 2))
        arr_labels = np.random.randint(0, 2, 50)
        arr_weights = np.random.random(50)

        def custom_generator(use_weights=False):
            batch_size = 10
            n_samples = 50

            while True:
                batch_index = np.random.randint(0, n_samples - batch_size)
                start = batch_index
                end = start + batch_size
                X = arr_data[start: end]
                y = arr_labels[start: end]
                if use_weights:
                    w = arr_weights[start: end]
                    yield X, y, w
                else:
                    yield X, y

        # Build a NN
        model = Sequential()
        model.add(Dense(1, input_shape=(2, )))
        model.compile(loss='mse', optimizer='adadelta')

        model.fit_generator(custom_generator(),
                            steps_per_epoch=5,
                            epochs=1,
                            verbose=1,
                            max_queue_size=10,
                            workers=4,
>                           use_multiprocessing=True)

test_multiprocessing.py:54:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
build\bdist.win-amd64\egg\keras\legacy\interfaces.py:87: in wrapper
    ???
build\bdist.win-amd64\egg\keras\models.py:1227: in fit_generator
    ???
build\bdist.win-amd64\egg\keras\legacy\interfaces.py:87: in wrapper
    ???
build\bdist.win-amd64\egg\keras\engine\training.py:2104: in fit_generator
    ???
build\bdist.win-amd64\egg\keras\utils\data_utils.py:674: in start
    ???
..\..\..\multiprocessing\process.py:130: in start
    self._popen = Popen(self)
..\..\..\multiprocessing\forking.py:277: in __init__
    dump(process_obj, to_child, HIGHEST_PROTOCOL)
..\..\..\multiprocessing\forking.py:199: in dump
    ForkingPickler(file, protocol).dump(obj)
..\..\..\pickle.py:224: in dump
    self.save(obj)
..\..\..\pickle.py:331: in save
    self.save_reduce(obj=obj, *rv)
..\..\..\pickle.py:425: in save_reduce
    save(state)
..\..\..\pickle.py:286: in save
    f(self, obj) # Call unbound method with explicit self
..\..\..\pickle.py:655: in save_dict
    self._batch_setitems(obj.iteritems())
..\..\..\pickle.py:687: in _batch_setitems
    save(v)
..\..\..\pickle.py:286: in save
    f(self, obj) # Call unbound method with explicit self
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <multiprocessing.forking.ForkingPickler instance at 0x0000000008817608>
obj = <function data_generator_task at 0x00000000087FE978>
name = 'data_generator_task', pack = <built-in function pack>

    def save_global(self, obj, name=None, pack=struct.pack):
        write = self.write
        memo = self.memo

        if name is None:
            name = obj.__name__

        module = getattr(obj, "__module__", None)
        if module is None:
            module = whichmodule(obj, name)

        try:
            __import__(module)
            mod = sys.modules[module]
            klass = getattr(mod, name)
        except (ImportError, KeyError, AttributeError):
            raise PicklingError(
                "Can't pickle %r: it's not found as %s.%s" %
>               (obj, module, name))
E           PicklingError: Can't pickle <function data_generator_task at 0x00000000087FE978>: it's not found as keras.utils.data_utils.data_generator_task

..\..\..\pickle.py:754: PicklingError
...
```

*Execution with the fix*

```
(dlwin27cntk23kerasmaster) Phil@SERVERP e:\toolkits.win\anaconda3-4.4.0\envs\dlwin27cntk23kerasmaster\Lib\site-packages\keras\tests
$ py.test test_multiprocessing.py
============================= test session starts =============================
platform win32 -- Python 2.7.13, pytest-3.2.1, py-1.4.34, pluggy-0.4.0 -- e:\toolkits.win\anaconda3-4.4.0\envs\dlwin27cntk23kerasmaster\python.exe
cachedir: ..\.cache
rootdir: e:\toolkits.win\anaconda3-4.4.0\envs\dlwin27cntk23kerasmaster\Lib\site-packages\keras, inifile: pytest.ini
collected 7 items

test_multiprocessing.py::test_multiprocessing_training PASSED
test_multiprocessing.py::test_multiprocessing_training_from_file PASSED
test_multiprocessing.py::test_multiprocessing_predicting PASSED
test_multiprocessing.py::test_multiprocessing_evaluating PASSED
test_multiprocessing.py::test_multiprocessing_fit_error PASSED
test_multiprocessing.py::test_multiprocessing_evaluate_error PASSED
test_multiprocessing.py::test_multiprocessing_predict_error PASSED

========================== slowest 10 test durations ==========================
2.40s call     tests/test_multiprocessing.py::test_multiprocessing_training
1.54s call     tests/test_multiprocessing.py::test_multiprocessing_training_from_file
0.80s call     tests/test_multiprocessing.py::test_multiprocessing_evaluating
0.51s call     tests/test_multiprocessing.py::test_multiprocessing_predicting
0.06s call     tests/test_multiprocessing.py::test_multiprocessing_fit_error
0.03s call     tests/test_multiprocessing.py::test_multiprocessing_evaluate_error
0.03s call     tests/test_multiprocessing.py::test_multiprocessing_predict_error
0.01s setup    tests/test_multiprocessing.py::test_multiprocessing_training_from_file
0.00s setup    tests/test_multiprocessing.py::test_multiprocessing_fit_error
0.00s teardown tests/test_multiprocessing.py::test_multiprocessing_training_from_file
============================== warnings summary ===============================
tests/test_multiprocessing.py::test_multiprocessing_training
  e:\toolkits.win\anaconda3-4.4.0\envs\dlwin27cntk23kerasmaster\lib\site-packages\keras-2.1.2-py2.7.egg\keras\engine\training.py:2023: UserWarning: Using a generator with `use_multiprocessing=True` and multiple workers may duplicate your data. Please consider using the`keras.utils.Sequence class.
  e:\toolkits.win\anaconda3-4.4.0\envs\dlwin27cntk23kerasmaster\lib\site-packages\cntk\core.py:361: UserWarning: your data is of type "float64", but your input variable (uid "Input23") expects "<type 'numpy.float32'>". Please convert your data beforehand to speed up training.
    (sample.dtype, var.uid, str(var.dtype)))
  e:\toolkits.win\anaconda3-4.4.0\envs\dlwin27cntk23kerasmaster\lib\site-packages\_pytest\warnings.py:88: UnicodeWarning: Warning is using unicode non convertible to ascii, converting to a safe representation:
    e:\toolkits.win\anaconda3-4.4.0\envs\dlwin27cntk23kerasmaster\lib\site-packages\cntk\core.py:361: UserWarning: your data is of type "float64", but your input variable (uid "Input23") expects "<type 'numpy.float32'>". Please convert your data beforehand to speed up training.
    (sample.dtype, var.uid, str(var.dtype)))

    UnicodeWarning)

tests/test_multiprocessing.py::test_multiprocessing_predicting
  e:\toolkits.win\anaconda3-4.4.0\envs\dlwin27cntk23kerasmaster\lib\site-packages\keras-2.1.2-py2.7.egg\keras\engine\training.py:2375: UserWarning: Using a generator with `use_multiprocessing=True` and multiple workers may duplicate your data. Please consider using the`keras.utils.Sequence class.

tests/test_multiprocessing.py::test_multiprocessing_evaluating
  e:\toolkits.win\anaconda3-4.4.0\envs\dlwin27cntk23kerasmaster\lib\site-packages\keras-2.1.2-py2.7.egg\keras\engine\training.py:2251: UserWarning: Using a generator with `use_multiprocessing=True` and multiple workers may duplicate your data. Please consider using the`keras.utils.Sequence class.

-- Docs: http://doc.pytest.org/en/latest/warnings.html
==================== 7 passed, 5 warnings in 6.69 seconds =====================
```

*Steps to recreate test environment*

```
$ conda create --yes -n dlwin27 python=2.7
$ activate dlwin27
$ conda install --yes numpy scipy mkl-service matplotlib pandas pillow scikit-learn jupyter pytest
$ deactivate
$ conda create --name dlwin27cntk23kerasmaster --clone dlwin27
$ activate dlwin27cntk23kerasmaster 
$ pip install https://cntk.ai/PythonWheel/GPU/cntk-2.3-cp27-cp27m-win_amd64.whl
$ cd "%CONDA_PREFIX%\Lib\site-packages"
$ git clone git://github.com/fchollet/keras.git
$ cd keras
$ python setup.py install
$ set KERAS_BACKEND=cntk
```


## `dlubu36tf140kerasmaster` (Python 3.6 on Ubuntu 16.04 with Tensorflow 1.4)

*Execution without the fix*

```
(dlubu36tf140kerasmaster) phil@DESKTOPP:/media/EDrive/toolkits.ubu/anaconda3-4.4.0/envs/dlubu36tf140kerasmaster/lib/python3.6/site-packages/keras/tests$ py.test test_multiprocessing.py
======================================================= test session starts ========================================================
platform linux -- Python 3.6.2, pytest-3.2.1, py-1.4.34, pluggy-0.4.0 -- /media/EDrive/toolkits.ubu/anaconda3-4.4.0/envs/dlubu36tf140kerasmaster/bin/python
cachedir: ../.cache
rootdir: /media/EDrive/toolkits.ubu/anaconda3-4.4.0/envs/dlubu36tf140kerasmaster/lib/python3.6/site-packages/keras, inifile: pytest.ini
collected 7 items                                                                                                                   

test_multiprocessing.py::test_multiprocessing_training PASSED
test_multiprocessing.py::test_multiprocessing_training_fromfile PASSED
test_multiprocessing.py::test_multiprocessing_predicting PASSED
test_multiprocessing.py::test_multiprocessing_evaluating PASSED
test_multiprocessing.py::test_multiprocessing_fit_error PASSED
test_multiprocessing.py::test_multiprocessing_evaluate_error PASSED
test_multiprocessing.py::test_multiprocessing_predict_error PASSED

==================================================== slowest 10 test durations =====================================================
1.58s call     tests/test_multiprocessing.py::test_multiprocessing_training
0.60s call     tests/test_multiprocessing.py::test_multiprocessing_training_fromfile
0.37s call     tests/test_multiprocessing.py::test_multiprocessing_fit_error
0.25s call     tests/test_multiprocessing.py::test_multiprocessing_evaluate_error
0.24s call     tests/test_multiprocessing.py::test_multiprocessing_predict_error
0.20s call     tests/test_multiprocessing.py::test_multiprocessing_evaluating
0.18s call     tests/test_multiprocessing.py::test_multiprocessing_predicting
0.01s setup    tests/test_multiprocessing.py::test_multiprocessing_training_fromfile
0.00s teardown tests/test_multiprocessing.py::test_multiprocessing_training_fromfile
0.00s teardown tests/test_multiprocessing.py::test_multiprocessing_predict_error
========================================================= warnings summary =========================================================
tests/test_multiprocessing.py::test_multiprocessing_training
  /media/EDrive/toolkits.ubu/anaconda3-4.4.0/envs/dlubu36tf140kerasmaster/lib/python3.6/site-packages/Keras-2.1.2-py3.6.egg/keras/engine/training.py:2023: UserWarning: Using a generator with `use_multiprocessing=True` and multiple workers may duplicate your data. Please consider using the`keras.utils.Sequence class.

tests/test_multiprocessing.py::test_multiprocessing_training_fromfile
  /media/EDrive/toolkits.ubu/anaconda3-4.4.0/envs/dlubu36tf140kerasmaster/lib/python3.6/site-packages/Keras-2.1.2-py3.6.egg/keras/engine/training.py:2023: UserWarning: Using a generator with `use_multiprocessing=True` and multiple workers may duplicate your data. Please consider using the`keras.utils.Sequence class.

tests/test_multiprocessing.py::test_multiprocessing_predicting
  /media/EDrive/toolkits.ubu/anaconda3-4.4.0/envs/dlubu36tf140kerasmaster/lib/python3.6/site-packages/Keras-2.1.2-py3.6.egg/keras/engine/training.py:2375: UserWarning: Using a generator with `use_multiprocessing=True` and multiple workers may duplicate your data. Please consider using the`keras.utils.Sequence class.

tests/test_multiprocessing.py::test_multiprocessing_evaluating
  /media/EDrive/toolkits.ubu/anaconda3-4.4.0/envs/dlubu36tf140kerasmaster/lib/python3.6/site-packages/Keras-2.1.2-py3.6.egg/keras/engine/training.py:2251: UserWarning: Using a generator with `use_multiprocessing=True` and multiple workers may duplicate your data. Please consider using the`keras.utils.Sequence class.

tests/test_multiprocessing.py::test_multiprocessing_fit_error
  /media/EDrive/toolkits.ubu/anaconda3-4.4.0/envs/dlubu36tf140kerasmaster/lib/python3.6/site-packages/Keras-2.1.2-py3.6.egg/keras/engine/training.py:2023: UserWarning: Using a generator with `use_multiprocessing=True` and multiple workers may duplicate your data. Please consider using the`keras.utils.Sequence class.

tests/test_multiprocessing.py::test_multiprocessing_evaluate_error
  /media/EDrive/toolkits.ubu/anaconda3-4.4.0/envs/dlubu36tf140kerasmaster/lib/python3.6/site-packages/Keras-2.1.2-py3.6.egg/keras/engine/training.py:2251: UserWarning: Using a generator with `use_multiprocessing=True` and multiple workers may duplicate your data. Please consider using the`keras.utils.Sequence class.

tests/test_multiprocessing.py::test_multiprocessing_predict_error
  /media/EDrive/toolkits.ubu/anaconda3-4.4.0/envs/dlubu36tf140kerasmaster/lib/python3.6/site-packages/Keras-2.1.2-py3.6.egg/keras/engine/training.py:2375: UserWarning: Using a generator with `use_multiprocessing=True` and multiple workers may duplicate your data. Please consider using the`keras.utils.Sequence class.

-- Docs: http://doc.pytest.org/en/latest/warnings.html
=============================================== 7 passed, 7 warnings in 8.70 seconds ===============================================
```

*Execution with the fix*

```
(dlubu36tf140kerasmaster) phil@DESKTOPP:/media/EDrive/toolkits.ubu/anaconda3-4.4.0/envs/dlubu36tf140kerasmaster/lib/python3.6/site-packages/keras/tests$ py.test /media/EDrive/repos/toolkits/keras_mpc_bug/tests/test_multiprocessing.py
======================================================= test session starts ========================================================
platform linux -- Python 3.6.2, pytest-3.2.1, py-1.4.34, pluggy-0.4.0 -- /media/EDrive/toolkits.ubu/anaconda3-4.4.0/envs/dlubu36tf140kerasmaster/bin/python
cachedir: ../.cache
rootdir: /media/EDrive/toolkits.ubu/anaconda3-4.4.0/envs/dlubu36tf140kerasmaster/lib/python3.6/site-packages/keras, inifile: pytest.ini
collected 7 items                                                                                                                   

test_multiprocessing.py::test_multiprocessing_training PASSED
test_multiprocessing.py::test_multiprocessing_training_from_file PASSED
test_multiprocessing.py::test_multiprocessing_predicting PASSED
test_multiprocessing.py::test_multiprocessing_evaluating PASSED
test_multiprocessing.py::test_multiprocessing_fit_error PASSED
test_multiprocessing.py::test_multiprocessing_evaluate_error PASSED
test_multiprocessing.py::test_multiprocessing_predict_error PASSED

==================================================== slowest 10 test durations =====================================================
5.51s call     tests/test_multiprocessing.py::test_multiprocessing_training
3.75s call     tests/test_multiprocessing.py::test_multiprocessing_training_from_file
1.46s call     tests/test_multiprocessing.py::test_multiprocessing_evaluating
1.15s call     tests/test_multiprocessing.py::test_multiprocessing_predicting
0.57s call     tests/test_multiprocessing.py::test_multiprocessing_fit_error
0.28s call     tests/test_multiprocessing.py::test_multiprocessing_evaluate_error
0.26s call     tests/test_multiprocessing.py::test_multiprocessing_predict_error
0.01s setup    tests/test_multiprocessing.py::test_multiprocessing_training_from_file
0.00s teardown tests/test_multiprocessing.py::test_multiprocessing_training_from_file
0.00s setup    tests/test_multiprocessing.py::test_multiprocessing_training
========================================================= warnings summary =========================================================
tests/test_multiprocessing.py::test_multiprocessing_training
  /media/EDrive/toolkits.ubu/anaconda3-4.4.0/envs/dlubu36tf140kerasmaster/lib/python3.6/site-packages/Keras-2.1.2-py3.6.egg/keras/engine/training.py:2023: UserWarning: Using a generator with `use_multiprocessing=True` and multiple workers may duplicate your data. Please consider using the`keras.utils.Sequence class.

tests/test_multiprocessing.py::test_multiprocessing_training_from_file
  /media/EDrive/toolkits.ubu/anaconda3-4.4.0/envs/dlubu36tf140kerasmaster/lib/python3.6/site-packages/Keras-2.1.2-py3.6.egg/keras/engine/training.py:2023: UserWarning: Using a generator with `use_multiprocessing=True` and multiple workers may duplicate your data. Please consider using the`keras.utils.Sequence class.

tests/test_multiprocessing.py::test_multiprocessing_predicting
  /media/EDrive/toolkits.ubu/anaconda3-4.4.0/envs/dlubu36tf140kerasmaster/lib/python3.6/site-packages/Keras-2.1.2-py3.6.egg/keras/engine/training.py:2375: UserWarning: Using a generator with `use_multiprocessing=True` and multiple workers may duplicate your data. Please consider using the`keras.utils.Sequence class.

tests/test_multiprocessing.py::test_multiprocessing_evaluating
  /media/EDrive/toolkits.ubu/anaconda3-4.4.0/envs/dlubu36tf140kerasmaster/lib/python3.6/site-packages/Keras-2.1.2-py3.6.egg/keras/engine/training.py:2251: UserWarning: Using a generator with `use_multiprocessing=True` and multiple workers may duplicate your data. Please consider using the`keras.utils.Sequence class.

tests/test_multiprocessing.py::test_multiprocessing_fit_error
  /media/EDrive/toolkits.ubu/anaconda3-4.4.0/envs/dlubu36tf140kerasmaster/lib/python3.6/site-packages/Keras-2.1.2-py3.6.egg/keras/engine/training.py:2023: UserWarning: Using a generator with `use_multiprocessing=True` and multiple workers may duplicate your data. Please consider using the`keras.utils.Sequence class.

tests/test_multiprocessing.py::test_multiprocessing_evaluate_error
  /media/EDrive/toolkits.ubu/anaconda3-4.4.0/envs/dlubu36tf140kerasmaster/lib/python3.6/site-packages/Keras-2.1.2-py3.6.egg/keras/engine/training.py:2251: UserWarning: Using a generator with `use_multiprocessing=True` and multiple workers may duplicate your data. Please consider using the`keras.utils.Sequence class.

tests/test_multiprocessing.py::test_multiprocessing_predict_error
  /media/EDrive/toolkits.ubu/anaconda3-4.4.0/envs/dlubu36tf140kerasmaster/lib/python3.6/site-packages/Keras-2.1.2-py3.6.egg/keras/engine/training.py:2375: UserWarning: Using a generator with `use_multiprocessing=True` and multiple workers may duplicate your data. Please consider using the`keras.utils.Sequence class.

-- Docs: http://doc.pytest.org/en/latest/warnings.html
============================================== 7 passed, 7 warnings in 18.28 seconds ===============================================
```

## `dlubu27cntk23kerasmaster` (Python 2.7 on Ubuntu 16.04 with CNTK 2.3)

*Execution without the fix*

```
(dlubu27cntk23kerasmaster) phil@DESKTOPP:/media/EDrive/toolkits.ubu/anaconda3-4.4.0/envs/dlubu27cntk23kerasmaster/lib/python2.7/site-packages/keras/tests$ py.test test_multiprocessing.py
======================================================= test session starts ========================================================
platform linux2 -- Python 2.7.13, pytest-3.2.1, py-1.4.34, pluggy-0.4.0 -- /media/EDrive/toolkits.ubu/anaconda3-4.4.0/envs/dlubu27cntk23kerasmaster/bin/python
cachedir: ../.cache
rootdir: /media/EDrive/toolkits.ubu/anaconda3-4.4.0/envs/dlubu27cntk23kerasmaster/lib/python2.7/site-packages/keras, inifile: pytest.ini
collected 7 items                                                                                                                   

test_multiprocessing.py::test_multiprocessing_training PASSED
test_multiprocessing.py::test_multiprocessing_training_fromfile PASSED
test_multiprocessing.py::test_multiprocessing_predicting PASSED
test_multiprocessing.py::test_multiprocessing_evaluating PASSED
test_multiprocessing.py::test_multiprocessing_fit_error PASSED
test_multiprocessing.py::test_multiprocessing_evaluate_error PASSED
test_multiprocessing.py::test_multiprocessing_predict_error PASSED

==================================================== slowest 10 test durations =====================================================
0.97s call     tests/test_multiprocessing.py::test_multiprocessing_training
0.19s call     tests/test_multiprocessing.py::test_multiprocessing_training_fromfile
0.17s call     tests/test_multiprocessing.py::test_multiprocessing_evaluate_error
0.14s call     tests/test_multiprocessing.py::test_multiprocessing_predict_error
0.12s call     tests/test_multiprocessing.py::test_multiprocessing_fit_error
0.12s call     tests/test_multiprocessing.py::test_multiprocessing_evaluating
0.10s call     tests/test_multiprocessing.py::test_multiprocessing_predicting
0.00s setup    tests/test_multiprocessing.py::test_multiprocessing_training_fromfile
0.00s teardown tests/test_multiprocessing.py::test_multiprocessing_training_fromfile
0.00s setup    tests/test_multiprocessing.py::test_multiprocessing_evaluate_error
========================================================= warnings summary =========================================================
tests/test_multiprocessing.py::test_multiprocessing_training
  /media/EDrive/toolkits.ubu/anaconda3-4.4.0/envs/dlubu27cntk23kerasmaster/lib/python2.7/site-packages/Keras-2.1.2-py2.7.egg/keras/engine/training.py:2023: UserWarning: Using a generator with `use_multiprocessing=True` and multiple workers may duplicate your data. Please consider using the`keras.utils.Sequence class.
  /media/EDrive/toolkits.ubu/anaconda3-4.4.0/envs/dlubu27cntk23kerasmaster/lib/python2.7/site-packages/cntk/core.py:361: UserWarning: your data is of type "float64", but your input variable (uid "Input23") expects "<type 'numpy.float32'>". Please convert your data beforehand to speed up training.
    (sample.dtype, var.uid, str(var.dtype)))
  /media/EDrive/toolkits.ubu/anaconda3-4.4.0/envs/dlubu27cntk23kerasmaster/lib/python2.7/site-packages/_pytest/warnings.py:88: UnicodeWarning: Warning is using unicode non convertible to ascii, converting to a safe representation:
    /media/EDrive/toolkits.ubu/anaconda3-4.4.0/envs/dlubu27cntk23kerasmaster/lib/python2.7/site-packages/cntk/core.py:361: UserWarning: your data is of type "float64", but your input variable (uid "Input23") expects "<type 'numpy.float32'>". Please convert your data beforehand to speed up training.
    (sample.dtype, var.uid, str(var.dtype)))
  
    UnicodeWarning)

tests/test_multiprocessing.py::test_multiprocessing_predicting
  /media/EDrive/toolkits.ubu/anaconda3-4.4.0/envs/dlubu27cntk23kerasmaster/lib/python2.7/site-packages/Keras-2.1.2-py2.7.egg/keras/engine/training.py:2375: UserWarning: Using a generator with `use_multiprocessing=True` and multiple workers may duplicate your data. Please consider using the`keras.utils.Sequence class.

tests/test_multiprocessing.py::test_multiprocessing_evaluating
  /media/EDrive/toolkits.ubu/anaconda3-4.4.0/envs/dlubu27cntk23kerasmaster/lib/python2.7/site-packages/Keras-2.1.2-py2.7.egg/keras/engine/training.py:2251: UserWarning: Using a generator with `use_multiprocessing=True` and multiple workers may duplicate your data. Please consider using the`keras.utils.Sequence class.

-- Docs: http://doc.pytest.org/en/latest/warnings.html
=============================================== 7 passed, 5 warnings in 3.74 seconds ===============================================
```

*Execution with the fix*

```
(dlubu27cntk23kerasmaster) phil@DESKTOPP:/media/EDrive/toolkits.ubu/anaconda3-4.4.0/envs/dlubu27cntk23kerasmaster/lib/python2.7/site-packages/keras$ py.test /media/EDrive/repos/toolkits/keras_mpc_bug/tests/test_multiprocessing.py
======================================================= test session starts ========================================================
platform linux2 -- Python 2.7.13, pytest-3.2.1, py-1.4.34, pluggy-0.4.0 -- /media/EDrive/toolkits.ubu/anaconda3-4.4.0/envs/dlubu27cntk23kerasmaster/bin/python
cachedir: ../.cache
rootdir: /media/EDrive/toolkits.ubu/anaconda3-4.4.0/envs/dlubu27cntk23kerasmaster/lib/python2.7/site-packages/keras, inifile: pytest.ini
collected 7 items                                                                                                                   

test_multiprocessing.py::test_multiprocessing_training PASSED
test_multiprocessing.py::test_multiprocessing_training_from_file PASSED
test_multiprocessing.py::test_multiprocessing_predicting PASSED
test_multiprocessing.py::test_multiprocessing_evaluating PASSED
test_multiprocessing.py::test_multiprocessing_fit_error PASSED
test_multiprocessing.py::test_multiprocessing_evaluate_error PASSED
test_multiprocessing.py::test_multiprocessing_predict_error PASSED

==================================================== slowest 10 test durations =====================================================
4.53s call     tests/test_multiprocessing.py::test_multiprocessing_training
2.85s call     tests/test_multiprocessing.py::test_multiprocessing_training_from_file
1.61s call     tests/test_multiprocessing.py::test_multiprocessing_evaluating
0.95s call     tests/test_multiprocessing.py::test_multiprocessing_predicting
0.23s call     tests/test_multiprocessing.py::test_multiprocessing_fit_error
0.18s call     tests/test_multiprocessing.py::test_multiprocessing_evaluate_error
0.17s call     tests/test_multiprocessing.py::test_multiprocessing_predict_error
0.00s setup    tests/test_multiprocessing.py::test_multiprocessing_training_from_file
0.00s teardown tests/test_multiprocessing.py::test_multiprocessing_training_from_file
0.00s setup    tests/test_multiprocessing.py::test_multiprocessing_predict_error
========================================================= warnings summary =========================================================
tests/test_multiprocessing.py::test_multiprocessing_training
  /media/EDrive/toolkits.ubu/anaconda3-4.4.0/envs/dlubu27cntk23kerasmaster/lib/python2.7/site-packages/Keras-2.1.2-py2.7.egg/keras/engine/training.py:2023: UserWarning: Using a generator with `use_multiprocessing=True` and multiple workers may duplicate your data. Please consider using the`keras.utils.Sequence class.
  /media/EDrive/toolkits.ubu/anaconda3-4.4.0/envs/dlubu27cntk23kerasmaster/lib/python2.7/site-packages/cntk/core.py:361: UserWarning: your data is of type "float64", but your input variable (uid "Input23") expects "<type 'numpy.float32'>". Please convert your data beforehand to speed up training.
    (sample.dtype, var.uid, str(var.dtype)))
  /media/EDrive/toolkits.ubu/anaconda3-4.4.0/envs/dlubu27cntk23kerasmaster/lib/python2.7/site-packages/_pytest/warnings.py:88: UnicodeWarning: Warning is using unicode non convertible to ascii, converting to a safe representation:
    /media/EDrive/toolkits.ubu/anaconda3-4.4.0/envs/dlubu27cntk23kerasmaster/lib/python2.7/site-packages/cntk/core.py:361: UserWarning: your data is of type "float64", but your input variable (uid "Input23") expects "<type 'numpy.float32'>". Please convert your data beforehand to speed up training.
    (sample.dtype, var.uid, str(var.dtype)))
  
    UnicodeWarning)

tests/test_multiprocessing.py::test_multiprocessing_predicting
  /media/EDrive/toolkits.ubu/anaconda3-4.4.0/envs/dlubu27cntk23kerasmaster/lib/python2.7/site-packages/Keras-2.1.2-py2.7.egg/keras/engine/training.py:2375: UserWarning: Using a generator with `use_multiprocessing=True` and multiple workers may duplicate your data. Please consider using the`keras.utils.Sequence class.

tests/test_multiprocessing.py::test_multiprocessing_evaluating
  /media/EDrive/toolkits.ubu/anaconda3-4.4.0/envs/dlubu27cntk23kerasmaster/lib/python2.7/site-packages/Keras-2.1.2-py2.7.egg/keras/engine/training.py:2251: UserWarning: Using a generator with `use_multiprocessing=True` and multiple workers may duplicate your data. Please consider using the`keras.utils.Sequence class.

-- Docs: http://doc.pytest.org/en/latest/warnings.html
============================================== 7 passed, 5 warnings in 12.50 seconds ===============================================
```

*Steps to recreate test environment*

```
$ conda create --yes -n dlubu27 python=2.7
$ source activate dlubu27
$ conda install --yes numpy scipy mkl-service matplotlib pandas pillow scikit-learn jupyter pytest
$ source deactivate
$ conda create --name dlubu27cntk23kerasmaster --clone dlubu27
$ source activate dlubu27cntk23kerasmaster 
$ pip install https://cntk.ai/PythonWheel/GPU/cntk-2.3-cp27-cp27mu-linux_x86_64.whl
$ cd $CONDA_PREFIX/lib/python2.7/site-packages
$ git clone git://github.com/fchollet/keras.git
$ cd keras
$ python setup.py install
```
