### PR TITLE
Add UniformNoise layer, and test

### DIFF
--- a/keras/layers/noise.py
+++ b/keras/layers/noise.py
@@ -49,6 +49,40 @@ class GaussianNoise(Layer):
         return dict(list(base_config.items()) + list(config.items()))
 
 
+class UniformNoise(Layer):
+    """Apply additive uniform noise
+    Only active at training time since it is a regularization layer.
+
+    # Arguments
+        minval: Minimum value of the uniform distribution
+        maxval: Maximum value of the uniform distribution
+
+    # Input shape
+        Arbitrary.
+
+    # Output shape
+        Same as the input shape.
+    """
+
+    def __init__(self, minval=-1.0, maxval=1.0, **kwargs):
+        super(UniformNoise, self).__init__(**kwargs)
+        self.supports_masking = True
+        self.minval = minval
+        self.maxval = maxval
+
+    def call(self, inputs, training=None):
+        def noised():
+            return inputs + K.random_uniform(shape=K.shape(inputs),
+                                             minval=self.minval,
+                                             maxval=self.maxval)
+        return K.in_train_phase(noised, inputs, training=training)
+
+    def get_config(self):
+        config = {'minval': self.minval, 'maxval': self.maxval}
+        base_config = super(UniformNoise, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))
+
+
 class GaussianDropout(Layer):
     """Apply multiplicative 1-centered Gaussian noise.
 

--- a/tests/keras/layers/noise_test.py
+++ b/tests/keras/layers/noise_test.py
@@ -17,6 +17,15 @@ def test_GaussianNoise():
 @keras_test
 @pytest.mark.skipif((K.backend() == 'cntk'),
                     reason="cntk does not support it yet")
+def test_UniformNoise():
+    layer_test(noise.UniformNoise,
+               kwargs={'minval': -1., 'maxval': 1.},
+               input_shape=(3, 2, 3))
+
+
+@keras_test
+@pytest.mark.skipif((K.backend() == 'cntk'),
+                    reason="cntk does not support it yet")
 def test_GaussianDropout():
     layer_test(noise.GaussianDropout,
                kwargs={'rate': 0.5},


### PR DESCRIPTION
Adding uniform noise to data is a common regularization technique that is currently missing from Keras. This is a simple layer that introduces that functionality.