### PR TITLE
Use io.open and utf8 encoding to fix UnicodeDecodeError for Python3

### DIFF
--- a/examples/lstm_text_generation.py
+++ b/examples/lstm_text_generation.py
@@ -19,9 +19,10 @@ from keras.utils.data_utils import get_file
 import numpy as np
 import random
 import sys
+import io
 
 path = get_file('nietzsche.txt', origin='https://s3.amazonaws.com/text-datasets/nietzsche.txt')
-text = open(path).read().lower()
+text = io.open(path, encoding='utf-8').read().lower()
 print('corpus length:', len(text))
 
 chars = sorted(list(set(text)))


### PR DESCRIPTION
I ran into this error with examples/lstm_text_generation.py under Python 3. 
```python
---------------------------------------------------------------------------
UnicodeDecodeError                        Traceback (most recent call last)
/opt/notebooks/git/keras/examples/lstm_text_generation.py in <module>()
     22 
     23 path = get_file('nietzsche.txt', origin='https://s3.amazonaws.com/text-datasets/nietzsche.txt')
---> 24 text = open(path).read().lower()
     25 print('corpus length:', len(text))
     26 

/opt/conda/lib/python3.6/encodings/ascii.py in decode(self, input, final)
     24 class IncrementalDecoder(codecs.IncrementalDecoder):
     25     def decode(self, input, final=False):
---> 26         return codecs.ascii_decode(input, self.errors)[0]
     27 
     28 class StreamWriter(Codec,codecs.StreamWriter):

UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 394533: ordinal not in range(128)
```
This commit fixes it for Python 3 and still works under Python 2.7.