### PR TITLE
Sync docs with default reality

### DIFF
--- a/keras/backend/common.py
+++ b/keras/backend/common.py
@@ -2,7 +2,7 @@ import numpy as np
 
 # the type of float to use throughout the session.
 _FLOATX = 'float32'
-_EPSILON = 10e-8
+_EPSILON = 1e-7
 _IMAGE_DATA_FORMAT = 'channels_last'
 
 
@@ -15,7 +15,7 @@ def epsilon():
     # Example
     ```python
         >>> keras.backend.epsilon()
-        1e-08
+        1e-07
     ```
     """
     return _EPSILON
@@ -31,7 +31,7 @@ def set_epsilon(e):
     ```python
         >>> from keras import backend as K
         >>> K.epsilon()
-        1e-08
+        1e-07
         >>> K.set_epsilon(1e-05)
         >>> K.epsilon()
         1e-05


### PR DESCRIPTION
also replace `10e-8` with `1e-7` for consistency with actual output.