### PR TITLE
Sparse gradient update in the SGD optimizer 

### DIFF
--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -903,10 +903,6 @@ def update_add(x, increment):
     return C.assign(x, result)
 
 
-def update_mul_scalar(x, scalar):
-    return C.assign(x, x * scalar)
-
-
 def gradients(loss, variables):
     # cntk does not support gradients as symbolic op,
     # to hook up with keras model

--- a/keras/backend/cntk_backend.py
+++ b/keras/backend/cntk_backend.py
@@ -903,6 +903,10 @@ def update_add(x, increment):
     return C.assign(x, result)
 
 
+def update_mul_scalar(x, scalar):
+    return C.assign(x, x * scalar)
+
+
 def gradients(loss, variables):
     # cntk does not support gradients as symbolic op,
     # to hook up with keras model

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -979,6 +979,7 @@ def update_sub(x, decrement):
     else:
         return tf.assign_sub(x, decrement)
 
+
 def update_mul_scalar(x, scalar):
     """Update the value of `x` by multiply a scalar `x`.
 
@@ -993,6 +994,7 @@ def update_mul_scalar(x, scalar):
         return tf.scalar_mul(scalar, x)
     else:
         return scalar * x
+
 
 def moving_average_update(x, value, momentum):
     """Compute the moving average of a variable.

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -36,7 +36,7 @@ _GRAPH_LEARNING_PHASES = {}
 
 # This dictionary holds a mapping {graph: UID_DICT}.
 # each UID_DICT is a dictionary mapping name prefixes to a current index,
-# used for generic graph-specific string UIDs
+# used for generating graph-specific string UIDs
 # for various names (e.g. layer names).
 _GRAPH_UID_DICTS = {}
 
@@ -365,7 +365,7 @@ def variable(value, dtype=None, name=None, constraint=None):
         'float64'
         >>> print(kvar)
         example_var
-        >>> kvar.eval()
+        >>> K.eval(kvar)
         array([[ 1.,  2.],
                [ 3.,  4.]])
     ```
@@ -937,15 +937,12 @@ def update(x, new_x):
 
     # Arguments
         x: A `Variable`.
-        new_x: A tensor of same shape as `x` or an IndexedSlices.
+        new_x: A tensor of same shape as `x`.
 
     # Returns
         The variable `x` updated.
     """
-    if isinstance(new_x, tf.IndexedSlices):
-        return tf.scatter_update(x, new_x.indices, new_x.values)
-    else:
-        return tf.assign(x, new_x)
+    return tf.assign(x, new_x)
 
 
 def update_add(x, increment):
@@ -953,15 +950,12 @@ def update_add(x, increment):
 
     # Arguments
         x: A `Variable`.
-        increment: A tensor of same shape as `x` or an IndexedSlices.
+        increment: A tensor of same shape as `x`.
 
     # Returns
         The variable `x` updated.
     """
-    if isinstance(increment, tf.IndexedSlices):
-        return tf.scatter_add(x, increment.indices, increment.values)
-    else:
-        return tf.assign_add(x, increment)
+    return tf.assign_add(x, increment)
 
 
 def update_sub(x, decrement):
@@ -969,30 +963,13 @@ def update_sub(x, decrement):
 
     # Arguments
         x: A `Variable`.
-        decrement: A tensor of same shape as `x` or an IndexedSlices.
+        decrement: A tensor of same shape as `x`.
 
     # Returns
         The variable `x` updated.
     """
-    if isinstance(decrement, tf.IndexedSlices):
-        return tf.scatter_sub(x, decrement.indices, decrement.values)
-    else:
-        return tf.assign_sub(x, decrement)
+    return tf.assign_sub(x, decrement)
 
-def update_mul_scalar(x, scalar):
-    """Update the value of `x` by multiply a scalar `x`.
-
-    # Arguments
-        x: A tensor or an IndexedSlices.
-        scalar: A tensor of same shape as `x` or an IndexedSlices.
-
-    # Returns
-        The tensor or IndexedSlices `x` updated.
-    """
-    if isinstance(x, tf.IndexedSlices):
-        return tf.scalar_mul(scalar, x)
-    else:
-        return scalar * x
 
 def moving_average_update(x, value, momentum):
     """Compute the moving average of a variable.
@@ -2943,8 +2920,9 @@ def sparse_categorical_crossentropy(target, output, from_logits=False):
     res = tf.nn.sparse_softmax_cross_entropy_with_logits(
         labels=targets,
         logits=logits)
-    if len(output_shape) == 3:
-        # if our output includes timesteps we need to reshape
+    if len(output_shape) >= 3:
+        # if our output includes timestep dimension
+        # or spatial dimensions we need to reshape
         return tf.reshape(res, tf.shape(output)[:-1])
     else:
         return res

--- a/keras/backend/tensorflow_backend.py
+++ b/keras/backend/tensorflow_backend.py
@@ -937,12 +937,15 @@ def update(x, new_x):
 
     # Arguments
         x: A `Variable`.
-        new_x: A tensor of same shape as `x`.
+        new_x: A tensor of same shape as `x` or an IndexedSlices.
 
     # Returns
         The variable `x` updated.
     """
-    return tf.assign(x, new_x)
+    if isinstance(new_x, tf.IndexedSlices):
+        return tf.scatter_update(x, new_x.indices, new_x.values)
+    else:
+        return tf.assign(x, new_x)
 
 
 def update_add(x, increment):
@@ -950,12 +953,15 @@ def update_add(x, increment):
 
     # Arguments
         x: A `Variable`.
-        increment: A tensor of same shape as `x`.
+        increment: A tensor of same shape as `x` or an IndexedSlices.
 
     # Returns
         The variable `x` updated.
     """
-    return tf.assign_add(x, increment)
+    if isinstance(increment, tf.IndexedSlices):
+        return tf.scatter_add(x, increment.indices, increment.values)
+    else:
+        return tf.assign_add(x, increment)
 
 
 def update_sub(x, decrement):
@@ -963,13 +969,30 @@ def update_sub(x, decrement):
 
     # Arguments
         x: A `Variable`.
-        decrement: A tensor of same shape as `x`.
+        decrement: A tensor of same shape as `x` or an IndexedSlices.
 
     # Returns
         The variable `x` updated.
     """
-    return tf.assign_sub(x, decrement)
+    if isinstance(decrement, tf.IndexedSlices):
+        return tf.scatter_sub(x, decrement.indices, decrement.values)
+    else:
+        return tf.assign_sub(x, decrement)
 
+def update_mul_scalar(x, scalar):
+    """Update the value of `x` by multiply a scalar `x`.
+
+    # Arguments
+        x: A tensor or an IndexedSlices.
+        scalar: A tensor of same shape as `x` or an IndexedSlices.
+
+    # Returns
+        The tensor or IndexedSlices `x` updated.
+    """
+    if isinstance(x, tf.IndexedSlices):
+        return tf.scalar_mul(scalar, x)
+    else:
+        return scalar * x
 
 def moving_average_update(x, value, momentum):
     """Compute the moving average of a variable.

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -373,8 +373,6 @@ def update_add(x, increment):
 def update_sub(x, decrement):
     return (x, x - decrement)
 
-def update_mul_scalar(x, scalar):
-    return (x, x * scalar)
 
 def moving_average_update(variable, value, momentum):
     return (variable, variable * momentum + value * (1. - momentum))

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -373,6 +373,8 @@ def update_add(x, increment):
 def update_sub(x, decrement):
     return (x, x - decrement)
 
+def update_mul_scalar(x, scalar):
+    return (x, x * scalar)
 
 def moving_average_update(variable, value, momentum):
     return (variable, variable * momentum + value * (1. - momentum))

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -373,8 +373,10 @@ def update_add(x, increment):
 def update_sub(x, decrement):
     return (x, x - decrement)
 
+
 def update_mul_scalar(x, scalar):
     return (x, x * scalar)
+
 
 def moving_average_update(variable, value, momentum):
     return (variable, variable * momentum + value * (1. - momentum))

--- a/keras/optimizers.py
+++ b/keras/optimizers.py
@@ -172,22 +172,18 @@ class SGD(Optimizer):
                 v = K.update_add(m, g_d)
 
                 if self.nesterov:
-                    p = K.update_add(p, self.momentum * v)
-                    p = K.update_add(p, g_d)
+                    new_p = K.update_add(p, self.momentum * v)
+                    new_p = K.update_add(new_p, g_d)
                 else:
-                    p = K.update_add(p, v)
+                    new_p = K.update_add(p, v)
             else:
-                p = K.update_add(p, g_d)
+                new_p = K.update_add(p, g_d)
 
             if getattr(p, 'constraint', None) is not None:
                 # Apply constraints.
-                new_p = p.constraint(p)
-                # TODO: change constraint to update in-place
-                #       then remove this extra assign
-                self.updates.append(K.update(p, new_p))
-            else:
-                # No need to assign again since we are doing in-place update
-                self.updates.append(p)
+                new_p = K.update(new_p, p.constraint(p))
+            # No need to assign again since we are doing in-place update
+            self.updates.append(new_p)
         return self.updates
 
     def get_config(self):

--- a/keras/optimizers.py
+++ b/keras/optimizers.py
@@ -11,6 +11,7 @@ from .legacy import interfaces
 if K.backend() == 'tensorflow':
     import tensorflow as tf
 
+
 def clip_norm(g, c, n):
     if c <= 0:  # if clipnorm == 0 no need to add ops to the graph
         return g
@@ -38,6 +39,7 @@ def clip_norm(g, c, n):
     else:
         g = K.switch(K.greater_equal(n, c), g * c / n, g)
     return g
+
 
 class Optimizer(object):
     """Abstract optimizer base class.
@@ -173,7 +175,7 @@ class SGD(Optimizer):
                     p = K.update_add(p, self.momentum * v)
                     p = K.update_add(p, g_d)
                 else:
-                    p = K.update_add(p, v) # v is dense
+                    p = K.update_add(p, v)
             else:
                 p = K.update_add(p, g_d)
 
@@ -187,7 +189,6 @@ class SGD(Optimizer):
                 # No need to assign again since we are doing in-place update
                 self.updates.append(p)
         return self.updates
-
 
     def get_config(self):
         config = {'lr': float(K.get_value(self.lr)),

--- a/keras/optimizers.py
+++ b/keras/optimizers.py
@@ -11,12 +11,11 @@ from .legacy import interfaces
 if K.backend() == 'tensorflow':
     import tensorflow as tf
 
-
 def clip_norm(g, c, n):
     if c <= 0:  # if clipnorm == 0 no need to add ops to the graph
         return g
 
-    # tf require using a special op to multiply IndexedSliced by scalar
+    # tf require using a special op to multiply IndexedSlices by scalar
     if K.backend() == 'tensorflow':
         condition = n >= c
         then_expression = tf.scalar_mul(c / n, g)
@@ -39,7 +38,6 @@ def clip_norm(g, c, n):
     else:
         g = K.switch(K.greater_equal(n, c), g * c / n, g)
     return g
-
 
 class Optimizer(object):
     """Abstract optimizer base class.
@@ -150,6 +148,7 @@ class SGD(Optimizer):
             self.decay = K.variable(decay, name='decay')
         self.initial_decay = decay
         self.nesterov = nesterov
+        self.momentum_enabled = momentum > 0
 
     @interfaces.legacy_get_updates_support
     def get_updates(self, loss, params):
@@ -160,25 +159,35 @@ class SGD(Optimizer):
         if self.initial_decay > 0:
             lr *= (1. / (1. + self.decay * K.cast(self.iterations,
                                                   K.dtype(self.decay))))
-        # momentum
         shapes = [K.int_shape(p) for p in params]
         moments = [K.zeros(shape) for shape in shapes]
         self.weights = [self.iterations] + moments
         for p, g, m in zip(params, grads, moments):
-            v = self.momentum * m - lr * g  # velocity
-            self.updates.append(K.update(m, v))
+            g_d = K.update_mul_scalar(g, -lr)
 
-            if self.nesterov:
-                new_p = p + self.momentum * v - lr * g
+            if self.momentum_enabled:
+                m = K.update(m, m * self.momentum)
+                v = K.update_add(m, g_d)
+
+                if self.nesterov:
+                    p = K.update_add(p, self.momentum * v)
+                    p = K.update_add(p, g_d)
+                else:
+                    p = K.update_add(p, v) # v is dense
             else:
-                new_p = p + v
+                p = K.update_add(p, g_d)
 
-            # Apply constraints.
             if getattr(p, 'constraint', None) is not None:
-                new_p = p.constraint(new_p)
-
-            self.updates.append(K.update(p, new_p))
+                # Apply constraints.
+                new_p = p.constraint(p)
+                # TODO: change constraint to update in-place
+                #       then remove this extra assign
+                self.updates.append(K.update(p, new_p))
+            else:
+                # No need to assign again since we are doing in-place update
+                self.updates.append(p)
         return self.updates
+
 
     def get_config(self):
         config = {'lr': float(K.get_value(self.lr)),


### PR DESCRIPTION
Support sparse gradients in SGD to improve embedding layers training. Related issue: 4365

IMPACT:

[TENSORFLOW, EMBEDDING] Handle sparse gradients from embedding layers. For a model with 409616384 parameters in its embedding layer, the times per batch decreases from 86ms to 33ms for SGD without momentum. The times per batch decreases from 103ms to 66ms for SGD with momentum. I was expecting the momentum will cripple sparse updates. But it looks like even sparse updating on the moment variable could help.
[TENSORFLOW] Replace several intermediate tensors with in-place updates.
[GENRALLY] Avoid a NOOP with the zero moment variable when momentum==0. The moment variable is big and expensive to evaluate. Vanilla SGD might run faster.
I didn't copy Tensorflow's apply_sparse() and apply_dense() interface because IMO it could be painful to keep two implementations consistency in the long term.